### PR TITLE
fix: improve test classification

### DIFF
--- a/ast/src/lang/mod.rs
+++ b/ast/src/lang/mod.rs
@@ -439,6 +439,12 @@ impl Lang {
             let more_tests = self.collect_tests(&qo2, code, file, graph)?;
             for (mt, edge) in more_tests {
                 let mut nd = mt.0.clone();
+                
+                if !self.lang.is_test(&nd.name, &nd.file) {
+                    println!("[DEBUG mod.rs] Skipping '{}' - not a real test (no test attribute)", nd.name);
+                    continue;
+                }
+                
                 let kind = self.lang.classify_test(&nd.name, file, &nd.body);
                 let meta_kind = match kind {
                     NodeType::IntegrationTest => "integration",

--- a/ast/src/testing/ruby/mod.rs
+++ b/ast/src/testing/ruby/mod.rs
@@ -602,8 +602,8 @@ pub async fn test_ruby_generic<G: Graph>() -> Result<()> {
     let unit_tests = graph.find_nodes_by_type(NodeType::UnitTest);
     assert_eq!(
         unit_tests.len(),
-        9,
-        "Expected 9 unit tests, got {}",
+        7,
+        "Expected 7 unit tests, got {}",
         unit_tests.len()
     );
     nodes_count += unit_tests.len();
@@ -646,8 +646,8 @@ pub async fn test_ruby_generic<G: Graph>() -> Result<()> {
     let integration_tests = graph.find_nodes_by_type(NodeType::IntegrationTest);
     assert_eq!(
         integration_tests.len(),
-        6,
-        "Expected 6 integration tests, got {}",
+        7,
+        "Expected 7 integration tests, got {}",
         integration_tests.len()
     );
     nodes_count += integration_tests.len();
@@ -686,8 +686,8 @@ pub async fn test_ruby_generic<G: Graph>() -> Result<()> {
     let e2e_tests = graph.find_nodes_by_type(NodeType::E2eTest);
     assert_eq!(
         e2e_tests.len(),
-        7,
-        "Expected 7 e2e tests, got {}",
+        8,
+        "Expected 8 e2e tests, got {}",
         e2e_tests.len()
     );
     nodes_count += e2e_tests.len();

--- a/ast/src/testing/rust_test.rs
+++ b/ast/src/testing/rust_test.rs
@@ -192,7 +192,7 @@ use std::net::SocketAddr;"#
 
     let contains_edges = graph.count_edges_of_type(EdgeType::Contains);
     edges_count += contains_edges;
-    assert_eq!(contains_edges, 106, "Expected 106 contains edges");
+    assert_eq!(contains_edges, 104, "Expected 104 contains edges");
 
     let calls_edges = graph.count_edges_of_type(EdgeType::Calls);
     edges_count += calls_edges;
@@ -201,27 +201,19 @@ use std::net::SocketAddr;"#
 
     let functions = graph.find_nodes_by_type(NodeType::Function);
     nodes_count += functions.len();
-    println!("{:#?}", functions.iter().map(|f| f.name.clone()).collect::<Vec<_>>());
     assert_eq!(functions.len(), 25, "Expected 25 functions");
 
 
     let unit_tests = graph.find_nodes_by_type(NodeType::UnitTest);
     nodes_count += unit_tests.len();
-    println!("--- Unit Tests ---");
-    println!("{:#?}", unit_tests.iter().map(|f| f.name.clone()).collect::<Vec<_>>());
-    // FIXME: Unit test deeply flawed... catches all other tests...
-    assert_eq!(unit_tests.len(), 9, "Expected 9 unit tests (4 db.rs + 2 axum + 2 benchmarks)");
+    assert_eq!(unit_tests.len(), 8, "Expected 8 unit tests (4 db.rs + 2 axum + 2 benchmarks)");
 
     let integration_tests = graph.find_nodes_by_type(NodeType::IntegrationTest);
     nodes_count += integration_tests.len();
-    println!("--- Integration Tests ---");
-    println!("{:#?}", integration_tests.iter().map(|f| f.name.clone()).collect::<Vec<_>>());
-    assert_eq!(integration_tests.len(), 5, "Expected 5 integration tests");
+    assert_eq!(integration_tests.len(), 4, "Expected 4 integration tests");
 
     let e2e_tests = graph.find_nodes_by_type(NodeType::E2eTest);
     nodes_count += e2e_tests.len();
-    println!("--- E2E Tests ---");
-    println!("{:#?}", e2e_tests.iter().map(|f| f.name.clone()).collect::<Vec<_>>());
     assert_eq!(e2e_tests.len(), 4, "Expected 4 e2e tests (including #[ignore] test)");
 
     let handlers = graph.count_edges_of_type(EdgeType::Handler);


### PR DESCRIPTION
- [X] Resolve test classification to use `classify_test`
- [x] Tighten rust test-like attributes query
