### PR TITLE
fix: update the mock discovery system

### DIFF
--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -583,7 +583,7 @@ class Db {
       node_type: "Mock",
       node_data: {
         name,
-        file: files[0] || "mock://generated",
+        file: `mock://${name}`,
         start: 0,
       },
     } as Node);
@@ -591,7 +591,7 @@ class Db {
       await session.run(Q.CREATE_MOCK_QUERY, {
         node_key,
         name,
-        file: files[0] || "mock://generated",
+        file: `mock://${name}`,
         body: JSON.stringify(files),
         description,
         mocked,
@@ -612,6 +612,23 @@ class Db {
       await session.run(Q.LINK_MOCK_TO_FILE_QUERY, {
         mock_ref_id,
         file_path,
+      });
+    } finally {
+      await session.close();
+    }
+  }
+
+  async update_mock_status(
+    name: string,
+    mocked: boolean,
+    files: string[]
+  ) {
+    const session = this.driver.session();
+    try {
+      await session.run(Q.UPDATE_MOCK_STATUS_QUERY, {
+        name,
+        mocked,
+        body: JSON.stringify(files),
       });
     } finally {
       await session.close();

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -138,8 +138,9 @@ RETURN collect(distinct f.id) as linked_features
 
 export const CREATE_MOCK_QUERY = `
 MERGE (n:Mock:${Data_Bank} {node_key: $node_key})
-ON CREATE SET n.ref_id = randomUUID(), n.date_added_to_graph = $ts, n.namespace = 'default'
-SET n.name = $name, n.file = $file, n.body = $body, n.start = 0, n.end = 0, n.description = $description, n.mocked = $mocked, n.namespace = 'default'
+ON CREATE SET n.ref_id = randomUUID(), n.date_added_to_graph = $ts, n.namespace = 'default',
+  n.name = $name, n.file = $file, n.body = $body, n.start = 0, n.end = 0, n.description = $description, n.mocked = $mocked
+ON MATCH SET n.name = $name, n.file = $file, n.body = $body, n.description = $description, n.mocked = $mocked
 RETURN n
 `;
 
@@ -166,6 +167,12 @@ WITH m, collect(f.file) as linked_files
 RETURN m.name as name, m.ref_id as ref_id, m.description as description,
        m.mocked as mocked, linked_files, size(linked_files) as file_count
 ORDER BY file_count DESC
+`;
+
+export const UPDATE_MOCK_STATUS_QUERY = `
+MATCH (n:Mock {name: $name})
+SET n.mocked = $mocked, n.body = $body
+RETURN n
 `;
 
 export const DELETE_NODE_BY_REF_ID_QUERY = `


### PR DESCRIPTION
- Added a `computeMockDelta` method that sorts our mocks into `new`, `changed`, and `unchanged` 
- Updated queries to have one that is dedicated to creating new mocks, and one to update mocks that have been updated during /sync
- Updated the prompts to be a little more strict about what it means to update mocks
- Created new pipelines for managing and updating mocks and creating new ones. 
