### PR TITLE
fix: retry transient Neo4j errors and surface real failure causes

### DIFF
--- a/ast/src/lang/graphs/graph_ops.rs
+++ b/ast/src/lang/graphs/graph_ops.rs
@@ -134,9 +134,15 @@ impl GraphOps {
 
                 let muted_nodes = self.collect_muted_nodes_for_files(&modified_files).await?;
 
+                info!(
+                    "[incremental] removing existing nodes for {} modified file(s)",
+                    modified_files.len()
+                );
                 for file in &modified_files {
+                    info!("[incremental] remove_nodes_by_file: {}", file);
                     self.graph.remove_nodes_by_file(file).await?;
                 }
+                info!("[incremental] finished removing nodes; re-detecting languages");
 
                 let mut subgraph_repos = Repo::new_multi_detect(
                     &repo_path,
@@ -146,12 +152,14 @@ impl GraphOps {
                     use_lsp,
                 )
                 .await?;
+                info!("[incremental] re-detect complete; building incremental graph");
 
                 if let Some(tx) = status_tx {
                     subgraph_repos.set_status_tx(tx).await;
                 }
 
                 subgraph_repos.build_graphs_neo4j_incremental().await?;
+                info!("[incremental] build_graphs_neo4j_incremental complete");
 
                 if !all_dynamic_edges.is_empty() {
                     let restored_count =
@@ -160,6 +168,7 @@ impl GraphOps {
                 }
 
                 if !muted_nodes.is_empty() {
+                    info!("[incremental] restoring {} muted nodes", muted_nodes.len());
                     self.restore_muted_nodes(muted_nodes).await?;
                 }
             }

--- a/ast/src/lang/graphs/neo4j/executor.rs
+++ b/ast/src/lang/graphs/neo4j/executor.rs
@@ -5,7 +5,57 @@ use crate::lang::{
 };
 use neo4rs::{query, BoltMap, BoltType, Graph as Neo4jConnection, Query};
 use shared::Result;
+use std::future::Future;
 use std::str::FromStr;
+use std::time::Duration;
+use tracing::warn;
+
+/// Returns true if the error string indicates a Neo4j transient error
+/// (deadlock, leader switch, lock client stopped, etc.) — Neo4j explicitly
+/// marks these as safe-to-retry.
+///
+/// We match on the formatted error string because `neo4rs::Error` does not
+/// expose a structured error code in a stable way across versions.
+fn is_transient_neo4j_error(err: &shared::Error) -> bool {
+    let s = err.to_string();
+    s.contains("TransientError")
+        || s.contains("DeadlockDetected")
+        || s.contains("LeaderSwitch")
+        || s.contains("LockClientStopped")
+}
+
+/// Retry an async operation while it returns a transient Neo4j error.
+/// Uses exponential backoff with jitter (50ms, 100ms, 200ms, ...).
+///
+/// Defaults: 5 attempts, ~1.5s total worst-case backoff. Tunable via
+/// `NEO4J_RETRY_ATTEMPTS` env var.
+pub async fn with_transient_retry<F, Fut, T>(label: &str, mut op: F) -> Result<T>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T>>,
+{
+    let max_attempts: u32 = std::env::var("NEO4J_RETRY_ATTEMPTS")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(5);
+    let mut attempt: u32 = 0;
+    loop {
+        match op().await {
+            Ok(v) => return Ok(v),
+            Err(e) if is_transient_neo4j_error(&e) && attempt + 1 < max_attempts => {
+                attempt += 1;
+                let backoff_ms = 50u64.saturating_mul(1u64 << (attempt - 1).min(6));
+                warn!(
+                    "[neo4j-retry] transient error on '{}' (attempt {}/{}), retrying in {}ms: {}",
+                    label, attempt, max_attempts, backoff_ms, e
+                );
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+                continue;
+            }
+            Err(e) => return Err(e),
+        }
+    }
+}
 
 fn bind_parameters(query_str: &str, params: BoltMap) -> Query {
     let mut query_obj = query(query_str);
@@ -133,32 +183,45 @@ impl<'a> TransactionManager<'a> {
     }
 
     pub async fn execute(self) -> Result<()> {
-        let mut txn = self.conn.start_txn().await?;
-        for (query_str, bolt_map) in self.queries {
-            let mut query_obj = query(&query_str);
-            if query_str.contains("$properties") {
-                if let Some(BoltType::String(node_key)) = bolt_map.value.get("node_key") {
-                    query_obj = query_obj.param("node_key", node_key.value.as_str());
-                }
-                let properties = boltmap_to_bolttype_map(bolt_map);
-                query_obj = query_obj.param("properties", properties);
-                if query_str.contains("$now") {
-                    use std::time::{SystemTime, UNIX_EPOCH};
-                    if let Ok(dur) = SystemTime::now().duration_since(UNIX_EPOCH) {
-                        let ts = dur.as_secs_f64();
-                        query_obj = query_obj
-                            .param("now", neo4rs::BoltType::String(format!("{:.7}", ts).into()));
+        let conn = self.conn;
+        let queries = self.queries;
+        // Retry the entire transaction on Neo4j transient errors (e.g. deadlocks).
+        // Neo4j explicitly marks these as safe-to-retry — see
+        // https://neo4j.com/docs/operations-manual/current/clustering/disaster-recovery/
+        with_transient_retry("TransactionManager::execute", || {
+            let queries = queries.clone();
+            async move {
+                let mut txn = conn.start_txn().await?;
+                for (query_str, bolt_map) in queries {
+                    let mut query_obj = query(&query_str);
+                    if query_str.contains("$properties") {
+                        if let Some(BoltType::String(node_key)) = bolt_map.value.get("node_key") {
+                            query_obj = query_obj.param("node_key", node_key.value.as_str());
+                        }
+                        let properties = boltmap_to_bolttype_map(bolt_map);
+                        query_obj = query_obj.param("properties", properties);
+                        if query_str.contains("$now") {
+                            use std::time::{SystemTime, UNIX_EPOCH};
+                            if let Ok(dur) = SystemTime::now().duration_since(UNIX_EPOCH) {
+                                let ts = dur.as_secs_f64();
+                                query_obj = query_obj.param(
+                                    "now",
+                                    neo4rs::BoltType::String(format!("{:.7}", ts).into()),
+                                );
+                            }
+                        }
+                    } else {
+                        for (key, value) in bolt_map.value.iter() {
+                            query_obj = query_obj.param(key.value.as_str(), value.clone());
+                        }
                     }
+                    txn.run(query_obj).await?;
                 }
-            } else {
-                for (key, value) in bolt_map.value.iter() {
-                    query_obj = query_obj.param(key.value.as_str(), value.clone());
-                }
+                txn.commit().await?;
+                Ok(())
             }
-            txn.run(query_obj).await?;
-        }
-        txn.commit().await?;
-        Ok(())
+        })
+        .await
     }
 }
 

--- a/ast/src/lang/graphs/neo4j/operations/migration.rs
+++ b/ast/src/lang/graphs/neo4j/operations/migration.rs
@@ -1,6 +1,8 @@
 use crate::lang::graphs::{
-    executor::TransactionManager, helpers::boltmap_insert_str, queries::*, Edge, EdgeType,
-    Neo4jGraph, NodeData, NodeKeys, NodeRef, NodeType,
+    executor::{with_transient_retry, TransactionManager},
+    helpers::boltmap_insert_str,
+    queries::*,
+    Edge, EdgeType, Neo4jGraph, NodeData, NodeKeys, NodeRef, NodeType,
 };
 use neo4rs::{query, BoltMap};
 use shared::{Error, Result};
@@ -28,16 +30,26 @@ impl Neo4jGraph {
     pub async fn remove_nodes_by_file(&self, file_path: &str) -> Result<u32> {
         let connection = self.ensure_connected().await?;
         let (query_str, params) = remove_nodes_by_file_query(file_path, &self.root);
-        let mut query_obj = query(&query_str);
-        for (k, v) in params.value.iter() {
-            query_obj = query_obj.param(k.value.as_str(), v.clone());
-        }
-        let mut result = connection.execute(query_obj).await?;
-        if let Some(row) = result.next().await? {
-            Ok(row.get::<u32>("count").unwrap_or(0))
-        } else {
-            Ok(0)
-        }
+        // DETACH DELETE on heavily-connected nodes can deadlock against concurrent
+        // writers; Neo4j flags this as TransientError and expects the client to retry.
+        with_transient_retry("remove_nodes_by_file", || {
+            let query_str = query_str.clone();
+            let params = params.clone();
+            let connection = connection.clone();
+            async move {
+                let mut query_obj = query(&query_str);
+                for (k, v) in params.value.iter() {
+                    query_obj = query_obj.param(k.value.as_str(), v.clone());
+                }
+                let mut result = connection.execute(query_obj).await?;
+                if let Some(row) = result.next().await? {
+                    Ok(row.get::<u32>("count").unwrap_or(0))
+                } else {
+                    Ok(0)
+                }
+            }
+        })
+        .await
     }
 
     pub async fn update_repository_hash(&self, repo_url: &str, new_hash: &str) -> Result<()> {

--- a/standalone/src/handlers/ingest.rs
+++ b/standalone/src/handlers/ingest.rs
@@ -51,6 +51,10 @@ pub async fn sync_async(
     let guard = match BusyGuard::try_new(state.clone()) {
         Some(g) => g,
         None => {
+            tracing::warn!(
+                "[sync_async] System busy, rejecting request for repo_url={}",
+                repo_url
+            );
             return Json(serde_json::json!({
                 "error": "System is busy processing another request. Please try again later."
             }))
@@ -142,7 +146,23 @@ pub async fn sync_async(
     tokio::spawn(async move {
         // Move guard into task - it will automatically clear busy flag on drop
         let _guard = guard;
-        let result = sync(State(state_for_process.clone()), body_clone).await;
+        // Hard upper bound so a stuck Neo4j/LSP/IO call surfaces as Err instead of
+        // hanging indefinitely waiting on TCP keepalives.
+        let timeout_secs: u64 = std::env::var("SYNC_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(30 * 60); // 30 minutes default
+        let result = match tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            sync(State(state_for_process.clone()), body_clone),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(crate::types::WebError(shared::Error::internal(
+                format!("sync() timed out after {}s", timeout_secs),
+            ))),
+        };
 
         let mut map = status_map.lock().await;
 
@@ -207,13 +227,19 @@ pub async fn sync_async(
                 }
             }
             Err(e) => {
+                let err_msg = format!("{}", e);
+                tracing::error!(
+                    "[sync_async] sync() failed for request {}: {}",
+                    request_id_for_work,
+                    err_msg
+                );
                 let entry = AsyncRequestStatus {
                     status: AsyncStatus::Failed,
                     result: None,
                     progress: 0,
                     update: Some(ast::repo::StatusUpdate {
                         status: "Failed".to_string(),
-                        message: format!("{}", e),
+                        message: err_msg.clone(),
                         step: 0,
                         total_steps: 16,
                         progress: 0,
@@ -229,7 +255,7 @@ pub async fn sync_async(
                             status: "Failed".to_string(),
                             progress: 0,
                             result: None,
-                            error: Some("Request processing failed".to_string()),
+                            error: Some(err_msg.clone()),
                             started_at: started_at.to_rfc3339(),
                             completed_at: Utc::now().to_rfc3339(),
                             duration_ms: (Utc::now() - started_at).num_milliseconds().max(0) as u64,
@@ -302,6 +328,10 @@ pub async fn ingest_async(
     let guard = match crate::busy::BusyGuard::try_new(state.clone()) {
         Some(g) => g,
         None => {
+            tracing::warn!(
+                "[ingest_async] System busy, rejecting request for repo_urls={:?}",
+                repo_urls
+            );
             return Json(serde_json::json!({
                 "error": "System is busy processing another request. Please try again later."
             }))
@@ -387,7 +417,24 @@ pub async fn ingest_async(
     tokio::spawn(async move {
         // Move guard into task - it will automatically clear busy flag on drop
         let _guard = guard;
-        let result = ingest(State(state_clone.clone()), body_clone).await;
+        // Hard upper bound so a stuck Neo4j/LSP/IO call surfaces as Err instead of
+        // hanging indefinitely waiting on TCP keepalives.
+        let timeout_secs: u64 = std::env::var("INGEST_TIMEOUT_SECS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(60 * 60); // 60 minutes default
+        let result = match tokio::time::timeout(
+            std::time::Duration::from_secs(timeout_secs),
+            ingest(State(state_clone.clone()), body_clone),
+        )
+        .await
+        {
+            Ok(r) => r,
+            Err(_) => Err(crate::types::WebError(shared::Error::internal(format!(
+                "ingest() timed out after {}s",
+                timeout_secs
+            )))),
+        };
 
         let mut map = status_map.lock().await;
 
@@ -446,6 +493,11 @@ pub async fn ingest_async(
             }
             Err(e) => {
                 let err_msg = format!("{}", e);
+                tracing::error!(
+                    "[ingest_async] ingest() failed for request {}: {}",
+                    request_id_clone,
+                    err_msg
+                );
                 let _ = state_clone.tx.send(ast::repo::StatusUpdate {
                     status: "Failed".to_string(),
                     message: err_msg.clone(),
@@ -461,7 +513,7 @@ pub async fn ingest_async(
                     progress: 0,
                     update: Some(ast::repo::StatusUpdate {
                         status: "Failed".to_string(),
-                        message: err_msg,
+                        message: err_msg.clone(),
                         step: 0,
                         total_steps: 16,
                         progress: 0,
@@ -477,7 +529,7 @@ pub async fn ingest_async(
                             status: "Failed".to_string(),
                             progress: 0,
                             result: None,
-                            error: Some("Request processing failed".to_string()),
+                            error: Some(err_msg.clone()),
                             started_at: started_at.to_rfc3339(),
                             completed_at: Utc::now().to_rfc3339(),
                             duration_ms: (Utc::now() - started_at).num_milliseconds().max(0) as u64,


### PR DESCRIPTION
- Retry on TransientError/DeadlockDetected in TransactionManager::execute and remove_nodes_by_file with exponential backoff (NEO4J_RETRY_ATTEMPTS).
- Add tokio::time::timeout around sync()/ingest() in async handlers (SYNC_TIMEOUT_SECS, INGEST_TIMEOUT_SECS) so stuck calls fail fast instead of hanging on TCP keepalives.
- Forward the actual error to webhook payloads and log it, instead of the generic 'Request processing failed' string.
- Log a warning when BusyGuard rejects a concurrent sync_async/ingest_async.
- Add per-step info! logs in update_incremental to pinpoint stalls.