### PR TITLE
fix gateway healthcheck (GET not HEAD)

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -184,12 +184,16 @@ ENV APP_HOST=127.0.0.1 \
 EXPOSE 8181
 VOLUME ["/app/data"]
 
-# Healthcheck hits the wrapper (the public listener). The wrapper only
-# starts accepting once bifrost is ready, so a 200 here confirms the
-# whole chain is up. /health is unauthenticated even when auth_config
-# is enabled — it's in Bifrost's systemWhitelistedRoutes.
+# Healthcheck hits the wrapper (the public listener at :8181). The
+# wrapper only starts accepting once bifrost is ready, so a 200 here
+# confirms the whole chain is up. /health is unauthenticated even when
+# auth_config is enabled — it's in Bifrost's systemWhitelistedRoutes.
+#
+# `wget -O- > /dev/null` does a GET (not HEAD). `wget --spider` issues
+# HEAD which bifrost-http rejects with 405 → unhealthy container →
+# traefik filters it out → no routing.
 HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
-    CMD wget -q --spider http://127.0.0.1:8181/health || exit 1
+    CMD wget -q -O- http://127.0.0.1:8181/health > /dev/null || exit 1
 
 ENTRYPOINT ["/sbin/tini", "--"]
 # The wrapper runs with no flags: its defaults produce exactly the


### PR DESCRIPTION
## Summary

Switch the gateway image's `HEALTHCHECK` from `wget --spider` (HEAD) to `wget -O- > /dev/null` (GET).

## Why

`bifrost-http` returns **405 Method Not Allowed** on `HEAD /health`. The old healthcheck always failed → docker marked the container `unhealthy` → traefik's docker provider silently filtered the container out of its routing table → requests to the published port got traefik's default 404.

Internally the container was perfectly healthy: `docker exec wget -qO- http://127.0.0.1:8181/health` returned 200 with bifrost's JSON. The healthcheck was the only thing broken.

`GET /health` returns 200, so the new healthcheck passes → docker reports `healthy` → traefik picks it up → routing works.

## Test plan

```sh
# After :latest is rebuilt from this commit:
docker inspect ghcr.io/stakwork/stakgraph-gateway:latest --format '{{json .Config.Healthcheck}}'
# expect: "wget -q -O- http://127.0.0.1:8181/health > /dev/null || exit 1"

# On a swarm host:
docker pull ghcr.io/stakwork/stakgraph-gateway:latest
docker stop bifrost.sphinx && docker rm bifrost.sphinx
# let sphinx-swarm recreate
sleep 60
docker inspect bifrost.sphinx --format '{{.State.Health.Status}}'  # healthy
curl -kI https://<swarm>:8181/health                                # 200
```