### PR TITLE
feat: setup multiple patterns of test coverage

### DIFF
--- a/ast/src/lang/graphs/coverage.rs
+++ b/ast/src/lang/graphs/coverage.rs
@@ -1,0 +1,345 @@
+use super::graph_ops::{CoverageStat, GraphCoverage, MockStat};
+use super::neo4j_graph::Neo4jGraph;
+use super::{EdgeType, NodeData, NodeType};
+use shared::Result;
+use std::collections::HashSet;
+
+#[derive(Debug, Clone)]
+pub enum CoverageLanguage {
+    Typescript,
+    Ruby,
+}
+
+impl CoverageLanguage {
+    pub async fn from_graph(graph: &Neo4jGraph) -> Self {
+        let language_nodes = graph.find_nodes_by_type_async(NodeType::Language).await;
+        
+        for lang_node in language_nodes {
+            let lang_name = lang_node.name.to_lowercase();
+            if lang_name == "ruby" {
+                return CoverageLanguage::Ruby;
+            }
+        }
+        
+        CoverageLanguage::Typescript
+    }
+
+    pub fn language_name(&self) -> String {
+        match self {
+            CoverageLanguage::Typescript => "typescript".to_string(),
+            CoverageLanguage::Ruby => "ruby".to_string(),
+        }
+    }
+
+    pub async fn get_coverage(
+        &self,
+        graph: &Neo4jGraph,
+        in_scope: impl Fn(&NodeData) -> bool,
+    ) -> Result<GraphCoverage> {
+        match self {
+            CoverageLanguage::Typescript => {
+                self.get_typescript_coverage(graph, in_scope).await
+            }
+            CoverageLanguage::Ruby => {
+                self.get_ruby_coverage(graph, in_scope).await
+            }
+        }
+    }
+
+    async fn get_typescript_coverage(
+        &self,
+        graph: &Neo4jGraph,
+        in_scope: impl Fn(&NodeData) -> bool,
+    ) -> Result<GraphCoverage> {
+        let unit_tests = graph.find_nodes_by_type_async(NodeType::UnitTest).await;
+        let integration_tests = graph.find_nodes_by_type_async(NodeType::IntegrationTest).await;
+        let e2e_tests = graph.find_nodes_by_type_async(NodeType::E2eTest).await;
+
+        let functions = graph.find_top_level_functions_async().await;
+        let endpoints = graph.find_nodes_by_type_async(NodeType::Endpoint).await;
+        let pages = graph.find_nodes_by_type_async(NodeType::Page).await;
+
+        let unit_calls_funcs = graph.find_nodes_with_edge_type_async(
+            NodeType::UnitTest,
+            NodeType::Function,
+            EdgeType::Calls,
+        ).await;
+        let integration_calls_endpoints = graph.find_nodes_with_edge_type_async(
+            NodeType::IntegrationTest,
+            NodeType::Endpoint,
+            EdgeType::Calls,
+        ).await;
+        let e2e_calls_pages = graph.find_nodes_with_edge_type_async(
+            NodeType::E2eTest,
+            NodeType::Page,
+            EdgeType::Calls,
+        ).await;
+
+        let collect_targets = |calls: &Vec<(NodeData, NodeData)>| -> HashSet<String> {
+            calls
+                .iter()
+                .map(|(_, tgt)| format!("{}:{}:{}", tgt.name, tgt.file, tgt.start))
+                .collect()
+        };
+
+        let unit_target_functions = collect_targets(&unit_calls_funcs);
+        let integration_target_endpoints = collect_targets(&integration_calls_endpoints);
+        let e2e_target_pages = collect_targets(&e2e_calls_pages);
+
+        let unit_functions_in_scope: Vec<NodeData> = functions
+            .into_iter()
+            .filter(|n| in_scope(n))
+            .filter(|n| {
+                if n.body.trim().is_empty() {
+                    return false;
+                }
+                let is_component = n
+                    .meta
+                    .get("component")
+                    .map(|v| v == "true")
+                    .unwrap_or(false);
+                let is_operand = n.meta.get("operand").is_some();
+                !is_component && !is_operand
+            })
+            .collect();
+
+        let integration_endpoints_in_scope: Vec<NodeData> =
+            endpoints.into_iter().filter(|n| in_scope(n)).collect();
+        let pages_in_scope: Vec<NodeData> = pages.into_iter().filter(|n| in_scope(n)).collect();
+        let unit_tests_in_scope: Vec<NodeData> =
+            unit_tests.into_iter().filter(|n| in_scope(n)).collect();
+        let integration_tests_in_scope: Vec<NodeData> = integration_tests
+            .into_iter()
+            .filter(|n| in_scope(n))
+            .collect();
+        let e2e_tests_in_scope: Vec<NodeData> =
+            e2e_tests.into_iter().filter(|n| in_scope(n)).collect();
+
+        let e2e_pages_in_scope = pages_in_scope.clone();
+
+        let build_stat = |total_nodes: &Vec<NodeData>,
+                          total_tests: &Vec<NodeData>,
+                          covered_set: &HashSet<String>|
+         -> Option<CoverageStat> {
+            if total_nodes.is_empty() {
+                return None;
+            }
+            let covered_count = total_nodes
+                .iter()
+                .filter(|n| covered_set.contains(&format!("{}:{}:{}", n.name, n.file, n.start)))
+                .count();
+            let percent = if total_nodes.is_empty() {
+                0.0
+            } else {
+                (covered_count as f64 / total_nodes.len() as f64) * 100.0
+            };
+
+            let total_lines: usize = total_nodes
+                .iter()
+                .map(|n| n.end.saturating_sub(n.start) + 1)
+                .sum();
+
+            let covered_lines: usize = total_nodes
+                .iter()
+                .filter(|n| covered_set.contains(&format!("{}:{}:{}", n.name, n.file, n.start)))
+                .map(|n| n.end.saturating_sub(n.start) + 1)
+                .sum();
+
+            let line_percent = if total_lines == 0 {
+                0.0
+            } else {
+                (covered_lines as f64 / total_lines as f64) * 100.0
+            };
+
+            Some(CoverageStat {
+                total: total_nodes.len(),
+                total_tests: total_tests.len(),
+                covered: covered_count,
+                percent: (percent * 100.0).round() / 100.0,
+                total_lines,
+                covered_lines,
+                line_percent: (line_percent * 100.0).round() / 100.0,
+            })
+        };
+
+        let mocks = graph.find_nodes_by_type_async(NodeType::Mock).await;
+        let mocks_in_scope: Vec<NodeData> = mocks.into_iter().filter(|n| in_scope(n)).collect();
+
+        let mocked_count = mocks_in_scope
+            .iter()
+            .filter(|n| n.meta.get("mocked").map(|v| v == "true").unwrap_or(false))
+            .count();
+
+        let mock_stat = if mocks_in_scope.is_empty() {
+            None
+        } else {
+            let percent = (mocked_count as f64 / mocks_in_scope.len() as f64) * 100.0;
+            Some(MockStat {
+                total: mocks_in_scope.len(),
+                mocked: mocked_count,
+                percent: (percent * 100.0).round() / 100.0,
+            })
+        };
+
+        Ok(GraphCoverage {
+            language: Some(self.language_name()),
+            unit_tests: build_stat(
+                &unit_functions_in_scope,
+                &unit_tests_in_scope,
+                &unit_target_functions,
+            ),
+            integration_tests: build_stat(
+                &integration_endpoints_in_scope,
+                &integration_tests_in_scope,
+                &integration_target_endpoints,
+            ),
+            e2e_tests: build_stat(&e2e_pages_in_scope, &e2e_tests_in_scope, &e2e_target_pages),
+            mocks: mock_stat,
+        })
+    }
+
+    async fn get_ruby_coverage(
+        &self,
+        graph: &Neo4jGraph,
+        in_scope: impl Fn(&NodeData) -> bool,
+    ) -> Result<GraphCoverage> {
+        let unit_tests = graph.find_nodes_by_type_async(NodeType::UnitTest).await;
+        let integration_tests = graph.find_nodes_by_type_async(NodeType::IntegrationTest).await;
+        let e2e_tests = graph.find_nodes_by_type_async(NodeType::E2eTest).await;
+
+        let classes = graph.find_nodes_by_type_async(NodeType::Class).await;
+        let pages = graph.find_nodes_by_type_async(NodeType::Page).await;
+
+        let unit_calls_classes = graph.find_nodes_with_edge_type_async(
+            NodeType::UnitTest,
+            NodeType::Class,
+            EdgeType::Calls,
+        ).await;
+        let integration_calls_classes = graph.find_nodes_with_edge_type_async(
+            NodeType::IntegrationTest,
+            NodeType::Class,
+            EdgeType::Calls,
+        ).await;
+        let e2e_calls_pages = graph.find_nodes_with_edge_type_async(
+            NodeType::E2eTest,
+            NodeType::Page,
+            EdgeType::Calls,
+        ).await;
+
+        let collect_targets = |calls: &Vec<(NodeData, NodeData)>| -> HashSet<String> {
+            calls
+                .iter()
+                .map(|(_, tgt)| format!("{}:{}:{}", tgt.name, tgt.file, tgt.start))
+                .collect()
+        };
+
+        let unit_target_classes = collect_targets(&unit_calls_classes);
+        let integration_target_classes = collect_targets(&integration_calls_classes);
+        let e2e_target_pages = collect_targets(&e2e_calls_pages);
+
+        let unit_classes_in_scope: Vec<NodeData> = classes
+            .iter()
+            .filter(|n| in_scope(n))
+            .filter(|n| !n.file.ends_with("_controller.rb"))
+            .cloned()
+            .collect();
+
+        let integration_classes_in_scope: Vec<NodeData> = classes
+            .into_iter()
+            .filter(|n| in_scope(n))
+            .filter(|n| n.file.ends_with("_controller.rb"))
+            .collect();
+
+        let pages_in_scope: Vec<NodeData> = pages.into_iter().filter(|n| in_scope(n)).collect();
+        let unit_tests_in_scope: Vec<NodeData> =
+            unit_tests.into_iter().filter(|n| in_scope(n)).collect();
+        let integration_tests_in_scope: Vec<NodeData> = integration_tests
+            .into_iter()
+            .filter(|n| in_scope(n))
+            .collect();
+        let e2e_tests_in_scope: Vec<NodeData> =
+            e2e_tests.into_iter().filter(|n| in_scope(n)).collect();
+
+        let e2e_pages_in_scope = pages_in_scope.clone();
+
+        let build_stat = |total_nodes: &Vec<NodeData>,
+                          total_tests: &Vec<NodeData>,
+                          covered_set: &HashSet<String>|
+         -> Option<CoverageStat> {
+            if total_nodes.is_empty() {
+                return None;
+            }
+            let covered_count = total_nodes
+                .iter()
+                .filter(|n| covered_set.contains(&format!("{}:{}:{}", n.name, n.file, n.start)))
+                .count();
+            let percent = if total_nodes.is_empty() {
+                0.0
+            } else {
+                (covered_count as f64 / total_nodes.len() as f64) * 100.0
+            };
+
+            let total_lines: usize = total_nodes
+                .iter()
+                .map(|n| n.end.saturating_sub(n.start) + 1)
+                .sum();
+
+            let covered_lines: usize = total_nodes
+                .iter()
+                .filter(|n| covered_set.contains(&format!("{}:{}:{}", n.name, n.file, n.start)))
+                .map(|n| n.end.saturating_sub(n.start) + 1)
+                .sum();
+
+            let line_percent = if total_lines == 0 {
+                0.0
+            } else {
+                (covered_lines as f64 / total_lines as f64) * 100.0
+            };
+
+            Some(CoverageStat {
+                total: total_nodes.len(),
+                total_tests: total_tests.len(),
+                covered: covered_count,
+                percent: (percent * 100.0).round() / 100.0,
+                total_lines,
+                covered_lines,
+                line_percent: (line_percent * 100.0).round() / 100.0,
+            })
+        };
+
+        let mocks = graph.find_nodes_by_type_async(NodeType::Mock).await;
+        let mocks_in_scope: Vec<NodeData> = mocks.into_iter().filter(|n| in_scope(n)).collect();
+
+        let mocked_count = mocks_in_scope
+            .iter()
+            .filter(|n| n.meta.get("mocked").map(|v| v == "true").unwrap_or(false))
+            .count();
+
+        let mock_stat = if mocks_in_scope.is_empty() {
+            None
+        } else {
+            let percent = (mocked_count as f64 / mocks_in_scope.len() as f64) * 100.0;
+            Some(MockStat {
+                total: mocks_in_scope.len(),
+                mocked: mocked_count,
+                percent: (percent * 100.0).round() / 100.0,
+            })
+        };
+
+        Ok(GraphCoverage {
+            language: Some(self.language_name()),
+            unit_tests: build_stat(
+                &unit_classes_in_scope,
+                &unit_tests_in_scope,
+                &unit_target_classes,
+            ),
+            integration_tests: build_stat(
+                &integration_classes_in_scope,
+                &integration_tests_in_scope,
+                &integration_target_classes,
+            ),
+            e2e_tests: build_stat(&e2e_pages_in_scope, &e2e_tests_in_scope, &e2e_target_pages),
+            mocks: mock_stat,
+        })
+    }
+}

--- a/ast/src/lang/graphs/graph_ops.rs
+++ b/ast/src/lang/graphs/graph_ops.rs
@@ -40,6 +40,7 @@ pub struct MockStat {
 
 #[derive(Debug, Clone)]
 pub struct GraphCoverage {
+    pub language: Option<String>,
     pub unit_tests: Option<CoverageStat>,
     pub integration_tests: Option<CoverageStat>,
     pub e2e_tests: Option<CoverageStat>,
@@ -319,6 +320,9 @@ impl GraphOps {
     ) -> Result<GraphCoverage> {
         self.graph.ensure_connected().await?;
 
+        use super::coverage::CoverageLanguage;
+        let coverage_lang = CoverageLanguage::from_graph(&self.graph).await;
+
         let ignore_dirs = test_filters
             .as_ref()
             .map(|f| f.ignore_dirs.clone())
@@ -353,165 +357,7 @@ impl GraphOps {
             repo_match && not_ignored && regex_match
         };
 
-        let unit_tests = self
-            .graph
-            .find_nodes_by_type_async(NodeType::UnitTest)
-            .await;
-        let integration_tests = self
-            .graph
-            .find_nodes_by_type_async(NodeType::IntegrationTest)
-            .await;
-        let e2e_tests = self.graph.find_nodes_by_type_async(NodeType::E2eTest).await;
-
-        let functions = self.graph.find_top_level_functions_async().await;
-        let endpoints = self
-            .graph
-            .find_nodes_by_type_async(NodeType::Endpoint)
-            .await;
-        let pages = self.graph.find_nodes_by_type_async(NodeType::Page).await;
-
-        let unit_calls_funcs = self
-            .graph
-            .find_nodes_with_edge_type_async(
-                NodeType::UnitTest,
-                NodeType::Function,
-                EdgeType::Calls,
-            )
-            .await;
-        let integration_calls_endpoints = self
-            .graph
-            .find_nodes_with_edge_type_async(
-                NodeType::IntegrationTest,
-                NodeType::Endpoint,
-                EdgeType::Calls,
-            )
-            .await;
-        let e2e_calls_pages = self
-            .graph
-            .find_nodes_with_edge_type_async(NodeType::E2eTest, NodeType::Page, EdgeType::Calls)
-            .await;
-
-        let collect_targets = |calls: &Vec<(NodeData, NodeData)>| -> HashSet<String> {
-            calls
-                .iter()
-                .map(|(_, tgt)| format!("{}:{}:{}", tgt.name, tgt.file, tgt.start))
-                .collect()
-        };
-
-        let unit_target_functions = collect_targets(&unit_calls_funcs);
-        let integration_target_endpoints = collect_targets(&integration_calls_endpoints);
-        let e2e_target_pages = collect_targets(&e2e_calls_pages);
-
-        let unit_functions_in_scope: Vec<NodeData> = functions
-            .into_iter()
-            .filter(|n| in_scope(n))
-            .filter(|n| {
-                if n.body.trim().is_empty() {
-                    return false;
-                }
-                let is_component = n
-                    .meta
-                    .get("component")
-                    .map(|v| v == "true")
-                    .unwrap_or(false);
-                let is_operand = n.meta.get("operand").is_some();
-                !is_component && !is_operand
-            })
-            .collect();
-        let integration_endpoints_in_scope: Vec<NodeData> =
-            endpoints.into_iter().filter(|n| in_scope(n)).collect();
-        let pages_in_scope: Vec<NodeData> = pages.into_iter().filter(|n| in_scope(n)).collect();
-        let unit_tests_in_scope: Vec<NodeData> =
-            unit_tests.into_iter().filter(|n| in_scope(n)).collect();
-        let integration_tests_in_scope: Vec<NodeData> = integration_tests
-            .into_iter()
-            .filter(|n| in_scope(n))
-            .collect();
-        let e2e_tests_in_scope: Vec<NodeData> =
-            e2e_tests.into_iter().filter(|n| in_scope(n)).collect();
-
-        let e2e_pages_in_scope = pages_in_scope.clone();
-
-        let build_stat = |total_nodes: &Vec<NodeData>,
-                          total_tests: &Vec<NodeData>,
-                          covered_set: &HashSet<String>|
-         -> Option<CoverageStat> {
-            if total_nodes.is_empty() {
-                return None;
-            }
-            let covered_count = total_nodes
-                .iter()
-                .filter(|n| covered_set.contains(&format!("{}:{}:{}", n.name, n.file, n.start)))
-                .count();
-            let percent = if total_nodes.is_empty() {
-                0.0
-            } else {
-                (covered_count as f64 / total_nodes.len() as f64) * 100.0
-            };
-
-            // Calculate line-based coverage
-            let total_lines: usize = total_nodes
-                .iter()
-                .map(|n| n.end.saturating_sub(n.start) + 1)
-                .sum();
-
-            let covered_lines: usize = total_nodes
-                .iter()
-                .filter(|n| covered_set.contains(&format!("{}:{}:{}", n.name, n.file, n.start)))
-                .map(|n| n.end.saturating_sub(n.start) + 1)
-                .sum();
-
-            let line_percent = if total_lines == 0 {
-                0.0
-            } else {
-                (covered_lines as f64 / total_lines as f64) * 100.0
-            };
-
-            Some(CoverageStat {
-                total: total_nodes.len(),
-                total_tests: total_tests.len(),
-                covered: covered_count,
-                percent: (percent * 100.0).round() / 100.0,
-                total_lines,
-                covered_lines,
-                line_percent: (line_percent * 100.0).round() / 100.0,
-            })
-        };
-
-        let mocks = self.graph.find_nodes_by_type_async(NodeType::Mock).await;
-        println!("{:#?}", mocks);
-        let mocks_in_scope: Vec<NodeData> = mocks.into_iter().filter(|n| in_scope(n)).collect();
-        
-        let mocked_count = mocks_in_scope
-            .iter()
-            .filter(|n| n.meta.get("mocked").map(|v| v == "true").unwrap_or(false))
-            .count();
-        
-        let mock_stat = if mocks_in_scope.is_empty() {
-            None
-        } else {
-            let percent = (mocked_count as f64 / mocks_in_scope.len() as f64) * 100.0;
-            Some(MockStat {
-                total: mocks_in_scope.len(),
-                mocked: mocked_count,
-                percent: (percent * 100.0).round() / 100.0,
-            })
-        };
-
-        Ok(GraphCoverage {
-            unit_tests: build_stat(
-                &unit_functions_in_scope,
-                &unit_tests_in_scope,
-                &unit_target_functions,
-            ),
-            integration_tests: build_stat(
-                &integration_endpoints_in_scope,
-                &integration_tests_in_scope,
-                &integration_target_endpoints,
-            ),
-            e2e_tests: build_stat(&e2e_pages_in_scope, &e2e_tests_in_scope, &e2e_target_pages),
-            mocks: mock_stat,
-        })
+        coverage_lang.get_coverage(&self.graph, in_scope).await
     }
 
     pub async fn upload_btreemap_to_neo4j(

--- a/ast/src/lang/graphs/mod.rs
+++ b/ast/src/lang/graphs/mod.rs
@@ -4,6 +4,9 @@ pub mod graph;
 pub mod utils;
 
 #[cfg(feature = "neo4j")]
+pub mod coverage;
+
+#[cfg(feature = "neo4j")]
 pub mod neo4j_graph;
 
 #[cfg(feature = "neo4j")]

--- a/standalone/src/handlers.rs
+++ b/standalone/src/handlers.rs
@@ -979,6 +979,7 @@ pub async fn coverage_handler(Query(params): Query<CoverageParams>) -> Result<Js
         .await?;
 
     Ok(Json(Coverage {
+        language: totals.language,
         unit_tests: totals.unit_tests.map(|s| CoverageStat {
             total: s.total,
             total_tests: s.total_tests,

--- a/standalone/src/types.rs
+++ b/standalone/src/types.rs
@@ -128,6 +128,8 @@ pub struct MockStat {
 /// mocks: mock nodes and their mocked status.
 #[derive(Serialize, Deserialize, Debug, Clone)]
 pub struct Coverage {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub language: Option<String>,
     pub unit_tests: Option<CoverageStat>,
     pub integration_tests: Option<CoverageStat>,
     pub e2e_tests: Option<CoverageStat>,


### PR DESCRIPTION

language is optional
```json
{
  "language": "ruby",
  "unit_tests": {
    "total": 2402,
    "total_tests": 297,
    "covered": 189,
    "percent": 7.87,
    "total_lines": 96306,
    "covered_lines": 28362,
    "line_percent": 29.45
  },
  "integration_tests": {
    "total": 230,
    "total_tests": 52,
    "covered": 30,
    "percent": 13.04,
    "total_lines": 29123,
    "covered_lines": 8965,
    "line_percent": 30.78
  },
  "e2e_tests": {
    "total": 327,
    "total_tests": 11,
    "covered": 1,
    "percent": 0.31,
    "total_lines": 641,
    "covered_lines": 1,
    "line_percent": 0.16
  },
  "mocks": null
}
```