### PR TITLE
Add language filtering capability to node search API

### DIFF
--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -97,6 +97,11 @@ export const LIST_QUERY = `
 WITH $node_label AS nodeLabel
 MATCH (f)
 WHERE any(label IN labels(f) WHERE label = nodeLabel)
+AND
+CASE
+  WHEN $extensions IS NULL OR size($extensions) = 0 THEN true
+  ELSE f.file IS NOT NULL AND ANY(ext IN $extensions WHERE f.file ENDS WITH ext)
+END
 RETURN f
 `;
 
@@ -104,6 +109,11 @@ export const REF_IDS_LIST_QUERY = `
 WITH $ref_ids AS refIdList
 MATCH (n)
 WHERE n.ref_id IN refIdList
+AND
+CASE
+  WHEN $extensions IS NULL OR size($extensions) = 0 THEN true
+  ELSE n.file IS NOT NULL AND ANY(ext IN $extensions WHERE n.file ENDS WITH ext)
+END
 RETURN n
 `;
 
@@ -160,6 +170,11 @@ WHERE
     WHEN $skip_node_types IS NULL OR size($skip_node_types) = 0 THEN true
     ELSE NOT ANY(label IN labels(node) WHERE label IN $skip_node_types)
   END
+  AND
+  CASE
+    WHEN $extensions IS NULL OR size($extensions) = 0 THEN true
+    ELSE node.file IS NOT NULL AND ANY(ext IN $extensions WHERE node.file ENDS WITH ext)
+  END
 RETURN node, score
 ORDER BY score DESC
 LIMIT toInteger($limit)`;
@@ -187,6 +202,11 @@ WHERE
     ELSE ANY(label IN labels(node) WHERE label IN $node_types)
   END
   AND node.embeddings IS NOT NULL
+  AND
+  CASE
+    WHEN $extensions IS NULL OR size($extensions) = 0 THEN true
+    ELSE node.file IS NOT NULL AND ANY(ext IN $extensions WHERE node.file ENDS WITH ext)
+  END
 WITH node, gds.similarity.cosine(node.embeddings, $embeddings) AS score
 WHERE score >= $similarityThreshold
 RETURN node, score

--- a/mcp/src/graph/routes.ts
+++ b/mcp/src/graph/routes.ts
@@ -50,7 +50,15 @@ export async function get_nodes(req: Request, res: Response) {
       ref_ids = (req.query.ref_ids as string).split(",");
     }
     const output = req.query.output as G.OutputFormat;
-    const result = await G.get_nodes(node_type, concise, ref_ids, output);
+    const language = req.query.language as string;
+
+    const result = await G.get_nodes(
+      node_type,
+      concise,
+      ref_ids,
+      output,
+      language
+    );
     if (output === "snippet") {
       res.send(result);
     } else {
@@ -77,6 +85,8 @@ export async function search(req: Request, res: Response) {
     const output = req.query.output as G.OutputFormat;
     let tests = isTrue(req.query.tests as string);
     const maxTokens = parseInt(req.query.max_tokens as string);
+    const language = req.query.language as string;
+
     if (maxTokens) {
       console.log("search with max tokens", maxTokens);
     }
@@ -88,7 +98,8 @@ export async function search(req: Request, res: Response) {
       maxTokens || 100000,
       method,
       output || "snippet",
-      tests
+      tests,
+      language
     );
     if (output === "snippet") {
       res.send(result);

--- a/mcp/src/graph/utils.ts
+++ b/mcp/src/graph/utils.ts
@@ -113,3 +113,46 @@ export function clean_node(n: Neo4jNode): Neo4jNode {
   }
   return n;
 }
+
+/**
+ * @param language The programming language name (case insensitive)
+ * @returns Array of file extensions including the dot (e.g. ['.js', '.jsx'])
+ */
+export function getExtensionsForLanguage(language: string): string[] {
+  const lang = language.toLowerCase();
+
+  const languageMap: Record<string, string[]> = {
+    javascript: [".js", ".jsx", ".cjs", ".mjs"],
+    typescript: [".ts", ".tsx", ".d.ts"],
+    python: [".py", ".pyi", ".pyw"],
+    ruby: [".rb", ".rake", ".gemspec"],
+    go: [".go"],
+    rust: [".rs"],
+    java: [".java"],
+    kotlin: [".kt", ".kts"],
+    swift: [".swift"],
+    c: [".c", ".h"],
+    cpp: [".cpp", ".cc", ".cxx", ".hpp", ".hxx", ".h"],
+    csharp: [".cs"],
+    php: [".php"],
+    html: [".html", ".htm"],
+    css: [".css", ".scss", ".sass", ".less"],
+    shell: [".sh", ".bash", ".zsh"],
+    sql: [".sql"],
+    markdown: [".md", ".markdown"],
+    json: [".json"],
+    yaml: [".yml", ".yaml"],
+    xml: [".xml"],
+    svelte: [".svelte"],
+    vue: [".vue"],
+    angular: [
+      ".component.ts",
+      ".service.ts",
+      ".directive.ts",
+      ".pipe.ts",
+      ".module.ts",
+    ],
+  };
+
+  return languageMap[lang] || [];
+}

--- a/mcp/src/tools/stakgraph/get_nodes.ts
+++ b/mcp/src/tools/stakgraph/get_nodes.ts
@@ -19,6 +19,12 @@ export const GetNodesSchema = z.object({
     .string()
     .optional()
     .describe("Comma-separated list of ref_ids to retrieve."),
+  language: z
+    .string()
+    .optional()
+    .describe(
+      "Filter nodes by programming language (e.g. 'javascript', 'python', 'typescript')"
+    ),
 });
 
 export const GetNodesTool: Tool = {
@@ -32,7 +38,9 @@ export async function getNodes(args: z.infer<typeof GetNodesSchema>) {
   const result = await G.get_nodes(
     args.node_type as NodeType,
     args.concise ?? false,
-    args.ref_ids?.split(",") ?? []
+    args.ref_ids?.split(",") ?? [],
+    "snippet",
+    args.language
   );
   return {
     content: [

--- a/mcp/src/tools/stakgraph/search.ts
+++ b/mcp/src/tools/stakgraph/search.ts
@@ -37,6 +37,12 @@ export const SearchSchema = z.object({
     .optional()
     .default(100000)
     .describe("Limit the number of tokens."),
+  language: z
+    .string()
+    .optional()
+    .describe(
+      "Filter nodes by programming language (e.g. 'javascript', 'python', 'typescript')"
+    ),
 });
 
 export const SearchTool: Tool = {
@@ -53,7 +59,10 @@ export async function search(args: z.infer<typeof SearchSchema>) {
     (args.node_types as NodeType[]) ?? [],
     args.concise ?? false,
     args.max_tokens ?? 100000,
-    args.method ?? "fulltext"
+    args.method ?? "fulltext",
+    "snippet",
+    false,
+    args.language
   );
   return {
     content: [


### PR DESCRIPTION
## Overview
This PR adds language filtering capability to the node search functionality. Users can now specify a programming language parameter to filter search results to only include files of that language type.

## Implementation Details
- Added optional `language` parameter to search and node retrieval methods
- Created `getExtensionsForLanguage()` utility function to map language names to file extensions
- Modified database queries to filter by file extensions at the database level
- Updated all relevant endpoints to pass the language parameter through the call chain
- Ensured backward compatibility with existing code (parameter is optional)

## Affected Components
- Graph API (neo4j.ts, queries.ts, graph.ts)
- Node search endpoints
- Search tool schemas

## Testing
Tested with various language filters:
- JavaScript: filters to .js, .jsx, .cjs, .mjs files
- TypeScript: filters to .ts, .tsx, .d.ts files
- Go: filters to .go files

All existing functionality works without regressions when the parameter is not specified.

## Closed: #420


<img width="1911" height="194" alt="image" src="https://github.com/user-attachments/assets/1229e59e-ce33-4e0d-8c18-8b29d49db38d" />

<img width="1920" height="134" alt="image" src="https://github.com/user-attachments/assets/dd529452-8afb-4859-8c01-a8482b9437ed" />

<img width="1920" height="176" alt="image" src="https://github.com/user-attachments/assets/b86b81cb-5ec6-482e-9fe3-6c2c54751133" />
