### PR TITLE
Add file-based search to map endpoint as alternative to name search

### DIFF
--- a/mcp/src/graph/graph.ts
+++ b/mcp/src/graph/graph.ts
@@ -187,6 +187,7 @@ function formatEdge(edge: Neo4jEdge): string {
 export interface MapParams {
   node_type: string;
   name: string;
+  file: string;
   ref_id: string;
   tests: boolean;
   depth: number;
@@ -198,6 +199,7 @@ export async function get_subtree(p: MapParams) {
   const r = await db.get_subtree(
     p.node_type as NodeType,
     p.name,
+    p.file,
     p.ref_id,
     p.tests,
     p.depth,
@@ -243,6 +245,7 @@ export async function get_file_map(file_end: string): Promise<string> {
   const record = await get_subtree({
     node_type: "File",
     name: "",
+    file: "",
     ref_id: f.ref_id as string,
     depth: 1,
     tests: false,

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -168,6 +168,7 @@ class Db {
   async get_subtree(
     node_type: NodeType,
     name: string,
+    file: string,
     ref_id: string,
     include_tests: boolean,
     depth: number,
@@ -190,6 +191,7 @@ class Db {
       return await session.run(Q.SUBGRAPH_QUERY, {
         node_label: node_type,
         node_name: name,
+        node_file: file,
         ref_id: ref_id,
         depth,
         direction,

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -333,23 +333,31 @@ LIMIT toInteger($limit)
 export const SUBGRAPH_QUERY = `
 WITH $node_label AS nodeLabel,
      $node_name as nodeName,
+     $node_file as nodeFile,
      $ref_id as refId,
      $direction as direction,
      $label_filter as labelFilter,
      $depth as depth,
      $trim as trim
 
-// Find the start node using either ref_id or name+label
+// Find the start node using either ref_id, name+label, or file+label
 OPTIONAL MATCH (fByName {name: nodeName})
 WHERE any(label IN labels(fByName) WHERE label = nodeLabel)
+
+OPTIONAL MATCH (fByFile)
+WHERE any(label IN labels(fByFile) WHERE label = nodeLabel)
+  AND fByFile.file IS NOT NULL
+  AND fByFile.file CONTAINS nodeFile
+  AND nodeFile <> ''
 
 OPTIONAL MATCH (fByRefId {ref_id: refId})
 WHERE refId <> ''
 
-// ref_id takes precedence over name+label
+// ref_id takes precedence, then name+label, then file+label
 WITH CASE
        WHEN fByRefId IS NOT NULL THEN fByRefId
-       ELSE fByName
+       WHEN fByName IS NOT NULL THEN fByName
+       ELSE fByFile
      END AS f,
      direction, labelFilter, depth, trim
 WHERE f IS NOT NULL

--- a/mcp/src/graph/routes.ts
+++ b/mcp/src/graph/routes.ts
@@ -573,6 +573,7 @@ const DEFAULT_DEPTH = 7;
 interface MapParams {
   node_type: string;
   name: string;
+  file: string;
   ref_id: string;
   tests: boolean;
   depth: number;
@@ -583,10 +584,12 @@ interface MapParams {
 function mapParams(req: Request): MapParams {
   const node_type = req.query.node_type as string;
   const name = req.query.name as string;
+  const file = req.query.file as string;
   const ref_id = req.query.ref_id as string;
   const name_and_type = node_type && name;
-  if (!name_and_type && !ref_id) {
-    throw new Error("either node_type+name or ref_id required");
+  const file_and_type = node_type && file;
+  if (!name_and_type && !file_and_type && !ref_id) {
+    throw new Error("either node_type+name, node_type+file, or ref_id required");
   }
   const direction = req.query.direction as G.Direction;
   const tests = !(req.query.tests === "false" || req.query.tests === "0");
@@ -595,6 +598,7 @@ function mapParams(req: Request): MapParams {
   return {
     node_type: node_type || "",
     name: name || "",
+    file: file || "",
     ref_id: ref_id || "",
     tests,
     depth,

--- a/mcp/src/tools/explore/tool.ts
+++ b/mcp/src/tools/explore/tool.ts
@@ -116,6 +116,7 @@ export async function get_context(
           return await G.get_map({
             node_type: "Function",
             name: starting_node,
+            file: "",
             ref_id: "",
             tests: false,
             depth: depth || 1,

--- a/mcp/src/tools/stakgraph/get_map.ts
+++ b/mcp/src/tools/stakgraph/get_map.ts
@@ -7,6 +7,7 @@ export function toMapParams(args: z.infer<typeof GetMapSchema>): G.MapParams {
   return {
     node_type: args.node_type || "",
     name: args.name || "",
+    file: args.file || "",
     ref_id: args.ref_id || "",
     tests: args.tests ?? false,
     depth: args.depth ?? 10,
@@ -23,11 +24,12 @@ export const GetMapSchema = z.object({
       "Type of the node. Does NOT support Repository, Directory, or File."
     ),
   name: z.string().optional().describe("Name of the node to map from."),
+  file: z.string().optional().describe("File path pattern to search for (node.file CONTAINS this value)."),
   ref_id: z
     .string()
     .optional()
     .describe(
-      "Reference ID of the node (either ref_id or node_type+name must be provided)."
+      "Reference ID of the node (either ref_id, node_type+name, or node_type+file must be provided)."
     ),
   tests: z
     .boolean()


### PR DESCRIPTION
## How It Works
The endpoint now accepts three different ways to find your starting node:

**Option 1: By name (existing)**
```bash
GET /map?node_type=Function&name=authenticateUser
```

**Option 2: By file path (new!)**  
```bash
GET /map?node_type=Function&file=auth/login.ts
GET /map?node_type=Component&file=components/user
```

**Option 3: By ref_id (existing)**
```bash
GET /map?ref_id=abc-123-def
```

## Closed: #648

## Technical Details
- Uses `CONTAINS` matching for file paths (so `file=auth` finds `src/auth/login.ts`)
- Maintains backward compatibility - all existing queries work unchanged
- Added proper validation to ensure you provide either name+type, file+type, or ref_id
- Updated the Cypher query to handle the new file-based node lookup

