### PR TITLE
improvement: faster of getting service details

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -33,11 +33,13 @@
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "express-fileupload": "^1.5.1",
+    "fast-glob": "^3.3.3",
     "fastembed": "^1.14.1",
     "git-url-parse": "^16.0.1",
     "js-yaml": "^4.1.0",
     "neo4j-driver": "^5.28.1",
     "node-cache": "^5.1.2",
+    "simple-git": "^3.28.0",
     "uuid": "^11.1.0",
     "zod": "3.24.1",
     "zod-to-json-schema": "3.24.1"

--- a/mcp/src/graph/types.ts
+++ b/mcp/src/graph/types.ts
@@ -173,3 +173,27 @@ export interface ServiceParser {
   envRegex: RegExp;
   build(pkgFile: Neo4jNode): Service;
 }
+
+export enum Language {
+  Rust = "rust",
+  Go = " go",
+  Typescript = "typescript",
+  Python = "python",
+  Ruby = "ruby",
+  Kotlin = "kotlin",
+  Swift = "swift",
+  Java = "java",
+  Cpp = "cpp",
+}
+
+export const LANGUAGE_PACKAGE_FILES: Record<Language, string[]> = {
+  [Language.Rust]: ["Cargo.toml"],
+  [Language.Go]: ["go.mod"],
+  [Language.Typescript]: ["package.json"],
+  [Language.Python]: ["requirements.txt"],
+  [Language.Ruby]: ["Gemfile"],
+  [Language.Kotlin]: [".gradle.kts", ".gradle", ".properties"],
+  [Language.Swift]: ["Podfile", "Cartfile"],
+  [Language.Java]: ["pom.xml"],
+  [Language.Cpp]: ["CMakeLists.txt"],
+};

--- a/mcp/src/graph/utils.ts
+++ b/mcp/src/graph/utils.ts
@@ -1,5 +1,9 @@
 import { Node, Neo4jNode, ReturnNode, NodeType, toNum } from "./types.js";
 import { Data_Bank } from "./neo4j.js";
+import { simpleGit } from "simple-git";
+import path from "path";
+import fg from "fast-glob";
+import { LANGUAGE_PACKAGE_FILES, Language } from "./types.js";
 
 export function isTrue(value: string): boolean {
   return value === "true" || value === "1" || value === "True";
@@ -155,4 +159,44 @@ export function getExtensionsForLanguage(language: string): string[] {
   };
 
   return languageMap[lang] || [];
+}
+
+export async function cloneRepoToTmp(
+  repoUrl: string,
+  username?: string,
+  pat?: string,
+  commit?: string
+): Promise<string> {
+  const repoName =
+    repoUrl
+      .split("/")
+      .pop()
+      ?.replace(/\.git$/, "") || "repo";
+  const cloneDir = path.join("/tmp", repoName + "-" + Date.now());
+
+  let url = repoUrl;
+  if (username && pat) {
+    url = repoUrl.replace("https://", `https://${username}:${pat}@`);
+  }
+
+  await simpleGit().clone(url, cloneDir);
+
+  if (commit) {
+    await simpleGit(cloneDir).checkout(commit);
+  }
+
+  return cloneDir;
+}
+export async function detectLanguagesAndPkgFiles(
+  repoDir: string
+): Promise<{ language: Language; pkgFile: string }[]> {
+  const detected: { language: Language; pkgFile: string }[] = [];
+  for (const lang of Object.values(Language)) {
+    const patterns = (LANGUAGE_PACKAGE_FILES[lang] || []).map((f) => `**/${f}`);
+    const found = await fg(patterns, { cwd: repoDir, absolute: true });
+    for (const pkgFile of found) {
+      detected.push({ language: lang, pkgFile });
+    }
+  }
+  return detected;
 }


### PR DESCRIPTION
Address #450 

- Clones the repo directly in mcp
- walk through the repo and search for package files using a lightweight library
- use the found pkg_files to get configurations. 


### Tested examples

```bash
curl -X GET "http://localhost:3000/services?clone=true&repo_url=https://github.com/stakwork/stakgraph"

curl -X GET "http://localhost:3000/services?clone=true&repo_url=https://github.com/stakwork/demo-repo"

curl -X GET "http://localhost:3000/services?clone=true&repo_url=https://github.com/fayekelmith/FayeKelmith"
```