### PR TITLE
Store generated test files in dedicated subdirectory

### DIFF
--- a/mcp/.gitignore
+++ b/mcp/.gitignore
@@ -42,6 +42,7 @@ tmp/
 
 tests/*.spec.js
 tests/*.spec.ts
+tests/generated_tests/
 !tests/.gitkeep
 !tests/playwright.config.js
 playwright-report/

--- a/mcp/set-tests-dir.bat
+++ b/mcp/set-tests-dir.bat
@@ -1,0 +1,3 @@
+@echo off
+set TESTS_DIR=%~dp0tests\generated_tests
+echo Tests directory set to: %TESTS_DIR% 

--- a/mcp/set-tests-dir.sh
+++ b/mcp/set-tests-dir.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+export TESTS_DIR="$(dirname "$0")/tests/generated_tests"
+echo "Tests directory set to: $TESTS_DIR" 

--- a/mcp/src/eval/tests.ts
+++ b/mcp/src/eval/tests.ts
@@ -18,7 +18,18 @@ const getBaseDir = (): string => {
 };
 
 const getTestsDir = (): string => {
-  return path.join(getBaseDir(), "tests");
+  let testsDir: string;
+  if (process.env.TESTS_DIR) {
+    testsDir = process.env.TESTS_DIR;
+  } else {
+    testsDir = path.join(getBaseDir(), "tests");
+  }
+
+  if (!testsDir.endsWith("generated_tests")) {
+    testsDir = path.join(testsDir, "generated_tests");
+  }
+
+  return testsDir;
 };
 
 // Utility function to sanitize filename
@@ -379,16 +390,13 @@ export function test_routes(app: Express) {
   app.get("/test/delete", deleteTestByName);
   app.post("/test/save", saveTest);
 
-  let base_path = path.join(__dirname, "../../tests");
-  if (process.env.TESTS_BASE_PATH) {
-    base_path = process.env.TESTS_BASE_PATH;
-  }
+  let tests_base_path = path.join(getBaseDir(), "tests");
 
   app.get("/tests", (_req, res) => {
-    res.sendFile(path.join(base_path, "tests.html"));
+    res.sendFile(path.join(tests_base_path, "tests.html"));
   });
   app.get("/tests/frame/frame.html", (_req, res) => {
-    res.sendFile(path.join(base_path, "frame/frame.html"));
+    res.sendFile(path.join(tests_base_path, "frame/frame.html"));
   });
 
   const static_files = [
@@ -402,7 +410,7 @@ export function test_routes(app: Express) {
     "staktrak/dist/playwright-generator.js",
   ];
 
-  serveStaticFiles(app, static_files, base_path);
+  serveStaticFiles(app, static_files, tests_base_path);
 }
 
 function serveStaticFiles(app: Express, files: string[], basePath: string) {

--- a/mcp/tests/README.md
+++ b/mcp/tests/README.md
@@ -1,0 +1,35 @@
+# StakTrak Tests
+
+This directory contains tests for the StakTrak application.
+
+## Test File Storage
+
+By default, test files are stored in the `tests/generated_tests` directory. This directory is ignored by git, so your local test files won't be committed.
+
+## Environment Variables
+
+When running the application, you can configure where test files are stored using the following environment variable:
+
+- `TESTS_DIR`: Sets the directory where test files are stored
+
+## Usage
+
+### Windows
+
+```batch
+# Set the tests directory (temporary for current session)
+set TESTS_DIR=D:\path\to\tests\generated_tests
+
+# Or use the provided script (sets to the /tests/generated_tests directory relative to the script)
+call mcp\set-tests-dir.bat
+```
+
+### Linux/Mac
+
+```bash
+# Set the tests directory (temporary for current session)
+export TESTS_DIR=/path/to/tests/generated_tests
+
+# Or use the provided script (sets to the ./tests/generated_tests directory relative to the script)
+source mcp/set-tests-dir.sh
+```


### PR DESCRIPTION
## Changes

This PR changes where test files are stored by default, moving them to a `generated_tests` subdirectory which is git-ignored.

### Details
- Modified `getTestsDir()` to use a `generated_tests` subdirectory
- Ensured directory paths are consistent across the application
- Updated helper scripts (set-tests-dir.bat and set-tests-dir.sh)
- Improved directory creation logic
- Updated documentation with the new structure

### Benefits
- Better organization of test files
- Clear separation between framework files and user-generated tests
- Avoids accidental commits of local test files
- More intuitive directory structure

### Testing
- Verified test files are saved to the correct location
- Confirmed directory creation works properly

### Evidence:

https://www.loom.com/share/d7baeadcddc44f5a9cb379df8f36693a
