### PR TITLE
Add e2e test count to coverage endpoint

### DIFF
--- a/ast/src/lang/graphs/graph_ops.rs
+++ b/ast/src/lang/graphs/graph_ops.rs
@@ -34,6 +34,7 @@ pub struct GraphCoverageStat {
 pub struct GraphCoverageTotals {
     pub functions: Option<GraphCoverageStat>,
     pub endpoints: Option<GraphCoverageStat>,
+    pub e2e_tests: Option<GraphCoverageStat>,
 }
 
 impl GraphOps {
@@ -526,9 +527,26 @@ impl GraphOps {
             });
         }
 
+        // Count e2e tests
+        let e2e_tests = self
+            .graph
+            .find_nodes_by_type_async(NodeType::E2eTest)
+            .await;
+        let e2e_test_total = e2e_tests.iter().filter(|e| in_scope(e)).count();
+        let e2e_tests_stat = if e2e_test_total > 0 {
+            Some(GraphCoverageStat {
+                total: e2e_test_total,
+                covered: 0, // TODO: implement e2e test coverage tracking
+                percent: 0.0,
+            })
+        } else {
+            None
+        };
+
         Ok(GraphCoverageTotals {
             functions: functions_stat,
             endpoints: endpoints_stat,
+            e2e_tests: e2e_tests_stat,
         })
     }
 

--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -679,6 +679,7 @@ pub async fn coverage_handler(
     Ok(Json(CoverageTotals {
         functions: map_stat(totals.functions),
         endpoints: map_stat(totals.endpoints),
+        e2e_tests: map_stat(totals.e2e_tests),
     }))
 }
 

--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -110,6 +110,7 @@ pub struct CoverageStat {
 pub struct CoverageTotals {
     pub functions: Option<CoverageStat>,
     pub endpoints: Option<CoverageStat>,
+    pub e2e_tests: Option<CoverageStat>,
 }
 
 #[derive(Deserialize)]


### PR DESCRIPTION
- Add e2e_tests field to CoverageTotals and GraphCoverageTotals structures
- Implement e2e test node counting in get_coverage method
- Return e2e test statistics in /tests/coverage endpoint response
- Maintain consistent API structure for future coverage tracking expansion