### PR TITLE
plumb baseUrl through log and graph agents

### DIFF
--- a/mcp/src/graph_agent/agent.ts
+++ b/mcp/src/graph_agent/agent.ts
@@ -40,6 +40,7 @@ export interface GraphAgentOptions {
   prompt: string | ModelMessage[];
   modelName?: ModelName;
   apiKey?: string;
+  baseUrl?: string;
   sessionId?: string;
   sessionConfig?: SessionConfig;
   abortSignal?: AbortSignal;
@@ -96,6 +97,7 @@ async function prepareGraphAgent(
     prompt,
     modelName,
     apiKey: apiKeyIn,
+    baseUrl,
     sessionId: inputSessionId,
     sessionConfig,
     abortSignal,
@@ -111,7 +113,7 @@ async function prepareGraphAgent(
   const { model, apiKey: _apiKey, provider, contextLimit, modelId } = getModelDetails(
     modelName,
     apiKeyIn,
-    undefined,
+    baseUrl,
     headers,
   );
   console.log(`[graph_agent] model=${modelId} provider=${provider} contextLimit=${contextLimit}`);

--- a/mcp/src/graph_agent/index.ts
+++ b/mcp/src/graph_agent/index.ts
@@ -36,6 +36,7 @@ function parseGraphAgentBody(req: Request) {
   const prompt = req.body.prompt as string | undefined;
   const modelName = req.body.model as ModelName | undefined;
   const apiKey = req.body.apiKey as string | undefined;
+  const baseUrl = req.body.baseUrl as string | undefined;
   const sessionId = (req.body.sessionId as string | undefined) || randomUUID();
   const sessionConfig = req.body.sessionConfig as SessionConfig | undefined;
   const stream = req.body.stream as boolean | undefined;
@@ -52,7 +53,7 @@ function parseGraphAgentBody(req: Request) {
 
   const headers = normalizeHeaders(req.body.headers);
 
-  return { prompt, modelName, apiKey, sessionId, sessionConfig, stream, maxTurns, authToken, headers };
+  return { prompt, modelName, apiKey, baseUrl, sessionId, sessionConfig, stream, maxTurns, authToken, headers };
 }
 
 // ── POST /graph_agent ────────────────────────────────────────────────────
@@ -99,6 +100,7 @@ export async function graph_agent(req: Request, res: Response) {
         prompt: body.prompt,
         modelName: body.modelName,
         apiKey: body.apiKey,
+        baseUrl: body.baseUrl,
         sessionId: body.sessionId,
         sessionConfig: body.sessionConfig,
         maxTurns: body.maxTurns,
@@ -197,6 +199,7 @@ export async function graph_agent(req: Request, res: Response) {
       prompt: body.prompt,
       modelName: body.modelName,
       apiKey: body.apiKey,
+      baseUrl: body.baseUrl,
       sessionId: body.sessionId,
       sessionConfig: body.sessionConfig,
       maxTurns: body.maxTurns,

--- a/mcp/src/log/agent.ts
+++ b/mcp/src/log/agent.ts
@@ -44,6 +44,7 @@ Your complete analysis here.
 export interface LogAgentOptions {
   modelName?: ModelName;
   apiKey?: string;
+  baseUrl?: string;
   logs?: boolean;
   sessionId?: string;
   sessionConfig?: SessionConfig;
@@ -61,7 +62,7 @@ export async function log_agent_context(
   opts: LogAgentOptions
 ): Promise<ContextResult> {
   const startTime = Date.now();
-  const { model, provider, modelId } = getModelDetails(opts.modelName, opts.apiKey, undefined, opts.headers);
+  const { model, provider, modelId } = getModelDetails(opts.modelName, opts.apiKey, opts.baseUrl, opts.headers);
   console.log("===> log_agent model", model);
 
   const tools = get_log_tools({

--- a/mcp/src/log/index.ts
+++ b/mcp/src/log/index.ts
@@ -45,6 +45,7 @@ export async function logs_agent(req: Request, res: Response) {
   const prompt = req.body.prompt as string;
   const modelName = req.body.model as ModelName | undefined;
   const apiKey = req.body.apiKey as string | undefined;
+  const baseUrl = req.body.baseUrl as string | undefined;
   const logs = req.body.logs as boolean | undefined;
   const swarmName = req.body.swarmName as string | undefined;
   const sessionId = (req.body.sessionId as string | undefined) || randomUUID();
@@ -124,7 +125,7 @@ export async function logs_agent(req: Request, res: Response) {
   const opId = startTracking("logs_agent");
 
   try {
-    log_agent_context(finalPrompt, { modelName, apiKey, logs, sessionId, sessionConfig, stakworkApiKey, stakworkRuns, logsDir, printAgentProgress, source: "logs_agent", headers })
+    log_agent_context(finalPrompt, { modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, stakworkApiKey, stakworkRuns, logsDir, printAgentProgress, source: "logs_agent", headers })
       .then((result) => {
         asyncReqs.finishReq(request_id, {
           success: true,


### PR DESCRIPTION
Extends the recent `baseUrl` support added to `repo/agent` (#1280) to the `logs_agent` and `graph_agent` endpoints so callers can route LLM traffic through a custom gateway for these agents too.

## Changes

**log agent**
- Add `baseUrl?: string` to `LogAgentOptions`
- Pass `opts.baseUrl` into `getModelDetails(...)`
- Parse `req.body.baseUrl` in the `logs_agent` handler and forward it to `log_agent_context`

**graph_agent**
- Add `baseUrl?: string` to `GraphAgentOptions`
- Pass `baseUrl` into `getModelDetails(...)` (replacing the previous `undefined`)
- Parse `req.body.baseUrl` in `parseGraphAgentBody` and forward it to both `get_context` and `stream_context`

Mirrors the pattern already in `mcp/src/repo/index.ts` and `mcp/src/repo/agent.ts`.

## Verification
- `yarn tsc --noEmit` passes cleanly in `mcp/`