### PR TITLE
Add form element tracking support (checkboxes, radios, and select dropdowns)

### DIFF
--- a/mcp/docs/staktrak/example-form-elements.spec.js
+++ b/mcp/docs/staktrak/example-form-elements.spec.js
@@ -1,0 +1,70 @@
+import { test, expect } from "@playwright/test";
+
+test("User interaction replay with form elements", async ({ page }) => {
+  await page.goto("http://localhost:3000/preact/frame.html");
+
+  await page.waitForLoadState("networkidle");
+
+  await page.setViewportSize({ width: 1280, height: 720 });
+
+  const showFormButton = page.locator('button:text("Show Form Elements")');
+  await showFormButton.waitFor({ state: "visible" });
+  await showFormButton.click();
+
+  await page.waitForTimeout(500);
+
+  const checkbox = page.locator('[data-testid="staktrak-checkbox"]');
+  await checkbox.waitFor({ state: "visible" });
+
+  await checkbox.check();
+
+  await expect(checkbox).toBeChecked();
+
+  await page.waitForTimeout(500);
+
+  await checkbox.uncheck();
+
+  await expect(checkbox).not.toBeChecked();
+
+  await page.waitForTimeout(500);
+
+  const radioOption2 = page.locator('[data-testid="staktrak-radio-2"]');
+  await radioOption2.waitFor({ state: "visible" });
+  await radioOption2.check();
+
+  await expect(radioOption2).toBeChecked();
+
+  const radioOption3 = page.locator('[data-testid="staktrak-radio-3"]');
+  await radioOption3.check();
+
+  await expect(radioOption3).toBeChecked();
+  await expect(radioOption2).not.toBeChecked();
+
+  await page.waitForTimeout(500);
+
+  const selectElement = page.locator('[data-testid="staktrak-select"]');
+  await selectElement.waitFor({ state: "visible" });
+
+  await selectElement.selectOption({ value: "banana" });
+
+  await expect(selectElement).toHaveValue("banana");
+
+  await page.waitForTimeout(500);
+
+  await selectElement.selectOption({ label: "Cherry" });
+
+  await expect(selectElement).toHaveValue("cherry");
+
+  await page.waitForTimeout(1000);
+
+  await checkbox.check();
+  await radioOption2.check();
+  await selectElement.selectOption({ label: "Durian" });
+
+  await expect(checkbox).toBeChecked();
+  await expect(radioOption2).toBeChecked();
+  await expect(radioOption3).not.toBeChecked();
+  await expect(selectElement).toHaveValue("durian");
+
+  await page.waitForTimeout(2500);
+});

--- a/mcp/docs/staktrak/index.html
+++ b/mcp/docs/staktrak/index.html
@@ -197,8 +197,25 @@
                 selectedText = event.data.text || "";
                 selectedSelector = event.data.selector || "";
 
+                const isCheckbox =
+                  selectedSelector.includes('input[type="checkbox"]') ||
+                  selectedSelector.includes("checkbox");
+                const isRadio =
+                  selectedSelector.includes('input[type="radio"]') ||
+                  selectedSelector.includes("radio");
+
                 if (selectedText && selectedSelector) {
-                  addAssertion();
+                  if (isCheckbox || isRadio) {
+                    const assertionType = confirm(
+                      "Is this a checked state assertion? Click OK for 'isChecked', Cancel for 'isNotChecked'"
+                    )
+                      ? "isChecked"
+                      : "isNotChecked";
+
+                    addAssertion(assertionType);
+                  } else {
+                    addAssertion();
+                  }
                   assertionCount++;
                 }
               }
@@ -293,7 +310,7 @@
 
       modeBtn.disabled = true;
 
-      function addAssertion() {
+      function addAssertion(assertionType = null) {
         if (!selectedSelector) {
           showPopup("No element selected", "error");
           return;
@@ -302,7 +319,10 @@
         let type = "isVisible";
         let value = "";
 
-        if (selectedText && selectedText.trim() !== "") {
+        if (assertionType) {
+          type = assertionType;
+          value = "";
+        } else if (selectedText && selectedText.trim() !== "") {
           type = "hasText";
           value = selectedText;
         }

--- a/mcp/docs/staktrak/preact/app.js
+++ b/mcp/docs/staktrak/preact/app.js
@@ -9,6 +9,10 @@ const Frame = () => {
   const [popups, setPopups] = useState([]);
   const [inputValue, setInputValue] = useState("");
   const [showInput, setShowInput] = useState(false);
+  const [checkboxValue, setCheckboxValue] = useState(false);
+  const [radioValue, setRadioValue] = useState("option1");
+  const [selectValue, setSelectValue] = useState("apple");
+  const [showFormElements, setShowFormElements] = useState(false);
 
   // Function to create and show popup
   const showPopup = (message, popupClass) => {
@@ -70,6 +74,28 @@ const Frame = () => {
     setShowInput(!showInput);
   };
 
+  const toggleFormElements = () => {
+    setShowFormElements(!showFormElements);
+  };
+
+  const handleCheckboxChange = (event) => {
+    const checked = event.target.checked;
+    setCheckboxValue(checked);
+    showPopup(`Checkbox: ${checked ? "Checked" : "Unchecked"}`, "popup-form");
+  };
+
+  const handleRadioChange = (event) => {
+    const value = event.target.value;
+    setRadioValue(value);
+    showPopup(`Radio: Selected ${value}`, "popup-form");
+  };
+
+  const handleSelectChange = (event) => {
+    const value = event.target.value;
+    setSelectValue(value);
+    showPopup(`Select: Chose ${value}`, "popup-form");
+  };
+
   useEffect(() => {
     const messageHandler = (event) => {
       if (event.data && event.data.type === "staktrak-show-popup") {
@@ -101,6 +127,9 @@ const Frame = () => {
         <button onClick=${toggleInput}>
           ${showInput ? "Hide Input" : "Show Input"}
         </button>
+        <button onClick=${toggleFormElements}>
+          ${showFormElements ? "Hide Form Elements" : "Show Form Elements"}
+        </button>
       </div>
 
       ${showInput &&
@@ -115,6 +144,76 @@ const Frame = () => {
             value=${inputValue}
             onInput=${handleInputChange}
           />
+        </div>
+      `}
+      ${showFormElements &&
+      html`
+        <div class="form-elements">
+          <div class="form-group">
+            <label>
+              <input
+                type="checkbox"
+                data-testid="staktrak-checkbox"
+                checked=${checkboxValue}
+                onChange=${handleCheckboxChange}
+              />
+              Test Checkbox
+            </label>
+          </div>
+
+          <div class="form-group">
+            <fieldset>
+              <legend>Test Radio Buttons</legend>
+              <label>
+                <input
+                  type="radio"
+                  name="test-radio"
+                  value="option1"
+                  data-testid="staktrak-radio-1"
+                  checked=${radioValue === "option1"}
+                  onChange=${handleRadioChange}
+                />
+                Option 1
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="test-radio"
+                  value="option2"
+                  data-testid="staktrak-radio-2"
+                  checked=${radioValue === "option2"}
+                  onChange=${handleRadioChange}
+                />
+                Option 2
+              </label>
+              <label>
+                <input
+                  type="radio"
+                  name="test-radio"
+                  value="option3"
+                  data-testid="staktrak-radio-3"
+                  checked=${radioValue === "option3"}
+                  onChange=${handleRadioChange}
+                />
+                Option 3
+              </label>
+            </fieldset>
+          </div>
+
+          <div class="form-group select-group">
+            <label for="test-select">Test Select:</label>
+            <select
+              id="test-select"
+              data-testid="staktrak-select"
+              value=${selectValue}
+              onChange=${handleSelectChange}
+            >
+              <option value="apple">Apple</option>
+              <option value="banana">Banana</option>
+              <option value="cherry">Cherry</option>
+              <option value="durian">Durian</option>
+            </select>
+          </div>
         </div>
       `}
       ${popups.map(

--- a/mcp/docs/staktrak/preact/style.css
+++ b/mcp/docs/staktrak/preact/style.css
@@ -39,6 +39,86 @@ input:focus {
   outline: none;
 }
 
+.form-elements {
+  margin: 20px 0;
+  padding: 15px;
+  background-color: #333;
+  border-radius: 5px;
+}
+
+.form-group {
+  margin-bottom: 15px;
+}
+
+input[type="checkbox"],
+input[type="radio"] {
+  width: auto;
+  margin-right: 8px;
+  cursor: pointer;
+}
+
+label {
+  display: inline-flex;
+  align-items: center;
+  margin: 8px 0;
+  cursor: pointer;
+  margin-right: 15px;
+}
+
+.form-group label {
+  display: inline-block;
+  margin-right: 15px;
+  min-width: 100px;
+  vertical-align: middle;
+}
+
+.select-group {
+  display: flex;
+  align-items: center;
+  margin: 15px 0;
+}
+
+.select-group label {
+  margin-right: -3px;
+  flex-shrink: 0;
+}
+
+select {
+  background-color: #333;
+  color: #fff;
+  border: 2px solid #666;
+  padding: 10px;
+  margin: 10px 0;
+  border-radius: 5px;
+  font-size: 16px;
+  cursor: pointer;
+  min-width: 200px;
+  vertical-align: middle;
+}
+
+select:focus {
+  border-color: #888;
+  outline: none;
+}
+
+option {
+  background-color: #333;
+  color: #fff;
+  padding: 5px;
+}
+
+fieldset {
+  border: 1px solid #666;
+  border-radius: 5px;
+  padding: 10px;
+  margin: 15px 0;
+}
+
+legend {
+  padding: 0 10px;
+  font-weight: bold;
+}
+
 .content-section {
   margin: 20px 0;
   padding: 15px;
@@ -97,5 +177,11 @@ input:focus {
 .popup-selection {
   background-color: #9c27b0;
   border: 2px solid #ba68c8;
+  color: #ffffff;
+}
+
+.popup-form {
+  background-color: #00bcd4;
+  border: 2px solid #4dd0e1;
   color: #ffffff;
 }


### PR DESCRIPTION
Adds support for tracking form element interactions (checkboxes, radio buttons, and select dropdowns) and generates appropriate Playwright test commands. Includes new assertion types (isChecked/isNotChecked) and demo UI enhancements to showcase the functionality. This completes the form element tracking feature.

## Demo:

https://www.loom.com/share/1db13831cadd411392c4d918cd28e1b4