### PR TITLE
chore: more data from /tests/nodes

### DIFF
--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -861,16 +861,26 @@ pub async fn nodes_handler(
         .into_iter()
         .map(
             |(node_data, usage_count, covered, test_count, ref_id, body_length, line_count)| {
+                let verb = if node_type == NodeType::Endpoint {
+                    node_data.meta.get("verb").cloned()
+                } else {
+                    None
+                };
+
                 if concise {
                     NodesResponseItem::Concise(NodeConcise {
-                        name: node_data.name,
-                        file: node_data.file,
+                        name: node_data.name.clone(),
+                        file: node_data.file.clone(),
                         ref_id,
                         weight: usage_count,
                         test_count,
                         covered,
                         body_length,
                         line_count,
+                        verb,
+                        start: node_data.start,
+                        end: node_data.end,
+                        meta: node_data.meta,
                     })
                 } else {
                     NodesResponseItem::Full(Node {

--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -146,6 +146,13 @@ pub struct NodeConcise {
     pub covered: bool,
     pub body_length: Option<i64>,
     pub line_count: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub verb: Option<String>,
+    pub start: usize,
+    pub end: usize,
+    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    #[serde(default)]
+    pub meta: std::collections::BTreeMap<String, String>,
 }
 
 #[derive(Serialize, Deserialize, Debug, Clone)]


### PR DESCRIPTION
```
pub struct NodeConcise {
    pub name: String,
    pub file: String,
    pub ref_id: String,
    pub weight: usize,
    pub test_count: usize,
    pub covered: bool,
    pub body_length: Option<i64>,
    pub line_count: Option<i64>,
    #[serde(skip_serializing_if = "Option::is_none")]
    pub verb: Option<String>,
    pub start: usize,
    pub end: usize,
    #[serde(skip_serializing_if = "std::collections::BTreeMap::is_empty")]
    #[serde(default)]
    pub meta: std::collections::BTreeMap<String, String>,
}
```

example: 

```
   {
      "name": "/api/bounties/[id]",
      "file": "stakwork/sphinx-bounties/src/app/api/bounties/[id]/route.ts",
      "ref_id": "6c43afb3-64a4-4c4c-911c-b6273d45144a",
      "weight": 4,
      "test_count": 4,
      "covered": true,
      "body_length": 4291,
      "line_count": 161,
      "verb": "GET",
      "start": 100,
      "end": 260,
      "meta": {
        "Data_Bank": "/api/bounties/[id]",
        "date_added_to_graph": "1761154252.9108951",
        "handler": "GET",
        "namespace": "default",
        "node_key": "endpoint-apibountiesid-stakworksphinxbountiessrcappapibountiesidroutets-100-get",
        "ref_id": "6c43afb3-64a4-4c4c-911c-b6273d45144a",
        "verb": "GET"
      }
    }
  ],
  "total_returned": 10,
  "total_count": 25,
  "total_pages": 3,
  "current_page": 1
  ```