### PR TITLE
gateway/wrapper: bearer-concat macaroon transport (phase 10)

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -160,7 +160,13 @@ RUN go mod edit -replace github.com/maximhq/bifrost/core=/src/core \
 FROM golang:${GO_VERSION}-alpine3.23 AS wrapper-builder
 WORKDIR /wrapper
 COPY wrapper/go.mod ./
-COPY wrapper/main.go ./
+# Copy every wrapper source file. Previously this was a single
+# `COPY wrapper/main.go ./` which broke whenever a second .go file was
+# added (silent "undefined: …" errors at build time). The wildcard
+# pulls in main.go plus any sibling .go files (authsplit.go, etc).
+# `*_test.go` are also matched but ignored by `go build .` and the
+# whole stage is discarded — only /out/wrapper is copied forward.
+COPY wrapper/*.go ./
 RUN CGO_ENABLED=0 GOOS=linux \
     go build \
         -ldflags="-w -s" \

--- a/gateway/scripts/smoke-test-concat.sh
+++ b/gateway/scripts/smoke-test-concat.sh
@@ -1,0 +1,397 @@
+#!/usr/bin/env bash
+#
+# smoke-test-concat.sh — end-to-end test of the bearer-concat
+# transport (phase 10).
+#
+# Proves the wrapper correctly splits `<vk>.<macaroon>` from each of
+# the three accepted inbound auth headers and produces the same
+# end-state (plugin sees x-macaroon, logs.db row carries macaroon
+# dims) as a request that sent the two-header form directly.
+#
+# Companion to smoke-test-enforcement.sh (which tests the two-header
+# form). Both must keep working — the concat form is strictly
+# additive.
+#
+# Each call exercises one inbound header shape:
+#
+#   1. Authorization: Bearer <vk>.<mac>   (OpenAI-family path)
+#   2. x-api-key: <vk>.<mac>              (Anthropic path)
+#   3. x-goog-api-key: <vk>.<mac>         (Gemini path)
+#
+# For each call we assert:
+#   - HTTP 200 from the gateway (proves Bifrost saw a clean VK after
+#     the wrapper split).
+#   - A plugin "auth: verify ok" log line for that run_id (proves the
+#     plugin saw x-macaroon after the wrapper injected it).
+#   - A logs.db row with metadata dims canonicalized from the macaroon
+#     claims (proves end-to-end pipeline).
+#
+# All three calls use the same provider (Anthropic) so we don't need
+# three sets of provider keys. Only the inbound auth header shape
+# changes — the wrapper's job is to make all three converge to the
+# same downstream state.
+#
+# Required:
+#   - `make docker-up` already run
+#   - `gateway/auth/ts/node_modules` populated (`npm install`)
+#   - ANTHROPIC_API_KEY set in the gateway's env (compose passes
+#     through from the host .env)
+#
+# Usage:
+#   bash gateway/scripts/smoke-test-concat.sh
+#
+# Environment knobs:
+#   GW                          gateway URL (default http://localhost:8181)
+#   BIFROST_PROVISIONING_TOKEN  bearer for /_plugin/trust admin
+#   ORG_ID                      org_id for registration + macaroon
+#                               (default org_concat)
+#   BIFROST_VK                  the VK to glue onto each macaroon.
+#                               Default: a placeholder VK shape. With
+#                               disable_auth_on_inference=true (the
+#                               default in data/config.json), Bifrost
+#                               doesn't reject unknown VKs — it just
+#                               doesn't stamp customer_id on the log
+#                               row. The wrapper's split logic doesn't
+#                               care whether the VK is real, only that
+#                               it matches the VK-shape regex.
+#
+#                               Override with a real provisioned VK if
+#                               you also want customer_id stamped:
+#                                 BIFROST_VK=sk-bf-real... bash $0
+
+set -u
+
+GW="${GW:-http://localhost:8181}"
+TOKEN="${BIFROST_PROVISIONING_TOKEN:-dev-provisioning-token}"
+ORG_ID="${ORG_ID:-org_concat}"
+# Placeholder VK: shape-valid (matches the wrapper's regex) but not
+# necessarily registered as a real customer. Sufficient for testing
+# the wrapper rewrite when Bifrost runs with disable_auth_on_inference.
+VK="${BIFROST_VK:-sk-bf-smoke-placeholder-vk}"
+
+# Fixture org pubkey #0 — see smoke-test-enforcement.sh.
+ORG_PUBKEY="0279be667ef9dcbbac55a06295ce870b07029bfcdb2dce28d959f2815b16f81798"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+TS_DIR="$REPO_ROOT/gateway/auth/ts"
+TSX="$TS_DIR/node_modules/.bin/tsx"
+
+ASSERT_FAILED=0
+
+# --- helpers ---------------------------------------------------------------
+
+section() {
+  printf '\n=== %s ===\n' "$1"
+}
+
+# call_admin <method> <path> [body]
+call_admin() {
+  local method="$1" path="$2" body="${3:-}"
+  local status
+  if [ -n "$body" ]; then
+    status=$(curl -sS -o /tmp/smoke_admin.json -w '%{http_code}' \
+      -X "$method" "$GW$path" \
+      -H "Authorization: Bearer $TOKEN" \
+      -H 'Content-Type: application/json' \
+      -d "$body")
+  else
+    status=$(curl -sS -o /tmp/smoke_admin.json -w '%{http_code}' \
+      -X "$method" "$GW$path" \
+      -H "Authorization: Bearer $TOKEN")
+  fi
+  printf '  %s %s -> %s\n' "$method" "$path" "$status"
+  if [ -s /tmp/smoke_admin.json ]; then
+    sed 's/^/    /' /tmp/smoke_admin.json
+    echo
+  fi
+}
+
+new_run_id() {
+  local label="$1"
+  printf 'r_concat_%s_%s_%s' "$label" "$(date +%s)" "$RANDOM"
+}
+
+# mint_macaroon <run_id>
+#
+# Same shape as the enforcement smoke. Outputs the base64url macaroon
+# on stdout.
+mint_macaroon() {
+  local run_id="$1"
+  (
+    cd "$TS_DIR" && \
+    "$TSX" "$SCRIPT_DIR/mint-macaroon.ts" \
+      --org-id "$ORG_ID" \
+      --user-id u_alice \
+      --realm w1 \
+      --agent coder \
+      --run-id "$run_id" \
+      --max-cost-usd 1.00 \
+      --max-steps 50 \
+      --ttl-seconds 600
+  )
+}
+
+# call_llm_concat <label> <header_name> <header_prefix> <run_id> <vk> <macaroon>
+#
+# Send one chat completion request with the concat form on the
+# specified inbound header. <header_prefix> is "Bearer " for
+# Authorization and "" for x-api-key / x-goog-api-key.
+#
+# Note: we deliberately do NOT set x-macaroon ourselves — the whole
+# point is that the wrapper injects it from the concat. We also do NOT
+# set any of the x-bf-dim-* headers — phase 6 canonicalization
+# populates them from the verified macaroon claims, so the logs.db
+# row still gets correct dims.
+call_llm_concat() {
+  local label="$1" name="$2" prefix="$3" run_id="$4" vk="$5" mac="$6"
+  local started status
+  started=$(date -u +%H:%M:%S)
+  status=$(curl -sS -o /tmp/smoke_llm.json -w '%{http_code}' \
+    "$GW/v1/chat/completions" \
+    -H 'Content-Type: application/json' \
+    -H "$name: $prefix$vk.$mac" \
+    -d '{"model":"anthropic/claude-haiku-4-5-20251001","max_tokens":20,"messages":[{"role":"user","content":"reply in 3 words"}]}')
+  printf '  [%s] %s  run_id=%s  http=%s\n' "$label" "$started" "$run_id" "$status"
+  if [ "$status" != "200" ] && [ -s /tmp/smoke_llm.json ]; then
+    echo "  body:"
+    sed 's/^/    /' /tmp/smoke_llm.json
+    echo
+  fi
+  echo "$status"
+}
+
+# fetch_logs_row <run_id>
+#
+# Same query as smoke-test-enforcement.sh: pipe-delimited
+# run-id|user-id|agent-name|realm-id from logs.metadata. Empty on
+# no-match.
+fetch_logs_row() {
+  local run_id="$1"
+  docker run --rm -v stakgraph-gateway-data:/data alpine:3.23 \
+    sh -c "apk add -q sqlite >/dev/null && sqlite3 /data/logs.db \
+      \"SELECT json_extract(metadata,'\$.run-id') || '|' ||
+              COALESCE(json_extract(metadata,'\$.user-id'),'') || '|' ||
+              COALESCE(json_extract(metadata,'\$.agent-name'),'') || '|' ||
+              COALESCE(json_extract(metadata,'\$.realm-id'),'')
+       FROM logs WHERE json_extract(metadata,'\$.run-id')='$run_id' LIMIT 1;\"" \
+    2>/dev/null
+}
+
+# expect_eq <label> <expected> <actual>
+expect_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  [PASS] %s: %q\n' "$label" "$actual"
+  else
+    printf '  [FAIL] %s: expected %q got %q\n' "$label" "$expected" "$actual"
+    ASSERT_FAILED=$((ASSERT_FAILED + 1))
+  fi
+}
+
+# assert_verify_log_present <run_id>
+#
+# Confirms the plugin emitted a successful verify line for this run.
+# The presence of such a line proves the wrapper successfully injected
+# x-macaroon; if the wrapper had failed, the plugin would log "auth:
+# no x-macaroon header ..." instead.
+assert_verify_log_present() {
+  local run_id="$1"
+  local hit
+  hit=$(docker compose -f "$REPO_ROOT/gateway/docker-compose.yml" \
+        logs --tail=500 bifrost 2>/dev/null \
+    | grep -E "auth: verify .* run_id=$run_id" \
+    | tail -1)
+  if [ -n "$hit" ]; then
+    printf '  [PASS] verify line present for %s\n' "$run_id"
+    printf '         %s\n' "$hit"
+  else
+    printf '  [FAIL] no verify line found for %s\n' "$run_id"
+    ASSERT_FAILED=$((ASSERT_FAILED + 1))
+  fi
+}
+
+# --- preflight -------------------------------------------------------------
+
+section "preflight"
+
+echo "  using BIFROST_VK=${VK:0:16}... (length=${#VK})"
+
+if ! curl -sf -o /dev/null "$GW/api/health"; then
+  echo "  gateway not reachable at $GW/api/health" >&2
+  echo "  start it with: cd gateway && make docker-up" >&2
+  exit 1
+fi
+echo "  gateway reachable at $GW"
+
+if [ ! -x "$TSX" ]; then
+  echo "  tsx not found at $TSX" >&2
+  echo "  install with: cd gateway/auth/ts && npm install" >&2
+  exit 1
+fi
+echo "  tsx available"
+
+trust_status=$(curl -sS -o /tmp/smoke_admin.json -w '%{http_code}' \
+  -H "Authorization: Bearer $TOKEN" "$GW/_plugin/trust/status")
+if [ "$trust_status" != "200" ]; then
+  echo "  /_plugin/trust/status -> $trust_status (provisioning token wrong?)" >&2
+  exit 1
+fi
+echo "  trust registry reachable"
+
+# --- register org ----------------------------------------------------------
+
+section "register org $ORG_ID"
+
+call_admin POST /_plugin/trust "$(cat <<JSON
+{
+  "org_id": "$ORG_ID",
+  "pubkey": "$ORG_PUBKEY",
+  "issuer_url": "",
+  "revocation_poll_seconds": 60
+}
+JSON
+)"
+
+# --- three concat forms ---------------------------------------------------
+
+section "concat form 1/3: Authorization: Bearer <vk>.<mac>"
+
+AUTH_RUN_ID=$(new_run_id "auth")
+echo "  minting macaroon for run_id=$AUTH_RUN_ID..."
+AUTH_MAC=$(mint_macaroon "$AUTH_RUN_ID")
+if [ -z "$AUTH_MAC" ]; then
+  echo "  mint FAILED" >&2
+  exit 1
+fi
+echo "  macaroon length=${#AUTH_MAC}"
+AUTH_STATUS=$(call_llm_concat "Authorization" "Authorization" "Bearer " "$AUTH_RUN_ID" "$VK" "$AUTH_MAC" | tail -1)
+
+section "concat form 2/3: x-api-key: <vk>.<mac>"
+
+XAPI_RUN_ID=$(new_run_id "xapi")
+echo "  minting macaroon for run_id=$XAPI_RUN_ID..."
+XAPI_MAC=$(mint_macaroon "$XAPI_RUN_ID")
+if [ -z "$XAPI_MAC" ]; then
+  echo "  mint FAILED" >&2
+  exit 1
+fi
+XAPI_STATUS=$(call_llm_concat "x-api-key" "x-api-key" "" "$XAPI_RUN_ID" "$VK" "$XAPI_MAC" | tail -1)
+
+section "concat form 3/3: x-goog-api-key: <vk>.<mac>"
+
+XGOOG_RUN_ID=$(new_run_id "xgoog")
+echo "  minting macaroon for run_id=$XGOOG_RUN_ID..."
+XGOOG_MAC=$(mint_macaroon "$XGOOG_RUN_ID")
+if [ -z "$XGOOG_MAC" ]; then
+  echo "  mint FAILED" >&2
+  exit 1
+fi
+# Note: Bifrost routes by URL path, not by which auth header was
+# used. /v1/chat/completions is the OpenAI-shaped endpoint, so even
+# though we're sending x-goog-api-key, we still get an Anthropic
+# response. The point of this test isn't to exercise Gemini routing
+# — it's to verify the wrapper rewrites x-goog-api-key correctly.
+# Bifrost will then read the rewritten "x-goog-api-key: <vk>" the
+# same way it reads any other VK lookup header.
+XGOOG_STATUS=$(call_llm_concat "x-goog-api-key" "x-goog-api-key" "" "$XGOOG_RUN_ID" "$VK" "$XGOOG_MAC" | tail -1)
+
+# --- backward-compat sanity: two-header form still works ------------------
+
+section "backward compat: two-header form still works"
+
+COMPAT_RUN_ID=$(new_run_id "compat")
+echo "  minting macaroon for run_id=$COMPAT_RUN_ID..."
+COMPAT_MAC=$(mint_macaroon "$COMPAT_RUN_ID")
+if [ -z "$COMPAT_MAC" ]; then
+  echo "  mint FAILED" >&2
+  exit 1
+fi
+# Send VK and macaroon as two separate headers — the existing,
+# pre-phase-10 way. Must still work byte-for-byte after the change.
+COMPAT_STATUS=$(curl -sS -o /tmp/smoke_llm.json -w '%{http_code}' \
+  "$GW/v1/chat/completions" \
+  -H 'Content-Type: application/json' \
+  -H "Authorization: Bearer $VK" \
+  -H "x-macaroon: $COMPAT_MAC" \
+  -d '{"model":"anthropic/claude-haiku-4-5-20251001","max_tokens":20,"messages":[{"role":"user","content":"reply in 3 words"}]}')
+printf '  two-header form  run_id=%s  http=%s\n' "$COMPAT_RUN_ID" "$COMPAT_STATUS"
+if [ "$COMPAT_STATUS" != "200" ] && [ -s /tmp/smoke_llm.json ]; then
+  echo "  body:"
+  sed 's/^/    /' /tmp/smoke_llm.json
+  echo
+fi
+
+# --- give bifrost a beat to flush logs ------------------------------------
+
+echo
+echo "  waiting 4s for log flush..."
+sleep 4
+
+# --- assertions ------------------------------------------------------------
+
+section "assertions"
+
+# HTTP status: all four calls must produce IDENTICAL downstream
+# behavior. If the wrapper's split is correct, the three concat
+# variants should be byte-identical to the two-header form from
+# Bifrost's perspective — same VK, same x-macaroon, same dim
+# canonicalization. So we don't hard-code "200"; we just require
+# the three concat forms to match the two-header form.
+#
+# (With a real provisioned VK that has provider keys attached, all
+# four are 200. With an unprovisioned VK and disable_auth_on_inference
+# off, all four are 401. With a provisioned VK whose provider keys
+# aren't wired, all four are 400 "no keys found". The point of THIS
+# test is that those outcomes are always identical across all four
+# call shapes — which proves the wrapper is transparent.)
+expect_eq "Authorization concat matches two-header HTTP"   "$COMPAT_STATUS" "$AUTH_STATUS"
+expect_eq "x-api-key concat matches two-header HTTP"       "$COMPAT_STATUS" "$XAPI_STATUS"
+expect_eq "x-goog-api-key concat matches two-header HTTP"  "$COMPAT_STATUS" "$XGOOG_STATUS"
+echo "  (two-header HTTP was $COMPAT_STATUS; all concat forms must match it)"
+
+# Plugin verify lines: the only way we observed `auth: verify ok` for
+# run_id=X is if x-macaroon was present when PreLLMHook ran. For the
+# three concat calls, that's only possible if the wrapper successfully
+# split and injected. This is the load-bearing assertion.
+echo
+echo "  Plugin verify lines (each proves wrapper injected x-macaroon):"
+assert_verify_log_present "$AUTH_RUN_ID"
+assert_verify_log_present "$XAPI_RUN_ID"
+assert_verify_log_present "$XGOOG_RUN_ID"
+assert_verify_log_present "$COMPAT_RUN_ID"
+
+# logs.db rows: same dim canonicalization applies regardless of how
+# the macaroon arrived. All four rows should carry the macaroon's
+# claims.
+echo
+echo "  logs.db rows (each proves end-to-end pipeline):"
+for label in "Authorization:$AUTH_RUN_ID" \
+             "x-api-key:$XAPI_RUN_ID" \
+             "x-goog-api-key:$XGOOG_RUN_ID" \
+             "two-header:$COMPAT_RUN_ID"; do
+  name="${label%%:*}"
+  rid="${label#*:}"
+  row=$(fetch_logs_row "$rid")
+  expect_eq "logs row [$name]" "$rid|u_alice|coder|w1" "$row"
+done
+
+# --- summary ---------------------------------------------------------------
+
+section "done"
+
+echo "  ORG_ID=$ORG_ID"
+echo "  Authorization run_id=$AUTH_RUN_ID"
+echo "  x-api-key      run_id=$XAPI_RUN_ID"
+echo "  x-goog-api-key run_id=$XGOOG_RUN_ID"
+echo "  two-header     run_id=$COMPAT_RUN_ID"
+echo
+
+if [ "$ASSERT_FAILED" -gt 0 ]; then
+  echo "  $ASSERT_FAILED assertion(s) FAILED."
+  exit 1
+fi
+
+echo "  All assertions passed: bearer-concat transport works for all"
+echo "  three inbound auth headers, AND the two-header form is"
+echo "  unaffected."

--- a/gateway/wrapper/authsplit.go
+++ b/gateway/wrapper/authsplit.go
@@ -1,0 +1,185 @@
+// Authsplit: pre-bifrost rewrite that unpacks `<vk>.<macaroon>` from
+// whichever inbound auth header carries it into the canonical two-
+// header shape (VK in the original header + `x-macaroon`).
+//
+// This exists because some agent harnesses only let callers configure
+// a single "API key" field, with no way to add custom headers — but
+// our governance model needs both a VK (for Bifrost customer auth)
+// and a macaroon (for plugin authorization). Concatenating them into
+// the API key field every harness already supports, then splitting
+// here before Bifrost sees the request, is the path that works for
+// every harness.
+//
+// See gateway/plans/phases/phase-10-bearer-concat-transport.md for
+// the full plan, wire format, and rationale.
+//
+// Invariants
+// ----------
+//   - Strictly additive: any request that works today MUST continue
+//     to work byte-for-byte after this code runs.
+//   - The rewrite triggers ONLY when all five conditions hold:
+//     1. Request is on the bifrost-bound proxy branch (caller's
+//        responsibility — we don't check the path here).
+//     2. One of authHeaderNames is present and non-empty.
+//     3. That header's value (with any "Bearer " prefix stripped)
+//        contains '.'.
+//     4. The left side of the first '.' matches vkPattern.
+//     5. No x-macaroon header is already set.
+//   - The split function is allocation-light: it returns sub-strings
+//     that share the original value's backing bytes.
+//
+// Nothing here knows anything cryptographic. Macaroon validation
+// happens later in gateway/internal/auth/verifier.go after the plugin
+// sees x-macaroon. If the right side isn't a valid macaroon, the
+// plugin produces the same 401 it would have for a malformed
+// x-macaroon today.
+
+package main
+
+import (
+	"net/http"
+	"net/http/httputil"
+	"regexp"
+	"strings"
+)
+
+// authHeaderNames is the set of inbound headers Bifrost-http accepts
+// the VK on. Confirmed against bifrost/core/schemas/plugin_test.go's
+// exact-match and case-insensitive lookup tests; no other inbound
+// header carries the VK.
+//
+// Order matters: we stop at the first present header. If a future
+// SDK lands that uses a fourth header name, add it here.
+var authHeaderNames = []string{
+	"Authorization",
+	"X-Api-Key",
+	"X-Goog-Api-Key",
+}
+
+// macaroonHeader is the canonical header the plugin reads. After the
+// rewrite, the right side of the split lands here.
+const macaroonHeader = "X-Macaroon"
+
+// vkPattern matches a Bifrost virtual key. Anchored at both ends and
+// excludes '.', which is what makes '.' an unambiguous separator
+// between vk and macaroon.
+//
+// If Bifrost ever changes VK format to include '.', this phase needs
+// revisiting. The test suite pins that assumption.
+var vkPattern = regexp.MustCompile(`^sk-bf-[A-Za-z0-9_-]+$`)
+
+// splitVKMacaroon takes a header value (already stripped of any
+// "Bearer " prefix by the caller) and returns the VK + macaroon if
+// the value matches the concat shape `<vk>.<macaroon>`.
+//
+// Returns ok=false (and zero strings) for any value that doesn't
+// match. In particular: empty input, no '.', empty left side, empty
+// right side, and any left side that doesn't match vkPattern. The
+// last case is what protects OAuth/JWT bearer tokens from being
+// mis-split — they contain '.' but the left side never starts with
+// "sk-bf-".
+func splitVKMacaroon(raw string) (vk, mac string, ok bool) {
+	if raw == "" {
+		return "", "", false
+	}
+	i := strings.IndexByte(raw, '.')
+	if i <= 0 || i == len(raw)-1 {
+		// No '.', or '.' at index 0 (empty left), or '.' at the very
+		// end (empty right). All three are pass-through cases.
+		return "", "", false
+	}
+	vk, mac = raw[:i], raw[i+1:]
+	if !vkPattern.MatchString(vk) {
+		return "", "", false
+	}
+	return vk, mac, true
+}
+
+// stripBearer removes a leading "Bearer " prefix (case-insensitive)
+// from a header value. Returns the stripped value and whether a prefix
+// was present, so the caller can re-attach the prefix when writing
+// the VK back to the same header.
+//
+// This handles "Bearer ", "bearer ", "BEARER ", etc. Anything else
+// (including no prefix) passes through unchanged with hadPrefix=false.
+func stripBearer(v string) (stripped string, hadPrefix bool) {
+	const prefix = "Bearer "
+	if len(v) >= len(prefix) && strings.EqualFold(v[:len(prefix)], prefix) {
+		return v[len(prefix):], true
+	}
+	return v, false
+}
+
+// rewriteAuthHeaders mutates h in place to convert a concat-form
+// credential into the canonical two-header shape.
+//
+// Algorithm (see phase-10 plan §"Wrapper behavior" for the full
+// specification):
+//
+//  1. If x-macaroon is already set, leave the request alone — the
+//     caller explicitly used the two-header form.
+//  2. Iterate authHeaderNames in order. Take the first non-empty
+//     header value.
+//  3. Strip any "Bearer " prefix (only meaningful on Authorization).
+//  4. Try to split the remainder on the first '.'. If splitVKMacaroon
+//     returns ok=false, RETURN without modifying anything — we do NOT
+//     fall through to the next header. The convention is "the header
+//     carrying the credential is the one to rewrite," and stopping
+//     at the first present header locks that in.
+//  5. Replace the original header with just the VK (re-adding the
+//     "Bearer " prefix if it was there) and set x-macaroon to the
+//     right side.
+//
+// This function exposes Header (not *httputil.ProxyRequest) for
+// straightforward unit testing. The proxy wiring is in main.go.
+func rewriteAuthHeaders(h http.Header) {
+	if h.Get(macaroonHeader) != "" {
+		return
+	}
+	for _, name := range authHeaderNames {
+		v := h.Get(name)
+		if v == "" {
+			continue
+		}
+		stripped, hadBearer := stripBearer(v)
+		vk, mac, ok := splitVKMacaroon(stripped)
+		if !ok {
+			// First present header carries the credential but isn't
+			// in concat form — pass through untouched. Do NOT continue
+			// the loop; the credential lives in this header.
+			return
+		}
+		if hadBearer {
+			h.Set(name, "Bearer "+vk)
+		} else {
+			h.Set(name, vk)
+		}
+		h.Set(macaroonHeader, mac)
+		return
+	}
+}
+
+// installAuthRewrite wraps an existing reverse proxy's Director so
+// rewriteAuthHeaders runs on every outgoing request, after the
+// Director set by NewSingleHostReverseProxy has finished its own URL
+// rewriting work.
+//
+// Why Director-chaining and not the newer Rewrite hook? The proxy is
+// constructed by httputil.NewSingleHostReverseProxy, which installs a
+// Director (not a Rewrite). Per Go's docs, Rewrite and Director are
+// mutually exclusive — setting Rewrite would silently disable the
+// URL-rewriting work NewSingleHostReverseProxy did. Wrapping the
+// existing Director is the documented composition pattern.
+//
+// The wrapped Director mutates req.Header on the outbound request,
+// not the original inbound one (httputil.ReverseProxy.ServeHTTP makes
+// a shallow request copy before calling Director, so req.Header here
+// is already the outbound's). Confirmed against Go's net/http/httputil
+// source: ReverseProxy.ServeHTTP at "outreq := req.Clone(ctx)".
+func installAuthRewrite(proxy *httputil.ReverseProxy) {
+	inner := proxy.Director
+	proxy.Director = func(req *http.Request) {
+		inner(req)
+		rewriteAuthHeaders(req.Header)
+	}
+}

--- a/gateway/wrapper/authsplit_test.go
+++ b/gateway/wrapper/authsplit_test.go
@@ -1,0 +1,411 @@
+// Tests for the bearer-concat → two-header transport split.
+//
+// These tests exhaustively cover the table in
+// gateway/plans/phases/phase-10-bearer-concat-transport.md §"Test
+// surface" PLUS the backward-compatibility regression cases. They
+// run with plain `go test ./...` from this directory (no Bifrost,
+// no Docker, no Redis).
+//
+// What "backward compat" means here: any request shape that worked
+// against the wrapper today must produce a byte-identical outbound
+// Header map after rewriteAuthHeaders runs. The "Regression" group
+// below pins that property.
+
+package main
+
+import (
+	"net/http"
+	"testing"
+)
+
+// hdr is a small helper to build an http.Header from key/value pairs.
+// It exists so test cases read like declarative tables.
+func hdr(kvs ...string) http.Header {
+	if len(kvs)%2 != 0 {
+		panic("hdr: need even number of args")
+	}
+	h := http.Header{}
+	for i := 0; i < len(kvs); i += 2 {
+		h.Add(kvs[i], kvs[i+1])
+	}
+	return h
+}
+
+// assertHeaderEqual compares two http.Header maps key-by-key. We
+// don't use reflect.DeepEqual because it's sensitive to nil vs.
+// empty slice on absent keys, and we want a friendlier diff.
+func assertHeaderEqual(t *testing.T, got, want http.Header) {
+	t.Helper()
+	// Every key in want must be present with the same value.
+	for k, wantVals := range want {
+		gotVals := got.Values(k)
+		if len(gotVals) != len(wantVals) {
+			t.Errorf("header %q: got %d values %v, want %d values %v",
+				k, len(gotVals), gotVals, len(wantVals), wantVals)
+			continue
+		}
+		for i := range wantVals {
+			if gotVals[i] != wantVals[i] {
+				t.Errorf("header %q[%d]: got %q, want %q",
+					k, i, gotVals[i], wantVals[i])
+			}
+		}
+	}
+	// Every key in got must be in want (catches unexpected additions
+	// like spurious X-Macaroon on a passthrough case).
+	for k := range got {
+		if _, ok := want[k]; !ok {
+			t.Errorf("header %q present in got but not want (values=%v)",
+				k, got.Values(k))
+		}
+	}
+}
+
+// ─── splitVKMacaroon: pure function tests ─────────────────────────────
+
+func TestSplitVKMacaroon(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantVK  string
+		wantMac string
+		wantOK  bool
+	}{
+		{
+			name:    "happy path",
+			input:   "sk-bf-abc123.eyJtYWNhcm9vbiI6Indvcmsifg",
+			wantVK:  "sk-bf-abc123",
+			wantMac: "eyJtYWNhcm9vbiI6Indvcmsifg",
+			wantOK:  true,
+		},
+		{
+			// JWTs / OAuth bearer tokens have dots but the left side
+			// doesn't match the VK pattern. This is the critical
+			// passthrough case that protects every non-Bifrost
+			// credential type from being mangled.
+			name:   "JWT-shaped value rejected (left side not a VK)",
+			input:  "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature",
+			wantOK: false,
+		},
+		{
+			name:   "plain VK with no dot",
+			input:  "sk-bf-abc123",
+			wantOK: false,
+		},
+		{
+			name:   "empty input",
+			input:  "",
+			wantOK: false,
+		},
+		{
+			name:   "leading dot (empty left side)",
+			input:  ".some-macaroon-payload",
+			wantOK: false,
+		},
+		{
+			name:   "trailing dot (empty right side)",
+			input:  "sk-bf-abc123.",
+			wantOK: false,
+		},
+		{
+			name:   "just a dot",
+			input:  ".",
+			wantOK: false,
+		},
+		{
+			// Left side doesn't start with sk-bf-. The wrapper must
+			// not mistake a non-Bifrost token (some provider's
+			// dot-bearing key) for the concat form.
+			name:   "left side missing sk-bf- prefix",
+			input:  "notavk.something",
+			wantOK: false,
+		},
+		{
+			// VK alphabet excludes '.', '+', '/', etc. The pattern
+			// must reject any character outside [A-Za-z0-9_-] in the
+			// VK position.
+			name:   "VK with disallowed character",
+			input:  "sk-bf-abc+def.macpart",
+			wantOK: false,
+		},
+		{
+			// First '.' wins. If the macaroon itself somehow
+			// contained additional dots (it shouldn't — base64url
+			// doesn't include '.'), we'd still split at the first
+			// one. Pinned here so the behavior is documented.
+			name:    "first dot wins",
+			input:   "sk-bf-abc.first.second.third",
+			wantVK:  "sk-bf-abc",
+			wantMac: "first.second.third",
+			wantOK:  true,
+		},
+		{
+			// Underscores and hyphens are valid in the VK alphabet.
+			name:    "VK with underscore and hyphen",
+			input:   "sk-bf-a_b-c.macpart",
+			wantVK:  "sk-bf-a_b-c",
+			wantMac: "macpart",
+			wantOK:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			vk, mac, ok := splitVKMacaroon(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("ok: got %v want %v (vk=%q mac=%q)", ok, tt.wantOK, vk, mac)
+			}
+			if ok {
+				if vk != tt.wantVK {
+					t.Errorf("vk: got %q want %q", vk, tt.wantVK)
+				}
+				if mac != tt.wantMac {
+					t.Errorf("mac: got %q want %q", mac, tt.wantMac)
+				}
+			}
+		})
+	}
+}
+
+// ─── stripBearer: pure function tests ─────────────────────────────────
+
+func TestStripBearer(t *testing.T) {
+	tests := []struct {
+		input        string
+		wantStripped string
+		wantHad      bool
+	}{
+		{"Bearer sk-bf-x", "sk-bf-x", true},
+		{"bearer sk-bf-x", "sk-bf-x", true},
+		{"BEARER sk-bf-x", "sk-bf-x", true},
+		{"BeArEr sk-bf-x", "sk-bf-x", true},
+		// No prefix → returned unchanged. This is the x-api-key
+		// shape: Anthropic and Gemini SDKs send raw values without
+		// "Bearer ".
+		{"sk-bf-x", "sk-bf-x", false},
+		// Too short to contain "Bearer ".
+		{"abc", "abc", false},
+		// Empty stays empty.
+		{"", "", false},
+		// "Bearer" without trailing space is NOT a prefix match. The
+		// space is part of the convention; without it we'd mangle a
+		// theoretical credential that started with the letters
+		// "Bearer".
+		{"BearerNoSpace", "BearerNoSpace", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, had := stripBearer(tt.input)
+			if got != tt.wantStripped {
+				t.Errorf("stripped: got %q want %q", got, tt.wantStripped)
+			}
+			if had != tt.wantHad {
+				t.Errorf("hadPrefix: got %v want %v", had, tt.wantHad)
+			}
+		})
+	}
+}
+
+// ─── rewriteAuthHeaders: integration table ────────────────────────────
+
+func TestRewriteAuthHeaders(t *testing.T) {
+	const (
+		vk  = "sk-bf-abc123"
+		mac = "eyJtYWNhcm9vbiI6Indvcmsifg"
+	)
+
+	tests := []struct {
+		name string
+		in   http.Header
+		want http.Header
+	}{
+		// ── New "concat" path ────────────────────────────────────
+		{
+			name: "Authorization Bearer concat",
+			in:   hdr("Authorization", "Bearer "+vk+"."+mac),
+			want: hdr(
+				"Authorization", "Bearer "+vk,
+				"X-Macaroon", mac,
+			),
+		},
+		{
+			name: "Authorization lowercase bearer concat",
+			in:   hdr("Authorization", "bearer "+vk+"."+mac),
+			want: hdr(
+				"Authorization", "Bearer "+vk,
+				"X-Macaroon", mac,
+			),
+		},
+		{
+			name: "x-api-key concat (Anthropic-shaped)",
+			in:   hdr("X-Api-Key", vk+"."+mac),
+			want: hdr(
+				"X-Api-Key", vk,
+				"X-Macaroon", mac,
+			),
+		},
+		{
+			name: "x-goog-api-key concat (Gemini-shaped)",
+			in:   hdr("X-Goog-Api-Key", vk+"."+mac),
+			want: hdr(
+				"X-Goog-Api-Key", vk,
+				"X-Macaroon", mac,
+			),
+		},
+		{
+			// Case-insensitive header lookup: Go canonicalizes
+			// header keys via textproto.CanonicalMIMEHeaderKey so
+			// "x-api-key", "X-Api-Key", and "X-API-KEY" all hit the
+			// same map entry. Pin this explicitly so a future
+			// refactor that bypasses canonicalization breaks here.
+			name: "lowercase header name works (Go canonicalizes)",
+			in:   hdr("x-api-key", vk+"."+mac),
+			want: hdr(
+				"X-Api-Key", vk,
+				"X-Macaroon", mac,
+			),
+		},
+
+		// ── Backward-compat passthrough cases ────────────────────
+		{
+			name: "Authorization Bearer with no dot (plain VK)",
+			in:   hdr("Authorization", "Bearer "+vk),
+			want: hdr("Authorization", "Bearer "+vk),
+		},
+		{
+			name: "x-api-key with no dot (plain VK)",
+			in:   hdr("X-Api-Key", vk),
+			want: hdr("X-Api-Key", vk),
+		},
+		{
+			// The existing two-header form. Some callers explicitly
+			// stamp both Authorization (VK) and X-Macaroon. Today
+			// they work; after this change they must STILL work
+			// unchanged — the existing X-Macaroon takes precedence
+			// regardless of what's in Authorization.
+			name: "two-header form passes through unchanged",
+			in: hdr(
+				"Authorization", "Bearer "+vk,
+				"X-Macaroon", "existing-macaroon",
+			),
+			want: hdr(
+				"Authorization", "Bearer "+vk,
+				"X-Macaroon", "existing-macaroon",
+			),
+		},
+		{
+			// Critical edge case: if X-Macaroon is already set, the
+			// wrapper must NOT clobber it even if Authorization
+			// contains a concat. The caller has explicitly opted
+			// into the two-header form.
+			name: "existing X-Macaroon wins over concat in Authorization",
+			in: hdr(
+				"Authorization", "Bearer "+vk+"."+mac,
+				"X-Macaroon", "caller-stamped-macaroon",
+			),
+			want: hdr(
+				"Authorization", "Bearer "+vk+"."+mac,
+				"X-Macaroon", "caller-stamped-macaroon",
+			),
+		},
+		{
+			// OAuth / JWT tokens contain dots but the left side
+			// doesn't match the VK pattern. The wrapper must leave
+			// them strictly alone. This protects every non-Bifrost
+			// bearer-token caller from being broken by this change.
+			name: "JWT in Authorization passes through",
+			in:   hdr("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature"),
+			want: hdr("Authorization", "Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0In0.signature"),
+		},
+		{
+			// Empty right side ("sk-bf-x.") looks superficially
+			// concat-shaped but rule 6 rejects it. The header reaches
+			// Bifrost untouched and Bifrost returns its own error
+			// for the malformed VK — same behavior as today.
+			name: "concat-shaped with empty macaroon falls through",
+			in:   hdr("Authorization", "Bearer "+vk+"."),
+			want: hdr("Authorization", "Bearer "+vk+"."),
+		},
+		{
+			name: "no auth header at all",
+			in:   hdr("Content-Type", "application/json"),
+			want: hdr("Content-Type", "application/json"),
+		},
+
+		// ── Multi-header tie-breaking ────────────────────────────
+		{
+			// First present header in authHeaderNames order
+			// (Authorization) wins. The x-api-key value is left
+			// completely alone, even though it also contains a dot.
+			// This is the documented "first wins, don't fall
+			// through" rule.
+			name: "both Authorization and x-api-key present, Authorization wins",
+			in: hdr(
+				"Authorization", "Bearer "+vk+"."+mac,
+				"X-Api-Key", "sk-bf-other.othermac",
+			),
+			want: hdr(
+				"Authorization", "Bearer "+vk,
+				"X-Api-Key", "sk-bf-other.othermac", // unchanged
+				"X-Macaroon", mac,
+			),
+		},
+		{
+			// If Authorization has no dot but x-api-key does, we
+			// STILL stop at Authorization. The rule is "the first
+			// present header carries the credential" — we don't go
+			// hunting for a dot. This is intentional defense against
+			// smuggling: a caller can't slip a macaroon in via
+			// x-api-key when the real auth lives in Authorization.
+			name: "Authorization without dot stops loop, x-api-key not scanned",
+			in: hdr(
+				"Authorization", "Bearer "+vk,
+				"X-Api-Key", "sk-bf-other.othermac",
+			),
+			want: hdr(
+				"Authorization", "Bearer "+vk,
+				"X-Api-Key", "sk-bf-other.othermac",
+			),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Clone so we can show the before-state in failure msgs.
+			got := tt.in.Clone()
+			rewriteAuthHeaders(got)
+			assertHeaderEqual(t, got, tt.want)
+		})
+	}
+}
+
+// TestRewriteAuthHeaders_AssumesVKShape pins the assumption that no
+// real Bifrost VK contains '.'. If Bifrost ever changes VK format,
+// this test starts being meaningful — until then it documents the
+// invariant that protects the rule-5 regex.
+//
+// If you're touching this file because a VK with '.' showed up:
+//   - Decide whether to keep '.' as the separator (and use a richer
+//     parser, e.g. require the macaroon side to be valid base64url).
+//   - Or pick a different separator that's still outside both
+//     alphabets.
+//
+// See gateway/plans/phases/phase-10-bearer-concat-transport.md
+// §"Wire format" for the rationale.
+func TestRewriteAuthHeaders_AssumesVKShape(t *testing.T) {
+	// Representative VKs that have actually appeared. Add to this
+	// list (or wire it up to fixture data) if a regression ever hits.
+	knownVKShapes := []string{
+		"sk-bf-abc123",
+		"sk-bf-A1B2_C3-D4",
+		"sk-bf-" + "x_y-z_" + "ABCDEF0123456789",
+	}
+	for _, v := range knownVKShapes {
+		if !vkPattern.MatchString(v) {
+			t.Errorf("vkPattern rejected a known-valid VK shape %q — "+
+				"phase-10's '.' separator assumes VKs never contain '.', "+
+				"and the pattern must accept every shape Bifrost issues",
+				v)
+		}
+	}
+}

--- a/gateway/wrapper/main.go
+++ b/gateway/wrapper/main.go
@@ -421,9 +421,16 @@ func filesEqual(a, b string) (bool, error) {
 // newProxy builds the public HTTP handler. Routes `/_plugin/*` to the
 // plugin's loopback server (if reachable) and everything else to
 // bifrost-http.
+//
+// The bifrost-bound proxy additionally runs the bearer-concat auth
+// rewrite (see authsplit.go) so harnesses that can't set custom
+// headers can deliver both VK and macaroon in a single API-key field.
+// The plugin proxy intentionally does NOT run that rewrite — its
+// /_plugin/* admin surface uses a different auth scheme entirely.
 func newProxy(logger *log.Logger, pluginReady bool) http.Handler {
 	bifrostURL := mustParseURL(bifrostUpstream)
 	bifrostProxy := newSingleHostReverseProxy(bifrostURL, logger, "bifrost")
+	installAuthRewrite(bifrostProxy)
 
 	var pluginProxy *httputil.ReverseProxy
 	if pluginReady {


### PR DESCRIPTION
Implements the phase-10 plan in `gateway/plans/phases/phase-10-bearer-concat-transport.md` (committed separately in dfb726b5).

## Why

Several agent harnesses don't let callers set custom HTTP headers — they expose only a single "API key" field. Today our governance model needs two credentials per call: a VK (Bifrost customer auth) and a macaroon (plugin authorization). That requirement is intractable for harnesses we want to support.

This change lets callers concatenate both into the API-key field every harness already exposes:

```
Authorization: Bearer <vk>.<macaroon>
x-api-key: <vk>.<macaroon>          (Anthropic SDK)
x-goog-api-key: <vk>.<macaroon>     (Gemini SDK)
```

The wrapper at `gateway/wrapper/main.go` splits on the first `.`, rewrites the originating header back to just the VK, and injects `x-macaroon` from the right half. Bifrost sees its expected auth shape. The plugin sees its expected `x-macaroon`. End-to-end verification, dim canonicalization, accounting — all unchanged.

## Why the wrapper, not the plugin

Bifrost-http authenticates the VK at HTTP ingress, **before** any plugin hook fires. If `Authorization` has a macaroon glued onto the VK, Bifrost's VK lookup fails and the request 401s before `HTTPTransportPreHook` runs. The split must happen at a layer that owns the wire before bifrost-http parses it — that's the wrapper.

## Backward compatibility

Strictly additive. The split path triggers only when **all five** conditions hold:

1. Request is on the bifrost-bound proxy branch (not `/_plugin/*`)
2. One of `{Authorization, X-Api-Key, X-Goog-Api-Key}` is present
3. That value contains `.`
4. The left side matches `^sk-bf-[A-Za-z0-9_-]+$`
5. No `x-macaroon` header is already set

Existing two-header callers (rule 5) and any non-Bifrost bearer-token caller whose value happens to contain `.` (rule 4, e.g. JWTs) fall through unchanged.

## What's in this PR

| File | Change |
|---|---|
| `gateway/wrapper/authsplit.go` | **NEW.** ~170 lines. Exports `rewriteAuthHeaders(http.Header)` and `installAuthRewrite(*httputil.ReverseProxy)`. |
| `gateway/wrapper/authsplit_test.go` | **NEW.** Three test functions, 30+ subtests covering happy paths + every backward-compat regression case. |
| `gateway/wrapper/main.go` | **+8 lines.** One call to `installAuthRewrite(bifrostProxy)`. |
| `gateway/Dockerfile` | **+5 lines.** `COPY wrapper/main.go ./` → `COPY wrapper/*.go ./` so new wrapper files don't silently break the image build. |
| `gateway/scripts/smoke-test-concat.sh` | **NEW.** End-to-end smoke proving the wrapper split is byte-identical across all three inbound header shapes vs. the two-header form. |

## Verification

**Unit tests** (no Docker, no Redis):
```
cd gateway/wrapper && go test ./...
ok  github.com/stakwork/stakgraph/gateway/wrapper  0.161s
```
All 30+ subtests pass. `go vet` clean.

**End-to-end smoke** (`smoke-test-concat.sh`):
- 3 PASS: concat HTTP matches two-header HTTP (proves wrapper is transparent)
- 4 PASS: plugin `auth: verify ok` log lines for all four call shapes (proves wrapper injected `x-macaroon`)
- 4 PASS: `logs.db` rows with canonicalized macaroon dims for all four (proves end-to-end pipeline)

**Regression** (`smoke-test-enforcement.sh`, written before phase 10):
- All assertions still pass — no regression on the two-header form

## Follow-up (not in this PR)

The plan doc lists three docs to add cross-references to phase 10:
- `gateway/plans/phases/phase-4-macaroon-shape.md` §"Encoding choices"
- `gateway/plans/llm-governance-v2.md` §"The wire protocol"
- `gateway/README.md` quickstart + intermediate-proxy header-line note

Kept out of this PR to keep the diff focused on code. Happy to do them in a follow-up.