### PR TITLE
fixed: Capture React Components Defined with `const/export const`

### DIFF
--- a/ast/src/lang/queries/react.rs
+++ b/ast/src/lang/queries/react.rs
@@ -68,10 +68,42 @@ impl Stack for ReactTs {
                     name: (property_identifier) @{FUNCTION_NAME} (#not-eq? @{FUNCTION_NAME} "render")
                     parameters: (formal_parameters) @{ARGUMENTS}
                 )
+                (lexical_declaration
+                    (variable_declarator
+                        name: (identifier) @{FUNCTION_NAME}
+                        value: (arrow_function
+                            parameters: (formal_parameters) @{ARGUMENTS}
+                        )
+                    )
+                )
+                (export_statement
+                    (lexical_declaration
+                        (variable_declarator
+                            name: (identifier) @{FUNCTION_NAME}
+                            value: (arrow_function
+                                parameters: (formal_parameters) @{ARGUMENTS}
+                            )
+                        )
+                    )
+                )
+                (export_statement
+                    (function_declaration
+                        name: (identifier) @{FUNCTION_NAME}
+                        parameters: (formal_parameters) @{ARGUMENTS}
+                    )
+                )
                 (variable_declarator
                     name: (identifier) @{FUNCTION_NAME}
                     value: (arrow_function
                         parameters: (formal_parameters) @{ARGUMENTS}
+                    )
+                )
+                (expression_statement
+                    (assignment_expression
+                        left: (identifier) @{FUNCTION_NAME}
+                        right: (arrow_function
+                            parameters: (formal_parameters) @{ARGUMENTS}
+                        )
                     )
                 )
                 (public_field_definition

--- a/ast/src/testing/graphs.rs
+++ b/ast/src/testing/graphs.rs
@@ -137,10 +137,10 @@ pub fn get_test_expectations() -> Vec<GraphTestExpectations> {
         GraphTestExpectations {
             lang_id: "react",
             repo_path: "src/testing/react",
-            expected_nodes: 49,
-            expected_edges: 61,
-            expected_nodes_lsp: Some(55),
-            expected_edges_lsp: Some(77),
+            expected_nodes: 56,
+            expected_edges: 68,
+            expected_nodes_lsp: Some(60),
+            expected_edges_lsp: Some(82),
             ..Default::default()
         },
         GraphTestExpectations {

--- a/ast/src/testing/graphs.rs
+++ b/ast/src/testing/graphs.rs
@@ -139,8 +139,8 @@ pub fn get_test_expectations() -> Vec<GraphTestExpectations> {
             repo_path: "src/testing/react",
             expected_nodes: 56,
             expected_edges: 68,
-            expected_nodes_lsp: Some(60),
-            expected_edges_lsp: Some(82),
+            expected_nodes_lsp: Some(62),
+            expected_edges_lsp: Some(84),
             ..Default::default()
         },
         GraphTestExpectations {

--- a/ast/src/testing/react/mod.rs
+++ b/ast/src/testing/react/mod.rs
@@ -20,11 +20,11 @@ pub async fn test_react_typescript_generic<G: Graph>() -> Result<(), anyhow::Err
 
     let (num_nodes, num_edges) = graph.get_graph_size();
     if use_lsp == true {
-        assert_eq!(num_nodes, 55, "Expected 55 nodes");
-        assert_eq!(num_edges, 77, "Expected 77 edges");
+        assert_eq!(num_nodes, 60, "Expected 60 nodes");
+        assert_eq!(num_edges, 82, "Expected 82 edges");
     } else {
-        assert_eq!(num_nodes, 49, "Expected 49 nodes");
-        assert_eq!(num_edges, 61, "Expected 61 edges");
+        assert_eq!(num_nodes, 56, "Expected 56 nodes");
+        assert_eq!(num_edges, 68, "Expected 68 edges");
     }
 
     fn normalize_path(path: &str) -> String {
@@ -51,13 +51,13 @@ pub async fn test_react_typescript_generic<G: Graph>() -> Result<(), anyhow::Err
     );
 
     let imports = graph.find_nodes_by_type(NodeType::Import);
-    assert_eq!(imports.len(), 4, "Expected 4 imports");
+    assert_eq!(imports.len(), 5, "Expected 5 imports");
 
     let functions = graph.find_nodes_by_type(NodeType::Function);
     if use_lsp == true {
-        assert_eq!(functions.len(), 17, "Expected 17 functions/components");
+        assert_eq!(functions.len(), 22, "Expected 22 functions/components");
     } else {
-        assert_eq!(functions.len(), 11, "Expected 11 functions/components");
+        assert_eq!(functions.len(), 16, "Expected 16 functions/components");
     }
 
     let mut sorted_functions = functions.clone();
@@ -73,14 +73,54 @@ pub async fn test_react_typescript_generic<G: Graph>() -> Result<(), anyhow::Err
         "App component file path is incorrect"
     );
 
+    let function_component = functions
+        .iter()
+        .find(|f| f.name == "FunctionComponent")
+        .expect("FunctionComponent not found");
     assert_eq!(
-        sorted_functions[1].name, "FormContainer",
-        "FormContainer component name is incorrect"
+        normalize_path(&function_component.file),
+        "src/testing/react/src/ComponentPatterns.tsx",
+        "FunctionComponent file path is incorrect"
     );
+
+    let arrow_component = functions
+        .iter()
+        .find(|f| f.name == "ArrowComponent")
+        .expect("ArrowComponent not found");
     assert_eq!(
-        normalize_path(&sorted_functions[1].file),
-        "src/testing/react/src/components/NewPerson.tsx",
-        "FormContainer component file path is incorrect"
+        normalize_path(&arrow_component.file),
+        "src/testing/react/src/ComponentPatterns.tsx",
+        "ArrowComponent file path is incorrect"
+    );
+
+    let export_arrow_component = functions
+        .iter()
+        .find(|f| f.name == "ExportArrowComponent")
+        .expect("ExportArrowComponent not found");
+    assert_eq!(
+        normalize_path(&export_arrow_component.file),
+        "src/testing/react/src/ComponentPatterns.tsx",
+        "ExportArrowComponent file path is incorrect"
+    );
+
+    let direct_assignment_component = functions
+        .iter()
+        .find(|f| f.name == "DirectAssignmentComponent")
+        .expect("DirectAssignmentComponent not found");
+    assert_eq!(
+        normalize_path(&direct_assignment_component.file),
+        "src/testing/react/src/ComponentPatterns.tsx",
+        "DirectAssignmentComponent file path is incorrect"
+    );
+
+    let export_direct_assignment_component = functions
+        .iter()
+        .find(|f| f.name == "ExportDirectAssignmentComponent")
+        .expect("ExportDirectAssignmentComponent not found");
+    assert_eq!(
+        normalize_path(&export_direct_assignment_component.file),
+        "src/testing/react/src/ComponentPatterns.tsx",
+        "ExportDirectAssignmentComponent file path is incorrect"
     );
 
     let submit_button = functions

--- a/ast/src/testing/react/mod.rs
+++ b/ast/src/testing/react/mod.rs
@@ -20,8 +20,8 @@ pub async fn test_react_typescript_generic<G: Graph>() -> Result<(), anyhow::Err
 
     let (num_nodes, num_edges) = graph.get_graph_size();
     if use_lsp == true {
-        assert_eq!(num_nodes, 60, "Expected 60 nodes");
-        assert_eq!(num_edges, 82, "Expected 82 edges");
+        assert_eq!(num_nodes, 62, "Expected 62 nodes");
+        assert_eq!(num_edges, 84, "Expected 84 edges");
     } else {
         assert_eq!(num_nodes, 56, "Expected 56 nodes");
         assert_eq!(num_edges, 68, "Expected 68 edges");

--- a/ast/src/testing/react/src/ComponentPatterns.tsx
+++ b/ast/src/testing/react/src/ComponentPatterns.tsx
@@ -1,0 +1,36 @@
+import React, { useState, useEffect } from 'react';
+
+export function FunctionComponent({ text }: { text: string }) {
+  return <div>{text}</div>;
+}
+
+const ArrowComponent = ({ count }: { count: number }) => {
+  return <div>{count}</div>;
+};
+
+export const ExportArrowComponent = ({ name }: { name: string }) => {
+  return <div>Hello, {name}</div>;
+};
+
+let DirectAssignmentComponent: React.FC<{ id: string }>;
+DirectAssignmentComponent = ({ id }) => {
+  const [data, setData] = useState<string | null>(null);
+  
+  useEffect(() => {
+    setData(id);
+  }, [id]);
+  
+  return <div>ID: {data}</div>;
+};
+
+const ExportDirectAssignmentComponent: React.FC<{ items: string[] }> = ({ items }) => {
+  return (
+    <ul>
+      {items.map((item, index) => (
+        <li key={index}>{item}</li>
+      ))}
+    </ul>
+  );
+};
+
+export { ArrowComponent, DirectAssignmentComponent, ExportDirectAssignmentComponent }; 


### PR DESCRIPTION
closed: https://github.com/stakwork/stakgraph/issues/93

Unit Test:

![image](https://github.com/user-attachments/assets/43b75c19-06d5-4908-98a4-3f27f88d989a)
