### PR TITLE
Add Assertion Support to Staktrak Test Recorder

### DIFF
--- a/mcp/docs/staktrak/example-test.spec.js
+++ b/mcp/docs/staktrak/example-test.spec.js
@@ -11,6 +11,8 @@ test("User interaction replay with input typing", async ({ page }) => {
   await button1.waitFor({ state: "visible" });
   await button1.click();
 
+  await expect(button1).toHaveText("data-testid");
+
   await page.waitForTimeout(500);
 
   const inputField = page.locator('[data-testid="staktrak-input"]');
@@ -19,13 +21,18 @@ test("User interaction replay with input typing", async ({ page }) => {
 
   await inputField.fill("Hello, this is a test input");
 
+  await expect(inputField).toHaveValue("Hello, this is a test input");
+
   await page.waitForTimeout(1000);
+
+  const content = page.locator(".content-section");
+  await expect(content).toBeVisible();
+
+  await expect(content).toContainText("You can select any text");
 
   const button3 = page.locator("#staktrak-div");
   await button3.waitFor({ state: "visible" });
   await button3.click();
-
-  await expect(inputField).toHaveValue("Hello, this is a test input");
 
   await page.waitForTimeout(2500);
 });

--- a/mcp/docs/staktrak/index.html
+++ b/mcp/docs/staktrak/index.html
@@ -39,6 +39,9 @@
       button.save {
         background-color: #9c27b0;
       }
+      button.assert {
+        background-color: #ff9800;
+      }
       button:disabled {
         background-color: #cccccc;
         cursor: not-allowed;
@@ -93,18 +96,158 @@
         background-color: #f44336;
         display: block;
       }
+      .assertion-panel {
+        margin-top: 20px;
+        background-color: #333;
+        padding: 15px;
+        border-radius: 5px;
+        display: none;
+      }
+      .assertion-panel.active {
+        display: block;
+      }
+      .assertion-panel select,
+      .assertion-panel input {
+        padding: 8px;
+        margin: 5px 0;
+        background-color: #444;
+        color: white;
+        border: 1px solid #555;
+        border-radius: 4px;
+        width: 30%;
+      }
+      .assertion-panel button {
+        margin-top: 10px;
+      }
+      .assertion-type-group {
+        margin-top: 10px;
+      }
+      .assertion-type-group label {
+        display: block;
+        margin-bottom: 5px;
+      }
+      .assertions-list {
+        margin-top: 20px;
+        background-color: #2a2a2a;
+        padding: 15px;
+        border-radius: 5px;
+        max-height: 200px;
+        overflow: auto;
+        display: none;
+      }
+      .assertions-list.active {
+        display: block;
+      }
+      .assertion-item {
+        padding: 8px;
+        margin-bottom: 5px;
+        background-color: #444;
+        border-radius: 4px;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
+      }
+      .remove-assertion {
+        background-color: #f44336;
+        border: none;
+        color: white;
+        border-radius: 50%;
+        width: 24px;
+        height: 24px;
+        line-height: 24px;
+        text-align: center;
+        padding: 0;
+        cursor: pointer;
+      }
+
+      .popup {
+        position: fixed;
+        top: 20px;
+        right: 20px;
+        padding: 15px 20px;
+        border-radius: 8px;
+        font-size: 14px;
+        font-weight: bold;
+        z-index: 1000;
+        transform: translateY(-100%);
+        transition: transform 0.3s ease;
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      .popup.show {
+        transform: translateY(0);
+      }
+
+      .popup-success {
+        background-color: #4caf50;
+        border: 2px solid #6abf6e;
+        color: #ffffff;
+      }
+
+      .popup-error {
+        background-color: #f44336;
+        border: 2px solid #f66e66;
+        color: #ffffff;
+      }
+
+      .popup-info {
+        background-color: #2196f3;
+        border: 2px solid #66a6ff;
+        color: #ffffff;
+      }
+
+      .popup-warning {
+        background-color: #ff9800;
+        border: 2px solid #ffb84d;
+        color: #ffffff;
+      }
     </style>
   </head>
   <body>
+    <div id="popupContainer"></div>
     <h1>Tracking Script Demo</h1>
     <iframe src="preact/frame.html" id="trackingFrame"></iframe>
 
     <div class="controls" id="trackingControls">
       <button id="recordBtn" class="record">Start Recording</button>
       <button id="stopBtn" class="stop" disabled>Stop Recording</button>
+      <button id="assertBtn" class="assert" disabled>Add Assertion</button>
       <button id="generateBtn" class="generate" disabled>
         Generate Playwright Test
       </button>
+    </div>
+
+    <div id="assertionPanel" class="assertion-panel">
+      <h3>Add Assertion</h3>
+      <div class="assertion-type-group">
+        <label for="assertionType">Assertion Type:</label>
+        <select id="assertionType">
+          <option value="hasText">Has Text</option>
+          <option value="containsText">Contains Text</option>
+          <option value="isVisible">Is Visible</option>
+          <option value="hasValue">Has Value</option>
+        </select>
+      </div>
+      <div class="assertion-type-group">
+        <label for="assertionSelector">Element Selector:</label>
+        <input
+          type="text"
+          id="assertionSelector"
+          placeholder="Enter selector or use selection"
+        />
+      </div>
+      <div class="assertion-type-group">
+        <label for="assertionValue">Expected Value:</label>
+        <input type="text" id="assertionValue" placeholder="Value to assert" />
+      </div>
+      <div id="assertionStatus" class="status"></div>
+      <button id="addAssertionBtn">Add to Test</button>
+      <button id="cancelAssertionBtn">Cancel</button>
+    </div>
+
+    <div id="assertionsList" class="assertions-list">
+      <h3>Added Assertions:</h3>
+      <div id="assertionsContainer"></div>
     </div>
 
     <!-- <div id="results"></div> -->
@@ -116,13 +259,28 @@
       const trackingControls = document.getElementById("trackingControls");
       const recordBtn = document.getElementById("recordBtn");
       const stopBtn = document.getElementById("stopBtn");
+      const assertBtn = document.getElementById("assertBtn");
       const generateBtn = document.getElementById("generateBtn");
+      const assertionPanel = document.getElementById("assertionPanel");
+      const addAssertionBtn = document.getElementById("addAssertionBtn");
+      const cancelAssertionBtn = document.getElementById("cancelAssertionBtn");
+      const assertionType = document.getElementById("assertionType");
+      const assertionSelector = document.getElementById("assertionSelector");
+      const assertionValue = document.getElementById("assertionValue");
+      const assertionStatus = document.getElementById("assertionStatus");
+      const assertionsList = document.getElementById("assertionsList");
+      const assertionsContainer = document.getElementById(
+        "assertionsContainer"
+      );
       // const resultsDiv = document.getElementById("results");
       const playwrightTestDiv = document.getElementById("playwrightTest");
 
       let isRecording = false;
       let currentTrackingData = null;
       let currentTestCode = null;
+      let assertions = [];
+      let selectedText = "";
+      let lastSelectedElement = null;
 
       window.addEventListener("message", (event) => {
         if (event.data && event.data.type) {
@@ -135,9 +293,55 @@
               currentTrackingData = event.data.data;
               generateBtn.disabled = false;
               break;
+            case "staktrak-selection":
+              selectedText = event.data.text || "";
+              lastSelectedElement = event.data.selector || "";
+              if (selectedText) {
+                assertionValue.value = selectedText;
+              }
+              if (lastSelectedElement) {
+                assertionSelector.value = lastSelectedElement;
+              }
+              break;
           }
         }
       });
+
+      function updateAssertionsList() {
+        assertionsContainer.innerHTML = "";
+
+        if (assertions.length === 0) {
+          assertionsList.classList.remove("active");
+          return;
+        }
+
+        assertionsList.classList.add("active");
+
+        assertions.forEach((assertion, index) => {
+          const item = document.createElement("div");
+          item.className = "assertion-item";
+
+          let assertionText = `${assertion.selector} ${assertion.type}`;
+          if (assertion.value) {
+            assertionText += `: "${assertion.value}"`;
+          }
+
+          item.innerHTML = `
+            <span>${assertionText}</span>
+            <button class="remove-assertion" data-index="${index}">✕</button>
+          `;
+
+          assertionsContainer.appendChild(item);
+        });
+
+        document.querySelectorAll(".remove-assertion").forEach((button) => {
+          button.addEventListener("click", function () {
+            const index = parseInt(this.getAttribute("data-index"));
+            assertions.splice(index, 1);
+            updateAssertionsList();
+          });
+        });
+      }
 
       recordBtn.addEventListener("click", () => {
         trackingFrame.contentWindow.postMessage(
@@ -146,27 +350,114 @@
         );
         recordBtn.disabled = true;
         stopBtn.disabled = false;
+        assertBtn.disabled = false;
         generateBtn.disabled = true;
         isRecording = true;
+        assertions = [];
+        updateAssertionsList();
         // resultsDiv.innerHTML = "";
         playwrightTestDiv.innerHTML = "";
+
+        showPopup("Recording started", "info");
       });
 
       stopBtn.addEventListener("click", () => {
         trackingFrame.contentWindow.postMessage({ type: "staktrak-stop" }, "*");
         recordBtn.disabled = false;
         stopBtn.disabled = true;
+        assertBtn.disabled = true;
         isRecording = false;
+
+        showPopup("Recording stopped", "warning");
+      });
+
+      assertBtn.addEventListener("click", () => {
+        assertionPanel.classList.add("active");
+
+        trackingFrame.contentWindow.postMessage(
+          { type: "staktrak-enable-selection" },
+          "*"
+        );
+      });
+
+      function showAssertionStatus(message, type) {
+        showPopup(message, type);
+      }
+
+      function isValidAssertion(type, selector, value) {
+        if (!selector || selector.trim() === "") {
+          showAssertionStatus("Please provide a valid selector", "error");
+          return false;
+        }
+
+        if (
+          (type === "hasText" ||
+            type === "containsText" ||
+            type === "hasValue") &&
+          (!value || value.trim() === "")
+        ) {
+          showAssertionStatus("Please provide an expected value", "error");
+          return false;
+        }
+
+        const isDuplicate = assertions.some(
+          (a) => a.type === type && a.selector === selector && a.value === value
+        );
+
+        if (isDuplicate) {
+          showAssertionStatus("This assertion already exists", "error");
+          return false;
+        }
+
+        return true;
+      }
+
+      addAssertionBtn.addEventListener("click", () => {
+        const type = assertionType.value;
+        const selector = assertionSelector.value;
+        const value = assertionValue.value;
+
+        if (!isValidAssertion(type, selector, value)) {
+          return;
+        }
+
+        assertions.push({
+          type,
+          selector,
+          value,
+          timestamp: Date.now(),
+        });
+
+        updateAssertionsList();
+
+        showPopup(`Assertion added: ${type} "${value || ""}"`, "success");
+
+        assertionValue.value = "";
+      });
+
+      cancelAssertionBtn.addEventListener("click", () => {
+        assertionPanel.classList.remove("active");
+        assertionValue.value = "";
+        assertionSelector.value = "";
+
+        showPopup("Assertion cancelled", "warning");
       });
 
       generateBtn.addEventListener("click", () => {
         if (currentTrackingData) {
+          if (!currentTrackingData.assertions) {
+            currentTrackingData.assertions = [];
+          }
+          currentTrackingData.assertions = assertions;
+
           const testCode = window.PlaywrightGenerator.generatePlaywrightTest(
             "http://localhost:3000/preact/frame.html",
             currentTrackingData
           );
           currentTestCode = testCode;
           displayPlaywrightTest(testCode);
+
+          showPopup("Playwright test generated successfully", "success");
         }
       });
 
@@ -193,7 +484,7 @@
       function copyTestToClipboard() {
         const testCode = playwrightTestDiv.querySelector("pre").textContent;
         navigator.clipboard.writeText(testCode).then(() => {
-          showStatus("Test code copied to clipboard!", "success");
+          showPopup("Test code copied to clipboard!", "success");
         });
       }
 
@@ -202,6 +493,11 @@
 
         const filenameInput = document.getElementById("filenameInput");
         const filename = filenameInput.value.trim();
+
+        if (!filename) {
+          showPopup("Please enter a filename", "error");
+          return;
+        }
 
         try {
           const response = await fetch("/api/save-test", {
@@ -218,23 +514,53 @@
           const result = await response.json();
 
           if (result.success) {
-            showStatus(`Test saved as ${result.filename}`, "success");
+            showPopup(`Test saved as ${result.filename}`, "success");
             filenameInput.value = "";
           } else {
-            showStatus(result.error || "Failed to save test", "error");
+            showPopup(result.error || "Failed to save test", "error");
           }
         } catch (error) {
-          showStatus("Error saving test: " + error.message, "error");
+          showPopup("Error saving test: " + error.message, "error");
         }
       }
 
       function showStatus(message, type) {
+        showPopup(message, type);
+
         const statusDiv = document.getElementById("saveStatus");
-        statusDiv.textContent = message;
-        statusDiv.className = `status ${type}`;
+        if (statusDiv) {
+          statusDiv.textContent = message;
+          statusDiv.className = `status ${type}`;
+
+          setTimeout(() => {
+            statusDiv.style.display = "none";
+          }, 3000);
+        }
+      }
+
+      function showPopup(message, type = "info") {
+        const existingPopup = document.querySelector(".popup");
+        if (existingPopup) {
+          existingPopup.remove();
+        }
+
+        const popup = document.createElement("div");
+        popup.className = `popup popup-${type}`;
+        popup.textContent = message;
+
+        document.getElementById("popupContainer").appendChild(popup);
 
         setTimeout(() => {
-          statusDiv.style.display = "none";
+          popup.classList.add("show");
+        }, 10);
+
+        setTimeout(() => {
+          popup.classList.remove("show");
+          setTimeout(() => {
+            if (popup.parentNode) {
+              popup.parentNode.removeChild(popup);
+            }
+          }, 300);
         }, 3000);
       }
     </script>

--- a/mcp/docs/staktrak/index.html
+++ b/mcp/docs/staktrak/index.html
@@ -198,6 +198,16 @@
                 }
               }
               break;
+            case "staktrak-show-popup":
+              trackingFrame.contentWindow.postMessage(
+                {
+                  type: "staktrak-show-popup",
+                  text: event.data.text,
+                  selector: event.data.selector,
+                },
+                "*"
+              );
+              break;
             case "staktrak-selection-mode-ended":
               break;
           }

--- a/mcp/docs/staktrak/index.html
+++ b/mcp/docs/staktrak/index.html
@@ -96,70 +96,6 @@
         background-color: #f44336;
         display: block;
       }
-      .assertion-panel {
-        margin-top: 20px;
-        background-color: #333;
-        padding: 15px;
-        border-radius: 5px;
-        display: none;
-      }
-      .assertion-panel.active {
-        display: block;
-      }
-      .assertion-panel select,
-      .assertion-panel input {
-        padding: 8px;
-        margin: 5px 0;
-        background-color: #444;
-        color: white;
-        border: 1px solid #555;
-        border-radius: 4px;
-        width: 30%;
-      }
-      .assertion-panel button {
-        margin-top: 10px;
-      }
-      .assertion-type-group {
-        margin-top: 10px;
-      }
-      .assertion-type-group label {
-        display: block;
-        margin-bottom: 5px;
-      }
-      .assertions-list {
-        margin-top: 20px;
-        background-color: #2a2a2a;
-        padding: 15px;
-        border-radius: 5px;
-        max-height: 200px;
-        overflow: auto;
-        display: none;
-      }
-      .assertions-list.active {
-        display: block;
-      }
-      .assertion-item {
-        padding: 8px;
-        margin-bottom: 5px;
-        background-color: #444;
-        border-radius: 4px;
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-      }
-      .remove-assertion {
-        background-color: #f44336;
-        border: none;
-        color: white;
-        border-radius: 50%;
-        width: 24px;
-        height: 24px;
-        line-height: 24px;
-        text-align: center;
-        padding: 0;
-        cursor: pointer;
-      }
-
       .popup {
         position: fixed;
         top: 20px;
@@ -216,41 +152,8 @@
         Generate Playwright Test
       </button>
     </div>
-
-    <div id="assertionPanel" class="assertion-panel">
-      <h3>Add Assertion</h3>
-      <div class="assertion-type-group">
-        <label for="assertionType">Assertion Type:</label>
-        <select id="assertionType">
-          <option value="hasText">Has Text</option>
-          <option value="containsText">Contains Text</option>
-          <option value="isVisible">Is Visible</option>
-          <option value="hasValue">Has Value</option>
-        </select>
-      </div>
-      <div class="assertion-type-group">
-        <label for="assertionSelector">Element Selector:</label>
-        <input
-          type="text"
-          id="assertionSelector"
-          placeholder="Enter selector or use selection"
-        />
-      </div>
-      <div class="assertion-type-group">
-        <label for="assertionValue">Expected Value:</label>
-        <input type="text" id="assertionValue" placeholder="Value to assert" />
-      </div>
-      <div id="assertionStatus" class="status"></div>
-      <button id="addAssertionBtn">Add to Test</button>
-      <button id="cancelAssertionBtn">Cancel</button>
-    </div>
-
-    <div id="assertionsList" class="assertions-list">
-      <h3>Added Assertions:</h3>
-      <div id="assertionsContainer"></div>
-    </div>
-
     <!-- <div id="results"></div> -->
+
     <div id="playwrightTest"></div>
 
     <script type="module" src="playwright-generator.js"></script>
@@ -261,17 +164,6 @@
       const stopBtn = document.getElementById("stopBtn");
       const assertBtn = document.getElementById("assertBtn");
       const generateBtn = document.getElementById("generateBtn");
-      const assertionPanel = document.getElementById("assertionPanel");
-      const addAssertionBtn = document.getElementById("addAssertionBtn");
-      const cancelAssertionBtn = document.getElementById("cancelAssertionBtn");
-      const assertionType = document.getElementById("assertionType");
-      const assertionSelector = document.getElementById("assertionSelector");
-      const assertionValue = document.getElementById("assertionValue");
-      const assertionStatus = document.getElementById("assertionStatus");
-      const assertionsList = document.getElementById("assertionsList");
-      const assertionsContainer = document.getElementById(
-        "assertionsContainer"
-      );
       // const resultsDiv = document.getElementById("results");
       const playwrightTestDiv = document.getElementById("playwrightTest");
 
@@ -280,7 +172,9 @@
       let currentTestCode = null;
       let assertions = [];
       let selectedText = "";
-      let lastSelectedElement = null;
+      let selectedSelector = "";
+      let isWaitingForSelection = false;
+      let assertionCount = 0;
 
       window.addEventListener("message", (event) => {
         if (event.data && event.data.type) {
@@ -294,54 +188,21 @@
               generateBtn.disabled = false;
               break;
             case "staktrak-selection":
-              selectedText = event.data.text || "";
-              lastSelectedElement = event.data.selector || "";
-              if (selectedText) {
-                assertionValue.value = selectedText;
+              if (isWaitingForSelection) {
+                selectedText = event.data.text || "";
+                selectedSelector = event.data.selector || "";
+
+                if (selectedText && selectedSelector) {
+                  addAssertion();
+                  assertionCount++;
+                }
               }
-              if (lastSelectedElement) {
-                assertionSelector.value = lastSelectedElement;
-              }
+              break;
+            case "staktrak-selection-mode-ended":
               break;
           }
         }
       });
-
-      function updateAssertionsList() {
-        assertionsContainer.innerHTML = "";
-
-        if (assertions.length === 0) {
-          assertionsList.classList.remove("active");
-          return;
-        }
-
-        assertionsList.classList.add("active");
-
-        assertions.forEach((assertion, index) => {
-          const item = document.createElement("div");
-          item.className = "assertion-item";
-
-          let assertionText = `${assertion.selector} ${assertion.type}`;
-          if (assertion.value) {
-            assertionText += `: "${assertion.value}"`;
-          }
-
-          item.innerHTML = `
-            <span>${assertionText}</span>
-            <button class="remove-assertion" data-index="${index}">✕</button>
-          `;
-
-          assertionsContainer.appendChild(item);
-        });
-
-        document.querySelectorAll(".remove-assertion").forEach((button) => {
-          button.addEventListener("click", function () {
-            const index = parseInt(this.getAttribute("data-index"));
-            assertions.splice(index, 1);
-            updateAssertionsList();
-          });
-        });
-      }
 
       recordBtn.addEventListener("click", () => {
         trackingFrame.contentWindow.postMessage(
@@ -354,7 +215,7 @@
         generateBtn.disabled = true;
         isRecording = true;
         assertions = [];
-        updateAssertionsList();
+        assertionCount = 0;
         // resultsDiv.innerHTML = "";
         playwrightTestDiv.innerHTML = "";
 
@@ -368,11 +229,20 @@
         assertBtn.disabled = true;
         isRecording = false;
 
+        if (isWaitingForSelection) {
+          isWaitingForSelection = false;
+          trackingFrame.contentWindow.postMessage(
+            { type: "staktrak-disable-selection" },
+            "*"
+          );
+        }
+
         showPopup("Recording stopped", "warning");
       });
 
       assertBtn.addEventListener("click", () => {
-        assertionPanel.classList.add("active");
+        isWaitingForSelection = true;
+        showPopup("Select text in the iframe to add assertions", "info");
 
         trackingFrame.contentWindow.postMessage(
           { type: "staktrak-enable-selection" },
@@ -380,74 +250,59 @@
         );
       });
 
-      function showAssertionStatus(message, type) {
-        showPopup(message, type);
-      }
-
-      function isValidAssertion(type, selector, value) {
-        if (!selector || selector.trim() === "") {
-          showAssertionStatus("Please provide a valid selector", "error");
-          return false;
-        }
-
-        if (
-          (type === "hasText" ||
-            type === "containsText" ||
-            type === "hasValue") &&
-          (!value || value.trim() === "")
-        ) {
-          showAssertionStatus("Please provide an expected value", "error");
-          return false;
-        }
-
-        const isDuplicate = assertions.some(
-          (a) => a.type === type && a.selector === selector && a.value === value
-        );
-
-        if (isDuplicate) {
-          showAssertionStatus("This assertion already exists", "error");
-          return false;
-        }
-
-        return true;
-      }
-
-      addAssertionBtn.addEventListener("click", () => {
-        const type = assertionType.value;
-        const selector = assertionSelector.value;
-        const value = assertionValue.value;
-
-        if (!isValidAssertion(type, selector, value)) {
+      function addAssertion() {
+        if (!selectedSelector) {
+          showPopup("No element selected", "error");
           return;
+        }
+
+        let type = "isVisible";
+        let value = "";
+
+        if (selectedText && selectedText.trim() !== "") {
+          type = "hasText";
+          value = selectedText;
         }
 
         assertions.push({
           type,
-          selector,
+          selector: selectedSelector,
           value,
           timestamp: Date.now(),
         });
 
-        updateAssertionsList();
-
         showPopup(`Assertion added: ${type} "${value || ""}"`, "success");
 
-        assertionValue.value = "";
-      });
-
-      cancelAssertionBtn.addEventListener("click", () => {
-        assertionPanel.classList.remove("active");
-        assertionValue.value = "";
-        assertionSelector.value = "";
-
-        showPopup("Assertion cancelled", "warning");
-      });
+        selectedText = "";
+        selectedSelector = "";
+      }
 
       generateBtn.addEventListener("click", () => {
         if (currentTrackingData) {
-          if (!currentTrackingData.assertions) {
-            currentTrackingData.assertions = [];
+          if (isWaitingForSelection) {
+            isWaitingForSelection = false;
+            trackingFrame.contentWindow.postMessage(
+              { type: "staktrak-disable-selection" },
+              "*"
+            );
           }
+
+          if (
+            currentTrackingData.clicks &&
+            currentTrackingData.clicks.clickDetails
+          ) {
+            const filteredClicks =
+              currentTrackingData.clicks.clickDetails.filter((clickDetail) => {
+                return !assertions.some((assertion) => {
+                  const assertionTime = assertion.timestamp;
+                  const clickTime = clickDetail[3];
+                  return Math.abs(clickTime - assertionTime) < 500;
+                });
+              });
+
+            currentTrackingData.clicks.clickDetails = filteredClicks;
+          }
+
           currentTrackingData.assertions = assertions;
 
           const testCode = window.PlaywrightGenerator.generatePlaywrightTest(
@@ -521,20 +376,6 @@
           }
         } catch (error) {
           showPopup("Error saving test: " + error.message, "error");
-        }
-      }
-
-      function showStatus(message, type) {
-        showPopup(message, type);
-
-        const statusDiv = document.getElementById("saveStatus");
-        if (statusDiv) {
-          statusDiv.textContent = message;
-          statusDiv.className = `status ${type}`;
-
-          setTimeout(() => {
-            statusDiv.style.display = "none";
-          }, 3000);
         }
       }
 

--- a/mcp/docs/staktrak/playwright-generator.js
+++ b/mcp/docs/staktrak/playwright-generator.js
@@ -9,13 +9,15 @@ export function generatePlaywrightTest(url, trackingData) {
     keyboardActivities,
     inputChanges,
     focusChanges,
+    assertions,
     userInfo,
     time,
   } = trackingData;
 
   if (
     (!clicks || !clicks.clickDetails || clicks.clickDetails.length === 0) &&
-    (!inputChanges || inputChanges.length === 0)
+    (!inputChanges || inputChanges.length === 0) &&
+    (!assertions || assertions.length === 0)
   ) {
     return generateEmptyTest(url);
   }
@@ -35,7 +37,7 @@ export function generatePlaywrightTest(url, trackingData) {
       height: ${userInfo.windowSize[1]} 
     });
   
-  ${generateUserInteractions(clicks, inputChanges, focusChanges)}
+  ${generateUserInteractions(clicks, inputChanges, focusChanges, assertions)}
 
     await page.waitForTimeout(2500);
   });`;
@@ -48,9 +50,15 @@ export function generatePlaywrightTest(url, trackingData) {
  * @param {Object} clicks - Click data
  * @param {Array} inputChanges - Input change data
  * @param {Array} focusChanges - Focus change data
+ * @param {Array} assertions - Assertions to add
  * @returns {string} - Generated interactions code
  */
-function generateUserInteractions(clicks, inputChanges, focusChanges) {
+function generateUserInteractions(
+  clicks,
+  inputChanges,
+  focusChanges,
+  assertions = []
+) {
   const allEvents = [];
 
   if (clicks && clicks.clickDetails && clicks.clickDetails.length > 0) {
@@ -69,7 +77,7 @@ function generateUserInteractions(clicks, inputChanges, focusChanges) {
   const inputEvents = [];
   if (inputChanges && inputChanges.length > 0) {
     const completedInputs = inputChanges.filter(
-      (change) => change.action === "complete" || !change.action
+      (change) => change.action === "complete" || !change.action // For backward compatibility
     );
 
     completedInputs.forEach((change) => {
@@ -82,6 +90,18 @@ function generateUserInteractions(clicks, inputChanges, focusChanges) {
     });
 
     allEvents.push(...inputEvents);
+  }
+
+  if (assertions && assertions.length > 0) {
+    assertions.forEach((assertion) => {
+      allEvents.push({
+        type: "assertion",
+        assertionType: assertion.type,
+        selector: assertion.selector,
+        value: assertion.value,
+        timestamp: assertion.timestamp,
+      });
+    });
   }
 
   allEvents.sort((a, b) => a.timestamp - b.timestamp);
@@ -130,6 +150,42 @@ function generateUserInteractions(clicks, inputChanges, focusChanges) {
 
         generatedSelectors.add(playwrightSelector);
       }
+    } else if (event.type === "assertion") {
+      const playwrightSelector = convertToPlaywrightSelector(event.selector);
+      let assertionCode = "";
+
+      switch (event.assertionType) {
+        case "hasText":
+          assertionCode = `await expect(page.locator('${playwrightSelector}')).toHaveText('${event.value.replace(
+            /'/g,
+            "\\'"
+          )}');`;
+          break;
+        case "containsText":
+          assertionCode = `await expect(page.locator('${playwrightSelector}')).toContainText('${event.value.replace(
+            /'/g,
+            "\\'"
+          )}');`;
+          break;
+        case "isVisible":
+          assertionCode = `await expect(page.locator('${playwrightSelector}')).toBeVisible();`;
+          break;
+        case "hasValue":
+          assertionCode = `await expect(page.locator('${playwrightSelector}')).toHaveValue('${event.value.replace(
+            /'/g,
+            "\\'"
+          )}');`;
+          break;
+        default:
+          assertionCode = `await expect(page.locator('${playwrightSelector}')).toBeVisible();`;
+      }
+
+      actionsCode += `  
+    // Assert that ${playwrightSelector} ${event.assertionType}: "${
+        event.value || ""
+      }"
+    ${assertionCode}
+  `;
     }
 
     previousTimestamp = event.timestamp;

--- a/mcp/docs/staktrak/playwright-generator.js
+++ b/mcp/docs/staktrak/playwright-generator.js
@@ -77,7 +77,7 @@ function generateUserInteractions(
   const inputEvents = [];
   if (inputChanges && inputChanges.length > 0) {
     const completedInputs = inputChanges.filter(
-      (change) => change.action === "complete" || !change.action // For backward compatibility
+      (change) => change.action === "complete" || !change.action
     );
 
     completedInputs.forEach((change) => {

--- a/mcp/docs/staktrak/preact/style.css
+++ b/mcp/docs/staktrak/preact/style.css
@@ -46,7 +46,7 @@ input:focus {
   border-radius: 5px;
 }
 
-.selection-active {
+.staktrak-selection-active {
   cursor: pointer;
 }
 

--- a/mcp/docs/staktrak/preact/style.css
+++ b/mcp/docs/staktrak/preact/style.css
@@ -39,6 +39,17 @@ input:focus {
   outline: none;
 }
 
+.content-section {
+  margin: 20px 0;
+  padding: 15px;
+  background-color: #333;
+  border-radius: 5px;
+}
+
+.selection-active {
+  cursor: pointer;
+}
+
 /* Popup styles */
 .popup {
   position: fixed;
@@ -80,5 +91,11 @@ input:focus {
 .popup-input {
   background-color: #ff9944;
   border: 2px solid #ffaa66;
+  color: #ffffff;
+}
+
+.popup-selection {
+  background-color: #9c27b0;
+  border: 2px solid #ba68c8;
   color: #ffffff;
 }

--- a/mcp/docs/staktrak/staktrak.js
+++ b/mcp/docs/staktrak/staktrak.js
@@ -276,9 +276,9 @@ var userBehaviour = (function () {
   function setSelectionMode(isActive) {
     mem.selectionMode = isActive;
     if (isActive) {
-      document.body.classList.add("selection-active");
+      document.body.classList.add("staktrak-selection-active");
     } else {
-      document.body.classList.remove("selection-active");
+      document.body.classList.remove("staktrak-selection-active");
     }
   }
 
@@ -700,9 +700,6 @@ window.addEventListener("message", (event) => {
         break;
       case "staktrak-disable-selection":
         userBehaviour.disableSelectionMode();
-        break;
-      case "staktrak-request-selection":
-        userBehaviour.enableSelectionMode();
         break;
     }
   }

--- a/mcp/docs/staktrak/staktrak.js
+++ b/mcp/docs/staktrak/staktrak.js
@@ -26,6 +26,7 @@ var userBehaviour = (function () {
     mouseInterval: null,
     mousePosition: [], //x,y,timestamp
     inputDebounceTimers: {},
+    selectionMode: false,
     eventListeners: {
       scroll: null,
       click: null,
@@ -39,6 +40,8 @@ var userBehaviour = (function () {
       documentFocus: null,
       documentBlur: null,
       documentInput: null,
+      mouseUp: null,
+      keyDown: null,
     },
     mutationObserver: null,
     eventsFunctions: {
@@ -199,9 +202,85 @@ var userBehaviour = (function () {
           getTimeStamp(),
         ]);
       },
+      mouseUp: (e) => {
+        if (!mem.selectionMode) return;
+
+        const selection = window.getSelection();
+        if (selection && selection.toString().trim() !== "") {
+          const selectedText = selection.toString().trim();
+          let selectedElement = null;
+
+          if (selection.rangeCount > 0) {
+            const range = selection.getRangeAt(0);
+            selectedElement = range.commonAncestorContainer;
+
+            if (selectedElement.nodeType === 3) {
+              selectedElement = selectedElement.parentElement;
+            }
+          }
+
+          const selector = selectedElement
+            ? getElementSelector(selectedElement)
+            : "";
+
+          results.assertions = results.assertions || [];
+          results.assertions.push({
+            type: "hasText",
+            selector: selector,
+            value: selectedText,
+            timestamp: getTimeStamp(),
+          });
+
+          window.parent.postMessage(
+            {
+              type: "staktrak-selection",
+              text: selectedText,
+              selector: selector,
+            },
+            "*"
+          );
+
+          window.parent.postMessage(
+            {
+              type: "staktrak-show-popup",
+              text: selectedText,
+              selector: selector,
+            },
+            "*"
+          );
+
+          setTimeout(() => {
+            if (window.getSelection) {
+              if (window.getSelection().empty) {
+                window.getSelection().empty();
+              } else if (window.getSelection().removeAllRanges) {
+                window.getSelection().removeAllRanges();
+              }
+            }
+          }, 500);
+        }
+      },
+      keyDown: (e) => {
+        if (mem.selectionMode && e.key === "Escape") {
+          setSelectionMode(false);
+          window.parent.postMessage(
+            { type: "staktrak-selection-mode-ended" },
+            "*"
+          );
+        }
+      },
     },
   };
   var results = {};
+
+  function setSelectionMode(isActive) {
+    mem.selectionMode = isActive;
+    if (isActive) {
+      document.body.classList.add("selection-active");
+    } else {
+      document.body.classList.remove("selection-active");
+    }
+  }
 
   function isInputOrTextarea(element) {
     return (
@@ -222,14 +301,28 @@ var userBehaviour = (function () {
       return `#${element.id}`;
     }
 
+    if (
+      element.tagName.match(
+        /^(P|H1|H2|H3|H4|H5|H6|SPAN|DIV|LI|TD|TH|BUTTON|LABEL)$/i
+      )
+    ) {
+      return element.tagName.toLowerCase();
+    }
+
+    let selector = element.tagName.toLowerCase();
     if (element.className) {
-      let classSelector = "";
-      element.classList.forEach((cls) => {
-        classSelector += `.${cls}`;
-      });
-      if (classSelector) {
-        return classSelector;
+      const classes = Array.from(element.classList).join(".");
+      if (classes) {
+        selector += `.${classes}`;
       }
+    }
+
+    let classSelector = "";
+    element.classList.forEach((cls) => {
+      classSelector += `.${cls}`;
+    });
+    if (classSelector) {
+      return classSelector;
     }
 
     let path = "";
@@ -257,7 +350,7 @@ var userBehaviour = (function () {
       depth++;
     }
 
-    return path;
+    return path || selector;
   }
 
   function resetResults() {
@@ -290,6 +383,7 @@ var userBehaviour = (function () {
       mediaInteractions: [],
       windowSizes: [],
       visibilitychanges: [],
+      assertions: [],
     };
   }
   resetResults();
@@ -474,6 +568,11 @@ var userBehaviour = (function () {
       });
     }
 
+    document.addEventListener("mouseup", mem.eventsFunctions.mouseUp);
+    document.addEventListener("keydown", mem.eventsFunctions.keyDown);
+    mem.eventListeners.mouseUp = true;
+    mem.eventListeners.keyDown = true;
+
     mem.mutationObserver = setupMutationObserver();
   }
 
@@ -519,10 +618,15 @@ var userBehaviour = (function () {
 
     window.removeEventListener("touchstart", mem.eventsFunctions.touchStart);
 
+    document.removeEventListener("mouseup", mem.eventsFunctions.mouseUp);
+    document.removeEventListener("keydown", mem.eventsFunctions.keyDown);
+
     if (mem.mutationObserver) {
       mem.mutationObserver.disconnect();
       mem.mutationObserver = null;
     }
+
+    setSelectionMode(false);
 
     results.time.stopTime = getTimeStamp();
     processResults();
@@ -559,6 +663,12 @@ var userBehaviour = (function () {
     registerCustomEvent: (eventName, callback) => {
       window.addEventListener(eventName, callback);
     },
+    enableSelectionMode: () => {
+      setSelectionMode(true);
+    },
+    disableSelectionMode: () => {
+      setSelectionMode(false);
+    },
   };
 })();
 
@@ -584,6 +694,15 @@ window.addEventListener("message", (event) => {
           "*"
         );
         userBehaviour.stop();
+        break;
+      case "staktrak-enable-selection":
+        userBehaviour.enableSelectionMode();
+        break;
+      case "staktrak-disable-selection":
+        userBehaviour.disableSelectionMode();
+        break;
+      case "staktrak-request-selection":
+        userBehaviour.enableSelectionMode();
         break;
     }
   }


### PR DESCRIPTION
## Features

- **Assertion Panel UI**: Added a panel for creating and managing assertions with different types (hasText, containsText, isVisible, hasValue)
- **Text Selection Support**: Implemented selection functionality in the Preact iframe to easily capture text for assertions
- **Assertion Management**: Added UI to display, modify, and remove assertions
- **Playwright Integration**: Updated the test generator to include assertions in chronological order within the test flow

## Implementation Details

- Added an "Add Assertion" button to the main controls
- Implemented message passing between the parent window and iframe for selection mode
- Enhanced the Preact app to support text selection and element identification
- Added styles for selection state and assertion UI
- Modified the Playwright generator to support different assertion types
- Ensured assertions are properly serialized and integrated into the test timeline

## Testing

The feature has been tested with various scenarios:
- Recording interactions and adding assertions at different points
- Selecting text from different elements (headings, paragraphs, buttons)
- Using different assertion types
- Ordering of assertions relative to other interactions

## Demo & Screenshots

![image](https://github.com/user-attachments/assets/45f2632b-50f8-41cd-a4ca-a3b4fc955c6d)

![image](https://github.com/user-attachments/assets/8035a5d1-054b-4376-9441-1b46cac14317)

![image](https://github.com/user-attachments/assets/63fc7a87-9844-4e3a-8d47-0ad0fd81f336)

![image](https://github.com/user-attachments/assets/c791cd35-6ab2-45fd-90e8-a33d7aa7eb48)

## Notes

- Assertions are saved with timestamps to ensure proper chronological ordering in the test
- The selection mode automatically times out after 30 seconds for better UX
- Users can select any text in the iframe, providing flexibility in what can be asserted