### PR TITLE
feat: add React component name extraction to DOM inspector

### DIFF
--- a/mcp/tests/staktrak/src/debug.ts
+++ b/mcp/tests/staktrak/src/debug.ts
@@ -1,5 +1,7 @@
 // DOM Inspector utilities for bug identification feature
 
+import { ComponentInfo } from './types';
+
 export interface SourceMapping {
   element: Element;
   source?: string;
@@ -57,6 +59,88 @@ export function isReactDevModeActive(): boolean {
   } catch (error) {
     console.error("Error checking React dev mode:", error);
     return false;
+  }
+}
+
+/**
+ * Extract React component name from a fiber node
+ */
+function getComponentNameFromFiber(element: Element): ComponentInfo | null {
+  try {
+    // Find React fiber key
+    const fiberKey = Object.keys(element).find(
+      (key) =>
+        key.startsWith("__reactFiber$") ||
+        key.startsWith("__reactInternalInstance$")
+    );
+
+    if (!fiberKey) {
+      return null;
+    }
+
+    // @ts-expect-error - Accessing React internals
+    let fiber = element[fiberKey];
+    let level = 0;
+    const maxTraversalDepth = 10;
+
+    while (fiber && level < maxTraversalDepth) {
+      // Skip host components (DOM elements like div, span, etc.)
+      if (typeof fiber.type === 'string') {
+        fiber = fiber.return;
+        level++;
+        continue;
+      }
+
+      // Extract component name from various React patterns
+      if (fiber.type) {
+        let componentName: string | null = null;
+
+        // Standard function/class components
+        if (fiber.type.displayName) {
+          componentName = fiber.type.displayName;
+        } else if (fiber.type.name) {
+          componentName = fiber.type.name;
+        }
+        // React.forwardRef components
+        else if (fiber.type.render) {
+          componentName = fiber.type.render.displayName || fiber.type.render.name || 'ForwardRef';
+        }
+        // React.memo components
+        else if (fiber.type.type) {
+          componentName = fiber.type.type.displayName || fiber.type.type.name || 'Memo';
+        }
+        // React.lazy components
+        else if (fiber.type._payload && fiber.type._payload._result) {
+          componentName = fiber.type._payload._result.name || 'LazyComponent';
+        }
+        // Context consumers/providers
+        else if (fiber.type._context) {
+          componentName = fiber.type._context.displayName || 'Context';
+        }
+        // Handle Fragment
+        else if (fiber.type === Symbol.for('react.fragment')) {
+          fiber = fiber.return;
+          level++;
+          continue;
+        }
+
+        if (componentName) {
+          return {
+            name: componentName,
+            level: level,
+            type: typeof fiber.type === 'function' ? 'function' : 'class'
+          };
+        }
+      }
+
+      fiber = fiber.return;
+      level++;
+    }
+
+    return null;
+  } catch (error) {
+    console.error("Error extracting component name:", error);
+    return null;
   }
 }
 
@@ -149,8 +233,24 @@ export function debugMsg(data: DebugMsgData) {
       file: string;
       lines: number[];
       context?: string;
+      message?: string;
+      componentNames?: Array<{
+        name: string;
+        level: number;
+        type: string;
+        element: string;
+      }>;
     }> = [];
     const processedFiles = new Map<string, Set<number>>();
+    
+    // Track component names found
+    const componentNames: Array<{
+      name: string;
+      level: number;
+      type: string;
+      element: string;
+    }> = [];
+    const processedComponents = new Set<string>();
 
     // Get element at point or elements in region
     let elementsToProcess: Element[] = [];
@@ -187,6 +287,18 @@ export function debugMsg(data: DebugMsgData) {
 
     // Process each element to extract debug source
     for (const element of elementsToProcess) {
+      // First try to extract React component name
+      const componentInfo = getComponentNameFromFiber(element);
+      if (componentInfo && !processedComponents.has(componentInfo.name)) {
+        processedComponents.add(componentInfo.name);
+        componentNames.push({
+          name: componentInfo.name,
+          level: componentInfo.level,
+          type: componentInfo.type,
+          element: element.tagName.toLowerCase()
+        });
+      }
+      
       // First check for data attributes (if using react-dev-inspector or similar)
       const dataSource =
         element.getAttribute("data-source") ||
@@ -253,6 +365,58 @@ export function debugMsg(data: DebugMsgData) {
     sourceFiles.forEach((file) => {
       file.lines.sort((a, b) => a - b);
     });
+    
+    // Helper function to format components for chat display
+    const formatComponentsForChat = (components: typeof componentNames): string | undefined => {
+      if (components.length === 0) return undefined;
+
+      // Sort by level (closest to clicked element first) and take top 3
+      const sortedComponents = components
+        .sort((a, b) => a.level - b.level)
+        .slice(0, 3);
+
+      const componentLines = sortedComponents.map(c => {
+        const nameToUse = c.name || 'Unknown';
+        return `&lt;${nameToUse}&gt; (${c.level} level${c.level !== 1 ? 's' : ''} up)`;
+      });
+
+      return "React Components Found:\n" + componentLines.join("\n");
+    };
+    
+    // Enhanced fallback with component information
+    if (sourceFiles.length === 0) {
+      if (componentNames.length > 0) {
+        // We found components but no source mapping
+        const formattedMessage = formatComponentsForChat(componentNames);
+        sourceFiles.push({
+          file: "React component detected",
+          lines: [],
+          context: `Components found: ${componentNames.map(c => c.name).join(", ")}`,
+          componentNames: componentNames,
+          message: formattedMessage
+        });
+      } else {
+        // No components or source mapping found
+        sourceFiles.push({
+          file: "No React components detected",
+          lines: [],
+          context: "The selected element may not be a React component or may be a native DOM element",
+          message: "Try selecting an interactive element like a button or link"
+        });
+      }
+    } else {
+      // Add component names to existing source files
+      sourceFiles.forEach(file => {
+        if (!file.componentNames && componentNames.length > 0) {
+          file.componentNames = componentNames;
+          // Add formatted message to existing files too
+          const formattedMessage = formatComponentsForChat(componentNames);
+          if (formattedMessage) {
+            file.message = formattedMessage;
+          }
+        }
+      });
+    }
 
     // Send response back to parent frame
     window.parent.postMessage(

--- a/mcp/tests/staktrak/src/types.ts
+++ b/mcp/tests/staktrak/src/types.ts
@@ -26,6 +26,12 @@ export interface Assertion {
   timestamp: number;
 }
 
+export interface ComponentInfo {
+  name: string;
+  level: number;
+  type: 'function' | 'class';
+}
+
 // Add to types.ts
 export interface ClickDetail {
   x: number;


### PR DESCRIPTION
- Add getComponentNameFromFiber function to extract component names from React fiber tree
- Support various React patterns: function/class components, ForwardRef, Memo, Lazy, Context
- Format component hierarchy with levels for chat display
- Add ComponentInfo type for component metadata
- Enhance debugMsg to collect and format component information
- Provide fallback messages when no components are detected