### PR TITLE
Add user-controlled recording for staktrak behavior tracking

### DIFF
--- a/mcp/docs/staktrak/index.html
+++ b/mcp/docs/staktrak/index.html
@@ -14,11 +14,96 @@
         width: 100%;
         height: 500px;
         border: 1px solid #333;
+        margin-bottom: 20px;
+      }
+      .controls {
+        margin-top: 20px;
+        display: none;
+      }
+      button {
+        padding: 10px 20px;
+        font-size: 16px;
+        background-color: #4caf50;
+        color: white;
+        border: none;
+        border-radius: 4px;
+        cursor: pointer;
+        margin-right: 10px;
+      }
+      button.stop {
+        background-color: #f44336;
+      }
+      button:disabled {
+        background-color: #cccccc;
+        cursor: not-allowed;
+      }
+      #results {
+        margin-top: 20px;
+        background-color: #2a2a2a;
+        padding: 15px;
+        border-radius: 5px;
+        max-height: 300px;
+        overflow: auto;
       }
     </style>
   </head>
   <body>
     <h1>Tracking Script Demo</h1>
-    <iframe src="frame.html"></iframe>
+    <iframe src="frame.html" id="trackingFrame"></iframe>
+
+    <div class="controls" id="trackingControls">
+      <button id="recordBtn" class="record">Start Recording</button>
+      <button id="stopBtn" class="stop" disabled>Stop Recording</button>
+    </div>
+
+    <div id="results"></div>
+
+    <script>
+      const trackingFrame = document.getElementById("trackingFrame");
+      const trackingControls = document.getElementById("trackingControls");
+      const recordBtn = document.getElementById("recordBtn");
+      const stopBtn = document.getElementById("stopBtn");
+      const resultsDiv = document.getElementById("results");
+
+      let isRecording = false;
+
+      window.addEventListener("message", (event) => {
+        if (event.data && event.data.type) {
+          switch (event.data.type) {
+            case "staktrak-setup":
+              trackingControls.style.display = "block";
+              break;
+            case "staktrak-results":
+              displayResults(event.data.data);
+              break;
+          }
+        }
+      });
+
+      recordBtn.addEventListener("click", () => {
+        trackingFrame.contentWindow.postMessage(
+          { type: "staktrak-start" },
+          "*"
+        );
+        recordBtn.disabled = true;
+        stopBtn.disabled = false;
+        isRecording = true;
+        resultsDiv.innerHTML = "";
+      });
+
+      stopBtn.addEventListener("click", () => {
+        trackingFrame.contentWindow.postMessage({ type: "staktrak-stop" }, "*");
+        recordBtn.disabled = false;
+        stopBtn.disabled = true;
+        isRecording = false;
+      });
+
+      function displayResults(data) {
+        const resultsPre = document.createElement("pre");
+        resultsPre.textContent = JSON.stringify(data, null, 2);
+        resultsDiv.innerHTML = "<h3>Tracking Results:</h3>";
+        resultsDiv.appendChild(resultsPre);
+      }
+    </script>
   </body>
 </html>

--- a/mcp/docs/staktrak/staktrak.js
+++ b/mcp/docs/staktrak/staktrak.js
@@ -320,8 +320,29 @@ var userBehaviour = (function () {
   };
 })();
 
-userBehaviour.start();
+window.addEventListener("DOMContentLoaded", () => {
+  setTimeout(() => {
+    window.parent.postMessage({ type: "staktrak-setup", status: "ready" }, "*");
+  }, 500);
+});
 
-setInterval(() => {
-  userBehaviour.stop();
-}, 5000);
+window.addEventListener("message", (event) => {
+  if (event.data && event.data.type) {
+    switch (event.data.type) {
+      case "staktrak-start":
+        userBehaviour.start();
+        break;
+      case "staktrak-stop":
+        const results = userBehaviour.showResult();
+        window.parent.postMessage(
+          {
+            type: "staktrak-results",
+            data: results,
+          },
+          "*"
+        );
+        userBehaviour.stop();
+        break;
+    }
+  }
+});


### PR DESCRIPTION
## Overview
Added record/stop buttons in the parent window to control user behavior tracking in the iframe. Communication happens through postMessage API with buttons initially hidden until iframe signals readiness. When recording stops, tracking results are displayed in the parent page.

## Closed: #331 

## Implementation Details
- The iframe sends a "staktrak-setup" message to the parent window when loaded
- Parent window shows control buttons after receiving setup message
- Start/stop buttons trigger corresponding messages to the iframe
- Results are displayed in formatted JSON in the parent window
- Button states are managed to prevent concurrent recording sessions

## How to Test
1. Navigate to the staktrak demo page
2. Verify that record/stop buttons appear after page load
3. Click "Start Recording" and interact with the iframe content
4. Click "Stop Recording" and verify that tracking results appear below

## Screenshots

![image](https://github.com/user-attachments/assets/a8347288-0390-4731-812c-8f49f53054a5)

![image](https://github.com/user-attachments/assets/1fe36d53-f96f-43a7-a534-8adabb02dbf8)

![image](https://github.com/user-attachments/assets/fec8fbf6-d5c5-41ba-b7e6-38a2daf44f0c)
