### PR TITLE
fix: add multiple node_types in /test/nodes

### DIFF
--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -140,6 +140,7 @@ pub struct Node {
 
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct NodeConcise {
+    pub node_type: String,
     pub name: String,
     pub file: String,
     pub ref_id: String,

--- a/standalone/src/utils.rs
+++ b/standalone/src/utils.rs
@@ -10,3 +10,10 @@ pub fn parse_node_type(node_type: &str) -> Result<NodeType> {
     let titled_case = chars.into_iter().collect::<String>();
     NodeType::from_str(&titled_case)
 }
+
+pub fn parse_node_types(node_types_str: &str) -> Result<Vec<NodeType>> {
+    node_types_str
+        .split(',')
+        .map(|s| parse_node_type(s.trim()))
+        .collect()
+}


### PR DESCRIPTION
```json
{
  "items": [
    {
      "node_type": "Class",
      "name": "LightningClient",
      "file": "stakwork/sphinx-bounties/src/lib/lightning/client.ts",
      "ref_id": "a29d694f-44a3-4ad9-8ae8-ab5f6e619368",
      "weight": 1,
      "test_count": 1,
      "covered": true,
      "body_length": 6502,
      "line_count": 226,
      "start": 76,
      "end": 301,
      "meta": {
        "Data_Bank": "LightningClient",
        "date_added_to_graph": "1764610157.7956190",
        "namespace": "default",
        "node_key": "class-lightningclient-stakworksphinxbountiessrcliblightningclientts-76",
        "ref_id": "a29d694f-44a3-4ad9-8ae8-ab5f6e619368"
      }
    },
    {
      "node_type": "Endpoint",
      "name": "/api/admin/analytics",
      "file": "stakwork/sphinx-bounties/src/app/api/admin/analytics/route.ts",
      "ref_id": "89c450a7-b1b9-454f-827c-f342176ef7ad",
      "weight": 0,
      "test_count": 0,
      "covered": false,
      "body_length": 3051,
      "line_count": 115,
      "verb": "GET",
      "start": 15,
      "end": 129,
      "meta": {
        "Data_Bank": "/api/admin/analytics",
        "date_added_to_graph": "1764610582.4481111",
        "handler": "GET",
        "namespace": "default",
        "node_key": "endpoint-apiadminanalytics-stakworksphinxbountiessrcappapiadminanalyticsroutets-15-get",
        "ref_id": "89c450a7-b1b9-454f-827c-f342176ef7ad",
        "verb": "GET"
      }
    },
    {
      "node_type": "Endpoint",
      "name": "/api/admin/bounties",
      "file": "stakwork/sphinx-bounties/src/app/api/admin/bounties/route.ts",
      "ref_id": "dfdbf953-ac94-4b0f-8bd0-3c7d71b006b1",
      "weight": 0,
      "test_count": 0,
      "covered": false,
      "body_length": 2409,
      "line_count": 94,
      "verb": "GET",
      "start": 14,
      "end": 107,
      "meta": {
        "Data_Bank": "/api/admin/bounties",
        "date_added_to_graph": "1764610582.4542160",
        "handler": "GET",
        "namespace": "default",
        "node_key": "endpoint-apiadminbounties-stakworksphinxbountiessrcappapiadminbountiesroutets-14-get",
        "ref_id": "dfdbf953-ac94-4b0f-8bd0-3c7d71b006b1",
        "verb": "GET"
      }
    }
  ],
  "total_returned": 3,
  "total_count": 139,
  "total_pages": 47,
  "current_page": 1
}
```