### PR TITLE
fix: handle SVGAnimatedString in click tracking

### DIFF
--- a/mcp/tests/staktrak/dist/playwright-generator.js
+++ b/mcp/tests/staktrak/dist/playwright-generator.js
@@ -224,8 +224,6 @@ var PlaywrightGenerator = (() => {
         pathname = url;
       }
     }
-    const workspacePattern = /^\/w\/[a-zA-Z0-9_-]+/;
-    pathname = pathname.replace(workspacePattern, "");
     if (!pathname) {
       pathname = "/";
     }

--- a/mcp/tests/staktrak/dist/staktrak.js
+++ b/mcp/tests/staktrak/dist/staktrak.js
@@ -459,6 +459,14 @@ var userBehaviour = (() => {
     }
     if (visualSelector)
       selectors.visualSelector = visualSelector;
+    let className;
+    if (target.className) {
+      if (typeof target.className === "string") {
+        className = target.className;
+      } else if (typeof target.className === "object" && "baseVal" in target.className) {
+        className = target.className.baseVal;
+      }
+    }
     return {
       x: e.clientX,
       y: e.clientY,
@@ -467,7 +475,7 @@ var userBehaviour = (() => {
       elementInfo: {
         tagName: target.tagName.toLowerCase(),
         id: target.id || void 0,
-        className: target.className || void 0,
+        className: className || void 0,
         attributes: getElementAttributes(target)
       }
     };
@@ -709,8 +717,6 @@ var userBehaviour = (() => {
         pathname = url;
       }
     }
-    const workspacePattern = /^\/w\/[a-zA-Z0-9_-]+/;
-    pathname = pathname.replace(workspacePattern, "");
     if (!pathname) {
       pathname = "/";
     }

--- a/mcp/tests/staktrak/src/utils.ts
+++ b/mcp/tests/staktrak/src/utils.ts
@@ -538,6 +538,17 @@ export const createClickDetail = (e: MouseEvent): ClickDetail => {
   }
   if (visualSelector) (selectors as any).visualSelector = visualSelector;
 
+  // Handle SVG elements where className is SVGAnimatedString instead of string
+  let className: string | undefined;
+  if (target.className) {
+    if (typeof target.className === 'string') {
+      className = target.className;
+    } else if (typeof target.className === 'object' && 'baseVal' in target.className) {
+      // SVGAnimatedString has a baseVal property
+      className = (target.className as any).baseVal;
+    }
+  }
+
   return {
     x: e.clientX,
     y: e.clientY,
@@ -546,7 +557,7 @@ export const createClickDetail = (e: MouseEvent): ClickDetail => {
     elementInfo: {
       tagName: target.tagName.toLowerCase(),
       id: (target as HTMLElement).id || undefined,
-      className: target.className || undefined,
+      className: className || undefined,
       attributes: getElementAttributes(target),
     },
   };


### PR DESCRIPTION
Fixes postMessage DataCloneError when clicking SVG elements by properly converting SVGAnimatedString className to string before serialization.