### PR TITLE
fix: trim out describe from react/nextjs integration tests

### DIFF
--- a/ast/src/lang/queries/react.rs
+++ b/ast/src/lang/queries/react.rs
@@ -84,10 +84,6 @@ impl Stack for ReactTs {
         if NETWORK_MARKERS.iter().any(|m| body_l.contains(m)) {
             return NodeType::IntegrationTest;
         }
-       if NETWORK_MARKERS.iter().any(|m| body_l.contains(m)) {
-            return NodeType::IntegrationTest;
-        }
-
         NodeType::UnitTest
     }
     fn is_lib_file(&self, file_name: &str) -> bool {
@@ -409,23 +405,6 @@ impl Stack for ReactTs {
             ] @{FUNCTION_DEFINITION}"#
         ))
     }
-    fn integration_test_query(&self) -> Option<String> {
-        Some(format!(
-            r#"[
-                (call_expression
-                    function: (identifier) @describe (#eq? @describe "describe")
-                    arguments: (arguments [ (string) (template_string) ] @{TEST_NAME} (_))
-                ) @{INTEGRATION_TEST}
-                (call_expression
-                    function: (member_expression
-                        object: (identifier) @describe2 (#eq? @describe2 "describe")
-                        property: (property_identifier) @mod (#match? @mod "^(only|skip|each)$")
-                    )
-                    arguments: (arguments [ (string) (template_string) ] @{TEST_NAME} (_))
-                ) @{INTEGRATION_TEST}
-            ]"#
-        ))
-    }
     fn e2e_test_query(&self) -> Option<String> {
         Some(format!(
             r#"[
@@ -704,25 +683,22 @@ impl Stack for ReactTs {
         }
         vec![format!(
             r#"
-(lexical_declaration
-	(variable_declarator
-    	name: (object_pattern
-        	;; first only
-        	. (shorthand_property_identifier_pattern) @{EXTRA_PROP}
-        )?
-        value: (call_expression
-            function: (identifier) @{EXTRA_NAME} (#match? @{EXTRA_NAME} "{extra_regex}")
-        )
-    )
-) @{EXTRA}?
+            (lexical_declaration
+                (variable_declarator
+                    name: (object_pattern
+                        ;; first only
+                        . (shorthand_property_identifier_pattern) @{EXTRA_PROP}
+                    )?
+                    value: (call_expression
+                        function: (identifier) @{EXTRA_NAME} (#match? @{EXTRA_NAME} "{extra_regex}")
+                    )
+                )
+            ) @{EXTRA}?
             "#,
         )]
     }
 
     fn use_extra_page_finder(&self) -> bool {
-        true
-    }
-    fn use_integration_test_finder(&self) -> bool {
         true
     }
     fn is_extra_page(&self, file_name: &str) -> bool {

--- a/ast/src/testing/nextjs/mod.rs
+++ b/ast/src/testing/nextjs/mod.rs
@@ -225,11 +225,11 @@ pub async fn test_nextjs_generic<G: Graph>() -> Result<()> {
 
     let calls = graph.count_edges_of_type(EdgeType::Calls);
     edges += calls;
-    assert_eq!(calls, 84, "Expected 84 Calls edges");
+    assert_eq!(calls, 74, "Expected 74 Calls edges");
 
     let contains = graph.count_edges_of_type(EdgeType::Contains);
     edges += contains;
-    assert_eq!(contains, 153, "Expected 153 Contains edges");
+    assert_eq!(contains, 150, "Expected 150 Contains edges");
 
     let handlers = graph.count_edges_of_type(EdgeType::Handler);
     edges += handlers;
@@ -241,7 +241,7 @@ pub async fn test_nextjs_generic<G: Graph>() -> Result<()> {
 
     let integration_test = graph.find_nodes_by_type(NodeType::IntegrationTest);
     nodes += integration_test.len();
-    assert_eq!(integration_test.len(), 13, "Expected 13 IntegrationTest nodes");
+    assert_eq!(integration_test.len(), 10, "Expected 10 IntegrationTest nodes");
 
 
     let e2e_tests = graph.find_nodes_by_type(NodeType::E2eTest);


### PR DESCRIPTION
Removed `describe` from integratin tests 

closes #586 