### PR TITLE
feat: add databank and namespace properties for nodes in realtime

### DIFF
--- a/ast/src/lang/graphs/neo4j_utils.rs
+++ b/ast/src/lang/graphs/neo4j_utils.rs
@@ -74,6 +74,14 @@ impl NodeQueryBuilder {
         let token_count = calculate_token_count(&self.node_data.body).unwrap_or(0);
         boltmap_insert_int(&mut properties, "token_count", token_count);
 
+        // Add Data_Bank property during node creation (fixes real-time streaming)
+        if !self.node_data.name.is_empty() {
+            boltmap_insert_str(&mut properties, "Data_Bank", &self.node_data.name);
+        }
+
+        // Add default namespace during node creation (fixes real-time streaming)
+        boltmap_insert_str(&mut properties, "namespace", "default");
+
         // println!("[NodeQueryBuilder] node_key: {}", node_key);
 
         let query = format!(

--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -309,15 +309,19 @@ pub async fn ingest(
         res
     };
 
-    // Set Data_Bank property for nodes that don't have it
-    info!("Setting Data_Bank property for nodes missing it...");
-    if let Err(e) = graph_ops.set_missing_data_bank().await {
-        tracing::warn!("Error setting Data_Bank property: {:?}", e);
-    }
+    // Only set missing properties if not using streaming (for backward compatibility)
+    if !streaming {
+        info!("Setting Data_Bank property for nodes missing it...");
+        if let Err(e) = graph_ops.set_missing_data_bank().await {
+            tracing::warn!("Error setting Data_Bank property: {:?}", e);
+        }
 
-    info!("Setting default namespace for nodes missing it...");
-    if let Err(e) = graph_ops.set_default_namespace().await {
-        tracing::warn!("Error setting default namespace: {:?}", e);
+        info!("Setting default namespace for nodes missing it...");
+        if let Err(e) = graph_ops.set_default_namespace().await {
+            tracing::warn!("Error setting default namespace: {:?}", e);
+        }
+    } else {
+        info!("Skipping post-processing - properties already set during streaming");
     }
 
     let _ = state.tx.send(ast::repo::StatusUpdate {


### PR DESCRIPTION
 - Add Data_Bank and namespace properties during 
  node creation instead of post-processing
  - Skip post-processing when streaming mode is 
  enabled  
  - Fixes issue where nodes appeared incomplete 
  during realtime progress updates"