### PR TITLE
fix: update the graph-sync logic

### DIFF
--- a/ast/src/lang/linker.rs
+++ b/ast/src/lang/linker.rs
@@ -46,7 +46,7 @@ pub fn link_e2e_tests<G: Graph>(graph: &mut G) -> Result<()> {
     Ok(())
 }
 
-fn infer_lang(nd: &NodeData) -> Result<Language> {
+pub fn infer_lang(nd: &NodeData) -> Result<Language> {
     for lang in PROGRAMMING_LANGUAGES {
         let pathy = &PathBuf::from(&nd.file);
         let ext = pathy
@@ -64,7 +64,7 @@ fn infer_lang(nd: &NodeData) -> Result<Language> {
     )))
 }
 
-fn extract_test_ids(content: &str, lang: &Language) -> Result<Vec<String>> {
+pub fn extract_test_ids(content: &str, lang: &Language) -> Result<Vec<String>> {
     if let None = lang.test_id_regex() {
         return Ok(Vec::new());
     }
@@ -181,7 +181,7 @@ pub fn normalize_backend_path(path: &str) -> Option<String> {
     Some(normalized)
 }
 
-fn verbs_match(req: &NodeData, endpoint: &NodeData) -> bool {
+pub fn verbs_match(req: &NodeData, endpoint: &NodeData) -> bool {
     match (req.meta.get("verb"), endpoint.meta.get("verb")) {
         (Some(req_verb), Some(endpoint_verb)) => {
             req_verb.to_uppercase() == endpoint_verb.to_uppercase()
@@ -190,7 +190,7 @@ fn verbs_match(req: &NodeData, endpoint: &NodeData) -> bool {
     }
 }
 
-fn paths_match(frontend_path: &str, backend_path: &str) -> bool {
+pub fn paths_match(frontend_path: &str, backend_path: &str) -> bool {
     let frontend_segments: Vec<&str> = frontend_path.split('/').filter(|s| !s.is_empty()).collect();
     let backend_segments: Vec<&str> = backend_path.split('/').filter(|s| !s.is_empty()).collect();
 

--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -1,5 +1,6 @@
 use crate::types::{
-    AsyncRequestStatus, AsyncStatus, EmbedCodeParams, FetchRepoBody, FetchRepoResponse, ProcessBody, ProcessResponse, Result, VectorSearchParams, VectorSearchResult, WebError
+    AsyncRequestStatus, AsyncStatus, EmbedCodeParams, FetchRepoBody, FetchRepoResponse,
+    ProcessBody, ProcessResponse, Result, VectorSearchParams, VectorSearchResult, WebError,
 };
 use crate::AppState;
 use ast::lang::graphs::graph_ops::GraphOps;
@@ -115,34 +116,23 @@ pub async fn process(body: Json<ProcessBody>) -> Result<Json<ProcessResponse>> {
         }
     }
 
+    let hash = stored_hash.as_deref().unwrap_or_default();
+
     let (prev_nodes, prev_edges) = graph_ops.graph.get_graph_size();
 
-    let (nodes, edges) = if let Some(hash) = stored_hash {
-        info!("Updating repository hash from {} to {}", hash, current_hash);
-        graph_ops
-            .update_incremental(
-                &repo_url,
-                username.clone(),
-                pat.clone(),
-                &current_hash,
-                &hash,
-                None,
-                use_lsp,
-            )
-            .await?
-    } else {
-        info!("Adding new repository hash: {}", current_hash);
-        graph_ops
-            .update_full(
-                &repo_url,
-                username.clone(),
-                pat.clone(),
-                &current_hash,
-                None,
-                use_lsp,
-            )
-            .await?
-    };
+    info!("Updating repository hash from {} to {}", hash, current_hash);
+    let (nodes, edges) = graph_ops
+        .update_incremental(
+            &repo_url,
+            username.clone(),
+            pat.clone(),
+            &current_hash,
+            hash,
+            None,
+            use_lsp,
+        )
+        .await?;
+
     info!(
         "\n\n ==>> Total processing time: {:.2?} \n\n",
         total_start.elapsed()


### PR DESCRIPTION
## Goal: 

Currently, the sync uploads a new repository when it's newly added, but does not link API calls. This PR implements a logic to ensure api calls from both graphs are created even when they are ingested at different times. 
