### PR TITLE
updated print_json to output like arraygraph

### DIFF
--- a/ast/src/index.rs
+++ b/ast/src/index.rs
@@ -61,6 +61,7 @@ async fn main() -> Result<()> {
     });
     println!("{}", name);
 
+    //let graph = repos.build_graphs_btree().await?;
     let graph = repos.build_graphs().await?;
 
     if std::env::var("OUTPUT_FORMAT")

--- a/ast/src/lang/graphs/btreemap_graph.rs
+++ b/ast/src/lang/graphs/btreemap_graph.rs
@@ -723,6 +723,33 @@ impl Graph for BTreeMapGraph {
     }
 }
 
+impl BTreeMapGraph {
+    pub fn to_array_graph_edges(&self) -> Vec<Edge> {
+        let mut formatted_edges = Vec::with_capacity(self.edges.len());
+
+        for (src_key, dst_key, edge_type) in &self.edges {
+            if let (Some(src_node), Some(dst_node)) =
+                (self.nodes.get(src_key), self.nodes.get(dst_key))
+            {
+                let edge = Edge {
+                    edge: edge_type.clone(),
+                    source: NodeRef {
+                        node_type: src_node.node_type.clone(),
+                        node_data: NodeKeys::from(&src_node.node_data),
+                    },
+                    target: NodeRef {
+                        node_type: dst_node.node_type.clone(),
+                        node_data: NodeKeys::from(&dst_node.node_data),
+                    },
+                };
+
+                formatted_edges.push(edge);
+            }
+        }
+
+        formatted_edges
+    }
+}
 impl Default for BTreeMapGraph {
     fn default() -> Self {
         BTreeMapGraph {

--- a/ast/src/utils.rs
+++ b/ast/src/utils.rs
@@ -22,9 +22,11 @@ pub fn print_json<G: Graph + Serialize + 'static>(graph: &G, name: &str) -> Resu
                 write_json_lines(edgepath, &array_graph.edges)?;
             } else if let Some(btreemap_graph) = as_btreemap_graph(graph) {
                 let nodepath = format!("ast/examples/{}-nodes.jsonl", name);
-                write_json_lines(nodepath, &btreemap_graph.nodes)?;
+                let node_values: Vec<_> = btreemap_graph.nodes.values().collect();
+                write_json_lines(nodepath, &node_values)?;
                 let edgepath = format!("ast/examples/{}-edges.jsonl", name);
-                write_json_lines(edgepath, &btreemap_graph.edges)?;
+                let edge_values = btreemap_graph.to_array_graph_edges();
+                write_json_lines(edgepath, &edge_values)?;
             } else {
                 //seriolize the whole graph otherwise
                 let pretty = serde_json::to_string_pretty(&graph)?;


### PR DESCRIPTION
Updated the format of `print_json` to output BTreeMapGraph's `jsonl` just like ArrayGraph's