### PR TITLE
fix: propagate errors to standalone

### DIFF
--- a/ast/src/testing/nextjs/mod.rs
+++ b/ast/src/testing/nextjs/mod.rs
@@ -441,7 +441,7 @@ pub async fn test_nextjs_generic<G: Graph>() -> Result<()> {
 }
 
 #[cfg(all(feature = "neo4j", feature = "fulltest"))]
-async fn test_remote_nextjs() -> Result<(), anyhow::Error> {
+async fn test_remote_nextjs() -> Result<()> {
     use crate::lang::graphs::Neo4jGraph;
     let repo_url = "https://github.com/clerk/clerk-nextjs-demo-pages-router";
     let use_lsp = get_use_lsp();

--- a/lsp/src/git.rs
+++ b/lsp/src/git.rs
@@ -32,7 +32,7 @@ pub async fn git_clone(
             }
             Err(e) => {
                 tracing::error!("git clone failed for {}: {}", repo_url, e);
-                return Err(anyhow::anyhow!("git clone failed for {}: {}", repo_url, e));
+                return Err(anyhow::anyhow!(e));
             }
         }
     }

--- a/lsp/src/git.rs
+++ b/lsp/src/git.rs
@@ -32,7 +32,7 @@ pub async fn git_clone(
             }
             Err(e) => {
                 tracing::error!("git clone failed for {}: {}", repo_url, e);
-                return Err(anyhow::anyhow!(e));
+                return Err(e);
             }
         }
     }

--- a/lsp/src/git.rs
+++ b/lsp/src/git.rs
@@ -25,11 +25,21 @@ pub async fn git_clone(
         run_res_in_dir("git", &["pull"], path).await?;
     } else {
         info!("Repository doesn't exist at {}, cloning it", path);
-        run("git", &["clone", &repo_url, "--single-branch", path]).await?;
-        info!("Cloned repo to {}", path);
+        let output = run("git", &["clone", &repo_url, "--single-branch", path]).await;
+        match output {
+            Ok(_) => {
+                tracing::info!("Cloned repo to {}", path);
+            }
+            Err(e) => {
+                tracing::error!("git clone failed for {}: {}", repo_url, e);
+                return Err(anyhow::anyhow!("git clone failed for {}: {}", repo_url, e));
+            }
+        }
     }
     if let Some(commit) = commit {
-        checkout_commit(path, commit).await?;
+        checkout_commit(path, commit)
+            .await
+            .context("git checkout failed")?;
     }
     Ok(())
 }

--- a/lsp/src/utils.rs
+++ b/lsp/src/utils.rs
@@ -4,13 +4,17 @@ use std::process::Stdio;
 
 use crate::Language;
 
-pub async fn run(cmd: &str, args: &[&str]) -> Result<()> {
-    async_process::Command::new(cmd)
+pub async fn run(cmd: &str, args: &[&str]) -> Result<String> {
+    let output = async_process::Command::new(cmd)
         .args(args)
         .kill_on_drop(true)
-        .status() // or "output"
+        .output() // or "output"
         .await?;
-    Ok(())
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).to_string();
+        return Err(anyhow::anyhow!("{} failed: {}", cmd, stderr));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 pub async fn run_res_in_dir(cmd: &str, args: &[&str], dir: &str) -> Result<String> {

--- a/lsp/src/utils.rs
+++ b/lsp/src/utils.rs
@@ -12,7 +12,7 @@ pub async fn run(cmd: &str, args: &[&str]) -> Result<String> {
         .await?;
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr).to_string();
-        return Err(anyhow::anyhow!("{} failed: {}", cmd, stderr));
+        return Err(Error::Custom(format!("{} failed: {}", cmd, stderr)));
     }
     Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }

--- a/shared/src/error.rs
+++ b/shared/src/error.rs
@@ -38,7 +38,7 @@ pub enum Error {
     #[error("Tree-sitter language error: {0}")]
     TreeSitterLanguage(#[from] tree_sitter::LanguageError),
 
-    #[error("Custom error: {0}")]
+    #[error("Error : {0}")]
     Custom(String),
 }
 impl Error {

--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -82,15 +82,16 @@ impl IntoResponse for WebError {
                 } else {
                     StatusCode::BAD_REQUEST
                 }
+
+                tracing::error!("Handler error: {:?}", self.0);
+                let resp = ErrorResponse {
+                    message: self.0.to_string(),
+                };
+
+                (status, Json(resp)).into_response()
             }
         };
-
-        tracing::error!("Handler error: {:?}", self.0);
-        let resp = ErrorResponse {
-            message: self.0.to_string(),
-        };
-
-        (status, Json(resp)).into_response()
+        (status, self.0.to_string()).into_response()
     }
 }
 

--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -82,16 +82,13 @@ impl IntoResponse for WebError {
                 } else {
                     StatusCode::BAD_REQUEST
                 }
-
-                tracing::error!("Handler error: {:?}", self.0);
-                let resp = ErrorResponse {
-                    message: self.0.to_string(),
-                };
-
-                (status, Json(resp)).into_response()
             }
         };
-        (status, self.0.to_string()).into_response()
+        tracing::error!("Handler error: {:?}", self.0);
+        let resp = ErrorResponse {
+            message: self.0.to_string(),
+        };
+        (status, Json(resp)).into_response()
     }
 }
 

--- a/standalone/static/app.js
+++ b/standalone/static/app.js
@@ -97,8 +97,11 @@ const App = () => {
     try {
       await utils.POST("/ingest", { repo_url: repoUrl, username, pat });
     } catch (e) {
-      console.log("====>>>> Error", e);
-      setStatus({ status: "Error", message: e.message });
+      let message = e.message
+        .split("\n")
+        .map((line) => `<p>${line}</p>`)
+        .join("");
+      setStatus({ status: "Error", message });
       setIsLoading(false);
       return;
     }
@@ -139,8 +142,11 @@ const App = () => {
       <div class="progress-container">
         <div class="progress-info">
           ${isCloning
-            ? html`<div class="clone-label">Clone Repository:</div>
-                <div class="progress-message">${status.message}</div>`
+            ? html`<div class="clone-label">Clone Repository</div>
+                <div
+                  class="progress-message"
+                  dangerouslySetInnerHTML=${{ __html: status.message }}
+                ></div>`
             : html`
                 ${showText &&
                 html`<div>Step ${status.step}/${status.total_steps}</div>`}

--- a/standalone/static/app.js
+++ b/standalone/static/app.js
@@ -94,7 +94,14 @@ const App = () => {
     setIsLoading(true);
     setStatus({ message: "Cloning repo to /tmp/..." });
     setStats({});
-    await utils.POST("/ingest", { repo_url: repoUrl, username, pat });
+    try {
+      await utils.POST("/ingest", { repo_url: repoUrl, username, pat });
+    } catch (e) {
+      console.log("====>>>> Error", e);
+      setStatus({ status: "Error", message: e.message });
+      setIsLoading(false);
+      return;
+    }
     setIsLoading(false);
   };
 
@@ -105,7 +112,13 @@ const App = () => {
     setIsLoading(true);
     setStatus(null);
     setStats({});
-    await utils.POST("/process", { repo_url: repoUrl, username, pat });
+    try {
+      await utils.POST("/process", { repo_url: repoUrl, username, pat });
+    } catch (e) {
+      setStatus({ status: "Error", message: e.message });
+      setIsLoading(false);
+      return;
+    }
     setIsLoading(false);
   };
 

--- a/standalone/static/styles.css
+++ b/standalone/static/styles.css
@@ -62,7 +62,7 @@ body {
   color: var(--text-color);
 }
 
-.app-header-title{
+.app-header-title {
   margin: 10px auto;
   padding: 0;
   font-weight: 500;
@@ -154,7 +154,8 @@ button:disabled {
 
 .progress-info {
   display: flex;
-  margin-bottom: 10px;
+  flex-direction: column;
+  margin: 10px auto;
   font-size: 14px;
   width: 100%;
   align-items: center;
@@ -170,8 +171,8 @@ button:disabled {
 
 .clone-label {
   font-weight: 600;
+  font-size: 16px;
   color: var(--accent-color);
-  margin-right: 10px;
 }
 
 .stats-container {
@@ -221,9 +222,12 @@ button:disabled {
 }
 
 .progress-message {
-  margin-left: 5px;
+  margin: 10px auto;
   font-weight: 400;
-  flex: 1;
+}
+
+.progress-message p {
+  margin: 6px 0;
 }
 
 .steps-fill {

--- a/standalone/static/utils.js
+++ b/standalone/static/utils.js
@@ -84,8 +84,9 @@ export const POST = async (url, body) => {
     headers: getFetchHeaders(),
   });
   if (!r.ok) {
-    throw new Error(`New Error for the POST endpoint`);
-    //throw new Error(`POST ${url} failed: ${r.statusText}`);
+    const data = await r.json();
+    const msg = data.message || "Something went wrong, Please try again.";
+    throw new Error(msg);
   }
   const data = await r.json();
   return data;

--- a/standalone/static/utils.js
+++ b/standalone/static/utils.js
@@ -62,10 +62,18 @@ export const GET = async (url) => {
     method: "GET",
     headers: getFetchHeaders(),
   });
-  if (!r.ok) {
-    throw new Error(`GET ${url} failed: ${r.statusText}`);
+
+  let data;
+  try {
+    data = await r.json();
+  } catch (e) {
+    data = {};
   }
-  const data = await r.json();
+  if (!r.ok) {
+    const msg =
+      data.message || r.statusText || "Something went wrong, Please try again.";
+    throw new Error(`POST ${url} failed: ${msg}`);
+  }
   return data;
 };
 
@@ -76,7 +84,8 @@ export const POST = async (url, body) => {
     headers: getFetchHeaders(),
   });
   if (!r.ok) {
-    throw new Error(`POST ${url} failed: ${r.statusText}`);
+    throw new Error(`New Error for the POST endpoint`);
+    //throw new Error(`POST ${url} failed: ${r.statusText}`);
   }
   const data = await r.json();
   return data;


### PR DESCRIPTION
- Propagate errors correctly from the source
- Use the Errors Propagated to Update the UI
- Using the API endpoint to get errors


Addressing #443 