### PR TITLE
unstuck swift lsp for compare graphs

### DIFF
--- a/ast/src/testing/graphs.rs
+++ b/ast/src/testing/graphs.rs
@@ -24,10 +24,6 @@ const PROGRAMMING_LANGUAGES: [&str; 11] = [
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn compare_graphs() {
-    let lsp = std::env::var("USE_LSP").unwrap_or_else(|_| "false".to_string());
-    if lsp == "true" || lsp == "1" {
-        return;
-    }
     for lang in PROGRAMMING_LANGUAGES.iter() {
         let repo_path = format!("src/testing/{}", lang);
         info!("Comparing graphs for {}", lang);

--- a/ast/src/testing/graphs.rs
+++ b/ast/src/testing/graphs.rs
@@ -39,7 +39,7 @@ async fn compare_graphs() {
 
 async fn compare_graphs_inner(lang_id: &str, repo_path: &str) -> Result<()> {
     let lang = Lang::from_str(lang_id).unwrap();
-    let use_lsp = get_use_lsp();
+    let use_lsp = get_use_lsp() && lang.kind.default_do_lsp();
     let repo = Repo::new(repo_path, lang, use_lsp, Vec::new(), Vec::new()).unwrap();
     let array_graph = repo.build_graph_inner::<ArrayGraph>().await?;
     info!("ArrayGraph Analysis for {}", lang_id);

--- a/lsp/src/language.rs
+++ b/lsp/src/language.rs
@@ -141,7 +141,7 @@ impl Language {
             Self::Python => false,
             Self::Ruby => false,
             Self::Kotlin => true,
-            Self::Swift => true,
+            Self::Swift => false,
             Self::Java => true,
             Self::Bash => false,
             Self::Toml => false,


### PR DESCRIPTION
Added `default_do_lsp` to test for lsp in compare_graphs