### PR TITLE
fix: java instances

### DIFF
--- a/ast/src/lang/queries/java.rs
+++ b/ast/src/lang/queries/java.rs
@@ -78,12 +78,20 @@ impl Stack for Java {
     fn instance_definition_query(&self) -> Option<String> {
         Some(format!(
             r#"
+            [
             (field_declaration
                 (type_identifier) @{CLASS_NAME}
                 (variable_declarator
                     (identifier) @{INSTANCE_NAME}
                 )
+            )(local_variable_declaration
+                type: (type_identifier)@{CLASS_NAME}
+                (variable_declarator
+                    (identifier) @{INSTANCE_NAME}
+                )
+            
             )
+            ]@{INSTANCE}
             "#
         ))
     }

--- a/ast/src/testing/java/mod.rs
+++ b/ast/src/testing/java/mod.rs
@@ -117,15 +117,19 @@ import java.util.Optional;"#
 
     let import_edges_count = graph.count_edges_of_type(EdgeType::Imports);
     edges_count += import_edges_count;
-    assert_eq!(import_edges_count, 2, "Expected at 2 import edges");
+    assert_eq!(import_edges_count, 3, "Expected at 3 import edges");
 
     let instances = graph.find_nodes_by_type(NodeType::Instance);
     nodes_count += instances.len();
-    assert_eq!(instances.len(), 0, "Expected 0 instances");
+    assert_eq!(instances.len(), 2, "Expected 2 instances");
+
+    let instance_edges_count = graph.count_edges_of_type(EdgeType::Of);
+    edges_count += instance_edges_count;
+    assert_eq!(instance_edges_count, 2, "Expected at 2 instance edges");
 
     let contains_edges_count = graph.count_edges_of_type(EdgeType::Contains);
     edges_count += contains_edges_count;
-    assert_eq!(contains_edges_count, 44, "Expected at 44 contains edges");
+    assert_eq!(contains_edges_count, 46, "Expected at 46 contains edges");
 
     let handler_edges_count = graph.count_edges_of_type(EdgeType::Handler);
     edges_count += handler_edges_count;

--- a/ast/src/testing/java/src/main/java/graph/stakgraph/java/JavaApplication.java
+++ b/ast/src/testing/java/src/main/java/graph/stakgraph/java/JavaApplication.java
@@ -1,5 +1,6 @@
 package graph.stakgraph.java;
 
+import graph.stakgraph.java.model.Person;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
@@ -7,6 +8,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 public class JavaApplication {
 
 	public static void main(String[] args) {
+		 Person testPerson = new Person("Bob", "bob@example.com");
 		SpringApplication.run(JavaApplication.class, args);
 	}
 

--- a/ast/src/testing/java/src/main/java/graph/stakgraph/java/controller/PersonController.java
+++ b/ast/src/testing/java/src/main/java/graph/stakgraph/java/controller/PersonController.java
@@ -12,6 +12,8 @@ protected static String appName = "stakgraph";
 public class PersonController {
     private final PersonRepository repository;
 
+    private static final Person examplePerson = new Person("Alice", "alice@example.com");
+
     public PersonController(PersonRepository repository) {
         this.repository = repository;
     }


### PR DESCRIPTION
Updated instance queries to pick up Java instances and test them. 


Note: Some instances are from a third-party library, so we'll need to use LSP to obtain the details and construct new edges & nodes. 