### PR TITLE
feat: budget tracking foundation

### DIFF
--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -22,6 +22,30 @@ const SOTA = {
   claude_code: "sonnet",
 };
 
+export interface TokenPricing {
+  inputTokenPrice: number;
+  outputTokenPrice: number;
+}
+
+const TOKEN_PRICING: Record<Provider, TokenPricing> = {
+  anthropic: {
+    inputTokenPrice: 3.0,
+    outputTokenPrice: 15.0,
+  },
+  google: {
+    inputTokenPrice: 1.25,
+    outputTokenPrice: 5.0,
+  },
+  openai: {
+    inputTokenPrice: 2.5,
+    outputTokenPrice: 10.0,
+  },
+  claude_code: {
+    inputTokenPrice: 3.0,
+    outputTokenPrice: 15.0,
+  },
+};
+
 export function getApiKeyForProvider(provider: Provider | string): string {
   let apiKey: string | undefined;
   switch (provider) {
@@ -90,6 +114,10 @@ export async function getModel(
     default:
       throw new Error(`Unsupported provider: ${provider}`);
   }
+}
+
+export function getTokenPricing(provider: Provider): TokenPricing {
+  return TOKEN_PRICING[provider];
 }
 
 export type ThinkingSpeed = "thinking" | "fast";

--- a/mcp/src/aieo/src/stream.ts
+++ b/mcp/src/aieo/src/stream.ts
@@ -17,7 +17,10 @@ interface CallModelOptions {
   executablePath?: string;
 }
 
-export async function callModel(opts: CallModelOptions): Promise<string> {
+export async function callModel(opts: CallModelOptions): Promise<{
+  text: string;
+  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+}> {
   const {
     provider,
     apiKey,
@@ -52,7 +55,15 @@ export async function callModel(opts: CallModelOptions): Promise<string> {
         break;
     }
   }
-  return fullResponse;
+  const usage = await result.usage;
+  return {
+    text: fullResponse,
+    usage: {
+      inputTokens: usage.inputTokens || 0,
+      outputTokens: usage.outputTokens || 0,
+      totalTokens: usage.totalTokens || 0,
+    },
+  };
 }
 
 interface GenerateObjectArgs {
@@ -62,12 +73,22 @@ interface GenerateObjectArgs {
   schema: any;
 }
 
-export async function callGenerateObject(args: GenerateObjectArgs) {
+export async function callGenerateObject(args: GenerateObjectArgs): Promise<{
+  object: any;
+  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+}> {
   const model = await getModel(args.provider, args.apiKey);
-  const { object } = await generateObject({
+  const { object, usage } = await generateObject({
     model,
     schema: args.schema,
     prompt: args.prompt,
   });
-  return object;
+  return {
+    object,
+    usage: {
+      inputTokens: usage.inputTokens || 0,
+      outputTokens: usage.outputTokens || 0,
+      totalTokens: usage.totalTokens || 0,
+    },
+  };
 }

--- a/mcp/src/tools/budget.ts
+++ b/mcp/src/tools/budget.ts
@@ -1,0 +1,74 @@
+import { getTokenPricing, Provider } from "../aieo/src/provider.js";
+
+export interface BudgetTracker {
+  budgetLimit: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  provider: Provider;
+}
+
+export interface BudgetInfo {
+  totalCost: number;
+  budgetExceeded: boolean;
+  remainingBudget: number;
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+}
+
+export function createBudgetTracker(
+  budgetDollars: number,
+  provider: Provider = "anthropic"
+): BudgetTracker {
+  return {
+    budgetLimit: budgetDollars,
+    inputTokens: 0,
+    outputTokens: 0,
+    totalTokens: 0,
+    provider,
+  };
+}
+
+export function addUsage(
+  tracker: BudgetTracker,
+  inputTokens: number,
+  outputTokens: number,
+  provider?: Provider
+): BudgetTracker {
+  return {
+    ...tracker,
+    inputTokens: tracker.inputTokens + inputTokens,
+    outputTokens: tracker.outputTokens + outputTokens,
+    totalTokens: tracker.totalTokens + inputTokens + outputTokens,
+    provider: provider || tracker.provider,
+  };
+}
+
+export function getTotalCost(tracker: BudgetTracker): number {
+  const pricing = getTokenPricing(tracker.provider);
+  const inputCost = (tracker.inputTokens / 1_000_000) * pricing.inputTokenPrice;
+  const outputCost =
+    (tracker.outputTokens / 1_000_000) * pricing.outputTokenPrice;
+  return inputCost + outputCost;
+}
+
+export function isBudgetExceeded(tracker: BudgetTracker): boolean {
+  return getTotalCost(tracker) >= tracker.budgetLimit;
+}
+
+export function getRemainingBudget(tracker: BudgetTracker): number {
+  return Math.max(0, tracker.budgetLimit - getTotalCost(tracker));
+}
+
+export function getBudgetInfo(tracker: BudgetTracker): BudgetInfo {
+  const totalCost = getTotalCost(tracker);
+  return {
+    totalCost,
+    budgetExceeded: totalCost >= tracker.budgetLimit,
+    remainingBudget: Math.max(0, tracker.budgetLimit - totalCost),
+    inputTokens: tracker.inputTokens,
+    outputTokens: tracker.outputTokens,
+    totalTokens: tracker.totalTokens,
+  };
+}

--- a/mcp/src/tools/explore/tool.ts
+++ b/mcp/src/tools/explore/tool.ts
@@ -54,11 +54,12 @@ interface ToolConfig {
 export async function get_context(
   prompt: string | ModelMessage[],
   re_explore: boolean = false,
-  general_explore: boolean = false
+  general_explore: boolean = false,
+  provider?: string
 ): Promise<ContextResult> {
-  const provider = process.env.LLM_PROVIDER || "anthropic";
-  const apiKey = getApiKeyForProvider(provider);
-  const model = await getModel(provider as Provider, apiKey as string);
+  const effectiveProvider = provider || process.env.LLM_PROVIDER || "anthropic";
+  const apiKey = getApiKeyForProvider(effectiveProvider);
+  const model = await getModel(effectiveProvider as Provider, apiKey as string);
   // console.log("call claude:");
   const tools = {
     repo_overview: tool({

--- a/mcp/src/tools/intelligence/filter.ts
+++ b/mcp/src/tools/intelligence/filter.ts
@@ -44,14 +44,20 @@ export async function filterAnswers(
   qas: string,
   originalPrompt: string,
   llm_provider?: string
-): Promise<FilteredAnswer> {
+): Promise<{
+  answer: FilteredAnswer;
+  usage: { inputTokens: number; outputTokens: number; totalTokens: number };
+}> {
   console.log(">> filterAnswers!!!!");
   const provider = (llm_provider || "anthropic") as Provider;
   const apiKey = getApiKeyForProvider(provider);
-  const filtered = await callModel({
+  const result = await callModel({
     provider,
     apiKey,
     messages: [{ role: "user", content: FILTER_PROMPT(originalPrompt, qas) }],
   });
-  return filtered;
+  return {
+    answer: result.text,
+    usage: result.usage,
+  };
 }

--- a/mcp/src/tools/intelligence/index.ts
+++ b/mcp/src/tools/intelligence/index.ts
@@ -18,6 +18,7 @@ function mapConnectedHints(connected_hints: any[]) {
     reused_question: hint.properties.question || hint.properties.name,
     edges_added: 0,
     linked_ref_ids: [],
+    usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
   }));
 }
 
@@ -132,11 +133,20 @@ export async function ask_prompt(
             // Fetch connected hints (sub_answers) for this existing prompt
             const connected_hints = await db.get_connected_hints(top.ref_id);
             const hints = mapConnectedHints(connected_hints);
+            const totalUsage = hints.reduce(
+              (acc, h) => ({
+                inputTokens: acc.inputTokens + h.usage.inputTokens,
+                outputTokens: acc.outputTokens + h.usage.outputTokens,
+                totalTokens: acc.totalTokens + h.usage.totalTokens,
+              }),
+              { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+            );
 
             return {
               answer: top.properties.body,
               hints,
               ref_id: top.ref_id,
+              usage: totalUsage,
             };
           }
         } else {
@@ -146,11 +156,20 @@ export async function ask_prompt(
           // Fetch connected hints (sub_answers) for this existing prompt
           const connected_hints = await db.get_connected_hints(top.ref_id);
           const hints = mapConnectedHints(connected_hints);
+          const totalUsage = hints.reduce(
+            (acc, h) => ({
+              inputTokens: acc.inputTokens + h.usage.inputTokens,
+              outputTokens: acc.outputTokens + h.usage.outputTokens,
+              totalTokens: acc.totalTokens + h.usage.totalTokens,
+            }),
+            { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+          );
 
           return {
             answer: top.properties.body,
             hints,
             ref_id: top.ref_id,
+            usage: totalUsage,
           };
         }
       } else {
@@ -159,11 +178,20 @@ export async function ask_prompt(
         // Fetch connected hints (sub_answers) for this existing prompt
         const connected_hints = await db.get_connected_hints(top.ref_id);
         const hints = mapConnectedHints(connected_hints);
+        const totalUsage = hints.reduce(
+          (acc, h) => ({
+            inputTokens: acc.inputTokens + h.usage.inputTokens,
+            outputTokens: acc.outputTokens + h.usage.outputTokens,
+            totalTokens: acc.totalTokens + h.usage.totalTokens,
+          }),
+          { inputTokens: 0, outputTokens: 0, totalTokens: 0 }
+        );
 
         return {
           answer: top.properties.body,
           hints,
           ref_id: top.ref_id,
+          usage: totalUsage,
         };
       }
     }
@@ -175,6 +203,7 @@ export async function ask_prompt(
     return {
       answer: "",
       hints: [],
+      usage: { inputTokens: 0, outputTokens: 0, totalTokens: 0 },
     };
   }
 

--- a/mcp/src/tools/intelligence/persona.ts
+++ b/mcp/src/tools/intelligence/persona.ts
@@ -39,12 +39,13 @@ export async function rephraseHint(
   const provider = (llm_provider || "anthropic") as Provider;
   const apiKey = getApiKeyForProvider(provider);
   const schema = z.object({ question: z.string(), answer: z.string() });
-  return await callGenerateObject({
+  const result = await callGenerateObject({
     provider,
     apiKey,
     prompt: personaPrompt(persona, question, answer),
     schema,
   });
+  return result.object;
 }
 
 export async function generate_persona_variants(llm_provider?: string) {


### PR DESCRIPTION
Closes: #735 

output for the custom test questions in the repo. 
```bash
fayekelmith in ~/Kelmith/Projects/stakgraph/mcp on feat/budget-stories ● ● λ curl -X POST "http://localhost:3355/seed_understanding?provider=anthropic&budget=0.50" | jq '.budget'
{
  "totalCost": 1.731294,
  "budgetExceeded": true,
  "remainingBudget": 0,
  "questionsProcessed": 2,
  "questionsSkipped": 46,
  "inputTokens": 560408,
  "outputTokens": 3338,
  "totalTokens": 563746
}
```