### PR TITLE
feature: test coverage for e2e-test on nextjs/react js

### DIFF
--- a/ast/src/lang/graphs/mod.rs
+++ b/ast/src/lang/graphs/mod.rs
@@ -1,6 +1,7 @@
 pub mod array_graph;
 pub mod btreemap_graph;
 pub mod graph;
+pub mod utils;
 
 #[cfg(feature = "neo4j")]
 pub mod neo4j_graph;

--- a/ast/src/lang/graphs/utils.rs
+++ b/ast/src/lang/graphs/utils.rs
@@ -1,0 +1,25 @@
+use super::NodeType;
+
+pub fn tests_sources(tests_filter: Option<&str>) -> Vec<NodeType> {
+    let unit = tests_filter
+        .map(|s| s.eq_ignore_ascii_case("unit"))
+        .unwrap_or(false);
+    let e2e = tests_filter
+        .map(|s| s.eq_ignore_ascii_case("e2e"))
+        .unwrap_or(false);
+    let both = tests_filter.is_none()
+        || tests_filter
+            .map(|s| s.eq_ignore_ascii_case("both"))
+            .unwrap_or(false);
+    if both || (!unit && !e2e) {
+        return vec![NodeType::Test, NodeType::E2eTest];
+    }
+    let mut sources = Vec::new();
+    if unit {
+        sources.push(NodeType::Test);
+    }
+    if e2e {
+        sources.push(NodeType::E2eTest);
+    }
+    sources
+}

--- a/ast/src/lang/queries/react.rs
+++ b/ast/src/lang/queries/react.rs
@@ -347,6 +347,29 @@ impl Stack for ReactTs {
                 ] @{FUNCTION_DEFINITION}"#
         ))
     }
+    fn integration_test_query(&self) -> Option<String> {
+        Some(format!(
+            r#"[
+                (call_expression
+                    function: (identifier) @describe (#eq? @describe "describe")
+                    arguments: (arguments
+                        [ (string) (template_string) ] @{E2E_TEST_NAME} (#match? @{E2E_TEST_NAME} "(?i)e2e")
+                        (_)
+                    )
+                ) @{INTEGRATION_TEST}
+                (call_expression
+                    function: (member_expression
+                        object: (identifier) @test (#eq? @test "test")
+                        property: (property_identifier) @desc (#eq? @desc "describe")
+                    )
+                    arguments: (arguments
+                        [ (string) (template_string) ] @{E2E_TEST_NAME} (#match? @{E2E_TEST_NAME} "(?i)e2e")
+                        (_)
+                    )
+                ) @{INTEGRATION_TEST}
+            ]"#
+        ))
+    }
     fn endpoint_finders(&self) -> Vec<String> {
         vec![format!(
             r#"
@@ -624,6 +647,9 @@ impl Stack for ReactTs {
     }
 
     fn use_extra_page_finder(&self) -> bool {
+        true
+    }
+    fn use_integration_test_finder(&self) -> bool {
         true
     }
     fn is_extra_page(&self, file_name: &str) -> bool {

--- a/ast/src/testing/nextjs/mod.rs
+++ b/ast/src/testing/nextjs/mod.rs
@@ -209,7 +209,7 @@ pub async fn test_nextjs_generic<G: Graph>() -> Result<()> {
 
     let contains = graph.count_edges_of_type(EdgeType::Contains);
     edges += contains;
-    assert_eq!(contains, 129, "Expected 129 Contains edges");
+    assert_eq!(contains, 130, "Expected 130 Contains edges");
 
     let handlers = graph.count_edges_of_type(EdgeType::Handler);
     edges += handlers;
@@ -218,6 +218,10 @@ pub async fn test_nextjs_generic<G: Graph>() -> Result<()> {
     let tests = graph.find_nodes_by_type(NodeType::Test);
     nodes += tests.len();
     assert_eq!(tests.len(), 10, "Expected 10 Test nodes");
+
+    let e2e_tests = graph.find_nodes_by_type(NodeType::E2eTest);
+    nodes += e2e_tests.len();
+    assert_eq!(e2e_tests.len(), 1, "Expected 1 E2eTest nodes");
 
     let import = graph.count_edges_of_type(EdgeType::Imports);
     edges += import;

--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -659,7 +659,12 @@ pub async fn coverage_handler(
     graph_ops.connect().await?;
 
     let totals = graph_ops
-        .get_coverage(include_functions, include_endpoints, params.root.as_deref())
+        .get_coverage(
+            include_functions,
+            include_endpoints,
+            params.root.as_deref(),
+            params.tests.as_deref(),
+        )
         .await?;
 
     let map_stat =
@@ -697,7 +702,13 @@ pub async fn uncovered_handler(Query(params): Query<UncoveredParams>) -> Result<
     graph_ops.connect().await?;
 
     let (funcs, endpoints) = graph_ops
-        .list_uncovered(node_type, with_usage, limit, params.root.as_deref())
+        .list_uncovered(
+            node_type,
+            with_usage,
+            limit,
+            params.root.as_deref(),
+            params.tests.as_deref(),
+        )
         .await?;
 
     let functions = if is_function {
@@ -748,6 +759,7 @@ pub async fn has_handler(Query(params): Query<HasParams>) -> Result<Json<HasResp
             &params.file,
             params.start,
             params.root.as_deref(),
+            params.tests.as_deref(),
         )
         .await?;
     Ok(Json(HasResponse { covered }))

--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -96,6 +96,7 @@ pub struct VectorSearchParams {
 pub struct CoverageParams {
     pub node_type: Option<String>,
     pub root: Option<String>,
+    pub tests: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -117,8 +118,9 @@ pub struct UncoveredParams {
     pub limit: Option<usize>,
     pub sort: Option<String>,
     pub root: Option<String>,
-    pub output: Option<String>,
     pub concise: Option<bool>,
+    pub tests: Option<String>,
+    pub output: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
@@ -156,6 +158,7 @@ pub struct HasParams {
     pub file: String,
     pub start: Option<usize>,
     pub root: Option<String>,
+    pub tests: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
Closes: #526 

has thesame params for `/test/coverage`, `/test/uncovered`, and /test/has` but with an added parameter `tests` to filter which test is needed, `e2e`, `unit` or `both` . 