### PR TITLE
fix: enum and types as DataModels for TS based languags

### DIFF
--- a/ast/src/lang/queries/angular.rs
+++ b/ast/src/lang/queries/angular.rs
@@ -195,10 +195,17 @@ impl Stack for Angular {
     fn data_model_query(&self) -> Option<String> {
         Some(format!(
             r#"
-                (interface_declaration
-                    name: (type_identifier) @{STRUCT_NAME}
-                    body: (interface_body) @{STRUCT}
-                )
+                [
+                    (interface_declaration
+                        name: (type_identifier) @{STRUCT_NAME}
+                    )
+                    (type_alias_declaration
+                        name: (type_identifier) @{STRUCT_NAME}
+                    )
+                    (enum_declaration
+                        name: (identifier) @{STRUCT_NAME}
+                    )
+                ] @{STRUCT}
 
              "#
         ))

--- a/ast/src/lang/queries/react.rs
+++ b/ast/src/lang/queries/react.rs
@@ -279,11 +279,13 @@ impl Stack for ReactTs {
             r#"[
                 (type_alias_declaration
                     name: (type_identifier) @{STRUCT_NAME}
-                ) @{STRUCT}
+                ) 
                 (interface_declaration
                     name: (type_identifier) @{STRUCT_NAME}
-                ) @{STRUCT}
-                ;; sequelize
+                )
+                (enum_declaration
+                    name: (identifier) @{STRUCT_NAME}
+                )
                 (class_declaration
                     name: (type_identifier) @{STRUCT_NAME}
                     (class_heritage
@@ -291,8 +293,7 @@ impl Stack for ReactTs {
                             value: (identifier) @model (#eq? @model "Model")
                         )
                     )
-                ) @{STRUCT}
-                ;; typeorm
+                ) 
                 (
                     (decorator
                         (call_expression
@@ -301,9 +302,10 @@ impl Stack for ReactTs {
                     )
                     (class_declaration
                         name: (type_identifier) @{STRUCT_NAME}
-                    ) @{STRUCT}
+                    ) 
                 )
-            ]"#
+            ] @{STRUCT}
+            "#
         ))
     }
     fn data_model_within_query(&self) -> Option<String> {

--- a/ast/src/lang/queries/typescript.rs
+++ b/ast/src/lang/queries/typescript.rs
@@ -195,6 +195,18 @@ impl Stack for TypeScript {
         }
     }
 
+    /*
+    POSSIBLE QUERY FOR DATA MODEL that picks up interfaces without methods -- needs work
+    (interface_declaration
+        name: (type_identifier) @struct-name
+        body: (interface_body
+
+            (method_signature) @method
+            (#is_not? @method _)
+
+        )
+    ) @struct
+     */
     fn data_model_query(&self) -> Option<String> {
         Some(format!(
             r#"

--- a/ast/src/lang/queries/typescript.rs
+++ b/ast/src/lang/queries/typescript.rs
@@ -198,31 +198,35 @@ impl Stack for TypeScript {
     fn data_model_query(&self) -> Option<String> {
         Some(format!(
             r#"
-                ;; Find TypeScript interfaces related to the model
-                (interface_declaration
-                    name: (type_identifier) @{STRUCT_NAME} 
-                    body: (interface_body) @{STRUCT}
-                )
-                ;; sequelize
-                (class_declaration
-                    name: (type_identifier) @{STRUCT_NAME}
-                    (class_heritage
-                        (extends_clause
-                            value: (identifier) @model (#eq? @model "Model")
-                        )
+                [
+                    (interface_declaration
+                        name: (type_identifier) @{STRUCT_NAME} 
                     )
-                ) @{STRUCT}
-                ;; typeorm
-                (
-                    (decorator
-                        (call_expression
-                            function: (identifier) @entity (#eq? @entity "Entity")
-                        )
+                    (type_alias_declaration
+                        name: (type_identifier) @{STRUCT_NAME}
+                    )
+                    (enum_declaration
+                        name: (identifier) @{STRUCT_NAME}
                     )
                     (class_declaration
                         name: (type_identifier) @{STRUCT_NAME}
-                    ) @{STRUCT}
-                )
+                        (class_heritage
+                            (extends_clause
+                                value: (identifier) @model (#eq? @model "Model")
+                            )
+                        )
+                    ) 
+                    (
+                        (decorator
+                            (call_expression
+                                function: (identifier) @entity (#eq? @entity "Entity")
+                            )
+                        )
+                        (class_declaration
+                            name: (type_identifier) @{STRUCT_NAME}
+                        ) 
+                    )
+                ] @{STRUCT}
              "#
         ))
     }

--- a/ast/src/testing/react/mod.rs
+++ b/ast/src/testing/react/mod.rs
@@ -343,7 +343,7 @@ import NewPerson from "./components/NewPerson";"#
 
     let variables = graph.find_nodes_by_type(NodeType::Var);
     nodes_count += variables.len();
-    assert_eq!(variables.len(), 6, "Expected 6 variables");
+    assert_eq!(variables.len(), 5, "Expected 5 variables");
 
     let initial_state_var = variables
         .iter()
@@ -433,7 +433,7 @@ import NewPerson from "./components/NewPerson";"#
 
     let data_models = graph.find_nodes_by_type(NodeType::DataModel);
     nodes_count += data_models.len();
-    assert_eq!(data_models.len(), 2, "Expected 2 data models");
+    assert_eq!(data_models.len(), 3, "Expected 3 data models");
 
     let person_data_model = data_models
         .iter()

--- a/ast/src/testing/react/src/App.tsx
+++ b/ast/src/testing/react/src/App.tsx
@@ -4,7 +4,13 @@ import "./App.css";
 import People from "./components/People";
 import NewPerson from "./components/NewPerson";
 
-export const AppName: string = "My React App";
+enum APP_NAMES{
+  MyReactApp = "My React App"
+  MyApp = "My App"
+  MyDemoApp = "My Demo App"
+}
+
+export const AppName: string = APP_NAMES.MyReactApp;
 export const hostPort: string = "http://localhost:5002";
 
 function App() {

--- a/ast/src/testing/react/src/components/Person.tsx
+++ b/ast/src/testing/react/src/components/Person.tsx
@@ -1,9 +1,9 @@
 import { useState, useCallback } from "react";
 
-export interface StoreState {
+export type StoreState = {
   people: Person[];
   loading: boolean;
-}
+};
 
 export interface Person {
   id: number;

--- a/ast/src/testing/typescript/mod.rs
+++ b/ast/src/testing/typescript/mod.rs
@@ -115,7 +115,7 @@ import {{ sequelize }} from "./config.js";"#
 
     let data_models = graph.find_nodes_by_type(NodeType::DataModel);
     nodes_count += data_models.len();
-    assert_eq!(data_models.len(), 7, "Expected 7 data models");
+    assert_eq!(data_models.len(), 8, "Expected 8 data models");
 
     let variables = graph.find_nodes_by_type(NodeType::Var);
     nodes_count += variables.len();
@@ -123,7 +123,7 @@ import {{ sequelize }} from "./config.js";"#
 
     let contains = graph.count_edges_of_type(EdgeType::Contains);
     edges_count += contains;
-    assert_eq!(contains, 58, "Expected 58 contains edges");
+    assert_eq!(contains, 60, "Expected 60 contains edges");
 
     let import_edges_count = graph.count_edges_of_type(EdgeType::Imports);
     edges_count += import_edges_count;

--- a/ast/src/testing/typescript/mod.rs
+++ b/ast/src/testing/typescript/mod.rs
@@ -115,7 +115,7 @@ import {{ sequelize }} from "./config.js";"#
 
     let data_models = graph.find_nodes_by_type(NodeType::DataModel);
     nodes_count += data_models.len();
-    assert_eq!(data_models.len(), 4, "Expected 4 data models");
+    assert_eq!(data_models.len(), 7, "Expected 7 data models");
 
     let variables = graph.find_nodes_by_type(NodeType::Var);
     nodes_count += variables.len();
@@ -123,7 +123,7 @@ import {{ sequelize }} from "./config.js";"#
 
     let contains = graph.count_edges_of_type(EdgeType::Contains);
     edges_count += contains;
-    assert_eq!(contains, 53, "Expected 53 contains edges");
+    assert_eq!(contains, 58, "Expected 58 contains edges");
 
     let import_edges_count = graph.count_edges_of_type(EdgeType::Imports);
     edges_count += import_edges_count;

--- a/ast/src/testing/typescript/src/model.ts
+++ b/ast/src/testing/typescript/src/model.ts
@@ -50,3 +50,13 @@ export class TypeORMPerson {
   @Column({ unique: true })
   email!: string;
 }
+
+//should not be DM
+// interface TestInterface {
+//   operand1: number;
+//   operand2: number;
+//   add(): number;
+//   subtract?(): number;
+// }
+
+// TO FIGURE OUT QUERY THAT DOES NOT PICK IT UP AS DM

--- a/ast/src/testing/typescript/src/routes.ts
+++ b/ast/src/testing/typescript/src/routes.ts
@@ -1,7 +1,15 @@
-import express from "express";
 import { Request, Response } from "express";
 import { getPersonById, newPerson, PersonData } from "./service.js";
 
+type PersonRequest = Request<{}, {}, { name: string; email: string }>;
+type PersonResponse = Response<PersonData | { error: string }>;
+
+export enum ResponseStatus {
+  SUCCESS = 200,
+  CREATED = 201,
+  NOT_FOUND = 404,
+  INTERNAL_ERROR = 500,
+}
 export function registerRoutes(app) {
   app.get("/person/:id", getPerson);
 
@@ -14,22 +22,28 @@ async function getPerson(req: Request, res: Response) {
   try {
     const person = (await getPersonById(Number(id))) as PersonData;
     if (!person) {
-      return res.status(404).json({ error: "Person not found" });
+      return res
+        .status(ResponseStatus.NOT_FOUND)
+        .json({ error: "Person not found" });
     }
     return res.json(person);
   } catch (error) {
     console.error(error);
-    return res.status(500).json({ error: "Internal server error" });
+    return res
+      .status(ResponseStatus.INTERNAL_ERROR)
+      .json({ error: "Internal server error" });
   }
 }
 
-async function createPerson(req: Request, res: Response) {
+async function createPerson(req: PersonRequest, res: PersonResponse) {
   const { name, email } = req.body;
   try {
     const person: PersonData = await newPerson({ name, email });
-    return res.status(201).json(person);
+    return res.status(ResponseStatus.CREATED).json(person);
   } catch (error) {
     console.error(error);
-    return res.status(500).json({ error: "Internal server error" });
+    return res
+      .status(ResponseStatus.INTERNAL_ERROR)
+      .json({ error: "Internal server error" });
   }
 }

--- a/ast/src/testing/typescript/src/service.ts
+++ b/ast/src/testing/typescript/src/service.ts
@@ -6,7 +6,9 @@ export interface PersonData {
   email: string;
 }
 
-export async function getPersonById(id: number): Promise<PersonData | null> {
+type IdType = number | string;
+
+export async function getPersonById(id: IdType): Promise<PersonData | null> {
   const person = await SequelizePerson.findByPk(id);
   if (!person) {
     return null;
@@ -18,7 +20,7 @@ export async function newPerson(personData: PersonData): Promise<PersonData> {
   return person.toJSON() as PersonData;
 }
 export class SequelizePersonService {
-  async getById(id: number): Promise<PersonData | null> {
+  async getById(id: IdType): Promise<PersonData | null> {
     const person = await SequelizePerson.findByPk(id);
     if (!person) {
       return null;
@@ -34,7 +36,7 @@ export class SequelizePersonService {
 export class TypeOrmPersonService {
   private respository = AppDataSource.getRepository(TypeORMPerson);
 
-  async getById(id: number): Promise<PersonData | null> {
+  async getById(id: IdType): Promise<PersonData | null> {
     const person = await this.respository.findOneBy({ id });
     if (!person) {
       return null;
@@ -50,7 +52,7 @@ export class TypeOrmPersonService {
 }
 
 export class PrismaPersonService {
-  async getById(id: number): Promise<PersonData | null> {
+  async getById(id: IdType): Promise<PersonData | null> {
     const person = await prisma.person.findUnique({
       where: { id },
     });


### PR DESCRIPTION
Address #455 for Typscritpt, Rust, and Angular. 

updated their queries to capture Enum and Types as DataModels as well. 