### PR TITLE
Add URL shortening to staktrak navigation capture

### DIFF
--- a/mcp/tests/staktrak/dist/playwright-generator.js
+++ b/mcp/tests/staktrak/dist/playwright-generator.js
@@ -196,6 +196,42 @@ var PlaywrightGenerator = (() => {
     }
   }
 
+  // src/utils.ts
+  function getRelativeUrl(url) {
+    if (!url)
+      return "/";
+    let pathname;
+    let search = "";
+    let hash = "";
+    try {
+      const urlObj = new URL(url);
+      pathname = urlObj.pathname;
+      search = urlObj.search;
+      hash = urlObj.hash;
+    } catch (e) {
+      if (!url.startsWith("/")) {
+        return url;
+      }
+      const hashIndex = url.indexOf("#");
+      const searchIndex = url.indexOf("?");
+      if (hashIndex !== -1) {
+        pathname = url.substring(0, hashIndex);
+        hash = url.substring(hashIndex);
+      } else if (searchIndex !== -1) {
+        pathname = url.substring(0, searchIndex);
+        search = url.substring(searchIndex);
+      } else {
+        pathname = url;
+      }
+    }
+    const workspacePattern = /^\/w\/[a-zA-Z0-9_-]+/;
+    pathname = pathname.replace(workspacePattern, "");
+    if (!pathname) {
+      pathname = "/";
+    }
+    return pathname + search + hash;
+  }
+
   // src/playwright-generator.ts
   var RecordingManager = class {
     constructor() {
@@ -287,7 +323,7 @@ var PlaywrightGenerator = (() => {
         case "navigation":
           return __spreadProps(__spreadValues({}, baseAction), {
             type: "goto",
-            url: eventData.url
+            url: getRelativeUrl(eventData.url)
           });
         case "input":
           return __spreadProps(__spreadValues({}, baseAction), {
@@ -428,7 +464,7 @@ var PlaywrightGenerator = (() => {
       var _a, _b, _c, _d, _e;
       switch (action.type) {
         case "goto":
-          return `  await page.goto('${action.url || baseUrl}');`;
+          return `  await page.goto('${getRelativeUrl(action.url || baseUrl)}');`;
         case "waitForURL":
           if (action.normalizedUrl) {
             return `  await page.waitForURL('${action.normalizedUrl}');`;

--- a/mcp/tests/staktrak/dist/staktrak.js
+++ b/mcp/tests/staktrak/dist/staktrak.js
@@ -682,6 +682,40 @@ var userBehaviour = (() => {
       return "textbox";
     return null;
   }
+  function getRelativeUrl(url) {
+    if (!url)
+      return "/";
+    let pathname;
+    let search = "";
+    let hash = "";
+    try {
+      const urlObj = new URL(url);
+      pathname = urlObj.pathname;
+      search = urlObj.search;
+      hash = urlObj.hash;
+    } catch (e) {
+      if (!url.startsWith("/")) {
+        return url;
+      }
+      const hashIndex = url.indexOf("#");
+      const searchIndex = url.indexOf("?");
+      if (hashIndex !== -1) {
+        pathname = url.substring(0, hashIndex);
+        hash = url.substring(hashIndex);
+      } else if (searchIndex !== -1) {
+        pathname = url.substring(0, searchIndex);
+        search = url.substring(searchIndex);
+      } else {
+        pathname = url;
+      }
+    }
+    const workspacePattern = /^\/w\/[a-zA-Z0-9_-]+/;
+    pathname = pathname.replace(workspacePattern, "");
+    if (!pathname) {
+      pathname = "/";
+    }
+    return pathname + search + hash;
+  }
 
   // src/debug.ts
   function rectsIntersect(rect1, rect2) {
@@ -4706,7 +4740,7 @@ var userBehaviour = (() => {
         case "navigation":
           return __spreadProps(__spreadValues({}, baseAction), {
             type: "goto",
-            url: eventData.url
+            url: getRelativeUrl(eventData.url)
           });
         case "input":
           return __spreadProps(__spreadValues({}, baseAction), {
@@ -4847,7 +4881,7 @@ var userBehaviour = (() => {
       var _a2, _b, _c, _d, _e;
       switch (action.type) {
         case "goto":
-          return `  await page.goto('${action.url || baseUrl}');`;
+          return `  await page.goto('${getRelativeUrl(action.url || baseUrl)}');`;
         case "waitForURL":
           if (action.normalizedUrl) {
             return `  await page.waitForURL('${action.normalizedUrl}');`;
@@ -5437,7 +5471,7 @@ ${initialGoto}${body.split("\n").filter((l) => l.trim()).map((l) => l).join("\n"
         try {
           const dest = new URL(href, window.location.href);
           if (dest.origin === window.location.origin) {
-            const navAction = { type: "anchorClick", url: dest.href, timestamp: getTimeStamp() };
+            const navAction = { type: "anchorClick", url: getRelativeUrl(dest.href), timestamp: getTimeStamp() };
             if (this.isRunning) {
               this.results.pageNavigation.push(navAction);
               window.parent.postMessage(

--- a/mcp/tests/staktrak/src/index.ts
+++ b/mcp/tests/staktrak/src/index.ts
@@ -5,6 +5,7 @@ import {
   getElementSelector,
   createClickDetail,
   filterClickDetails,
+  getRelativeUrl,
 } from "./utils";
 import { debugMsg, isReactDevModeActive } from "./debug";
 import { initPlaywrightReplay } from "./playwright-replay/index";
@@ -657,7 +658,7 @@ class UserBehaviorTracker {
       try {
         const dest = new URL(href, window.location.href);
         if (dest.origin === window.location.origin) {
-          const navAction = { type: "anchorClick", url: dest.href, timestamp: getTimeStamp() };
+          const navAction = { type: "anchorClick", url: getRelativeUrl(dest.href), timestamp: getTimeStamp() };
 
           // Only record navigation when actively recording
           if (this.isRunning) {

--- a/mcp/tests/staktrak/src/playwright-generator.ts
+++ b/mcp/tests/staktrak/src/playwright-generator.ts
@@ -1,5 +1,6 @@
 import { Action, resultsToActions } from "./actionModel";
 import { Results as TrackingResults } from "./types";
+import { getRelativeUrl } from "./utils";
 
 export interface GenerateOptions {
   baseUrl?: string;
@@ -107,7 +108,7 @@ export class RecordingManager {
         return {
           ...baseAction,
           type: "goto",
-          url: eventData.url,
+          url: getRelativeUrl(eventData.url),
         } as Action;
       case "input":
         return {
@@ -271,7 +272,7 @@ export function generatePlaywrightTestFromActions(
     .map((action) => {
       switch (action.type) {
         case "goto":
-          return `  await page.goto('${action.url || baseUrl}');`;
+          return `  await page.goto('${getRelativeUrl(action.url || baseUrl)}');`;
         case "waitForURL":
           if (action.normalizedUrl) {
             return `  await page.waitForURL('${action.normalizedUrl}');`;

--- a/mcp/tests/staktrak/src/utils.ts
+++ b/mcp/tests/staktrak/src/utils.ts
@@ -811,3 +811,55 @@ function inferRole(el: HTMLElement): string | null {
   if (tag === 'input') return 'textbox';
   return null;
 }
+
+/**
+ * Extracts the relative URL (pathname + search + hash) from a full URL
+ * and removes workspace prefix (/w/[slug]) to show only the page path
+ * Returns "/" if the URL is just a domain without a path
+ * Returns the original string if it's already a relative URL or can't be parsed
+ */
+export function getRelativeUrl(url: string): string {
+  if (!url) return "/";
+
+  let pathname: string;
+  let search = "";
+  let hash = "";
+
+  try {
+    // Try to parse as URL
+    const urlObj = new URL(url);
+    pathname = urlObj.pathname;
+    search = urlObj.search;
+    hash = urlObj.hash;
+  } catch {
+    // If parsing fails, it might already be a relative URL
+    if (!url.startsWith("/")) {
+      return url;
+    }
+    // Extract parts manually for relative URLs
+    const hashIndex = url.indexOf("#");
+    const searchIndex = url.indexOf("?");
+
+    if (hashIndex !== -1) {
+      pathname = url.substring(0, hashIndex);
+      hash = url.substring(hashIndex);
+    } else if (searchIndex !== -1) {
+      pathname = url.substring(0, searchIndex);
+      search = url.substring(searchIndex);
+    } else {
+      pathname = url;
+    }
+  }
+
+  // Remove workspace prefix pattern: /w/[slug]/
+  // Match /w/ followed by any slug (alphanumeric, hyphens, underscores) followed by /
+  const workspacePattern = /^\/w\/[a-zA-Z0-9_-]+/;
+  pathname = pathname.replace(workspacePattern, "");
+
+  // If pathname is now empty, default to "/"
+  if (!pathname) {
+    pathname = "/";
+  }
+
+  return pathname + search + hash;
+}


### PR DESCRIPTION
Adds getRelativeUrl() utility to strip pod domains and workspace prefixes from navigation URLs. Related to stakwork/hive#1455