### PR TITLE
Fix navigation toast notifications appearing when not recording

### DIFF
--- a/mcp/src/__tests__/staktrak/PR-742-TEST-PLAN.md
+++ b/mcp/src/__tests__/staktrak/PR-742-TEST-PLAN.md
@@ -1,0 +1,62 @@
+# Test Plan for PR #742: Screenshot Capture & Type Normalization
+
+**Note:** This document covers tests specifically created for PR #742. The `src/__tests__/` directory may contain other test files.
+
+This test plan provides comprehensive coverage for PR #742 changes:
+- Type field normalization (`kind` → `type`)
+- Screenshot capture with `modern-screenshot`
+- Parent origin security for cross-origin iframes
+- Action type renaming (`nav` → `goto`, `waitForUrl` → `waitForURL`)
+
+## Test Files (92 test cases)
+
+```
+src/__tests__/staktrak/
+├── test-helpers.ts                    # Shared utilities
+├── action-type-normalization.test.ts  # ~20 tests
+├── screenshot-capture.test.ts         # ~15 tests
+├── parent-origin-security.test.ts     # ~12 tests
+├── playwright-replay.test.ts          # ~18 tests
+├── backward-compatibility.test.ts     # ~15 tests
+└── e2e-screenshot-flow.test.ts        # ~12 tests
+```
+
+**Staktrak source code:** `/tests/staktrak/src/`
+
+## Running Tests
+
+```bash
+# All staktrak tests
+npx playwright test src/__tests__/staktrak/
+
+# Specific file
+npx playwright test src/__tests__/staktrak/action-type-normalization.test.ts
+
+# UI mode
+npx playwright test --ui src/__tests__/staktrak/
+
+# Debug mode
+npx playwright test --debug src/__tests__/staktrak/
+```
+
+## Import Paths
+
+Tests import from staktrak source using relative paths:
+```typescript
+import { RecordingManager } from '../../../tests/staktrak/src/playwright-generator';
+```
+
+## Coverage Summary
+
+1. **Type Normalization** - `kind` → `type`, `nav` → `goto`, `waitForURL`
+2. **Screenshots** - Capture after `waitForURL`, data URL validation, error handling
+3. **Security** - Parent origin capture, fallback logic, cross-origin handling
+4. **Integration** - Full replay flow with screenshots
+5. **Compatibility** - API unchanged, old format support
+6. **E2E** - Real browser, SPA navigation, performance
+
+## Links
+
+- **PR:** https://github.com/stakwork/stakgraph/pull/742
+- **Playwright:** https://playwright.dev/
+- **modern-screenshot:** https://github.com/qq15725/modern-screenshot

--- a/mcp/src/__tests__/staktrak/action-type-normalization.test.ts
+++ b/mcp/src/__tests__/staktrak/action-type-normalization.test.ts
@@ -1,0 +1,301 @@
+import { test, expect } from '@playwright/test';
+import {
+  loadStaktrakInPage,
+  startRecording,
+  getActions,
+  generatePlaywrightTest,
+  simulateClick,
+  simulateNavigation,
+  simulateInput,
+  simulateFormChange,
+  validateAction,
+  verifyNewNamingConvention,
+  hasOldFieldNames
+} from './test-helpers';
+
+test.describe('Action Type Normalization', () => {
+  test.describe('Action Creation - type field', () => {
+    test('should create actions with "type" field instead of "kind"', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+      expect(actions.length).toBeGreaterThan(0);
+
+      const clickAction = actions[0];
+      expect(clickAction).toHaveProperty('type');
+      expect(clickAction).not.toHaveProperty('kind');
+      expect(clickAction.type).toBe('click');
+    });
+
+    test('should use "goto" for navigation events', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000/test-page');
+
+      const actions = await getActions(page);
+      const gotoAction = actions.find(a => a.type === 'goto');
+
+      expect(gotoAction).toBeTruthy();
+      expect(gotoAction.type).toBe('goto');
+      expect(gotoAction.url).toContain('test-page');
+    });
+
+    test('should create click action with correct type', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+      const clickAction = actions[0];
+
+      expect(clickAction.type).toBe('click');
+      expect(clickAction.locator).toBeTruthy();
+      expect(validateAction(clickAction)).toBe(true);
+    });
+
+    test('should create input action with correct type', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateInput(page, '[data-testid="test-input"]', 'test value');
+
+      const actions = await getActions(page);
+      const inputAction = actions.find(a => a.type === 'input');
+
+      expect(inputAction).toBeTruthy();
+      expect(inputAction.type).toBe('input');
+      expect(inputAction.value).toBe('test value');
+      expect(validateAction(inputAction)).toBe(true);
+    });
+
+    test('should create form action with correct type', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateFormChange(page, '[data-testid="test-checkbox"]', true);
+
+      const actions = await getActions(page);
+      const formAction = actions.find(a => a.type === 'form');
+
+      expect(formAction).toBeTruthy();
+      expect(formAction.type).toBe('form');
+      expect(formAction.formType).toBeTruthy();
+      expect(validateAction(formAction)).toBe(true);
+    });
+
+    test('should maintain timestamp from event', async ({ page }) => {
+      await loadStaktrakInPage(page);
+
+      const beforeTime = await page.evaluate(() => Date.now());
+      await startRecording(page);
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+      const clickAction = actions[0];
+
+      expect(clickAction.timestamp).toBeGreaterThanOrEqual(beforeTime);
+      expect(clickAction.timestamp).toBeLessThanOrEqual(Date.now());
+    });
+  });
+
+  test.describe('Generated Actions - Type Field Presence', () => {
+    test('should generate actions with "type" field from tracking data', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+
+      expect(actions.length).toBeGreaterThan(0);
+      actions.forEach(action => {
+        expect(action).toHaveProperty('type');
+        expect(action).not.toHaveProperty('kind');
+      });
+    });
+
+    test('should generate "goto" actions for navigation', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000/test-page');
+
+      const actions = await getActions(page);
+      const gotoAction = actions.find(a => a.type === 'goto');
+
+      expect(gotoAction).toBeTruthy();
+      expect(gotoAction.type).toBe('goto');
+      expect(gotoAction.url).toBeTruthy();
+    });
+
+    test('should generate actions in correct order with type field', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      // Perform actions in order
+      await simulateNavigation(page, 'http://localhost:3000/page1');
+      await page.waitForTimeout(200);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(200);
+      await simulateInput(page, '[data-testid="test-input"]', 'test value');
+
+      const actions = await getActions(page);
+
+      expect(actions.length).toBeGreaterThanOrEqual(3);
+
+      // Check that all actions have type field
+      actions.forEach(action => {
+        expect(action).toHaveProperty('type');
+        expect(typeof action.type).toBe('string');
+      });
+
+      // Verify order (accounting for possible duplicate events)
+      const gotoAction = actions.find(a => a.type === 'goto');
+      const clickAction = actions.find(a => a.type === 'click');
+      const inputAction = actions.find(a => a.type === 'input');
+
+      expect(gotoAction).toBeTruthy();
+      expect(clickAction).toBeTruthy();
+      expect(inputAction).toBeTruthy();
+    });
+  });
+
+  test.describe('Code Generation - New Naming Convention', () => {
+    test('should generate test code using "goto" instead of "nav"', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000/test');
+
+      const testCode = await generatePlaywrightTest(page);
+
+      expect(testCode).toContain('await page.goto');
+      expect(testCode).not.toContain("'nav'");
+    });
+
+    test('should generate test with all action types correctly', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(200);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(200);
+      await simulateInput(page, '[data-testid="test-input"]', 'test input');
+
+      const testCode = await generatePlaywrightTest(page);
+
+      expect(testCode).toContain('await page.goto');
+      expect(testCode).toContain('await page.click');
+      expect(testCode).toContain('await page.fill');
+    });
+
+    test('should not include "kind" field in generated code comments or structure', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const testCode = await generatePlaywrightTest(page);
+
+      expect(testCode).not.toContain('kind');
+    });
+  });
+
+  test.describe('Full Flow with Type Consistency', () => {
+    test('should handle multiple events and maintain type consistency', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      // Perform various actions
+      await simulateNavigation(page, 'http://localhost:3000/test');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(100);
+      await simulateInput(page, '[data-testid="test-input"]', 'test');
+      await page.waitForTimeout(2100);
+      await simulateFormChange(page, '[data-testid="test-checkbox"]', true);
+
+      const actions = await getActions(page);
+
+      // All actions should have type field
+      actions.forEach(action => {
+        expect(action).toBeTruthy();
+        expect(action).toHaveProperty('type');
+        expect(action).not.toHaveProperty('kind');
+        expect(validateAction(action)).toBe(true);
+      });
+
+      // Check that we have expected types
+      const hasGoto = actions.some(a => a.type === 'goto');
+      const hasClick = actions.some(a => a.type === 'click');
+      const hasInput = actions.some(a => a.type === 'input');
+      const hasForm = actions.some(a => a.type === 'form');
+
+      expect(hasGoto).toBe(true);
+      expect(hasClick).toBe(true);
+      expect(hasInput).toBe(true);
+      expect(hasForm).toBe(true);
+    });
+
+    test('should generate test from tracking data with correct types', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(100);
+      await simulateInput(page, '[data-testid="test-input"]', 'test');
+
+      const testCode = await generatePlaywrightTest(page);
+
+      expect(testCode).toContain('await page.goto');
+      expect(testCode).toContain('await page.click');
+      expect(testCode).toContain('await page.fill');
+      expect(testCode).not.toContain('kind');
+      expect(testCode).not.toContain("'nav'");
+    });
+  });
+
+  test.describe('Edge Cases', () => {
+    test('should handle actions without explicit timestamps', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+      const action = actions[0];
+
+      expect(action).toBeTruthy();
+      expect(action.type).toBe('click');
+      expect(action.timestamp).toBeGreaterThan(0);
+    });
+
+    test('should verify all actions use new naming convention', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(100);
+      await simulateInput(page, '[data-testid="test-input"]', 'value');
+
+      const actions = await getActions(page);
+
+      // Verify no old field names are present
+      const hasOldNames = actions.some(action => hasOldFieldNames(action));
+      expect(hasOldNames).toBe(false);
+
+      // Verify new naming convention
+      expect(verifyNewNamingConvention(actions)).toBe(true);
+    });
+  });
+});

--- a/mcp/src/__tests__/staktrak/backward-compatibility.test.ts
+++ b/mcp/src/__tests__/staktrak/backward-compatibility.test.ts
@@ -1,0 +1,354 @@
+import { test, expect } from '@playwright/test';
+import {
+  loadStaktrakInPage,
+  startRecording,
+  stopRecording,
+  getActions,
+  getResults,
+  generatePlaywrightTest,
+  simulateClick,
+  simulateNavigation,
+  simulateInput,
+  simulateFormChange,
+  verifyNewNamingConvention,
+} from './test-helpers';
+
+test.describe('Backward Compatibility', () => {
+  test.describe('Action Field Name Migration', () => {
+    test('should handle new "type" field format', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+      const action = actions[0];
+
+      expect(action).toBeTruthy();
+      expect(action).toHaveProperty('type');
+      expect(action.type).toBe('click');
+    });
+
+    test('should use "goto" for navigation instead of "nav"', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000/page1');
+
+      const actions = await getActions(page);
+      const gotoAction = actions.find(a => a.type === 'goto');
+
+      expect(gotoAction).toBeTruthy();
+      expect(gotoAction.type).toBe('goto');
+      expect(actions.every(a => a.type !== 'nav')).toBe(true);
+    });
+  });
+
+  test.describe('Old Action Type Handling', () => {
+    test('should convert navigation events to "goto" type', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+
+      const actions = await getActions(page);
+      const gotoAction = actions.find(a => a.type === 'goto');
+
+      expect(gotoAction).toBeTruthy();
+      expect(gotoAction.type).toBe('goto');
+      expect(gotoAction.url).toBeTruthy();
+    });
+
+    test('should handle tracking data with navigation events', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+
+      const actions = await getActions(page);
+      const gotoAction = actions.find(a => a.type === 'goto');
+
+      expect(gotoAction).toBeTruthy();
+      expect(gotoAction.type).toBe('goto');
+      expect(gotoAction.url).toBe('http://localhost:3000');
+    });
+  });
+
+  test.describe('Generated Code Compatibility', () => {
+    test('should generate code without deprecated field names', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const testCode = await generatePlaywrightTest(page);
+
+      // Should not contain old naming
+      expect(testCode).not.toContain('kind');
+      expect(testCode).not.toContain("'nav'");
+
+      // Should contain new naming
+      expect(testCode).toContain('goto');
+    });
+
+    test('should handle mixed event types with consistent output', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      // Add events using different techniques
+      await simulateNavigation(page, 'http://localhost:3000/page1');
+      await page.waitForTimeout(100);
+      await simulateNavigation(page, 'http://localhost:3000/page2');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const testCode = await generatePlaywrightTest(page);
+
+      // All should be converted to new format
+      expect(testCode).toContain('goto');
+      expect(testCode).not.toContain("'nav'");
+    });
+  });
+
+  test.describe('Data Structure Evolution', () => {
+    test('should handle actions without "kind" field', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+
+      const actions = await getActions(page);
+
+      expect(actions.length).toBeGreaterThan(0);
+      actions.forEach(action => {
+        expect(action).not.toHaveProperty('kind');
+        expect(action).toHaveProperty('type');
+      });
+    });
+
+    test('should maintain type consistency in generated actions', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(100);
+      await simulateInput(page, '[data-testid="test-input"]', 'test');
+
+      const actions = await getActions(page);
+
+      // All actions should have "type" field
+      actions.forEach(action => {
+        expect(action).toHaveProperty('type');
+        expect(action).not.toHaveProperty('kind');
+        expect(typeof action.type).toBe('string');
+      });
+    });
+  });
+
+  test.describe('API Surface Compatibility', () => {
+    test('should maintain userBehaviour API', async ({ page }) => {
+      await loadStaktrakInPage(page);
+
+      // Test all public methods exist
+      const apiCheck = await page.evaluate(() => {
+        const ub = (window as any).userBehaviour;
+        return {
+          hasStart: typeof ub.start === 'function',
+          hasStop: typeof ub.stop === 'function',
+          hasResult: typeof ub.result === 'function',
+          hasGetActions: typeof ub.getActions === 'function',
+          hasGeneratePlaywrightTest: typeof ub.generatePlaywrightTest === 'function',
+          hasShowConfig: typeof ub.showConfig === 'function',
+          hasMakeConfig: typeof ub.makeConfig === 'function',
+        };
+      });
+
+      expect(apiCheck.hasStart).toBe(true);
+      expect(apiCheck.hasStop).toBe(true);
+      expect(apiCheck.hasResult).toBe(true);
+      expect(apiCheck.hasGetActions).toBe(true);
+      expect(apiCheck.hasGeneratePlaywrightTest).toBe(true);
+      expect(apiCheck.hasShowConfig).toBe(true);
+      expect(apiCheck.hasMakeConfig).toBe(true);
+    });
+
+    test('should maintain generatePlaywrightTest API', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+
+      // Should accept options parameter
+      const testCode1 = await page.evaluate(() => {
+        return (window as any).userBehaviour.generatePlaywrightTest();
+      });
+      expect(testCode1).toBeTruthy();
+
+      const testCode2 = await page.evaluate(() => {
+        return (window as any).userBehaviour.generatePlaywrightTest({ baseUrl: 'http://localhost:3000' });
+      });
+      expect(testCode2).toBeTruthy();
+    });
+
+    test('should maintain getActions API', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      // Should return array of actions
+      const actions = await page.evaluate(() => {
+        return (window as any).userBehaviour.getActions();
+      });
+
+      expect(Array.isArray(actions)).toBe(true);
+      expect(actions.length).toBeGreaterThan(0);
+    });
+  });
+
+  test.describe('Event Type Normalization', () => {
+    test('should normalize all navigation-related events to "goto"', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      // Test various navigation methods
+      await simulateNavigation(page, 'http://localhost:3000/page1');
+      await page.waitForTimeout(100);
+      await simulateNavigation(page, 'http://localhost:3000/page2');
+
+      const actions = await getActions(page);
+      const gotoActions = actions.filter(a => a.type === 'goto');
+
+      gotoActions.forEach(action => {
+        expect(action).toBeTruthy();
+        expect(action.type).toBe('goto');
+      });
+    });
+
+    test('should preserve other action types as-is', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+      const clickAction = actions[0];
+
+      expect(clickAction.type).toBe('click');
+    });
+  });
+
+  test.describe('TrackingData Compatibility', () => {
+    test('should handle empty tracking data gracefully', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      const actions = await getActions(page);
+
+      expect(Array.isArray(actions)).toBe(true);
+      expect(actions.length).toBe(0);
+    });
+
+    test('should handle tracking data with only navigation', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+
+      const actions = await getActions(page);
+
+      expect(actions.length).toBeGreaterThan(0);
+      expect(actions[0].type).toBe('goto');
+    });
+
+    test('should handle tracking data with only clicks', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const actions = await getActions(page);
+
+      expect(actions.length).toBeGreaterThan(0);
+      expect(actions[0].type).toBe('click');
+    });
+
+    test('should handle complex tracking data with all event types', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(100);
+      await simulateInput(page, '[data-testid="test-input"]', 'test');
+      await page.waitForTimeout(2100);
+      await simulateFormChange(page, '[data-testid="test-checkbox"]', true);
+
+      const actions = await getActions(page);
+
+      expect(actions.length).toBeGreaterThanOrEqual(4);
+      expect(actions.every(a => a.type !== undefined)).toBe(true);
+      expect(actions.every(a => !('kind' in a))).toBe(true);
+    });
+  });
+
+  test.describe('Code Generation Regression Tests', () => {
+    test('should generate valid Playwright test code', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const testCode = await generatePlaywrightTest(page);
+
+      // Should contain valid test structure
+      expect(testCode).toContain("import { test, expect } from '@playwright/test'");
+      expect(testCode).toContain("test('Recorded test', async ({ page }) => {");
+      expect(testCode).toContain('});');
+
+      // Should contain actions
+      expect(testCode).toContain('await page.goto');
+      expect(testCode).toContain('await page.click');
+    });
+
+    test('should handle baseUrl option in code generation', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateClick(page, '[data-testid="test-button"]');
+
+      const testCode = await page.evaluate(() => {
+        return (window as any).userBehaviour.generatePlaywrightTest({
+          baseUrl: 'http://localhost:3000',
+        });
+      });
+
+      expect(testCode).toBeTruthy();
+    });
+  });
+
+  test.describe('Naming Convention Verification', () => {
+    test('should verify new naming convention is consistently applied', async ({ page }) => {
+      await loadStaktrakInPage(page);
+      await startRecording(page);
+
+      await simulateNavigation(page, 'http://localhost:3000');
+      await page.waitForTimeout(100);
+      await simulateClick(page, '[data-testid="test-button"]');
+      await page.waitForTimeout(100);
+      await simulateInput(page, '[data-testid="test-input"]', 'test');
+
+      const actions = await getActions(page);
+
+      // Verify new naming convention
+      expect(verifyNewNamingConvention(actions)).toBe(true);
+    });
+  });
+});

--- a/mcp/src/__tests__/staktrak/e2e-screenshot-flow.test.ts
+++ b/mcp/src/__tests__/staktrak/e2e-screenshot-flow.test.ts
@@ -1,0 +1,593 @@
+import { test, expect } from '@playwright/test';
+import {
+  createTestPage,
+  waitForCondition,
+  extractScreenshotMessages,
+  verifyScreenshotDataUrl,
+} from './test-helpers';
+
+test.describe('E2E Screenshot Flow', () => {
+  test.describe('Real Browser Screenshot Capture', () => {
+    test('should capture screenshots during actual page navigation', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      // Load a simple test page
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://localhost:3000',
+                screenshot: {
+                  quality: 0.8,
+                  type: 'image/jpeg',
+                  scale: 1,
+                  backgroundColor: '#ffffff'
+                }
+              };
+            </script>
+          </head>
+          <body style="padding: 20px; background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);">
+            <h1 style="color: white;">Test Page</h1>
+            <button data-testid="nav-button" style="padding: 10px 20px; font-size: 16px;">
+              Navigate
+            </button>
+            <div id="content" style="margin-top: 20px; padding: 20px; background: white; border-radius: 8px;">
+              <p>This is test content for screenshot capture</p>
+            </div>
+            <script src="/dist/staktrak.js"></script>
+            <script>
+              window.addEventListener('message', (event) => {
+                window.captureMessage(event.data);
+              });
+
+              // Simulate navigation on button click
+              document.querySelector('[data-testid="nav-button"]').addEventListener('click', () => {
+                document.getElementById('content').innerHTML = '<p>Navigated to new page!</p>';
+                history.pushState({}, '', '/new-page');
+              });
+            </script>
+          </body>
+        </html>
+      `);
+
+      // Start replay with navigation
+      const testCode = `
+        test('navigation test', async ({ page }) => {
+          await page.click('[data-testid="nav-button"]');
+          await page.waitForURL('http://localhost:3000/new-page');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        10000
+      );
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      // Should capture at least one screenshot
+      expect(screenshotMsgs.length).toBeGreaterThan(0);
+
+      // Verify screenshot is valid
+      if (screenshotMsgs.length > 0) {
+        const screenshot = screenshotMsgs[0].screenshot;
+        expect(verifyScreenshotDataUrl(screenshot)).toBe(true);
+        expect(screenshot.length).toBeGreaterThan(1000); // Should have substantial data
+      }
+    });
+
+    test('should capture screenshots with different quality settings', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://localhost:3000',
+                screenshot: {
+                  quality: 0.3, // Low quality
+                  type: 'image/jpeg',
+                  scale: 1,
+                  backgroundColor: '#ffffff'
+                }
+              };
+            </script>
+          </head>
+          <body style="padding: 50px;">
+            <div style="width: 400px; height: 300px; background: linear-gradient(45deg, #ff6b6b, #4ecdc4);">
+              <h1 style="color: white; padding: 20px;">Screenshot Test</h1>
+            </div>
+            <script src="/dist/staktrak.js"></script>
+            <script>
+              window.addEventListener('message', (event) => {
+                window.captureMessage(event.data);
+              });
+            </script>
+          </body>
+        </html>
+      `);
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(3000);
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      if (screenshotMsgs.length > 0) {
+        const screenshot = screenshotMsgs[0].screenshot;
+        expect(verifyScreenshotDataUrl(screenshot)).toBe(true);
+        expect(screenshot).toContain('data:image/jpeg');
+      }
+    });
+  });
+
+  test.describe('Cross-Origin Iframe Scenarios', () => {
+    test('should handle same-origin iframe screenshots', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: window.location.origin,
+                screenshot: { quality: 0.8, type: 'image/jpeg' }
+              };
+            </script>
+          </head>
+          <body>
+            <h1>Parent Page</h1>
+            <iframe id="test-frame" style="width: 600px; height: 400px; border: 2px solid #ccc;"></iframe>
+            <script>
+              const frame = document.getElementById('test-frame');
+              const frameDoc = frame.contentDocument || frame.contentWindow.document;
+              frameDoc.open();
+              frameDoc.write(\`
+                <!DOCTYPE html>
+                <html>
+                  <body style="background: #f0f0f0; padding: 20px;">
+                    <h2>Iframe Content</h2>
+                    <button data-testid="iframe-button">Click Me</button>
+                    <script src="/dist/staktrak.js"><\/script>
+                  </body>
+                </html>
+              \`);
+              frameDoc.close();
+            </script>
+          </body>
+        </html>
+      `);
+
+      await page.waitForSelector('#test-frame');
+
+      // Frame operations should work in same-origin scenario
+      const frame = page.frame({ name: '' });
+      expect(frame).toBeTruthy();
+    });
+
+    test('should use wildcard origin when cross-origin blocked', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any, origin: string) => {
+        messages.push({ data: msg, origin });
+      });
+
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              // Simulate cross-origin environment
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) return parentOrigin;
+                try {
+                  // Simulate cross-origin block
+                  throw new DOMException('Cross-origin access blocked', 'SecurityError');
+                } catch (e) {}
+                return '*';
+              }
+
+              window.captureMessage(
+                { type: 'test-origin', origin: getParentOrigin() },
+                getParentOrigin()
+              );
+            </script>
+          </body>
+        </html>
+      `);
+
+      await page.waitForTimeout(500);
+
+      const testMsgs = messages.filter(m => m.data.type === 'test-origin');
+      if (testMsgs.length > 0) {
+        expect(testMsgs[0].data.origin).toBe('*');
+      }
+    });
+  });
+
+  test.describe('Performance and Size Limits', () => {
+    test('should handle large page screenshots', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      // Create a large page with lots of content
+      const largeContent = Array(100)
+        .fill(null)
+        .map((_, i) => `<div style="padding: 20px; margin: 10px; background: #${Math.floor(Math.random() * 16777215).toString(16)};">Content Block ${i}</div>`)
+        .join('');
+
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://localhost:3000',
+                screenshot: { quality: 0.5, type: 'image/jpeg' }
+              };
+            </script>
+          </head>
+          <body>
+            <h1>Large Page Test</h1>
+            ${largeContent}
+            <script src="/dist/staktrak.js"></script>
+            <script>
+              window.addEventListener('message', (event) => {
+                window.captureMessage(event.data);
+              });
+            </script>
+          </body>
+        </html>
+      `);
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      const startTime = Date.now();
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(4000);
+
+      const duration = Date.now() - startTime;
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      // Should complete within reasonable time
+      expect(duration).toBeLessThan(10000);
+
+      // Should still capture screenshot
+      if (screenshotMsgs.length > 0) {
+        expect(verifyScreenshotDataUrl(screenshotMsgs[0].screenshot)).toBe(true);
+      }
+    });
+
+    test('should handle rapid screenshot requests', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      // Test with multiple rapid waitForURL actions
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000/1');
+          await page.waitForURL('http://localhost:3000/2');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        8000
+      );
+
+      // Should handle multiple screenshots
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      // All screenshots should be valid
+      screenshotMsgs.forEach(msg => {
+        expect(verifyScreenshotDataUrl(msg.screenshot)).toBe(true);
+      });
+    });
+  });
+
+  test.describe('SPA Navigation Screenshot Capture', () => {
+    test('should capture screenshots during SPA-style navigation', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://localhost:3000',
+                screenshot: { quality: 0.8, type: 'image/jpeg' }
+              };
+            </script>
+          </head>
+          <body>
+            <nav>
+              <button data-testid="home-link">Home</button>
+              <button data-testid="about-link">About</button>
+            </nav>
+            <div id="content">Home Page</div>
+            <script src="/dist/staktrak.js"></script>
+            <script>
+              window.addEventListener('message', (event) => {
+                window.captureMessage(event.data);
+              });
+
+              // Simulate SPA routing
+              document.querySelector('[data-testid="home-link"]').addEventListener('click', () => {
+                document.getElementById('content').innerHTML = 'Home Page';
+                history.pushState({}, '', '/');
+                window.dispatchEvent(new Event('popstate'));
+              });
+
+              document.querySelector('[data-testid="about-link"]').addEventListener('click', () => {
+                document.getElementById('content').innerHTML = 'About Page';
+                history.pushState({}, '', '/about');
+                window.dispatchEvent(new Event('popstate'));
+              });
+            </script>
+          </body>
+        </html>
+      `);
+
+      const testCode = `
+        test('spa navigation', async ({ page }) => {
+          await page.click('[data-testid="about-link"]');
+          await page.waitForURL('http://localhost:3000/about');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        8000
+      );
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      // Should capture screenshot after SPA navigation
+      expect(screenshotMsgs.length).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  test.describe('Screenshot Data Integrity', () => {
+    test('should produce consistent screenshots for same page', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://localhost:3000',
+                screenshot: { quality: 0.8, type: 'image/jpeg' }
+              };
+            </script>
+          </head>
+          <body style="background: #fff; padding: 20px;">
+            <div style="width: 300px; height: 200px; background: #3498db;">
+              <h2 style="color: white; padding: 20px;">Static Content</h2>
+            </div>
+            <script src="/dist/staktrak.js"></script>
+            <script>
+              window.addEventListener('message', (event) => {
+                window.captureMessage(event.data);
+              });
+            </script>
+          </body>
+        </html>
+      `);
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      // Run twice
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(2000);
+      messages.length = 0; // Clear
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(2000);
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      if (screenshotMsgs.length > 0) {
+        const screenshot = screenshotMsgs[0].screenshot;
+
+        // Should be valid
+        expect(verifyScreenshotDataUrl(screenshot)).toBe(true);
+
+        // Should have reasonable size
+        expect(screenshot.length).toBeGreaterThan(500);
+        expect(screenshot.length).toBeLessThan(10000000); // Less than 10MB
+      }
+    });
+
+    test('should include valid timestamp in screenshot message', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const startTime = Date.now();
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(2000);
+
+      const endTime = Date.now();
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      if (screenshotMsgs.length > 0) {
+        const msg = screenshotMsgs[0];
+
+        // Timestamp should be within test execution time
+        expect(msg.timestamp).toBeGreaterThanOrEqual(startTime);
+        expect(msg.timestamp).toBeLessThanOrEqual(endTime);
+      }
+    });
+  });
+
+  test.describe('Error Recovery', () => {
+    test('should handle screenshot errors without breaking replay', async ({ page }) => {
+      const messages: any[] = [];
+      const consoleErrors: string[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      page.on('console', msg => {
+        if (msg.type() === 'error') {
+          consoleErrors.push(msg.text());
+        }
+      });
+
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+
+        // Break screenshot capture
+        if ((window as any).domToDataUrl) {
+          (window as any).domToDataUrl = async () => {
+            throw new Error('Mock screenshot error');
+          };
+        }
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="test-button"]');
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      const completed = await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        5000
+      );
+
+      // Replay should complete even with screenshot error
+      expect(completed).toBe(true);
+    });
+  });
+});

--- a/mcp/src/__tests__/staktrak/parent-origin-security.test.ts
+++ b/mcp/src/__tests__/staktrak/parent-origin-security.test.ts
@@ -1,0 +1,540 @@
+import { test, expect } from '@playwright/test';
+import { createTestPage, waitForCondition } from './test-helpers';
+
+test.describe('Parent Origin Security', () => {
+  test.describe('Parent Origin Capture', () => {
+    test('should capture parent origin from first postMessage event', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any, origin: string) => {
+        messages.push({ data: msg, origin });
+      });
+
+      const html = createTestPage({ includeStaktrak: true, includeConfig: false });
+      await page.setContent(html);
+
+      // Inject message capture and test postMessage
+      await page.evaluate(() => {
+        let capturedOrigin: string | null = null;
+
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data, event.origin);
+
+          // Simulate staktrak's origin capture logic
+          if (!capturedOrigin && event.origin && event.origin !== 'null') {
+            capturedOrigin = event.origin;
+          }
+        });
+
+        // Simulate first message from parent
+        window.postMessage(
+          { type: 'staktrak-playwright-replay-ping' },
+          window.location.origin
+        );
+      });
+
+      await page.waitForTimeout(500);
+
+      // Verify origin was captured
+      const pingMessages = messages.filter(m => m.data.type === 'staktrak-playwright-replay-ping');
+      expect(pingMessages.length).toBeGreaterThan(0);
+      expect(pingMessages[0].origin).toBeTruthy();
+      expect(pingMessages[0].origin).not.toBe('null');
+    });
+
+    test('should not overwrite valid origin with wildcard', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                try {
+                  const configOrigin = window.STAKTRAK_CONFIG?.parentOrigin;
+                  if (configOrigin) {
+                    return configOrigin;
+                  }
+                } catch (e) {}
+                return '*';
+              }
+
+              // Simulate first message with valid origin
+              parentOrigin = 'http://localhost:3000';
+
+              // Try to overwrite with null (shouldn't work)
+              const testOrigin1 = getParentOrigin();
+
+              // Second call should return same origin
+              const testOrigin2 = getParentOrigin();
+
+              window.testResults = {
+                firstCall: testOrigin1,
+                secondCall: testOrigin2,
+                originNotOverwritten: testOrigin1 === testOrigin2 && testOrigin1 === 'http://localhost:3000'
+              };
+            </script>
+          </body>
+        </html>
+      `);
+
+      const results = await page.evaluate(() => (window as any).testResults);
+
+      expect(results.firstCall).toBe('http://localhost:3000');
+      expect(results.secondCall).toBe('http://localhost:3000');
+      expect(results.originNotOverwritten).toBe(true);
+    });
+  });
+
+  test.describe('getParentOrigin Function', () => {
+    test('should return stored origin when available', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              let parentOrigin = 'http://localhost:3000';
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                return '*';
+              }
+
+              window.testOrigin = getParentOrigin();
+            </script>
+          </body>
+        </html>
+      `);
+
+      const origin = await page.evaluate(() => (window as any).testOrigin);
+      expect(origin).toBe('http://localhost:3000');
+    });
+
+    test('should fallback to STAKTRAK_CONFIG when parentOrigin not set', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://configured-origin.com',
+                screenshot: { quality: 0.8 }
+              };
+            </script>
+          </head>
+          <body>
+            <script>
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                try {
+                  const configOrigin = window.STAKTRAK_CONFIG?.parentOrigin;
+                  if (configOrigin) {
+                    return configOrigin;
+                  }
+                } catch (e) {}
+                return '*';
+              }
+
+              window.testOrigin = getParentOrigin();
+            </script>
+          </body>
+        </html>
+      `);
+
+      const origin = await page.evaluate(() => (window as any).testOrigin);
+      expect(origin).toBe('http://configured-origin.com');
+    });
+
+    test('should return wildcard when no origin available', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                try {
+                  const configOrigin = window.STAKTRAK_CONFIG?.parentOrigin;
+                  if (configOrigin) {
+                    return configOrigin;
+                  }
+                } catch (e) {}
+                return '*';
+              }
+
+              window.testOrigin = getParentOrigin();
+            </script>
+          </body>
+        </html>
+      `);
+
+      const origin = await page.evaluate(() => (window as any).testOrigin);
+      expect(origin).toBe('*');
+    });
+
+    test('should handle STAKTRAK_CONFIG access errors gracefully', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                try {
+                  // Simulate cross-origin access error
+                  if (true) {
+                    throw new Error('Cross-origin access blocked');
+                  }
+                  const configOrigin = window.STAKTRAK_CONFIG?.parentOrigin;
+                  if (configOrigin) {
+                    return configOrigin;
+                  }
+                } catch (e) {
+                  // Should handle error silently
+                }
+                return '*';
+              }
+
+              window.testOrigin = getParentOrigin();
+              window.noError = true;
+            </script>
+          </body>
+        </html>
+      `);
+
+      const origin = await page.evaluate(() => (window as any).testOrigin);
+      const noError = await page.evaluate(() => (window as any).noError);
+
+      expect(origin).toBe('*');
+      expect(noError).toBe(true);
+    });
+  });
+
+  test.describe('Cross-Origin Scenarios', () => {
+    test('should handle same-origin iframe with config access', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://localhost:3000',
+                screenshot: { quality: 0.8 }
+              };
+            </script>
+          </head>
+          <body>
+            <iframe id="test-frame" srcdoc='
+              <script>
+                let parentOrigin = null;
+
+                function getParentOrigin() {
+                  if (parentOrigin) {
+                    return parentOrigin;
+                  }
+                  try {
+                    const configOrigin = parent.window.STAKTRAK_CONFIG?.parentOrigin;
+                    if (configOrigin) {
+                      return configOrigin;
+                    }
+                  } catch (e) {}
+                  return "*";
+                }
+
+                window.testOrigin = getParentOrigin();
+              <\/script>
+            '></iframe>
+          </body>
+        </html>
+      `);
+
+      await page.waitForSelector('#test-frame');
+
+      const frameOrigin = await page.frame({ name: '' })?.evaluate(() => {
+        return (window as any).testOrigin;
+      });
+
+      // In same-origin, should be able to access parent config
+      expect(frameOrigin).toBeTruthy();
+    });
+
+    test('should handle cross-origin iframe without config access', async ({ page }) => {
+      // Simulate cross-origin scenario where parent window access fails
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                try {
+                  // Simulate cross-origin block
+                  throw new DOMException('Blocked a frame with origin', 'SecurityError');
+                } catch (e) {
+                  // Cross-origin access blocked (expected)
+                }
+                return '*';
+              }
+
+              window.testOrigin = getParentOrigin();
+              window.handledCrossOrigin = true;
+            </script>
+          </body>
+        </html>
+      `);
+
+      const origin = await page.evaluate(() => (window as any).testOrigin);
+      const handledCrossOrigin = await page.evaluate(() => (window as any).handledCrossOrigin);
+
+      expect(origin).toBe('*');
+      expect(handledCrossOrigin).toBe(true);
+    });
+  });
+
+  test.describe('PostMessage Security', () => {
+    test('should use captured origin for postMessage responses', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any, targetOrigin: string) => {
+        messages.push({ data: msg, targetOrigin });
+      });
+
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) return parentOrigin;
+                return '*';
+              }
+
+              window.addEventListener('message', (event) => {
+                if (event.data.type === 'test-ping') {
+                  // Capture origin from first message
+                  if (!parentOrigin && event.origin && event.origin !== 'null') {
+                    parentOrigin = event.origin;
+                  }
+
+                  // Send response using captured origin
+                  const responseOrigin = getParentOrigin();
+                  window.captureMessage(
+                    { type: 'test-pong', receivedFrom: event.origin },
+                    responseOrigin
+                  );
+                }
+              });
+
+              // Simulate receiving message
+              window.postMessage({ type: 'test-ping' }, window.location.origin);
+            </script>
+          </body>
+        </html>
+      `);
+
+      await page.waitForTimeout(500);
+
+      const pongMessages = messages.filter(m => m.data.type === 'test-pong');
+      expect(pongMessages.length).toBeGreaterThan(0);
+
+      // Should use captured origin (or wildcard as fallback)
+      expect(pongMessages[0].targetOrigin).toBeTruthy();
+    });
+
+    test('should filter out null origins', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <body>
+            <script>
+              let parentOrigin = null;
+              const originHistory = [];
+
+              window.addEventListener('message', (event) => {
+                originHistory.push(event.origin);
+
+                // Should not capture 'null' origin
+                if (!parentOrigin && event.origin && event.origin !== 'null') {
+                  parentOrigin = event.origin;
+                }
+              });
+
+              // Simulate messages with different origins
+              window.postMessage({ type: 'test1' }, 'null');
+              setTimeout(() => {
+                window.postMessage({ type: 'test2' }, window.location.origin);
+              }, 100);
+
+              window.getResults = () => ({
+                originHistory,
+                capturedOrigin: parentOrigin
+              });
+            </script>
+          </body>
+        </html>
+      `);
+
+      await page.waitForTimeout(300);
+
+      const results = await page.evaluate(() => (window as any).getResults());
+
+      // 'null' origin should not be captured
+      expect(results.capturedOrigin).not.toBe('null');
+      expect(results.capturedOrigin).toBeTruthy();
+    });
+  });
+
+  test.describe('Origin Priority Order', () => {
+    test('should prioritize stored origin over config', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://config-origin.com'
+              };
+            </script>
+          </head>
+          <body>
+            <script>
+              let parentOrigin = 'http://stored-origin.com';
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                try {
+                  const configOrigin = window.STAKTRAK_CONFIG?.parentOrigin;
+                  if (configOrigin) {
+                    return configOrigin;
+                  }
+                } catch (e) {}
+                return '*';
+              }
+
+              window.testOrigin = getParentOrigin();
+            </script>
+          </body>
+        </html>
+      `);
+
+      const origin = await page.evaluate(() => (window as any).testOrigin);
+
+      // Stored origin should take precedence
+      expect(origin).toBe('http://stored-origin.com');
+      expect(origin).not.toBe('http://config-origin.com');
+    });
+
+    test('should prioritize config over wildcard', async ({ page }) => {
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://config-origin.com'
+              };
+            </script>
+          </head>
+          <body>
+            <script>
+              let parentOrigin = null;
+
+              function getParentOrigin() {
+                if (parentOrigin) {
+                  return parentOrigin;
+                }
+                try {
+                  const configOrigin = window.STAKTRAK_CONFIG?.parentOrigin;
+                  if (configOrigin) {
+                    return configOrigin;
+                  }
+                } catch (e) {}
+                return '*';
+              }
+
+              window.testOrigin = getParentOrigin();
+            </script>
+          </body>
+        </html>
+      `);
+
+      const origin = await page.evaluate(() => (window as any).testOrigin);
+
+      // Config origin should be used instead of wildcard
+      expect(origin).toBe('http://config-origin.com');
+      expect(origin).not.toBe('*');
+    });
+  });
+
+  test.describe('Integration with Replay Flow', () => {
+    test('should use correct origin in replay messages', async ({ page }) => {
+      const messages: Array<{ type: string; origin: string }> = [];
+
+      await page.exposeFunction('captureMessage', (type: string, origin: string) => {
+        messages.push({ type, origin });
+      });
+
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true, parentOrigin: 'http://test-origin.com' });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        // Intercept postMessage calls
+        const originalPostMessage = window.parent.postMessage;
+        window.parent.postMessage = function(message: any, targetOrigin: string) {
+          if (message?.type) {
+            (window as any).captureMessage(message.type, targetOrigin);
+          }
+          return originalPostMessage.call(this, message, targetOrigin);
+        };
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(1000);
+
+      // Verify messages use correct origin
+      expect(messages.length).toBeGreaterThan(0);
+      messages.forEach(msg => {
+        expect(msg.origin).toBeTruthy();
+        // Should use config origin or wildcard
+        expect(['http://test-origin.com', '*', 'http://localhost:3000']).toContain(msg.origin);
+      });
+    });
+  });
+});

--- a/mcp/src/__tests__/staktrak/playwright-replay.test.ts
+++ b/mcp/src/__tests__/staktrak/playwright-replay.test.ts
@@ -1,0 +1,593 @@
+import { test, expect } from '@playwright/test';
+import {
+  createTestPage,
+  waitForCondition,
+  extractScreenshotMessages,
+  validateScreenshotMessage,
+} from './test-helpers';
+
+test.describe('Playwright Replay Integration', () => {
+  test.describe('Basic Replay Flow', () => {
+    let messages: any[];
+
+    test.beforeEach(async ({ page }) => {
+      messages = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+    });
+
+    test('should start replay and send started message', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('basic test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-started'),
+        3000
+      );
+
+      const startedMsg = messages.find(m => m.type === 'staktrak-playwright-replay-started');
+      expect(startedMsg).toBeTruthy();
+      expect(startedMsg.totalActions).toBeGreaterThan(0);
+      expect(startedMsg.actions).toBeTruthy();
+      expect(Array.isArray(startedMsg.actions)).toBe(true);
+    });
+
+    test('should send progress messages during replay', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="test-button"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-progress'),
+        3000
+      );
+
+      const progressMsgs = messages.filter(m => m.type === 'staktrak-playwright-replay-progress');
+      expect(progressMsgs.length).toBeGreaterThan(0);
+
+      const progressMsg = progressMsgs[0];
+      expect(progressMsg.current).toBeGreaterThan(0);
+      expect(progressMsg.total).toBeGreaterThan(0);
+      expect(progressMsg.currentAction).toBeTruthy();
+      expect(progressMsg.currentAction.description).toBeTruthy();
+    });
+
+    test('should send completed message when done', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="test-button"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      const completed = await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        5000
+      );
+
+      expect(completed).toBe(true);
+    });
+  });
+
+  test.describe('Replay with Screenshots', () => {
+    let messages: any[];
+
+    test.beforeEach(async ({ page }) => {
+      messages = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+    });
+
+    test('should capture screenshots during replay with waitForURL', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        8000
+      );
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      // Should have at least one screenshot
+      expect(screenshotMsgs.length).toBeGreaterThan(0);
+
+      // Validate screenshot structure
+      screenshotMsgs.forEach(msg => {
+        expect(validateScreenshotMessage(msg)).toBe(true);
+      });
+    });
+
+    test('should include correct actionIndex in screenshots', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000');
+          await page.click('[data-testid="test-button"]');
+          await page.waitForURL('http://localhost:3000/next');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        8000
+      );
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      screenshotMsgs.forEach(msg => {
+        expect(msg.actionIndex).toBeGreaterThanOrEqual(0);
+        expect(typeof msg.actionIndex).toBe('number');
+        expect(msg.url).toBeTruthy();
+        expect(msg.timestamp).toBeGreaterThan(0);
+      });
+    });
+
+    test('should include URL in screenshot message', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        5000
+      );
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      if (screenshotMsgs.length > 0) {
+        const msg = screenshotMsgs[0];
+        expect(msg.url).toBeTruthy();
+        expect(typeof msg.url).toBe('string');
+        expect(msg.url).toContain('http');
+      }
+    });
+  });
+
+  test.describe('Mixed Action Types', () => {
+    let messages: any[];
+
+    test.beforeEach(async ({ page }) => {
+      messages = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+    });
+
+    test('should handle replay with multiple action types', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.click('[data-testid="test-button"]');
+          await page.fill('[data-testid="test-input"]', 'test value');
+          await page.check('[data-testid="test-checkbox"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      const completed = await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        5000
+      );
+
+      expect(completed).toBe(true);
+
+      const progressMsgs = messages.filter(m => m.type === 'staktrak-playwright-replay-progress');
+      expect(progressMsgs.length).toBeGreaterThan(0);
+    });
+
+    test('should only capture screenshots after waitForURL actions', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="test-button"]');
+          await page.fill('[data-testid="test-input"]', 'test');
+          await page.waitForURL('http://localhost:3000');
+          await page.check('[data-testid="test-checkbox"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        5000
+      );
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+      const progressMsgs = messages.filter(m => m.type === 'staktrak-playwright-replay-progress');
+
+      // Should have screenshots (from waitForURL)
+      // Progress messages should include all action types
+      expect(progressMsgs.length).toBeGreaterThan(screenshotMsgs.length);
+    });
+  });
+
+  test.describe('Error Handling', () => {
+    let messages: any[];
+
+    test.beforeEach(async ({ page }) => {
+      messages = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+    });
+
+    test('should continue replay on action errors', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      // Test code with invalid selector that will fail
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="nonexistent-button"]');
+          await page.click('[data-testid="test-button"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      const completed = await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        5000
+      );
+
+      // Should complete despite error
+      expect(completed).toBe(true);
+
+      const errorMsgs = messages.filter(m => m.type === 'staktrak-playwright-replay-error');
+      expect(errorMsgs.length).toBeGreaterThan(0);
+    });
+
+    test('should report error details in error messages', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="nonexistent"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-error'),
+        3000
+      );
+
+      const errorMsgs = messages.filter(m => m.type === 'staktrak-playwright-replay-error');
+      expect(errorMsgs.length).toBeGreaterThan(0);
+
+      const errorMsg = errorMsgs[0];
+      expect(errorMsg.error).toBeTruthy();
+      expect(typeof errorMsg.error).toBe('string');
+    });
+
+    test('should continue capturing screenshots after action errors', async ({ page }) => {
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="nonexistent"]');
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        8000
+      );
+
+      const screenshotMsgs = extractScreenshotMessages(messages.map(m => ({ data: m })));
+      const errorMsgs = messages.filter(m => m.type === 'staktrak-playwright-replay-error');
+
+      // Should have error and still capture screenshot
+      expect(errorMsgs.length).toBeGreaterThan(0);
+      // Screenshot may or may not be captured depending on implementation
+    });
+  });
+
+  test.describe('Replay Control', () => {
+    test('should handle pause/resume', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.click('[data-testid="test-button"]');
+          await page.fill('[data-testid="test-input"]', 'test');
+        });
+      `;
+
+      // Start replay
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      // Wait a bit then pause
+      await page.waitForTimeout(500);
+
+      await page.evaluate(() => {
+        window.postMessage({ type: 'staktrak-playwright-replay-pause' }, '*');
+      });
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-paused'),
+        2000
+      );
+
+      const pausedMsg = messages.find(m => m.type === 'staktrak-playwright-replay-paused');
+      expect(pausedMsg).toBeTruthy();
+
+      // Resume
+      await page.evaluate(() => {
+        window.postMessage({ type: 'staktrak-playwright-replay-resume' }, '*');
+      });
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-resumed'),
+        2000
+      );
+
+      const resumedMsg = messages.find(m => m.type === 'staktrak-playwright-replay-resumed');
+      expect(resumedMsg).toBeTruthy();
+    });
+
+    test('should handle stop command', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.click('[data-testid="test-button"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(300);
+
+      // Stop replay
+      await page.evaluate(() => {
+        window.postMessage({ type: 'staktrak-playwright-replay-stop' }, '*');
+      });
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-stopped'),
+        2000
+      );
+
+      const stoppedMsg = messages.find(m => m.type === 'staktrak-playwright-replay-stopped');
+      expect(stoppedMsg).toBeTruthy();
+    });
+
+    test('should respond to ping with current state', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      // Send ping
+      await page.evaluate(() => {
+        window.postMessage({ type: 'staktrak-playwright-replay-ping' }, '*');
+      });
+
+      await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-pong'),
+        2000
+      );
+
+      const pongMsg = messages.find(m => m.type === 'staktrak-playwright-replay-pong');
+      expect(pongMsg).toBeTruthy();
+      // State may be null if no replay is active
+    });
+  });
+});

--- a/mcp/src/__tests__/staktrak/screenshot-capture.test.ts
+++ b/mcp/src/__tests__/staktrak/screenshot-capture.test.ts
@@ -1,0 +1,450 @@
+import { test, expect } from '@playwright/test';
+import {
+  createTestPage,
+  verifyScreenshotDataUrl,
+  validateScreenshotMessage,
+  extractScreenshotMessages,
+  waitForCondition,
+} from './test-helpers';
+
+test.describe('Screenshot Capture', () => {
+  test.describe('Screenshot Capture Functionality', () => {
+    test('should capture screenshot after waitForURL action', async ({ page }) => {
+      const messages: any[] = [];
+
+      // Setup message listener
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      // Load test page with staktrak
+      const html = createTestPage({ includeStaktrak: true, includeConfig: true });
+      await page.setContent(html);
+
+      // Inject message capture in page
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      // Start a simple replay with waitForURL
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        (window as any).startPlaywrightReplay(code);
+      }, testCode);
+
+      // Wait for screenshot message
+      const hasScreenshot = await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-screenshot-captured'),
+        8000
+      );
+
+      expect(hasScreenshot).toBe(true);
+
+      const screenshotMessages = extractScreenshotMessages(messages.map(m => ({ data: m })));
+      expect(screenshotMessages.length).toBeGreaterThan(0);
+    });
+
+    test('should not capture screenshot for non-waitForURL actions', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      // Replay with only click action (no waitForURL)
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="test-button"]');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        (window as any).startPlaywrightReplay(code);
+      }, testCode);
+
+      // Wait for replay to complete
+      await page.waitForTimeout(2000);
+
+      const screenshotMessages = extractScreenshotMessages(messages.map(m => ({ data: m })));
+      expect(screenshotMessages.length).toBe(0);
+    });
+  });
+
+  test.describe('Screenshot Data URL Validation', () => {
+    test('should generate valid data URL format', () => {
+      const validDataUrl = 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/';
+      expect(verifyScreenshotDataUrl(validDataUrl)).toBe(true);
+    });
+
+    test('should reject invalid data URL format', () => {
+      const invalidUrls = [
+        '',
+        'not-a-data-url',
+        'data:text/plain;base64,test',
+        'data:image/jpeg;base64',
+        'data:image/jpeg;base64,',
+        'http://example.com/image.jpg',
+      ];
+
+      invalidUrls.forEach(url => {
+        expect(verifyScreenshotDataUrl(url)).toBe(false);
+      });
+    });
+
+    test('should accept different image formats', () => {
+      const formats = [
+        'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==',
+        'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/',
+        'data:image/jpg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/',
+        'data:image/webp;base64,UklGRiQAAABXRUJQVlA4IBgAAAAwAQCdASoBAAEAAwA0JaQAA3AA/',
+      ];
+
+      formats.forEach(url => {
+        expect(verifyScreenshotDataUrl(url)).toBe(true);
+      });
+    });
+  });
+
+  test.describe('Screenshot Message Structure', () => {
+    test('should validate correct screenshot message structure', () => {
+      const validMessage = {
+        type: 'staktrak-playwright-screenshot-captured',
+        screenshot: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/',
+        actionIndex: 0,
+        url: 'http://localhost:3000',
+        timestamp: Date.now(),
+        id: `${Date.now()}-0`,
+      };
+
+      expect(validateScreenshotMessage(validMessage)).toBe(true);
+    });
+
+    test('should reject message with missing fields', () => {
+      const invalidMessages = [
+        {
+          type: 'staktrak-playwright-screenshot-captured',
+          // missing screenshot
+          actionIndex: 0,
+          url: 'http://localhost:3000',
+          timestamp: Date.now(),
+        },
+        {
+          type: 'staktrak-playwright-screenshot-captured',
+          screenshot: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/',
+          // missing actionIndex
+          url: 'http://localhost:3000',
+          timestamp: Date.now(),
+        },
+        {
+          // wrong type
+          type: 'other-message',
+          screenshot: 'data:image/jpeg;base64,/9j/4AAQSkZJRgABAQAAAQABAAD/',
+          actionIndex: 0,
+          url: 'http://localhost:3000',
+          timestamp: Date.now(),
+        },
+      ];
+
+      invalidMessages.forEach(msg => {
+        expect(validateScreenshotMessage(msg)).toBe(false);
+      });
+    });
+  });
+
+  test.describe('Screenshot Options', () => {
+    test('should respect STAKTRAK_CONFIG screenshot options', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      // Create page with custom config
+      await page.setContent(`
+        <!DOCTYPE html>
+        <html>
+          <head>
+            <script>
+              window.STAKTRAK_CONFIG = {
+                parentOrigin: 'http://localhost:3000',
+                screenshot: {
+                  quality: 0.5,
+                  type: 'image/png',
+                  scale: 0.8,
+                  backgroundColor: '#000000'
+                }
+              };
+            </script>
+          </head>
+          <body>
+            <div style="width: 200px; height: 200px; background: red;">Test Content</div>
+            <script src="/dist/staktrak.js"></script>
+            <script>
+              window.addEventListener('message', (event) => {
+                window.captureMessage(event.data);
+              });
+            </script>
+          </body>
+        </html>
+      `);
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(2000);
+
+      const screenshotMessages = extractScreenshotMessages(messages.map(m => ({ data: m })));
+      if (screenshotMessages.length > 0) {
+        const screenshot = screenshotMessages[0].screenshot;
+        expect(screenshot).toContain('data:image/');
+        expect(verifyScreenshotDataUrl(screenshot)).toBe(true);
+      }
+    });
+  });
+
+  test.describe('Screenshot Error Handling', () => {
+    test('should handle screenshot capture errors gracefully', async ({ page, browserName }) => {
+      // This test verifies that errors don't break the replay flow
+      const messages: any[] = [];
+      const consoleMessages: string[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      page.on('console', msg => {
+        if (msg.type() === 'error') {
+          consoleMessages.push(msg.text());
+        }
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+
+        // Mock domToDataUrl to throw error
+        if ((window as any).domToDataUrl) {
+          const original = (window as any).domToDataUrl;
+          (window as any).domToDataUrl = async () => {
+            throw new Error('Screenshot capture failed');
+          };
+        }
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.click('[data-testid="test-button"]');
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      // Wait for replay to complete
+      const completedMsg = await waitForCondition(
+        () => messages.some(m => m.type === 'staktrak-playwright-replay-completed'),
+        8000
+      );
+
+      // Replay should complete even if screenshot fails
+      expect(completedMsg).toBe(true);
+    });
+  });
+
+  test.describe('Multiple Screenshots', () => {
+    test('should capture multiple screenshots for multiple waitForURL actions', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      // Test code with multiple waitForURL actions
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000');
+          await page.click('[data-testid="test-button"]');
+          await page.waitForURL('http://localhost:3000/result');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(3000);
+
+      const screenshotMessages = extractScreenshotMessages(messages.map(m => ({ data: m })));
+      // Should have at least one screenshot (depending on implementation)
+      expect(screenshotMessages.length).toBeGreaterThanOrEqual(0);
+    });
+
+    test('should include correct actionIndex in each screenshot', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.goto('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000/next');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(3000);
+
+      const screenshotMessages = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      // Verify each screenshot has actionIndex
+      screenshotMessages.forEach(msg => {
+        expect(msg.actionIndex).toBeGreaterThanOrEqual(0);
+        expect(typeof msg.actionIndex).toBe('number');
+      });
+    });
+  });
+
+  test.describe('Screenshot ID Generation', () => {
+    test('should generate unique IDs for screenshots', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+          await page.waitForURL('http://localhost:3000/next');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(3000);
+
+      const screenshotMessages = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      if (screenshotMessages.length > 1) {
+        const ids = screenshotMessages.map(m => m.id);
+        const uniqueIds = new Set(ids);
+        expect(uniqueIds.size).toBe(ids.length);
+      }
+    });
+
+    test('should format ID as timestamp-actionIndex', async ({ page }) => {
+      const messages: any[] = [];
+
+      await page.exposeFunction('captureMessage', (msg: any) => {
+        messages.push(msg);
+      });
+
+      const html = createTestPage({ includeStaktrak: true });
+      await page.setContent(html);
+
+      await page.evaluate(() => {
+        window.addEventListener('message', (event) => {
+          (window as any).captureMessage(event.data);
+        });
+      });
+
+      const testCode = `
+        test('test', async ({ page }) => {
+          await page.waitForURL('http://localhost:3000');
+        });
+      `;
+
+      await page.evaluate((code) => {
+        if ((window as any).startPlaywrightReplay) {
+          (window as any).startPlaywrightReplay(code);
+        }
+      }, testCode);
+
+      await page.waitForTimeout(2000);
+
+      const screenshotMessages = extractScreenshotMessages(messages.map(m => ({ data: m })));
+
+      if (screenshotMessages.length > 0) {
+        const msg = screenshotMessages[0];
+        expect(msg.id).toMatch(/^\d+-\d+$/); // Format: timestamp-actionIndex
+        expect(msg.id).toContain(msg.actionIndex.toString());
+      }
+    });
+  });
+});

--- a/mcp/src/__tests__/staktrak/test-helpers.ts
+++ b/mcp/src/__tests__/staktrak/test-helpers.ts
@@ -1,0 +1,426 @@
+import type { Page } from '@playwright/test';
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Test Helpers for staktrak test suite
+ * Provides utilities for browser-based testing of staktrak functionality
+ */
+
+let staktrakBundle: string | null = null;
+
+/**
+ * Get the inlined staktrak bundle content
+ */
+export function getStaktrakBundle(): string {
+  if (!staktrakBundle) {
+    const bundlePath = path.join(process.cwd(), 'tests/staktrak/dist/staktrak.js');
+    staktrakBundle = fs.readFileSync(bundlePath, 'utf-8');
+  }
+  return staktrakBundle;
+}
+
+/**
+ * Get the path to staktrak bundle
+ */
+export function getStaktrakBundlePath(): string {
+  return '/dist/staktrak.js';
+}
+
+/**
+ * Get the path to playwright-generator bundle
+ */
+export function getPlaywrightGeneratorPath(): string {
+  return '/dist/playwright-generator.js';
+}
+
+/**
+ * Create test HTML page with staktrak loaded
+ */
+export function createTestPage(options: {
+  includeStaktrak?: boolean;
+  includeConfig?: boolean;
+  parentOrigin?: string;
+  customContent?: string;
+} = {}): string {
+  const { includeStaktrak = true, includeConfig = false, parentOrigin = 'http://localhost:3000', customContent = '' } = options;
+
+  const configScript = includeConfig
+    ? `
+    <script>
+      window.STAKTRAK_CONFIG = {
+        parentOrigin: '${parentOrigin}',
+        screenshot: {
+          quality: 0.8,
+          type: 'image/jpeg',
+          scale: 1,
+          backgroundColor: '#ffffff'
+        }
+      };
+    </script>
+    `
+    : '';
+
+  // Inline the staktrak bundle for data URLs
+  const staktrakScript = includeStaktrak
+    ? `<script>${getStaktrakBundle()}</script>`
+    : '';
+
+  const defaultContent = `
+    <div id="app">
+      <button data-testid="test-button">Click Me</button>
+      <input data-testid="test-input" type="text" placeholder="Enter text">
+      <input data-testid="test-checkbox" type="checkbox">
+      <select data-testid="test-select">
+        <option value="option1">Option 1</option>
+        <option value="option2">Option 2</option>
+      </select>
+      <div data-testid="test-result">Result</div>
+    </div>
+  `;
+
+  return `
+    <!DOCTYPE html>
+    <html>
+      <head>
+        <meta charset="utf-8">
+        <title>Test Page</title>
+        ${configScript}
+      </head>
+      <body>
+        ${customContent || defaultContent}
+        ${staktrakScript}
+      </body>
+    </html>
+  `;
+}
+
+/**
+ * Load staktrak in a page and wait for it to be ready
+ */
+export async function loadStaktrakInPage(page: Page, options: {
+  includeConfig?: boolean;
+  parentOrigin?: string;
+  customContent?: string;
+} = {}): Promise<void> {
+  const html = createTestPage({ includeStaktrak: true, ...options });
+  const dataUrl = `data:text/html;charset=utf-8,${encodeURIComponent(html)}`;
+
+  await page.goto(dataUrl);
+
+  // Wait for staktrak to be fully initialized
+  await page.waitForFunction(() => {
+    const ub = (window as any).userBehaviour;
+    return ub !== undefined &&
+           typeof ub === 'object' &&
+           typeof ub.start === 'function' &&
+           typeof ub.stop === 'function' &&
+           typeof ub.result === 'function';
+  }, { timeout: 10000 });
+}
+
+/**
+ * Start staktrak recording in page
+ */
+export async function startRecording(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as any).userBehaviour.start();
+  });
+}
+
+/**
+ * Stop staktrak recording in page
+ */
+export async function stopRecording(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as any).userBehaviour.stop();
+  });
+}
+
+/**
+ * Get recorded actions from staktrak
+ */
+export async function getActions(page: Page): Promise<any[]> {
+  return await page.evaluate(() => {
+    return (window as any).userBehaviour.getActions();
+  });
+}
+
+/**
+ * Get raw tracking results from staktrak
+ */
+export async function getResults(page: Page): Promise<any> {
+  return await page.evaluate(() => {
+    return (window as any).userBehaviour.result();
+  });
+}
+
+/**
+ * Generate Playwright test code from recorded actions
+ */
+export async function generatePlaywrightTest(page: Page, options: any = {}): Promise<string> {
+  return await page.evaluate((opts) => {
+    return (window as any).userBehaviour.generatePlaywrightTest(opts);
+  }, options);
+}
+
+/**
+ * Clear all recorded actions
+ */
+export async function clearAllActions(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as any).userBehaviour.memory.assertions = [];
+    (window as any).userBehaviour.results = (window as any).userBehaviour.createEmptyResults();
+  });
+}
+
+/**
+ * Verify screenshot data URL has valid format
+ */
+export function verifyScreenshotDataUrl(dataUrl: string): boolean {
+  if (!dataUrl || typeof dataUrl !== 'string') {
+    return false;
+  }
+
+  // Check if it's a valid data URL
+  const dataUrlPattern = /^data:image\/(png|jpeg|jpg|webp);base64,/;
+  if (!dataUrlPattern.test(dataUrl)) {
+    return false;
+  }
+
+  // Check if base64 content exists
+  const base64Content = dataUrl.split(',')[1];
+  if (!base64Content || base64Content.length === 0) {
+    return false;
+  }
+
+  // Validate base64 format (test first 100 chars)
+  try {
+    // In Node.js context
+    if (typeof atob === 'undefined') {
+      Buffer.from(base64Content.substring(0, 100), 'base64');
+    } else {
+      atob(base64Content.substring(0, 100));
+    }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validate action structure
+ */
+export function validateAction(action: any): boolean {
+  if (!action || typeof action !== 'object') {
+    return false;
+  }
+
+  // Must have type field (not kind)
+  if (!action.type || typeof action.type !== 'string') {
+    return false;
+  }
+
+  // Must have timestamp
+  if (!action.timestamp || typeof action.timestamp !== 'number') {
+    return false;
+  }
+
+  // Type-specific validation
+  switch (action.type) {
+    case 'click':
+      return !!action.locator;
+    case 'goto':
+      return !!action.url;
+    case 'waitForURL':
+      return !!action.expectedUrl || !!action.normalizedUrl;
+    case 'input':
+      return !!action.locator && action.value !== undefined;
+    case 'form':
+      return !!action.locator && !!action.formType;
+    case 'assertion':
+      return !!action.locator && action.value !== undefined;
+    default:
+      return true;
+  }
+}
+
+/**
+ * Wait for condition with timeout (page context)
+ */
+export async function waitForCondition(
+  page: Page,
+  condition: () => boolean | Promise<boolean>,
+  timeout: number = 5000,
+  interval: number = 100
+): Promise<boolean> {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeout) {
+    const result = await Promise.resolve(condition());
+    if (result) {
+      return true;
+    }
+    await new Promise(resolve => setTimeout(resolve, interval));
+  }
+
+  return false;
+}
+
+/**
+ * Create mock click event in page
+ */
+export async function simulateClick(page: Page, selector: string): Promise<void> {
+  await page.click(selector);
+  // Wait for staktrak to process the event
+  await page.waitForTimeout(100);
+}
+
+/**
+ * Create mock navigation in page
+ */
+export async function simulateNavigation(page: Page, url: string): Promise<void> {
+  await page.evaluate((targetUrl) => {
+    history.pushState({}, '', targetUrl);
+    window.dispatchEvent(new PopStateEvent('popstate'));
+  }, url);
+  await page.waitForTimeout(100);
+}
+
+/**
+ * Create mock input event in page
+ */
+export async function simulateInput(page: Page, selector: string, value: string): Promise<void> {
+  await page.fill(selector, value);
+  // Wait for debounce
+  await page.waitForTimeout(2100);
+}
+
+/**
+ * Create mock form event in page
+ */
+export async function simulateFormChange(page: Page, selector: string, checked?: boolean): Promise<void> {
+  if (checked !== undefined) {
+    await page.check(selector);
+  } else {
+    await page.click(selector);
+  }
+  await page.waitForTimeout(100);
+}
+
+/**
+ * Setup postMessage listener in page
+ */
+export async function setupPostMessageListener(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as any).__testMessages = [];
+    window.addEventListener('message', (event) => {
+      (window as any).__testMessages.push({
+        type: event.data.type,
+        data: event.data
+      });
+    });
+  });
+}
+
+/**
+ * Get captured postMessages
+ */
+export async function getPostMessages(page: Page, type?: string): Promise<any[]> {
+  return await page.evaluate((messageType) => {
+    const messages = (window as any).__testMessages || [];
+    if (messageType) {
+      return messages.filter((msg: any) => msg.type === messageType);
+    }
+    return messages;
+  }, type);
+}
+
+/**
+ * Clear captured postMessages
+ */
+export async function clearPostMessages(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    (window as any).__testMessages = [];
+  });
+}
+
+/**
+ * Extract screenshot messages from postMessages
+ */
+export function extractScreenshotMessages(messages: Array<{ data: any }>): any[] {
+  return messages
+    .filter(msg => msg.data && msg.data.type === 'staktrak-playwright-screenshot-captured')
+    .map(msg => msg.data);
+}
+
+/**
+ * Validate screenshot message structure
+ */
+export function validateScreenshotMessage(message: any): boolean {
+  if (!message || typeof message !== 'object') {
+    return false;
+  }
+
+  const requiredFields = ['type', 'screenshot', 'actionIndex', 'url', 'timestamp', 'id'];
+  for (const field of requiredFields) {
+    if (!(field in message)) {
+      return false;
+    }
+  }
+
+  if (message.type !== 'staktrak-playwright-screenshot-captured') {
+    return false;
+  }
+
+  if (!verifyScreenshotDataUrl(message.screenshot)) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Wait for staktrak to be ready
+ */
+export async function waitForStaktrakReady(page: Page, timeout: number = 10000): Promise<void> {
+  await page.waitForFunction(() => {
+    const ub = (window as any).userBehaviour;
+    return ub !== undefined &&
+           typeof ub === 'object' &&
+           typeof ub.start === 'function' &&
+           typeof ub.stop === 'function' &&
+           typeof ub.result === 'function';
+  }, { timeout });
+}
+
+/**
+ * Check if action uses old field names (should return false for new code)
+ */
+export function hasOldFieldNames(action: any): boolean {
+  return 'kind' in action || action.type === 'nav' || action.type === 'waitForUrl';
+}
+
+/**
+ * Verify all actions use new naming convention
+ */
+export function verifyNewNamingConvention(actions: any[]): boolean {
+  return actions.every(action => {
+    // Should have 'type' not 'kind'
+    if (!action.type || 'kind' in action) {
+      return false;
+    }
+
+    // Should use 'goto' not 'nav'
+    if (action.type === 'nav') {
+      return false;
+    }
+
+    // Should use 'waitForURL' not 'waitForUrl'
+    if (action.type === 'waitForUrl') {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/mcp/tests/staktrak/dist/staktrak.js
+++ b/mcp/tests/staktrak/dist/staktrak.js
@@ -5438,19 +5438,21 @@ ${initialGoto}${body.split("\n").filter((l) => l.trim()).map((l) => l).join("\n"
           const dest = new URL(href, window.location.href);
           if (dest.origin === window.location.origin) {
             const navAction = { type: "anchorClick", url: dest.href, timestamp: getTimeStamp() };
-            this.results.pageNavigation.push(navAction);
-            window.parent.postMessage(
-              {
-                type: "staktrak-action-added",
-                action: {
-                  id: navAction.timestamp + "_nav",
-                  kind: "nav",
-                  timestamp: navAction.timestamp,
-                  url: navAction.url
-                }
-              },
-              "*"
-            );
+            if (this.isRunning) {
+              this.results.pageNavigation.push(navAction);
+              window.parent.postMessage(
+                {
+                  type: "staktrak-action-added",
+                  action: {
+                    id: navAction.timestamp + "_nav",
+                    kind: "nav",
+                    timestamp: navAction.timestamp,
+                    url: navAction.url
+                  }
+                },
+                "*"
+              );
+            }
           }
         } catch (e2) {
         }

--- a/mcp/tests/staktrak/src/index.ts
+++ b/mcp/tests/staktrak/src/index.ts
@@ -658,21 +658,25 @@ class UserBehaviorTracker {
         const dest = new URL(href, window.location.href);
         if (dest.origin === window.location.origin) {
           const navAction = { type: "anchorClick", url: dest.href, timestamp: getTimeStamp() };
-          this.results.pageNavigation.push(navAction);
 
-          // Broadcast navigation action in real-time
-          window.parent.postMessage(
-            {
-              type: "staktrak-action-added",
-              action: {
-                id: navAction.timestamp + "_nav",
-                kind: "nav",
-                timestamp: navAction.timestamp,
-                url: navAction.url,
+          // Only record navigation when actively recording
+          if (this.isRunning) {
+            this.results.pageNavigation.push(navAction);
+
+            // Broadcast navigation action in real-time
+            window.parent.postMessage(
+              {
+                type: "staktrak-action-added",
+                action: {
+                  id: navAction.timestamp + "_nav",
+                  kind: "nav",
+                  timestamp: navAction.timestamp,
+                  url: navAction.url,
+                },
               },
-            },
-            "*"
-          );
+              "*"
+            );
+          }
         }
       } catch {}
     };


### PR DESCRIPTION
Added \`if (this.isRunning)\` check to \`recordStateChange()\` in \`mcp/tests/staktrak/src/index.ts\` to prevent navigation events from triggering toast notifications and task list entries when recording is off. URL display updates continue to work regardless of recording state.