### PR TITLE
feat: capture progress

### DIFF
--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -295,7 +295,12 @@ pub async fn ingest_async(
         while let Ok(update) = rx.recv().await {
             let mut map = status_map_clone.lock().await;
             if let Some(status) = map.get_mut(&request_id_clone) {
-                status.progress = update.progress;
+                let total_steps = update.total_steps.max(1);
+                let step = update.step.max(1);
+                let step_progress = update.progress.min(100);
+                let overall_progress =
+                    ((step as f64 / total_steps as f64) * step_progress as f64) as u32;
+                status.progress = overall_progress.min(100);
             }
         }
     });

--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -272,6 +272,7 @@ pub async fn ingest_async(
 ) -> impl IntoResponse {
     let request_id = uuid::Uuid::new_v4().to_string();
     let status_map = state.async_status.clone();
+    let mut rx = state.tx.subscribe();
 
     {
         let mut map = status_map.lock().await;
@@ -280,12 +281,25 @@ pub async fn ingest_async(
             AsyncRequestStatus {
                 status: AsyncStatus::InProgress,
                 result: None,
+                progress: 0,
             },
         );
     }
 
     let state_clone = state.clone();
+    let status_map_clone = status_map.clone();
     let body_clone = body.clone();
+    let request_id_clone = request_id.clone();
+
+    tokio::spawn(async move {
+        while let Ok(update) = rx.recv().await {
+            let mut map = status_map_clone.lock().await;
+            if let Some(status) = map.get_mut(&request_id_clone) {
+                status.progress = update.progress;
+            }
+        }
+    });
+
     let request_id_clone = request_id.clone();
 
     //run ingest as a background task
@@ -299,6 +313,7 @@ pub async fn ingest_async(
                 AsyncRequestStatus {
                     status: AsyncStatus::Complete,
                     result: Some(resp),
+                    progress: 100,
                 },
             ),
             Err(e) => map.insert(
@@ -306,6 +321,7 @@ pub async fn ingest_async(
                 AsyncRequestStatus {
                     status: AsyncStatus::Failed(format!("{:?}", e)),
                     result: None,
+                    progress: 0,
                 },
             ),
         }
@@ -329,6 +345,7 @@ pub async fn sync_async(
             AsyncRequestStatus {
                 status: AsyncStatus::InProgress,
                 result: None,
+                progress: 0,
             },
         );
     }
@@ -346,6 +363,7 @@ pub async fn sync_async(
                 AsyncRequestStatus {
                     status: AsyncStatus::Complete,
                     result: Some(resp),
+                    progress: 100,
                 },
             ),
             Err(e) => map.insert(
@@ -353,6 +371,7 @@ pub async fn sync_async(
                 AsyncRequestStatus {
                     status: AsyncStatus::Failed(format!("{:?}", e)),
                     result: None,
+                    progress: 0,
                 },
             ),
         }

--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -45,6 +45,7 @@ pub enum AsyncStatus {
 pub struct AsyncRequestStatus {
     pub status: AsyncStatus,
     pub result: Option<ProcessResponse>,
+    pub progress: u32,
 }
 
 pub type AsyncStatusMap = Arc<Mutex<HashMap<String, AsyncRequestStatus>>>;


### PR DESCRIPTION
- Capture the progress
- Return it on the `/ingest_async` endpoint