### PR TITLE
chore: clean up collect.rs

### DIFF
--- a/ast/src/lang/parse/collect.rs
+++ b/ast/src/lang/parse/collect.rs
@@ -325,20 +325,7 @@ impl Lang {
         if self.lang.e2e_test_query().is_none() {
             return Ok(Vec::new());
         }
-        let f = file.replace('\\', "/");
-        let lower_code = code.to_lowercase();
-        let fname = f.rsplit('/').next().unwrap_or(&f).to_lowercase();
-        let is_e2e_dir = f.contains("/tests/e2e/")
-            || f.contains("/test/e2e")
-            || f.contains("/e2e/")
-            || f.contains("/__e2e__/")
-            || f.contains("e2e.");
-        let has_e2e_in_name = fname.contains("e2e");
-        let has_playwright = lower_code.contains("@playwright/test");
-        let has_cypress = lower_code.contains("cy.");
-        let has_puppeteer =
-            lower_code.contains("puppeteer") || lower_code.contains("browser.newpage");
-        if !(is_e2e_dir || has_e2e_in_name || has_playwright || has_cypress || has_puppeteer) {
+        if !self.lang.is_e2e_test_file(file, code) {
             return Ok(Vec::new());
         }
         let q = self.q(&self.lang.e2e_test_query().unwrap(), &NodeType::E2eTest);

--- a/ast/src/lang/queries/go.rs
+++ b/ast/src/lang/queries/go.rs
@@ -285,6 +285,38 @@ impl Stack for Go {
     fn is_test_file(&self, filename: &str) -> bool {
         filename.ends_with("_test.go")
     }
+
+    fn is_e2e_test_file(&self, file: &str, code: &str) -> bool {
+        let f = file.replace('\\', "/").to_lowercase();
+        let lower_code = code.to_lowercase();
+        
+        if f.contains("/e2e/") 
+            || f.contains("/test/e2e/")
+            || f.contains("/tests/e2e/")
+        {
+            return true;
+        }
+        
+        let fname = f.rsplit('/').next().unwrap_or(&f);
+        if fname.contains("e2e") || fname.contains("_e2e_test.go") {
+            return true;
+        }
+        
+        let has_selenium = lower_code.contains("selenium") 
+            || lower_code.contains("webdriver")
+            || lower_code.contains("github.com/tebeka/selenium");
+        
+        let has_chromedp = lower_code.contains("chromedp")
+            || lower_code.contains("github.com/chromedp/chromedp");
+        
+        let has_playwright = lower_code.contains("playwright")
+            || lower_code.contains("github.com/playwright-community/playwright-go");
+        
+        let has_rod = lower_code.contains("github.com/go-rod/rod");
+        
+        has_selenium || has_chromedp || has_playwright || has_rod
+    }
+
     fn integration_test_query(&self) -> Option<String> {
         Some(format!(
             r#"(call_expression

--- a/ast/src/lang/queries/mod.rs
+++ b/ast/src/lang/queries/mod.rs
@@ -185,6 +185,9 @@ pub trait Stack {
     fn is_test_file(&self, _filename: &str) -> bool {
         false
     }
+    fn is_e2e_test_file(&self, _file: &str, _code: &str) -> bool {
+        false
+    }
     fn classify_test(&self, _name: &str, _file: &str, _body: &str) -> NodeType {
         NodeType::UnitTest
     }

--- a/ast/src/lang/queries/react.rs
+++ b/ast/src/lang/queries/react.rs
@@ -926,6 +926,25 @@ impl Stack for ReactTs {
             || file_name.ends_with(".spec.js")
     }
 
+    fn is_e2e_test_file(&self, file: &str, code: &str) -> bool {
+        let f = file.replace('\\', "/");
+        let lower_code = code.to_lowercase();
+        let fname = f.rsplit('/').next().unwrap_or(&f).to_lowercase();
+        
+        let is_e2e_dir = f.contains("/tests/e2e/")
+            || f.contains("/test/e2e")
+            || f.contains("/e2e/")
+            || f.contains("/__e2e__/")
+            || f.contains("e2e.");
+        let has_e2e_in_name = fname.contains("e2e");
+        let has_playwright = lower_code.contains("@playwright/test");
+        let has_cypress = lower_code.contains("cy.");
+        let has_puppeteer =
+            lower_code.contains("puppeteer") || lower_code.contains("browser.newpage");
+        
+        is_e2e_dir || has_e2e_in_name || has_playwright || has_cypress || has_puppeteer
+    }
+
     fn is_test(&self, _func_name: &str, func_file: &str) -> bool {
         if self.is_test_file(func_file) {
             true

--- a/ast/src/lang/queries/ruby.rs
+++ b/ast/src/lang/queries/ruby.rs
@@ -253,11 +253,44 @@ impl Stack for Ruby {
         self.is_test_file(func_file)
     }
     fn is_test_file(&self, filename: &str) -> bool {
-    filename.ends_with("_spec.rb")          
-        || filename.ends_with("_test.rb")   
-        || filename.contains("/spec/")       
-        || filename.contains("/test/")
-}
+        filename.ends_with("_spec.rb")          
+            || filename.ends_with("_test.rb")   
+            || filename.contains("/spec/")       
+            || filename.contains("/test/")
+    }
+
+    fn is_e2e_test_file(&self, file: &str, code: &str) -> bool {
+        let f = file.replace('\\', "/").to_lowercase();
+        let lower_code = code.to_lowercase();
+        
+        if f.contains("/spec/system/")
+            || f.contains("/spec/features/")
+            || f.contains("/spec/feature/")
+            || f.contains("/spec/acceptance/")
+            || f.contains("/test/system/")
+        {
+            return true;
+        }
+        
+        let fname = f.rsplit('/').next().unwrap_or(&f);
+        if fname.contains("e2e") || fname.contains("system") {
+            return true;
+        }
+        
+        let has_capybara = lower_code.contains("visit(") 
+            || lower_code.contains("click_")
+            || lower_code.contains("fill_in(")
+            || lower_code.contains("have_content(");
+        
+        let has_selenium = lower_code.contains("selenium") 
+            || lower_code.contains("webdriver");
+        
+        let has_cuprite = lower_code.contains("cuprite")
+            || lower_code.contains("driven_by(:cuprite)");
+        
+        has_capybara || has_selenium || has_cuprite
+    }
+
     fn e2e_test_id_finder_string(&self) -> Option<String> {
         Some("get_by_test_id".to_string())
     }

--- a/ast/src/lang/queries/typescript.rs
+++ b/ast/src/lang/queries/typescript.rs
@@ -335,18 +335,35 @@ impl Stack for TypeScript {
     }
      fn is_test_file(&self, file_name: &str) -> bool {
         file_name.contains("__tests__")
+            || file_name.contains(".test.")
+            || file_name.contains(".spec.")
             || file_name.ends_with(".test.ts")
             || file_name.ends_with(".test.tsx")
-            || file_name.ends_with(".test.jsx")
             || file_name.ends_with(".test.js")
-            || file_name.ends_with(".e2e.ts")
-            || file_name.ends_with(".e2e.tsx")
-            || file_name.ends_with(".e2e.jsx")
-            || file_name.ends_with(".e2e.js")
+            || file_name.ends_with(".test.jsx")
             || file_name.ends_with(".spec.ts")
             || file_name.ends_with(".spec.tsx")
-            || file_name.ends_with(".spec.jsx")
             || file_name.ends_with(".spec.js")
+            || file_name.ends_with(".spec.jsx")
+    }
+
+    fn is_e2e_test_file(&self, file: &str, code: &str) -> bool {
+        let f = file.replace('\\', "/");
+        let lower_code = code.to_lowercase();
+        let fname = f.rsplit('/').next().unwrap_or(&f).to_lowercase();
+        
+        let is_e2e_dir = f.contains("/tests/e2e/")
+            || f.contains("/test/e2e")
+            || f.contains("/e2e/")
+            || f.contains("/__e2e__/")
+            || f.contains("e2e.");
+        let has_e2e_in_name = fname.contains("e2e");
+        let has_playwright = lower_code.contains("@playwright/test");
+        let has_cypress = lower_code.contains("cy.");
+        let has_puppeteer =
+            lower_code.contains("puppeteer") || lower_code.contains("browser.newpage");
+        
+        is_e2e_dir || has_e2e_in_name || has_playwright || has_cypress || has_puppeteer
     }
 
     fn is_test(&self, _func_name: &str, func_file: &str) -> bool {


### PR DESCRIPTION
Removes `collect_e2e_tests` from `collect.rs` to make agnostic.. moves it to language queries. 

Closes: #643 