### PR TITLE
fix: update publish standalone ci

### DIFF
--- a/.github/workflows/publish-standalone.yml
+++ b/.github/workflows/publish-standalone.yml
@@ -6,11 +6,18 @@ on:
 
 jobs:
   build-and-push:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     timeout-minutes: 120
     permissions:
       contents: read
       packages: write
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            platform: linux/amd64
+          - runner: ubuntu-24.04-arm64
+            platform: linux/arm64
 
     steps:
       - name: Checkout code
@@ -31,28 +38,37 @@ jobs:
         with:
           context: .
           file: Dockerfile.standalone
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           push: true
-          # Use registry cache which is more reliable for multi-platform
-          cache-from: type=registry,ref=ghcr.io/stakwork/stakgraph-standalone:buildcache
-          cache-to: type=registry,ref=ghcr.io/stakwork/stakgraph-standalone:buildcache,mode=max
+          cache-from: type=registry,ref=ghcr.io/stakwork/stakgraph-standalone:buildcache-${{ matrix.platform }}
+          cache-to: type=registry,ref=ghcr.io/stakwork/stakgraph-standalone:buildcache-${{ matrix.platform }},mode=max
           provenance: false
           sbom: false
           tags: |
-            ghcr.io/stakwork/stakgraph-standalone:${{ github.ref_name }}
-            ghcr.io/stakwork/stakgraph-standalone:latest
+            ghcr.io/stakwork/stakgraph-standalone:${{ github.ref_name }}-${{ matrix.platform }}
+            ghcr.io/stakwork/stakgraph-standalone:latest-${{ matrix.platform }}
 
-      - name: Build and push Docker image (fallback)
-        if: failure()
-        uses: docker/build-push-action@v5
+  create-manifest:
+    needs: build-and-push
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
         with:
-          context: .
-          file: Dockerfile.standalone
-          platforms: linux/amd64,linux/arm64
-          push: true
-          no-cache: true
-          provenance: false
-          sbom: false
-          tags: |
-            ghcr.io/stakwork/stakgraph-standalone:${{ github.ref_name }}
-            ghcr.io/stakwork/stakgraph-standalone:latest
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create -t ghcr.io/stakwork/stakgraph-standalone:${{ github.ref_name }} \
+            ghcr.io/stakwork/stakgraph-standalone:${{ github.ref_name }}-linux/amd64 \
+            ghcr.io/stakwork/stakgraph-standalone:${{ github.ref_name }}-linux/arm64
+          
+          docker buildx imagetools create -t ghcr.io/stakwork/stakgraph-standalone:latest \
+            ghcr.io/stakwork/stakgraph-standalone:latest-linux/amd64 \
+            ghcr.io/stakwork/stakgraph-standalone:latest-linux/arm64


### PR DESCRIPTION
CI to use the matrix strategy: 
```
Job 1:

Runs on ubuntu-latest (x86_64/amd64 machine)
Builds linux/amd64 image natively (fast, no emulation)
Pushes as stakgraph-standalone:latest-linux/amd64
Job 2:

Runs on ubuntu-24.04-arm64 (ARM64 machine)
Builds linux/arm64 image natively (fast, no emulation)
Pushes as stakgraph-standalone:latest-linux/arm64
Job 3 (create-manifest):

Waits for both builds to finish
Combines the two architecture-specific images into one multi-arch image
Creates stakgraph-standalone:latest that works on both amd64 and arm64
```

