### PR TITLE
docs(gateway): require key_ids on VK provider_configs

### DIFF
--- a/gateway/plans/phases/phase-1-reconciler.md
+++ b/gateway/plans/phases/phase-1-reconciler.md
@@ -300,10 +300,10 @@ Content-Type: application/json
   "description": "Hive user u_alice — auto-provisioned",
   "customer_id": "9f8e7d6c-…",
   "provider_configs": [
-    { "provider": "anthropic",  "allowed_models": ["*"] },
-    { "provider": "openai",     "allowed_models": ["*"] },
-    { "provider": "openrouter", "allowed_models": ["*"] },
-    { "provider": "gemini",     "allowed_models": ["*"] }
+    { "provider": "anthropic",  "allowed_models": ["*"], "key_ids": ["*"] },
+    { "provider": "openai",     "allowed_models": ["*"], "key_ids": ["*"] },
+    { "provider": "openrouter", "allowed_models": ["*"], "key_ids": ["*"] },
+    { "provider": "gemini",     "allowed_models": ["*"], "key_ids": ["*"] }
   ]
 }
 ```
@@ -316,6 +316,16 @@ Field notes:
 - `provider_configs` — empty array means deny-by-default; we want
   permissive, so list every provider we'll use. `allowed_models: ["*"]`
   permits all models for that provider.
+- `key_ids: ["*"]` — **required for inference to actually work.** Tells
+  Bifrost to set `allow_all_keys: true` on the resulting provider_config
+  so the VK can use every provider-level API key. If you omit this,
+  Bifrost defaults to "no keys attached" and every inference call fails
+  with `no keys found for provider: <p> and model: <m>`, even though
+  the provider key clearly exists in `/api/providers/<p>/keys`. The
+  field name is `key_ids` on the **request** — the response-side
+  `keys` array is hydrated/read-only and unrelated. Source:
+  `transports/bifrost-http/handlers/governance.go` (`KeyIDs
+  schemas.WhiteList json:"key_ids"`).
 - `budgets` (optional, omitted here) — Customer's $1000/day already
   governs alice's spend. If you ever want a *separate* VK-level cap
   (e.g. one VK $100/day on top of $1000/day customer cap), put it


### PR DESCRIPTION
## Summary

- The phase-1 reconciler plan's example VK-create payload was missing the `key_ids` field on each `provider_configs[]` entry.
- Bifrost's governance API requires `key_ids: ["*"]` (or a list of specific provider-key UUIDs) to attach provider keys to a VK. Omitting it leaves `allow_all_keys: false` with no attached keys, so every inference fails with `no keys found for provider: <p> and model: <m>` even when the provider clearly has keys in `/api/providers/<p>/keys`.
- This bit us on swarm38 — Hive's reconciler (built from this plan) provisioned VKs that 100% failed at inference time. The Hive code fix is in https://github.com/stakwork/hive/pull/4070; this PR fixes the source-of-truth doc so the next person reading the plan doesn't reintroduce the same bug.

## Notes

- Also documents the request/response asymmetry: `key_ids` is request-only, `keys` on the response is hydrated/read-only. Setting `keys` or `allow_all_keys` on a request body is silently ignored by Bifrost.
- Source reference: `transports/bifrost-http/handlers/governance.go` in the Bifrost repo (`KeyIDs schemas.WhiteList json:"key_ids"`).