### PR TITLE
depends: adding ai-sdk-provider-claude-code

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -27,6 +27,7 @@
     "@octokit/rest": "^21.1.1",
     "@playwright/test": "^1.53.0",
     "ai": "^5.0.22",
+    "ai-sdk-provider-claude-code": "^1.1.1",
     "archy": "^1.0.0",
     "axios": "^1.9.0",
     "cors": "^2.8.5",


### PR DESCRIPTION
## Summary
I was getting this error, but only when running from a docker image

```
docker logs b98
node:internal/modules/package_json_reader:255
  throw new ERR_MODULE_NOT_FOUND(packageName, fileURLToPath(base), null);
        ^

Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'ai-sdk-provider-claude-code' imported from /usr/src/app/build/aieo/src/provider.js
    at Object.getPackageJSONURL (node:internal/modules/package_json_reader:255:9)
    at packageResolve (node:internal/modules/esm/resolve:767:81)
    at moduleResolve (node:internal/modules/esm/resolve:853:18)
    at defaultResolve (node:internal/modules/esm/resolve:983:11)
    at ModuleLoader.defaultResolve (node:internal/modules/esm/loader:783:12)
    at #cachedDefaultResolve (node:internal/modules/esm/loader:707:25)
    at ModuleLoader.resolve (node:internal/modules/esm/loader:690:38)
    at ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:307:38)
    at ModuleJob._link (node:internal/modules/esm/module_job:183:49) {
  code: 'ERR_MODULE_NOT_FOUND'
}

Node.js v22.18.0
```

---

note: adding this package to package.json isnt the correct way since it should work when in `src/aieo/package.json` but for some reason it was not working but this is a quick fix so the docker image works 