### PR TITLE
Vein evals foundation: self-improving workflow loops

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -49,6 +49,26 @@ Experimentation seams (edit without touching code):
 - **orchestration** → fork the top-level workflow (chronological vs
   bootstrap vs future adaptive/loop variants)
 
+### `eval/` — generic, reusable eval primitives (NOT an experiment)
+
+Domain-agnostic eval substrate, shared by every experiment. See
+`vein/EVAL_SPEC.md`. **Steps only** — no domain config baked in:
+
+- `eval/steps/score.ts` (`eval/score`) — match a produced set vs an expected
+  gold set by a `rubric`; recall-weighted F-beta score.
+- `eval/steps/reflect.ts` (`eval/reflect`) — propose a better prompt from the
+  AGGREGATED results across a dataset (multi-example → avoids overfitting).
+- `eval/steps/optimize.ts` (`eval/optimize`) — the `eval → keep best → reflect`
+  loop, run as a single detached "background job" (EVAL_SPEC §8). Runs
+  sub-workflows via an injected `services.optimizer` (closure over `vein.run`).
+
+**Naming rule:** `eval/*` = generic. The eval *workflows* that wire these with
+a rubric/task/dataset belong to the experiment and are named `<experiment>-…`.
+The concepts experiment's live in `concepts/workflows/`: `concepts-eval`
+(harness), `concepts-eval-score` (rubric), `concepts-eval-reflect`
+(task+guidance), `concepts-optimize` (the wired loop). A new experiment `foo`
+adds `foo-eval`, `foo-eval-score`, … reusing the same `eval/*` steps.
+
 ## Running / gotchas
 
 - Needs **Neo4j** + `GITHUB_TOKEN` + an LLM key (e.g. `ANTHROPIC_API_KEY`).

--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -81,15 +81,19 @@ Nothing is automated yet — no CI job exercises `/lab`. Manual steps:
 4. **Init + seed** (lazy on first hit): `curl localhost:3355/lab/health`,
    then `curl localhost:3355/lab/workflows` to confirm the 3 workflows
    seeded.
-5. **Run** (SSE stream):
+5. **Run** (detached launch + reattach — see `vein/EVAL_SPEC.md` §8). The
+   `POST …/run` returns `{ runId }` immediately (the run executes server-side);
+   reattach to its SSE event tail to watch it:
    ```
-   curl -N -X POST localhost:3355/lab/workflows/bootstrap-then-process/run \
+   RUN=$(curl -s -X POST localhost:3355/lab/workflows/bootstrap-then-process/run \
      -H 'content-type: application/json' \
-     -d '{"input":{"owner":"OWNER","repo":"REPO","token":"<gh token>"}}'
+     -d '{"input":{"owner":"OWNER","repo":"REPO","token":"<gh token>"}}' \
+     | jq -r .runId)
+   curl -N localhost:3355/lab/workflows/bootstrap-then-process/runs/$RUN/stream
    ```
    Use a **tiny repo** first (LLM cost/time per PR+commit).
 6. **Verify**: query Neo4j directly — `MATCH (c:Concept) RETURN c.name,
-   c.description` — or watch the SSE `step.*` events. (There is no
+   c.description` — or watch the reattached SSE `step.*` events. (There is no
    concept-listing HTTP endpoint yet; vein only exposes `/workflows`.)
 
 **Prerequisite gap for file linking:** `concepts/link-files` connects

--- a/mcp/src/lab/concepts/bootstrap.ts
+++ b/mcp/src/lab/concepts/bootstrap.ts
@@ -105,39 +105,46 @@ function classifyRepo(fileCount: number): {
 }
 
 /**
- * Build the bootstrap prompt with sizing hints
+ * Bootstrap prompt configuration — the experiment surface. NOT baked in here:
+ * the prompt text lives in the calling workflow's `params` block
+ * (`workflows/bootstrap-then-process.yaml`) and is passed in via the
+ * `concepts/bootstrap-explore` step config (mirrors how `concepts/decide`
+ * sources its prompt). This keeps the big prompt visible + editable + tunable
+ * in the vein UI rather than hidden in code.
+ *
+ *   - `system`   — the system override (no placeholders).
+ *   - `template` — the exploration prompt, with `{slot}` placeholders the step
+ *     fills with runtime-computed values: {owner}, {repo}, {size},
+ *     {fileCount}, {min}, {max}.
  */
-function buildBootstrapPrompt(
-  owner: string,
-  repo: string,
-  fileCount: number,
-  sizing: { size: RepoSize; min: number; max: number }
+export interface BootstrapPromptConfig {
+  system: string;
+  template: string;
+}
+
+/**
+ * Fill the `{slot}` placeholders in a bootstrap prompt template with the
+ * runtime-computed sizing values. (Single-brace slots, distinct from vein's
+ * `{{ }}` templates, so they survive config resolution untouched.)
+ */
+function fillBootstrapPrompt(
+  template: string,
+  vals: {
+    owner: string;
+    repo: string;
+    size: RepoSize;
+    fileCount: number;
+    min: number;
+    max: number;
+  }
 ): string {
-  return `Explore the repository "${owner}/${repo}" and identify its core features.
-
-This is a ${sizing.size} repository (~${fileCount} source files). Aim for ${sizing.min}-${sizing.max} features.
-
-A "feature" is a distinct user-facing capability or business function — something a product owner or end user would recognize. Examples: "Authentication System", "Payment Processing", "Real-time Notifications", "Search and Filtering".
-
-Do NOT create features for:
-- Build tooling, CI/CD, or infrastructure
-- Individual utility functions or helpers
-- Code style, linting, or formatting
-- Generic "bug fixes" or "refactoring"
-- Testing infrastructure (unless it IS the product)
-
-For each feature provide:
-- **name**: A clear, non-technical name (no framework/library names)
-- **description**: 1-2 sentences explaining what this capability does for users
-- **summary**: SUCCINCT high-level documentation (30-80 lines markdown) for this feature's CURRENT state
-- **files**: List the core source files that implement this feature (relative paths from repo root, e.g. "src/auth/login.ts"). Include only the most important files — entry points, main modules, route definitions, core logic. Aim for 3-15 files per feature depending on scope.
-
-**Summary requirements** — focus on what developers need to know to work on this feature:
-${DOC_GUIDELINES.include}
-
-${DOC_GUIDELINES.avoid}
-
-Prefer fewer, broader features over many granular ones. Two closely related capabilities should be one feature, not two.`;
+  return template
+    .replaceAll("{owner}", vals.owner)
+    .replaceAll("{repo}", vals.repo)
+    .replaceAll("{size}", vals.size)
+    .replaceAll("{fileCount}", String(vals.fileCount))
+    .replaceAll("{min}", String(vals.min))
+    .replaceAll("{max}", String(vals.max));
 }
 
 /**
@@ -191,6 +198,7 @@ export async function bootstrapConcepts(
   repo: string,
   repoPath: string,
   storage: Storage,
+  promptConfig: BootstrapPromptConfig,
   sessionId?: string,
   lookbackDays: number = DEFAULT_BOOTSTRAP_LOOKBACK_DAYS
 ): Promise<BootstrapResult> {
@@ -205,12 +213,19 @@ export async function bootstrapConcepts(
     `   📊 Found ${fileCount} source files (${sizing.size} repo, targeting ${sizing.min}-${sizing.max} features)`
   );
 
-  // 2. Build prompt and call get_context with structured schema
-  const prompt = buildBootstrapPrompt(owner, repo, fileCount, sizing);
+  // 2. Fill the prompt template (the experiment surface) and call get_context.
+  const prompt = fillBootstrapPrompt(promptConfig.template, {
+    owner,
+    repo,
+    size: sizing.size,
+    fileCount,
+    min: sizing.min,
+    max: sizing.max,
+  });
 
   const result = await get_context(prompt, repoPath, {
     schema: BOOTSTRAP_SCHEMA,
-    systemOverride: `You are a software architect analyzing a codebase to identify its core features. Use the provided tools to explore the repository structure, read key files (README, entry points, route definitions, main modules), and identify the distinct user-facing capabilities this software provides. Be thorough but focused — read enough to understand what each feature does, but don't try to read every file.`,
+    systemOverride: promptConfig.system,
     sessionId,
     isolatedContext: true,
   });

--- a/mcp/src/lab/concepts/seed.ts
+++ b/mcp/src/lab/concepts/seed.ts
@@ -43,6 +43,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "collect-results.ts", type: "concepts/collect-results" },
   { file: "summarize-concept.ts", type: "concepts/summarize" },
   { file: "link-files.ts", type: "concepts/link-files" },
+  { file: "collect-for-eval.ts", type: "concepts/collect-for-eval" },
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));

--- a/mcp/src/lab/concepts/seed.ts
+++ b/mcp/src/lab/concepts/seed.ts
@@ -21,7 +21,12 @@ const SEED_WORKFLOWS = [
   "process-change",
   "process-repo-chronological",
   "bootstrap-then-process",
-  "eval-concepts",
+  // Concept-specific eval workflows: wire the generic eval/* steps with the
+  // concept rubric / task / dataset. (The generic steps are seeded by eval/seed.)
+  "concepts-eval", // harness: bootstrap-only produce → score
+  "concepts-eval-score", // eval/score + concept rubric
+  "concepts-eval-reflect", // eval/reflect + concept task/guidance
+  "concepts-optimize", // eval/optimize loop, wired to the above
 ];
 
 /**

--- a/mcp/src/lab/concepts/seed.ts
+++ b/mcp/src/lab/concepts/seed.ts
@@ -21,6 +21,7 @@ const SEED_WORKFLOWS = [
   "process-change",
   "process-repo-chronological",
   "bootstrap-then-process",
+  "eval-concepts",
 ];
 
 /**
@@ -44,6 +45,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "summarize-concept.ts", type: "concepts/summarize" },
   { file: "link-files.ts", type: "concepts/link-files" },
   { file: "collect-for-eval.ts", type: "concepts/collect-for-eval" },
+  { file: "reset-repo.ts", type: "concepts/reset-repo" },
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));

--- a/mcp/src/lab/concepts/services.ts
+++ b/mcp/src/lab/concepts/services.ts
@@ -34,11 +34,14 @@ export interface ConceptServices {
   clone(owner: string, repo: string, token?: string): Promise<string>;
 
   /** Agentically explore a fresh clone to seed initial concepts and set the
-   *  checkpoint to a recent lookback window. */
+   *  checkpoint to a recent lookback window. The prompt (`system` + `template`)
+   *  is the experiment surface — supplied by the workflow's `params` via the
+   *  `concepts/bootstrap-explore` step, not baked into the service. */
   bootstrap(
     owner: string,
     repo: string,
     repoPath: string,
+    promptConfig: { system: string; template: string },
     lookbackDays?: number,
   ): Promise<{ concepts: Concept[]; usage: Usage }>;
 
@@ -104,13 +107,14 @@ export async function buildConceptServices(
       );
     },
 
-    async bootstrap(owner, repo, repoPath, lookbackDays) {
+    async bootstrap(owner, repo, repoPath, promptConfig, lookbackDays) {
       const { bootstrapConcepts } = await import("./bootstrap.js");
       const result = await bootstrapConcepts(
         owner,
         repo,
         repoPath,
         storage,
+        promptConfig,
         undefined,
         lookbackDays,
       );

--- a/mcp/src/lab/concepts/steps/bootstrap-explore.ts
+++ b/mcp/src/lab/concepts/steps/bootstrap-explore.ts
@@ -23,7 +23,7 @@ export default defineStep({
     repoPath: z.string(),
     systemPrompt: z.string(),
     promptTemplate: z.string(),
-    lookbackDays: z.number().int().positive().default(10),
+    lookbackDays: z.number().int().nonnegative().default(10),
   }),
   output: z.any(),
   async run(cfg, ctx) {

--- a/mcp/src/lab/concepts/steps/bootstrap-explore.ts
+++ b/mcp/src/lab/concepts/steps/bootstrap-explore.ts
@@ -5,14 +5,24 @@ import type { ConceptServices } from "../services.js";
  * Seed initial concepts for a brand-new repo by agentically exploring the
  * local clone, then set the checkpoint to a recent lookback window.
  * Output: { concepts, usage }.
+ *
+ * Pure mechanism: the exploration prompt — `systemPrompt` and `promptTemplate`
+ * — is NOT baked in here. It's the experiment surface and lives in the calling
+ * workflow's `params` block (see `workflows/bootstrap-then-process.yaml`),
+ * passed in via config. `promptTemplate` uses `{slot}` placeholders
+ * ({owner}, {repo}, {size}, {fileCount}, {min}, {max}) filled at runtime.
+ * Sweep prompt variants by overriding `params`; promote a winner by editing
+ * the workflow's `params` default.
  */
 export default defineStep({
   type: "concepts/bootstrap-explore",
-  description: "Seed initial concepts by exploring the cloned repo (for new repos). Config: lookbackDays (how many days back to set the checkpoint, default 10). Output: { concepts, usage }.",
+  description: "Seed initial concepts by exploring the cloned repo (for new repos). Required config: systemPrompt, promptTemplate — supplied by the calling workflow's `params` block (the prompt experiment surface). Optional: lookbackDays (checkpoint lookback, default 10). Output: { concepts, usage }.",
   input: z.object({
     owner: z.string(),
     repo: z.string(),
     repoPath: z.string(),
+    systemPrompt: z.string(),
+    promptTemplate: z.string(),
     lookbackDays: z.number().int().positive().default(10),
   }),
   output: z.any(),
@@ -22,6 +32,7 @@ export default defineStep({
       cfg.owner,
       cfg.repo,
       cfg.repoPath,
+      { system: cfg.systemPrompt, template: cfg.promptTemplate },
       cfg.lookbackDays,
     );
     return { concepts, usage };

--- a/mcp/src/lab/concepts/steps/collect-for-eval.ts
+++ b/mcp/src/lab/concepts/steps/collect-for-eval.ts
@@ -1,0 +1,70 @@
+import { z, defineStep } from "vein";
+import type { ConceptServices } from "../services.js";
+import type { Concept } from "../types.js";
+
+/**
+ * Collect the repo's final Concept set into a single, scoreable artifact —
+ * the **eval output**. The concepts pipeline writes Concepts to the graph
+ * (Neo4j) rather than returning them, so without this step the run's recorded
+ * output is the last pipeline step (link-files), not the concepts themselves.
+ *
+ * Placing this as the FINAL step of an eval target workflow means its output
+ * automatically becomes the run output (recorded in run.json + rendered in the
+ * UI via the `markdown` field) — so an eval just reads the run output and
+ * scores `markdown` / `concepts` against the expected gold set. No out-of-band
+ * graph query needed.
+ *
+ * Output: { count, concepts, markdown }.
+ */
+
+function activity(c: Concept): number {
+  return (c.prNumbers?.length ?? 0) + (c.commitShas?.length ?? 0);
+}
+
+function renderMarkdown(repoId: string, concepts: Concept[]): string {
+  const header = `# Concepts: ${repoId}\n\n${concepts.length} concept${concepts.length === 1 ? "" : "s"}.`;
+  if (concepts.length === 0) return `${header}\n\n_No concepts._`;
+  const body = concepts
+    .map((c) => {
+      const prs = c.prNumbers?.length ?? 0;
+      const commits = c.commitShas?.length ?? 0;
+      const meta =
+        commits > 0 ? `_${prs} PRs, ${commits} commits_` : `_${prs} PRs_`;
+      return `## ${c.name}\n\n${c.description}\n\n${meta}`;
+    })
+    .join("\n\n");
+  return `${header}\n\n${body}`;
+}
+
+export default defineStep({
+  type: "concepts/collect-for-eval",
+  description:
+    "Collect the repo's final Concept set from the graph into a single scoreable artifact (the eval output). Use as the LAST step of an eval target so its output becomes the recorded, UI-visible run output. Output: { count, concepts, markdown }.",
+  input: z.object({
+    owner: z.string(),
+    repo: z.string(),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { storage } = ctx.services as ConceptServices;
+    const repoId = `${cfg.owner}/${cfg.repo}`;
+
+    const all = await storage.getAllConcepts(repoId);
+    // Sort by activity (most-touched first), then name — a stable "top N" order.
+    const concepts = all
+      .slice()
+      .sort((a, b) => activity(b) - activity(a) || a.name.localeCompare(b.name));
+
+    return {
+      count: concepts.length,
+      concepts: concepts.map((c) => ({
+        id: c.id,
+        name: c.name,
+        description: c.description,
+        prNumbers: c.prNumbers ?? [],
+        commitShas: c.commitShas ?? [],
+      })),
+      markdown: renderMarkdown(repoId, concepts),
+    };
+  },
+});

--- a/mcp/src/lab/concepts/steps/reset-repo.ts
+++ b/mcp/src/lab/concepts/steps/reset-repo.ts
@@ -1,0 +1,30 @@
+import { z, defineStep } from "vein";
+import type { ConceptServices } from "../services.js";
+
+/**
+ * Delete all Concepts for a repo so the next run starts fresh. Needed for
+ * iterative evals: the `is-new-repo` gate only bootstraps when no concepts
+ * exist, so without a reset a second eval run would skip bootstrap. Bootstrap
+ * overwrites the checkpoint on its own, so clearing concepts is sufficient.
+ *
+ * Output: { repoId, deleted }.
+ */
+export default defineStep({
+  type: "concepts/reset-repo",
+  description:
+    "Delete all Concepts for owner/repo so a re-run bootstraps fresh (for iterative evals). Output: { repoId, deleted }.",
+  input: z.object({
+    owner: z.string(),
+    repo: z.string(),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { storage } = ctx.services as ConceptServices;
+    const repoId = `${cfg.owner}/${cfg.repo}`;
+    const all = await storage.getAllConcepts(repoId);
+    for (const c of all) {
+      await storage.deleteConcept(c.id, repoId);
+    }
+    return { repoId, deleted: all.length };
+  },
+});

--- a/mcp/src/lab/concepts/workflows/bootstrap-then-process.yaml
+++ b/mcp/src/lab/concepts/workflows/bootstrap-then-process.yaml
@@ -71,6 +71,9 @@ steps:
 # paramOverrides: { "bootstrap-then-process": { bootstrapPrompt } }.
 # `bootstrapPrompt` uses {slot} placeholders filled at runtime by the step:
 #   {owner} {repo} {size} {fileCount} {min} {max}
+# NB: the `bootstrapPrompt` default below was promoted from a `concepts-optimize`
+# run (gen 1, score 0.96 vs 0.85 seed) — it added an explicit "include media /
+# real-time" section + sharpened infra/agent/eval exclusions.
 params:
   bootstrapSystem: |-
     You are a software architect analyzing a codebase to identify its core features. Use the provided tools to explore the repository structure, read key files (README, entry points, route definitions, main modules), and identify the distinct user-facing capabilities this software provides. Be thorough but focused — read enough to understand what each feature does, but don't try to read every file.
@@ -79,7 +82,16 @@ params:
 
     This is a {size} repository (~{fileCount} source files). Aim for {min}-{max} features.
 
-    A "feature" is a distinct user-facing capability or business function — something a product owner or end user would recognize. Examples: "Authentication System", "Payment Processing", "Real-time Notifications", "Search and Filtering".
+    A "feature" is a distinct user-facing capability or business function — something an END USER directly interacts with or derives value from. Think: what would appear in a product demo or user manual? Examples: "Authentication System", "Payment Processing", "Real-time Notifications", "Search and Filtering", "Video Calling", "Voice Recording", "Live Chat".
+
+    **INCLUDE user-facing capabilities like:**
+    - Interactive media (voice, video, audio recording/playback)
+    - Real-time communication and collaboration
+    - Content creation, editing, and sharing
+    - Data visualization and reporting for users
+    - Search, filtering, and discovery
+    - Authentication and user management
+    - Payment and billing workflows
 
     Do NOT create features for:
     - Build tooling, CI/CD, or infrastructure
@@ -87,9 +99,10 @@ params:
     - Code style, linting, or formatting
     - Generic "bug fixes" or "refactoring"
     - Testing infrastructure (unless it IS the product)
+    - Integration plumbing or API connectors (unless the integration itself is the user value)
 
     For each feature provide:
-    - **name**: A clear, non-technical name (no framework/library names)
+    - **name**: A clear, non-technical name focusing on user value (no framework/library names)
     - **description**: 1-2 sentences explaining what this capability does for users
     - **summary**: SUCCINCT high-level documentation (30-80 lines markdown) for this feature's CURRENT state
     - **files**: List the core source files that implement this feature (relative paths from repo root, e.g. "src/auth/login.ts"). Include only the most important files — entry points, main modules, route definitions, core logic. Aim for 3-15 files per feature depending on scope.
@@ -110,4 +123,4 @@ params:
     - Detailed API documentation
     - Step-by-step flows unless absolutely essential
 
-    Prefer fewer, broader features over many granular ones. Two closely related capabilities should be one feature, not two.
+    Prefer fewer, broader features over many granular ones. Two closely related capabilities should be one feature, not two. Focus on what users DO with the product, not how operators manage it.

--- a/mcp/src/lab/concepts/workflows/bootstrap-then-process.yaml
+++ b/mcp/src/lab/concepts/workflows/bootstrap-then-process.yaml
@@ -35,6 +35,12 @@ steps:
       # How many days back to set the checkpoint after seeding (default 10).
       # Edit this literal, or pass `lookbackDays` in the run input.
       lookbackDays: "{{ input.lookbackDays }}"
+      # The bootstrap exploration prompt lives in this workflow's `params`
+      # block below — the experiment surface. `promptTemplate` uses {slot}
+      # placeholders ({owner}, {repo}, {size}, {fileCount}, {min}, {max})
+      # filled at runtime by the step. Sweep by overriding params per run.
+      systemPrompt: "{{ params.bootstrapSystem }}"
+      promptTemplate: "{{ params.bootstrapPrompt }}"
 
   - id: process
     type: subflow
@@ -47,3 +53,61 @@ steps:
         token: "{{ input.token }}"
         repoPath: "{{ clone.repoPath }}"
         strategy: "{{ input.strategy }}"
+
+  # Final step: collect the repo's Concept set into one scoreable artifact.
+  # Being the last step, its { count, concepts, markdown } becomes the run
+  # output — recorded in run.json and rendered in the UI — and is the thing
+  # an eval scores against the expected gold concepts.
+  - id: result
+    type: concepts/collect-for-eval
+    depends: process
+    config:
+      owner: "{{ input.owner }}"
+      repo: "{{ input.repo }}"
+
+# ── params: the bootstrap exploration prompt (the experiment surface) ────────
+# Defaults below; override per-run via POST /run { params: { bootstrapPrompt } }
+# or, since bootstrap-explore runs at this top level, via
+# paramOverrides: { "bootstrap-then-process": { bootstrapPrompt } }.
+# `bootstrapPrompt` uses {slot} placeholders filled at runtime by the step:
+#   {owner} {repo} {size} {fileCount} {min} {max}
+params:
+  bootstrapSystem: |-
+    You are a software architect analyzing a codebase to identify its core features. Use the provided tools to explore the repository structure, read key files (README, entry points, route definitions, main modules), and identify the distinct user-facing capabilities this software provides. Be thorough but focused — read enough to understand what each feature does, but don't try to read every file.
+  bootstrapPrompt: |-
+    Explore the repository "{owner}/{repo}" and identify its core features.
+
+    This is a {size} repository (~{fileCount} source files). Aim for {min}-{max} features.
+
+    A "feature" is a distinct user-facing capability or business function — something a product owner or end user would recognize. Examples: "Authentication System", "Payment Processing", "Real-time Notifications", "Search and Filtering".
+
+    Do NOT create features for:
+    - Build tooling, CI/CD, or infrastructure
+    - Individual utility functions or helpers
+    - Code style, linting, or formatting
+    - Generic "bug fixes" or "refactoring"
+    - Testing infrastructure (unless it IS the product)
+
+    For each feature provide:
+    - **name**: A clear, non-technical name (no framework/library names)
+    - **description**: 1-2 sentences explaining what this capability does for users
+    - **summary**: SUCCINCT high-level documentation (30-80 lines markdown) for this feature's CURRENT state
+    - **files**: List the core source files that implement this feature (relative paths from repo root, e.g. "src/auth/login.ts"). Include only the most important files — entry points, main modules, route definitions, core logic. Aim for 3-15 files per feature depending on scope.
+
+    **Summary requirements** — focus on what developers need to know to work on this feature:
+    **What to include**:
+    - Brief overview (just a few sentences, including any major integrations or dependencies)
+    - List the 5-15 core files (just paths and 1-line purposes)
+    - Key concepts/components (high-level only)
+    - Main API endpoints/functions (names only, no implementations)
+    - Core data models (names only, brief purpose)
+    - Essential patterns and gotchas (briefly, if any)
+
+    **What to AVOID**:
+    - Code snippets or implementation details
+    - Long explanations of how things work internally
+    - Historical information about how it evolved
+    - Detailed API documentation
+    - Step-by-step flows unless absolutely essential
+
+    Prefer fewer, broader features over many granular ones. Two closely related capabilities should be one feature, not two.

--- a/mcp/src/lab/concepts/workflows/concepts-eval-reflect.yaml
+++ b/mcp/src/lab/concepts/workflows/concepts-eval-reflect.yaml
@@ -1,0 +1,31 @@
+name: concepts-eval-reflect
+# Concept-specific "propose" workflow: wraps the generic `eval/reflect` step with
+# the CONCEPT task framing + revision guidance, so the optimize loop can call it
+# to get an improved bootstrapPrompt from aggregated eval results.
+#
+# Input:  { prompt, results[ { score?, missing[], spurious[], insight? } ] }
+# Output: { prompt, rationale }
+steps:
+  - id: reflect
+    type: eval/reflect
+    config:
+      prompt: "{{ input.prompt }}"
+      results: "{{ input.results }}"
+      task: "{{ params.task }}"
+      guidance: "{{ params.guidance }}"
+
+# ── params: the concept-specific framing for the reflector ──────────────────
+params:
+  task: |-
+    The prompt drives an automated "core capability" extractor: it reads a
+    repository and lists its distinct, user-facing capabilities. We score each
+    run against a gold set for recall (did we recover the real capabilities?) and
+    precision (did we avoid noise?).
+  guidance: |-
+    - Treat real-time / media / voice / collaboration surfaces as first-class
+      user-facing capabilities, not infrastructure.
+    - Demote infra, dev-tooling, agent-internal, and integration-plumbing items
+      to NON-capabilities unless they are the product itself.
+    - Prefer broad capability names over implementation names.
+    - The prompt uses {owner} {repo} {size} {fileCount} {min} {max} placeholders —
+      keep them all intact.

--- a/mcp/src/lab/concepts/workflows/concepts-eval-score.yaml
+++ b/mcp/src/lab/concepts/workflows/concepts-eval-score.yaml
@@ -1,12 +1,10 @@
-name: eval-score
-# Score a produced concept set against an expected gold set via recall-based
-# LLM matching. Pass `actual` (e.g. the `markdown` from a collect-for-eval run)
-# and `expected` (the gold markdown) as input. The matching CRITERIA live in
-# the `rubric` param below (the experiment surface); the step computes the
-# numeric score. Output: { score, recall, precision, matched, missing,
-# spurious, reason, insight, markdown }.
+name: concepts-eval-score
+# Concept-specific scorer: wraps the generic `eval/score` step with the CONCEPT
+# rubric (the matching criteria for software Concepts). Score a produced concept
+# set against an expected gold set; the step computes the numeric score.
 #
-# Input: { actual, expected }
+# Input:  { actual, expected }
+# Output: { score, recall, precision, matched, missing, spurious, reason, insight, markdown }
 steps:
   - id: judge
     type: eval/score
@@ -14,15 +12,15 @@ steps:
       actual: "{{ input.actual }}"
       expected: "{{ input.expected }}"
       # The rubric (matching criteria) lives in this workflow's `params` block
-      # below. Swap it per run via POST /run { params: { rubric } }, or edit
-      # the default to retune the measuring stick.
+      # below. Swap it per run via POST /run { params: { rubric } }, or edit the
+      # default to retune the measuring stick.
       rubric: "{{ params.rubric }}"
       # Optionally override the judge model (e.g. a stronger model for scoring):
       # model: claude-opus-4-20250514
 
-# ── params: the rubric (matching criteria) ──────────────────────────────────
-# The step does the scoring math (recall-weighted F-beta); this just tells the
-# judge HOW to decide what counts as a match / what's spurious.
+# ── params: the rubric (the concept-specific matching criteria) ─────────────
+# The step does the scoring math (recall-weighted F-beta); this tells the judge
+# HOW to decide what counts as a match / what's spurious for software Concepts.
 params:
   rubric: |-
     You are matching a PRODUCED set of software Concepts against an EXPECTED gold

--- a/mcp/src/lab/concepts/workflows/concepts-eval.yaml
+++ b/mcp/src/lab/concepts/workflows/concepts-eval.yaml
@@ -1,11 +1,13 @@
-name: eval-concepts
-# Bootstrap-only eval: produce a repo's Concept set from JUST the bootstrap
-# agent (lookbackDays: 0 → no PR/commit processing), then score it against an
-# expected gold set. Iterate on the bootstrap prompt (in `bootstrap-then-process`
-# params, or via paramOverrides) until the score is high.
+name: concepts-eval
+# Bootstrap-only eval HARNESS for the concepts experiment: produce a repo's
+# Concept set from JUST the bootstrap agent (lookbackDays: 0 → no PR/commit
+# processing), then score it against an expected gold set. Iterate on the
+# bootstrap prompt (in `bootstrap-then-process` params, or via paramOverrides)
+# until the score is high.
 #
 # Input: { owner, repo, token? }
-# Output: { score, reason, insight, markdown } (from eval-score)
+# Output: { score, recall, precision, missing, spurious, reason, insight, markdown }
+#         (from concepts-eval-score)
 steps:
   # 1. Clear existing concepts so bootstrap re-runs fresh (the is-new-repo gate
   #    only bootstraps an empty repo).
@@ -34,7 +36,7 @@ steps:
   - id: score
     type: subflow
     config:
-      workflow: eval-score
+      workflow: concepts-eval-score
       input:
         actual: "{{ produce.markdown }}"
         expected: "{{ params.expected }}"

--- a/mcp/src/lab/concepts/workflows/concepts-optimize.yaml
+++ b/mcp/src/lab/concepts/workflows/concepts-optimize.yaml
@@ -1,0 +1,33 @@
+name: concepts-optimize
+# Self-improving loop (EVAL_SPEC §7/§11.4) for the concepts bootstrap prompt:
+# repeatedly eval the prompt (via concepts-eval) and reflect a better one (via
+# concepts-eval-reflect), keeping the best. Each generation injects the candidate
+# prompt into bootstrap-then-process via paramOverrides.
+#
+# Launch DETACHED (§8) — it's a multi-run background job:
+#   RUN=$(curl -s -X POST .../concepts-optimize/run -d '{"input":{"owner":"O","repo":"R"}}' | jq -r .runId)
+#   curl -N .../concepts-optimize/runs/$RUN/stream
+#
+# Input:  { owner, repo }
+# Output: { bestScore, bestGen, bestPrompt, firstScore, generations }
+# Promote a winner by writing bestPrompt into bootstrap-then-process's
+# bootstrapPrompt param default + publishing a new version.
+steps:
+  - id: optimize
+    type: eval/optimize
+    config:
+      evalWorkflow: concepts-eval
+      evalInput:
+        owner: "{{ input.owner }}"
+        repo: "{{ input.repo }}"
+      targetWorkflow: bootstrap-then-process
+      promptParam: bootstrapPrompt
+      reflectWorkflow: concepts-eval-reflect
+      label: "{{ input.owner }}/{{ input.repo }}"
+      maxGenerations: "{{ params.maxGenerations }}"
+      threshold: "{{ params.threshold }}"
+
+# ── params: the loop's stopping knobs (the experiment surface) ──────────────
+params:
+  maxGenerations: 5
+  threshold: 0.9

--- a/mcp/src/lab/concepts/workflows/eval-concepts.yaml
+++ b/mcp/src/lab/concepts/workflows/eval-concepts.yaml
@@ -1,0 +1,60 @@
+name: eval-concepts
+# Bootstrap-only eval: produce a repo's Concept set from JUST the bootstrap
+# agent (lookbackDays: 0 → no PR/commit processing), then score it against an
+# expected gold set. Iterate on the bootstrap prompt (in `bootstrap-then-process`
+# params, or via paramOverrides) until the score is high.
+#
+# Input: { owner, repo, token? }
+# Output: { score, reason, insight, markdown } (from eval-score)
+steps:
+  # 1. Clear existing concepts so bootstrap re-runs fresh (the is-new-repo gate
+  #    only bootstraps an empty repo).
+  - id: reset
+    type: concepts/reset-repo
+    config:
+      owner: "{{ input.owner }}"
+      repo: "{{ input.repo }}"
+
+  # 2. Produce concepts via the full pipeline, but lookbackDays: 0 makes the
+  #    checkpoint "now" so no PRs/commits are processed — bootstrap only.
+  #    Tune the bootstrap prompt via bootstrap-then-process's `params`, or per
+  #    run via paramOverrides: { "bootstrap-then-process": { bootstrapPrompt } }.
+  - id: produce
+    type: subflow
+    config:
+      workflow: bootstrap-then-process
+      input:
+        owner: "{{ input.owner }}"
+        repo: "{{ input.repo }}"
+        token: "{{ input.token }}"
+        lookbackDays: 0
+    # subflow output = bootstrap-then-process's `result` = { count, concepts, markdown }
+
+  # 3. Score the produced concept set against the expected gold (a param).
+  - id: score
+    type: subflow
+    config:
+      workflow: eval-score
+      input:
+        actual: "{{ produce.markdown }}"
+        expected: "{{ params.expected }}"
+
+# ── params: the expected gold concept set (the dataset, as a param) ──────────
+# Edit this in the Params flyout and Publish to set up the eval; authored in the
+# same markdown shape `collect-for-eval` emits (scoring is semantic, so counts
+# and exact wording don't need to match).
+params:
+  expected: |-
+    # Concepts: owner/repo
+
+    ## Authentication
+
+    Users can sign up, log in, and manage sessions.
+
+    ## Task Management
+
+    Users can create, assign, track, and complete tasks.
+
+    ## Real-time Chat
+
+    Users can exchange messages in real time within a workspace.

--- a/mcp/src/lab/concepts/workflows/eval-concepts.yaml
+++ b/mcp/src/lab/concepts/workflows/eval-concepts.yaml
@@ -47,14 +47,42 @@ params:
   expected: |-
     # Concepts: owner/repo
 
-    ## Authentication
+    ## AI-assisted code generation
 
-    Users can sign up, log in, and manage sessions.
+    Users can create feature plans and coding tasks, and chat with AI agents who help them implement the tasks.
 
-    ## Task Management
+    ## Github Integration
 
-    Users can create, assign, track, and complete tasks.
+    User can sign in with github, and also connect a Github App to their repos, to process and create PRs for them.
 
-    ## Real-time Chat
+    ## Knowledge Graph
 
-    Users can exchange messages in real time within a workspace.
+    A detailed knowledge graph of code and higher-level Concepts is created for each workspace, and users can chat with the graph to learn about the codebase and the concepts.
+
+    ## AI Chat & Codebase Assistant
+
+    An AI chat assistant is available, that can do deep research into codebases and knowledge graphs in order to answer complex questions.
+
+    ## Org Canvas
+
+    An interactive canvas whiteboard of the organzation, allowing users + LLMs to create a mind-map of the organization, with concepts and links between them.
+
+    ## Automatied code quality and test generation janitors
+
+    Automated code quality and test generation janitors can suggest and generate test cases and optimizationsfor code.
+
+    ## Feature Planning & Roadmap
+
+    Users can create feature plans and roadmap, with a conversational AI assistant who can research the codebase and wider context.
+
+    ## Call Recording & Voice
+
+    Calls are recorded and transcribed, and can be viewed after the fact. Also real-time voice integration with the AI assistant.
+
+    ## Collaborative Whiteboards
+
+    Collaborative whiteboards allow users to create and share diagrams, mind maps, and other visualizations with their team.
+
+    ## Workflow Automation
+
+    Workflow assistant can help you construct and edit workflows, to build sophisticated processes automating diverse tasks.

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -2,6 +2,7 @@ import {
   createVein,
   WorkspaceManager,
   type Vein,
+  type RunResult,
 } from "vein";
 import {
   buildConceptServices,
@@ -9,7 +10,22 @@ import {
   type BuildServicesOptions,
 } from "./concepts/services.js";
 import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
-import { seedEvalWorkflows, seedEvalSteps } from "./eval/seed.js";
+import { seedEvalSteps } from "./eval/seed.js";
+
+/**
+ * Lets a step run other workflows (and read their params) from inside a run —
+ * the `eval/optimize` loop uses this to eval/reflect across generations. A leaf
+ * step has no runner of its own, so we hand it a closure over `vein.run`. Set
+ * AFTER the vein is built (it closes over the instance); see `createLabVein`.
+ */
+export interface OptimizerCapability {
+  run(
+    name: string,
+    input: unknown,
+    opts?: { paramOverrides?: Record<string, Record<string, unknown>> },
+  ): Promise<RunResult>;
+  getParams(name: string): Promise<Record<string, unknown>>;
+}
 
 /**
  * The merged capabilities bag for ALL lab experiments. Each experiment's
@@ -17,7 +33,10 @@ import { seedEvalWorkflows, seedEvalSteps } from "./eval/seed.js";
  * untyped at runtime), so a single merged bag serves every experiment.
  * Extend this as experiments are added.
  */
-export interface LabServices extends ConceptServices {}
+export interface LabServices extends ConceptServices {
+  /** Run-sub-workflows capability for the optimize loop. Injected post-build. */
+  optimizer?: OptimizerCapability;
+}
 
 export interface CreateLabVeinOptions extends BuildServicesOptions {
   /** Pre-built merged services bag. If omitted, built from env. */
@@ -62,17 +81,26 @@ export async function createLabVein(
   // vein API/UI. No `registry` is passed, so createVein discovers core + lib +
   // these custom steps from `workspace.path` (and step publishing is enabled).
   const workspace = new WorkspaceManager(workspacePath);
+  // Generic, domain-agnostic eval primitives (steps). The concept-specific eval
+  // WORKFLOWS that wire them (concepts-eval*) are seeded with the concepts
+  // experiment below.
+  await seedEvalSteps(workspace);
   await seedConceptWorkflows(workspace);
   await seedConceptSteps(workspace);
-  // Generic eval machinery (scorer step + eval-score workflow).
-  await seedEvalSteps(workspace);
-  await seedEvalWorkflows(workspace);
 
   const vein = await createVein<LabServices>({
     workspace,
     services,
     serveUi: opts.serveUi ?? true,
   });
+
+  // Inject the run-sub-workflows capability now that the instance exists. We
+  // mutate the SAME `services` object createVein holds by reference, so steps
+  // see it at run time. This is what lets `eval/optimize` loop eval→reflect.
+  services.optimizer = {
+    run: (name, input, runOpts) => vein.run(name, input, runOpts),
+    getParams: async (name) => (await vein.workspace.getWorkflow(name)).params ?? {},
+  };
 
   return vein;
 }

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -9,6 +9,7 @@ import {
   type BuildServicesOptions,
 } from "./concepts/services.js";
 import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
+import { seedEvalWorkflows, seedEvalSteps } from "./eval/seed.js";
 
 /**
  * The merged capabilities bag for ALL lab experiments. Each experiment's
@@ -63,6 +64,9 @@ export async function createLabVein(
   const workspace = new WorkspaceManager(workspacePath);
   await seedConceptWorkflows(workspace);
   await seedConceptSteps(workspace);
+  // Generic eval machinery (scorer step + eval-score workflow).
+  await seedEvalSteps(workspace);
+  await seedEvalWorkflows(workspace);
 
   const vein = await createVein<LabServices>({
     workspace,

--- a/mcp/src/lab/eval/seed.ts
+++ b/mcp/src/lab/eval/seed.ts
@@ -1,0 +1,55 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { WorkspaceManager } from "vein";
+
+/**
+ * Generic eval machinery (scorer step + scoring workflow), seeded into the
+ * vein workspace like the concepts experiment. Reconciled by content hash on
+ * boot, so edits publish a new active version (see concepts/seed.ts for the
+ * reconciliation contract).
+ *
+ * Not concepts-specific: `eval/score` compares any `actual` vs `expected`
+ * markdown using a `rubric`. The default `eval-score` workflow ships a
+ * concept-quality rubric in its `params`, overridable per run.
+ */
+
+const SEED_WORKFLOWS = ["eval-score"];
+
+const SEED_STEPS: Array<{ file: string; type: string }> = [
+  { file: "score.ts", type: "eval/score" },
+];
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function seedEvalWorkflows(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "workflows");
+  for (const name of SEED_WORKFLOWS) {
+    try {
+      const yaml = await readFile(join(dir, `${name}.yaml`), "utf-8");
+      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml);
+      if (changed) console.log(`[eval] seeded workflow: ${name} @ ${version}`);
+    } catch (err) {
+      console.warn(
+        `[eval] could not seed workflow "${name}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}
+
+export async function seedEvalSteps(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "steps");
+  for (const { file, type } of SEED_STEPS) {
+    try {
+      const code = await readFile(join(dir, file), "utf-8");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "eval-seed");
+      if (changed) console.log(`[eval] seeded step: ${type} @ ${version}`);
+    } catch (err) {
+      console.warn(
+        `[eval] could not seed step "${type}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/mcp/src/lab/eval/seed.ts
+++ b/mcp/src/lab/eval/seed.ts
@@ -4,39 +4,26 @@ import { dirname, join } from "node:path";
 import type { WorkspaceManager } from "vein";
 
 /**
- * Generic eval machinery (scorer step + scoring workflow), seeded into the
- * vein workspace like the concepts experiment. Reconciled by content hash on
- * boot, so edits publish a new active version (see concepts/seed.ts for the
- * reconciliation contract).
+ * GENERIC, domain-agnostic eval primitives (STEPS only), seeded into the vein
+ * workspace. Reconciled by content hash on boot, so edits publish a new active
+ * version (see concepts/seed.ts for the reconciliation contract).
  *
- * Not concepts-specific: `eval/score` compares any `actual` vs `expected`
- * markdown using a `rubric`. The default `eval-score` workflow ships a
- * concept-quality rubric in its `params`, overridable per run.
+ * These steps are reusable across ALL experiments — they carry no domain
+ * config. An experiment supplies its own eval WORKFLOWS that wire these steps
+ * with its rubric / task / dataset (e.g. the concepts experiment ships
+ * `concepts-eval*` in concepts/workflows, seeded by concepts/seed.ts):
+ *   - `eval/score`    — match produced vs expected by a `rubric`, recall-weighted.
+ *   - `eval/reflect`  — propose a better prompt from AGGREGATED results.
+ *   - `eval/optimize` — eval → keep best → reflect loop (a detached job).
  */
-
-const SEED_WORKFLOWS = ["eval-score"];
 
 const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "score.ts", type: "eval/score" },
+  { file: "reflect.ts", type: "eval/reflect" },
+  { file: "optimize.ts", type: "eval/optimize" },
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));
-
-export async function seedEvalWorkflows(workspace: WorkspaceManager): Promise<void> {
-  const dir = join(HERE, "workflows");
-  for (const name of SEED_WORKFLOWS) {
-    try {
-      const yaml = await readFile(join(dir, `${name}.yaml`), "utf-8");
-      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml);
-      if (changed) console.log(`[eval] seeded workflow: ${name} @ ${version}`);
-    } catch (err) {
-      console.warn(
-        `[eval] could not seed workflow "${name}":`,
-        err instanceof Error ? err.message : err,
-      );
-    }
-  }
-}
 
 export async function seedEvalSteps(workspace: WorkspaceManager): Promise<void> {
   const dir = join(HERE, "steps");

--- a/mcp/src/lab/eval/steps/optimize.ts
+++ b/mcp/src/lab/eval/steps/optimize.ts
@@ -1,4 +1,4 @@
-import { z, defineStep } from "vein";
+import { z, defineStep, type RunEvent } from "vein";
 
 /**
  * GENERIC self-improving LOOP (EVAL_SPEC §7/§11.4). Runs the optimize cycle as a
@@ -90,37 +90,79 @@ export default defineStep({
     }> = [];
     let best = { gen: -1, prompt: candidate, score: -1 };
 
+    // Per-generation progress is emitted under a synthetic `<path>#<gen>` path
+    // (the loop runs inside one step, so generations aren't real runner events).
+    // These show up live as rows in the Events panel and persist to the log, so
+    // you can watch the individual tries — and reattach to them — mid-run.
+    const emitGen = (gen: number, e: Partial<RunEvent> & { type: RunEvent["type"] }) =>
+      ctx.emit({
+        ts: new Date().toISOString(),
+        runId: ctx.runId,
+        path: `${ctx.path}#${gen}`,
+        stepType: "eval/optimize",
+        iteration: gen,
+        ...e,
+      });
+
+    // Why the current candidate looks the way it does (the prior reflect's
+    // rationale). Surfaced in each generation's start so you can read the
+    // prompt's evolution try-by-try. Undefined for gen 0 (the seed prompt).
+    let rationale: string | undefined;
+
     for (let gen = 0; gen < cfg.maxGenerations; gen++) {
-      // ── eval the current candidate ──────────────────────────────────────
-      const evalRun = await opt.run(cfg.evalWorkflow, cfg.evalInput ?? {}, {
-        paramOverrides: { [cfg.targetWorkflow]: { [cfg.promptParam]: candidate } },
-      });
-      if (evalRun.status !== "success") {
-        throw new Error(`eval run (gen ${gen}) failed: ${evalRun.error?.message ?? "unknown"}`);
-      }
-      const out = (evalRun.output ?? {}) as EvalOutput;
-      const score = out.score ?? 0;
-      const missing = out.missing ?? [];
-      const spurious = out.spurious ?? [];
-      generations.push({ gen, score, prompt: candidate, missing, spurious });
+      const genStart = Date.now();
+      await emitGen(gen, { type: "step.start", input: { gen, prompt: candidate, rationale } });
 
-      if (score > best.score) best = { gen, prompt: candidate, score };
-      // "until it's satisfied": stop once good enough, or on the last generation.
-      if (score >= cfg.threshold || gen === cfg.maxGenerations - 1) break;
+      try {
+        // ── eval the current candidate ────────────────────────────────────
+        const evalRun = await opt.run(cfg.evalWorkflow, cfg.evalInput ?? {}, {
+          paramOverrides: { [cfg.targetWorkflow]: { [cfg.promptParam]: candidate } },
+        });
+        if (evalRun.status !== "success") {
+          throw new Error(`eval run failed: ${evalRun.error?.message ?? "unknown"}`);
+        }
+        const out = (evalRun.output ?? {}) as EvalOutput;
+        const score = out.score ?? 0;
+        const missing = out.missing ?? [];
+        const spurious = out.spurious ?? [];
+        generations.push({ gen, score, prompt: candidate, missing, spurious });
 
-      // ── reflect → next candidate (generalizing across the dataset) ───────
-      const reflectRun = await opt.run(cfg.reflectWorkflow, {
-        prompt: candidate,
-        results: [{ label: cfg.label, score, missing, spurious, insight: out.insight }],
-      });
-      if (reflectRun.status !== "success") {
-        throw new Error(`reflect run (gen ${gen}) failed: ${reflectRun.error?.message ?? "unknown"}`);
+        if (score > best.score) best = { gen, prompt: candidate, score };
+
+        await emitGen(gen, {
+          type: "step.end",
+          durationMs: Date.now() - genStart,
+          output: { gen, score, bestScore: best.score, bestGen: best.gen, missing, spurious },
+        });
+
+        // "until it's satisfied": stop once good enough, or on the last generation.
+        if (score >= cfg.threshold || gen === cfg.maxGenerations - 1) break;
+
+        // ── reflect → next candidate (generalizing across the dataset) ─────
+        const reflectRun = await opt.run(cfg.reflectWorkflow, {
+          prompt: candidate,
+          results: [{ label: cfg.label, score, missing, spurious, insight: out.insight }],
+        });
+        if (reflectRun.status !== "success") {
+          throw new Error(`reflect run failed: ${reflectRun.error?.message ?? "unknown"}`);
+        }
+        const proposal = reflectRun.output as { prompt?: string; rationale?: string } | undefined;
+        if (typeof proposal?.prompt !== "string" || !proposal.prompt.trim()) {
+          throw new Error(`reflect returned no prompt`);
+        }
+        candidate = proposal.prompt;
+        rationale = proposal.rationale;
+      } catch (err) {
+        // Log the failure on THIS generation's row before bubbling up, so a
+        // failed try is visible in the panel (not just the outer step error).
+        const message = err instanceof Error ? err.message : String(err);
+        await emitGen(gen, {
+          type: "step.error",
+          durationMs: Date.now() - genStart,
+          error: { message: `gen ${gen}: ${message}` },
+        });
+        throw err;
       }
-      const next = (reflectRun.output as { prompt?: string } | undefined)?.prompt;
-      if (typeof next !== "string" || !next.trim()) {
-        throw new Error(`reflect (gen ${gen}) returned no prompt`);
-      }
-      candidate = next;
     }
 
     return {

--- a/mcp/src/lab/eval/steps/optimize.ts
+++ b/mcp/src/lab/eval/steps/optimize.ts
@@ -35,9 +35,18 @@ interface EvalOutput {
 }
 
 interface RunResultLike {
+  runId: string;
   status: string;
   output?: unknown;
   error?: { message?: string };
+}
+
+/** A pointer to a child run, surfaced on progress events so the UI can link
+ *  "open this generation's eval/reflect run" (and drill into its nested logs). */
+interface RunRef {
+  label: string;
+  workflow: string;
+  runId: string;
 }
 
 interface Optimizer {
@@ -87,6 +96,7 @@ export default defineStep({
       prompt: string;
       missing: string[];
       spurious: string[];
+      evalRunId: string;
     }> = [];
     let best = { gen: -1, prompt: candidate, score: -1 };
 
@@ -105,13 +115,18 @@ export default defineStep({
       });
 
     // Why the current candidate looks the way it does (the prior reflect's
-    // rationale). Surfaced in each generation's start so you can read the
-    // prompt's evolution try-by-try. Undefined for gen 0 (the seed prompt).
+    // rationale + a link to that reflect run). Surfaced in each generation's
+    // start so you can read the prompt's evolution try-by-try and open the run
+    // that proposed it. Undefined for gen 0 (the seed prompt).
     let rationale: string | undefined;
+    let fromReflect: RunRef | undefined;
 
     for (let gen = 0; gen < cfg.maxGenerations; gen++) {
       const genStart = Date.now();
-      await emitGen(gen, { type: "step.start", input: { gen, prompt: candidate, rationale } });
+      await emitGen(gen, {
+        type: "step.start",
+        input: { gen, prompt: candidate, rationale, ...(fromReflect ? { runs: [fromReflect] } : {}) },
+      });
 
       try {
         // ── eval the current candidate ────────────────────────────────────
@@ -125,14 +140,17 @@ export default defineStep({
         const score = out.score ?? 0;
         const missing = out.missing ?? [];
         const spurious = out.spurious ?? [];
-        generations.push({ gen, score, prompt: candidate, missing, spurious });
+        // `evalRunId` links this generation to its full eval run (which nests
+        // the bootstrap-then-process subflow — i.e. the bootstrap logs).
+        generations.push({ gen, score, prompt: candidate, missing, spurious, evalRunId: evalRun.runId });
 
         if (score > best.score) best = { gen, prompt: candidate, score };
 
+        const evalRef: RunRef = { label: "eval run", workflow: cfg.evalWorkflow, runId: evalRun.runId };
         await emitGen(gen, {
           type: "step.end",
           durationMs: Date.now() - genStart,
-          output: { gen, score, bestScore: best.score, bestGen: best.gen, missing, spurious },
+          output: { gen, score, bestScore: best.score, bestGen: best.gen, missing, spurious, runs: [evalRef] },
         });
 
         // "until it's satisfied": stop once good enough, or on the last generation.
@@ -152,6 +170,7 @@ export default defineStep({
         }
         candidate = proposal.prompt;
         rationale = proposal.rationale;
+        fromReflect = { label: "reflect run", workflow: cfg.reflectWorkflow, runId: reflectRun.runId };
       } catch (err) {
         // Log the failure on THIS generation's row before bubbling up, so a
         // failed try is visible in the panel (not just the outer step error).

--- a/mcp/src/lab/eval/steps/optimize.ts
+++ b/mcp/src/lab/eval/steps/optimize.ts
@@ -1,0 +1,136 @@
+import { z, defineStep } from "vein";
+
+/**
+ * GENERIC self-improving LOOP (EVAL_SPEC §7/§11.4). Runs the optimize cycle as a
+ * single step so the whole thing is one detached run (a "background job", §8):
+ *
+ *   eval  → score the current candidate prompt on the dataset
+ *   keep  → track the best-scoring candidate so far
+ *   stop? → score ≥ threshold, or out of generations
+ *   reflect → propose the next candidate (generalizing) and repeat
+ *
+ * Domain-agnostic: it tunes some `promptParam` on a `targetWorkflow` by running
+ * an `evalWorkflow` (whose output has { score, missing, spurious, insight }) and
+ * a `reflectWorkflow` (which proposes the next prompt). The concepts experiment
+ * wires these in `concepts-optimize`. "Store the params to optimize" = the
+ * returned `generations` array (persisted in this run's run.json). Promote a
+ * winner by writing `bestPrompt` into the target's `promptParam` default and
+ * publishing a new version (a separate, explicit action).
+ *
+ * A leaf step has no runner, so the host injects a tiny `services.optimizer`
+ * capability (a closure over `vein.run` + `workspace.getWorkflow`) — see
+ * `createLabVein`. Each eval/reflect is its own `vein.run`, because the
+ * candidate prompt varies per generation via `paramOverrides` (run-global).
+ *
+ * Single-example for now: `results` passed to reflect has one entry. Multi-
+ * example (the real overfitting fix, §11.2) = loop the eval over a dataset of
+ * `evalInput`s and pass the aggregate array — reflect already accepts it.
+ */
+
+interface EvalOutput {
+  score?: number;
+  missing?: string[];
+  spurious?: string[];
+  insight?: string;
+}
+
+interface RunResultLike {
+  status: string;
+  output?: unknown;
+  error?: { message?: string };
+}
+
+interface Optimizer {
+  run(
+    name: string,
+    input: unknown,
+    opts?: { paramOverrides?: Record<string, Record<string, unknown>> },
+  ): Promise<RunResultLike>;
+  getParams(name: string): Promise<Record<string, unknown>>;
+}
+
+export default defineStep({
+  type: "eval/optimize",
+  description:
+    "Generic self-improving loop: eval the candidate prompt → keep best → reflect a better one → repeat until score ≥ threshold or generations exhausted. Requires a `services.optimizer` capability. Config: evalWorkflow, evalInput, targetWorkflow, promptParam, reflectWorkflow, maxGenerations, threshold, prompt? (starting candidate, defaults to target's current value), label?. Output: { bestScore, bestGen, bestPrompt, firstScore, generations }.",
+  input: z.object({
+    evalWorkflow: z.string().describe("workflow that scores a candidate; output must have { score, missing, spurious, insight }"),
+    evalInput: z.any().describe("input passed to evalWorkflow each generation (e.g. { owner, repo })"),
+    targetWorkflow: z.string().describe("workflow whose param is being tuned"),
+    promptParam: z.string().describe("the param on targetWorkflow to tune (overridden per generation via paramOverrides)"),
+    reflectWorkflow: z.string().describe("workflow that proposes the next prompt; output must have { prompt }"),
+    maxGenerations: z.number().int().positive().default(5),
+    threshold: z.number().min(0).max(1).default(0.9),
+    prompt: z.string().optional().describe("starting candidate; defaults to targetWorkflow's current promptParam value"),
+    label: z.string().optional().describe("label for this example in the reflect digest"),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const opt = (ctx.services as { optimizer?: Optimizer })?.optimizer;
+    if (!opt) {
+      throw new Error(
+        "eval/optimize requires a `services.optimizer` capability — inject it in createLabVein (run + getParams over vein).",
+      );
+    }
+
+    let candidate =
+      cfg.prompt ?? ((await opt.getParams(cfg.targetWorkflow))[cfg.promptParam] as string | undefined);
+    if (typeof candidate !== "string" || !candidate.trim()) {
+      throw new Error(
+        `No starting prompt: pass config.prompt, or ensure ${cfg.targetWorkflow}.${cfg.promptParam} has a default.`,
+      );
+    }
+
+    const generations: Array<{
+      gen: number;
+      score: number;
+      prompt: string;
+      missing: string[];
+      spurious: string[];
+    }> = [];
+    let best = { gen: -1, prompt: candidate, score: -1 };
+
+    for (let gen = 0; gen < cfg.maxGenerations; gen++) {
+      // ── eval the current candidate ──────────────────────────────────────
+      const evalRun = await opt.run(cfg.evalWorkflow, cfg.evalInput ?? {}, {
+        paramOverrides: { [cfg.targetWorkflow]: { [cfg.promptParam]: candidate } },
+      });
+      if (evalRun.status !== "success") {
+        throw new Error(`eval run (gen ${gen}) failed: ${evalRun.error?.message ?? "unknown"}`);
+      }
+      const out = (evalRun.output ?? {}) as EvalOutput;
+      const score = out.score ?? 0;
+      const missing = out.missing ?? [];
+      const spurious = out.spurious ?? [];
+      generations.push({ gen, score, prompt: candidate, missing, spurious });
+
+      if (score > best.score) best = { gen, prompt: candidate, score };
+      // "until it's satisfied": stop once good enough, or on the last generation.
+      if (score >= cfg.threshold || gen === cfg.maxGenerations - 1) break;
+
+      // ── reflect → next candidate (generalizing across the dataset) ───────
+      const reflectRun = await opt.run(cfg.reflectWorkflow, {
+        prompt: candidate,
+        results: [{ label: cfg.label, score, missing, spurious, insight: out.insight }],
+      });
+      if (reflectRun.status !== "success") {
+        throw new Error(`reflect run (gen ${gen}) failed: ${reflectRun.error?.message ?? "unknown"}`);
+      }
+      const next = (reflectRun.output as { prompt?: string } | undefined)?.prompt;
+      if (typeof next !== "string" || !next.trim()) {
+        throw new Error(`reflect (gen ${gen}) returned no prompt`);
+      }
+      candidate = next;
+    }
+
+    return {
+      bestScore: best.score,
+      bestGen: best.gen,
+      bestPrompt: best.prompt,
+      firstScore: generations[0]?.score ?? null,
+      target: cfg.targetWorkflow,
+      promptParam: cfg.promptParam,
+      generations,
+    };
+  },
+});

--- a/mcp/src/lab/eval/steps/reflect.ts
+++ b/mcp/src/lab/eval/steps/reflect.ts
@@ -1,0 +1,125 @@
+import { z, defineStep } from "vein";
+
+/**
+ * GENERIC optimizer "propose" step: given the CURRENT candidate prompt and the
+ * AGGREGATED scoring results across a dataset, emit an improved prompt. This is
+ * the step that "changes a param" — its output is the next value for the prompt
+ * being tuned, fed back into the next eval round. Pair it with `eval/score` in
+ * a loop:
+ *
+ *   score (per example) → aggregate → reflect → new prompt → score again → …
+ *
+ * Domain-agnostic: the only domain framing comes from `task` (what the prompt is
+ * supposed to do) + optional `rubric`/`guidance`. The concepts experiment wraps
+ * this with a concept-specific task in `concepts-eval-reflect`.
+ *
+ * CRITICAL — generalization (EVAL_SPEC §4/§7): reflect must see the
+ * **aggregate over many examples**, not one, or it overfits (fixing one
+ * example's specific miss instead of the underlying weakness). So `results` is
+ * an ARRAY; the prompt is told to only make changes that help across ALL of
+ * them and never encode a single example's specifics.
+ *
+ * Self-contained: reaches the model via dynamic `import("ai")` (no services),
+ * structured output (`generateObject`). Output: { prompt, rationale }.
+ */
+
+const ResultSchema = z.object({
+  label: z.string().optional().describe("which example this result is for (e.g. owner/repo)"),
+  score: z.number().optional(),
+  missing: z.array(z.string()).default([]).describe("expected items the prompt FAILED to produce for this example"),
+  spurious: z.array(z.string()).default([]).describe("noise / over-granular items the prompt produced for this example"),
+  insight: z.string().optional().describe("the per-example judge's general lesson (already domain-agnostic)"),
+});
+
+const ProposalSchema = z.object({
+  rationale: z
+    .string()
+    .describe("2-4 sentences: the GENERAL patterns seen across ALL examples (recurring missing kinds, recurring spurious kinds) and the specific, transferable changes you made to address them. No single-example specifics."),
+  prompt: z
+    .string()
+    .describe("The full improved prompt, ready to drop in. Preserve any {placeholder} tokens present in the current prompt verbatim. Change wording/criteria/structure only."),
+});
+
+interface Proposal {
+  rationale: string;
+  prompt: string;
+}
+
+export default defineStep({
+  type: "eval/reflect",
+  description:
+    "Generic optimizer 'propose' step: from the current candidate prompt + AGGREGATED per-example scoring results (an array — must be multi-example to avoid overfitting), emit an improved prompt. Required config: prompt, results (array of { score?, missing[], spurious[], insight? }). Optional: task (what the prompt should do), rubric (the target / standards), guidance (meta-rules for revising), provider, model. Output: { prompt, rationale }.",
+  input: z.object({
+    prompt: z.string().describe("the current candidate prompt being tuned"),
+    results: z.array(ResultSchema).describe("per-example scoring results across the dataset (>=1; more = less overfit)"),
+    task: z.string().optional().describe("one line: what this prompt is supposed to accomplish (the domain framing)"),
+    rubric: z.string().optional().describe("what a good output looks like (matching criteria / standards)"),
+    guidance: z.string().optional().describe("meta-rules for how to revise (e.g. 'prefer broad names', 'never name a specific item')"),
+    provider: z.string().optional(),
+    model: z.string().optional(),
+  }),
+  output: z.any(),
+  async run(cfg) {
+    const provider = cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? "anthropic";
+    const modelName = cfg.model ?? process.env["VEIN_LLM_MODEL"];
+
+    const { generateObject } = await import("ai");
+    let model: any;
+    switch (provider) {
+      case "anthropic": {
+        const { anthropic } = await import("@ai-sdk/anthropic");
+        model = anthropic(modelName ?? "claude-sonnet-4-20250514");
+        break;
+      }
+      case "openai": {
+        const { openai } = await import("@ai-sdk/openai");
+        model = openai(modelName ?? "gpt-4o");
+        break;
+      }
+      default:
+        throw new Error(`Unknown LLM provider: "${provider}". Supported: anthropic, openai`);
+    }
+
+    // Aggregate the dataset into a compact, labeled digest so the model
+    // optimizes for the COMMON failure modes, not one example's quirks.
+    const digest = cfg.results
+      .map((r, i) => {
+        const tag = r.label ?? `example ${i + 1}`;
+        const score = r.score != null ? ` (score ${r.score})` : "";
+        const missing = r.missing.length ? `\n  missing:  ${r.missing.join(", ")}` : "";
+        const spurious = r.spurious.length ? `\n  spurious: ${r.spurious.join(", ")}` : "";
+        const insight = r.insight ? `\n  insight:  ${r.insight}` : "";
+        return `- ${tag}${score}${missing}${spurious}${insight}`;
+      })
+      .join("\n");
+
+    const meanScore =
+      cfg.results.length && cfg.results.every((r) => r.score != null)
+        ? cfg.results.reduce((s, r) => s + (r.score ?? 0), 0) / cfg.results.length
+        : undefined;
+
+    const prompt = `You are optimizing a PROMPT. ${cfg.task ?? "The prompt produces a set of items that we score against a gold set for recall (did we recover the real items?) and precision (did we avoid noise?)."}
+
+# CURRENT PROMPT (what produced the results below)
+"""
+${cfg.prompt}
+"""
+${cfg.rubric ? `\n# WHAT "GOOD" LOOKS LIKE (rubric)\n${cfg.rubric}\n` : ""}${cfg.guidance ? `\n# HOW TO REVISE (guidance)\n${cfg.guidance}\n` : ""}
+# RESULTS ACROSS ${cfg.results.length} EXAMPLE(S)${meanScore != null ? ` — mean score ${Math.round(meanScore * 100) / 100}` : ""}
+${digest}
+
+Propose a BETTER version of the prompt that raises the mean score across ALL of
+these examples. Rules:
+- Generalize. Only make changes justified by patterns that recur across MULTIPLE
+  examples. Never encode a single example's specific domain or missing item —
+  encode the underlying PRINCIPLE instead.
+- Recall first: the biggest lever is recovering recurring 'missing' kinds.
+- Cut recurring 'spurious' kinds by sharpening the inclusion/exclusion criteria.
+- Preserve any {placeholder} tokens present in the current prompt verbatim.
+- Return the COMPLETE new prompt (not a diff).`;
+
+    const { object } = await generateObject({ model, prompt, schema: ProposalSchema as any });
+    const p = object as Proposal;
+    return { prompt: p.prompt, rationale: p.rationale };
+  },
+});

--- a/mcp/src/lab/eval/steps/score.ts
+++ b/mcp/src/lab/eval/steps/score.ts
@@ -1,42 +1,57 @@
 import { z, defineStep } from "vein";
 
 /**
- * LLM-as-judge scorer. Compares an `actual` output against an `expected` gold
- * standard using a `rubric` (the scoring criteria) and returns a structured
- * verdict: { score, reason, insight }.
+ * Recall-oriented LLM-as-judge for concept sets. The judge MATCHES each
+ * expected (gold) capability to a produced concept semantically and reports
+ * matched / missing / spurious; the step then computes a continuous score
+ * (recall-weighted F-beta) deterministically from those counts — so the number
+ * is consistent and the gradient is informative for optimization.
  *
- * Pure mechanism: the rubric (WHAT to weigh) is NOT baked in here — it's the
- * experiment surface and lives in the calling workflow's `params` block (see
- * `workflows/eval-score.yaml`), passed in via config. The step only enforces
- * the strict SCORE/REASON/INSIGHT output contract so the result parses.
+ * Pure mechanism: the matching criteria (WHAT counts as a match, what's
+ * "spurious", naming standards) live in the `rubric` param (the experiment
+ * surface). The step enforces the structured output contract + the scoring math.
  *
- * Self-contained: like vein's core `llm` step, it reaches the model via a
- * dynamic `import("ai")` — no services needed — so it's portable as a custom
- * step on disk.
+ * Self-contained: reaches the model via dynamic `import("ai")` (no services),
+ * using structured output (`generateObject`).
  *
- * Output: { score, reason, insight, markdown }.
+ * Output: { score, recall, precision, matched, missing, spurious, reason,
+ *           insight, markdown }.
  */
 
-const FORMAT = `Respond in EXACTLY this format and nothing else:
-SCORE: <0 or 0.5 or 1>
-REASON: <1-3 sentences on what is right or wrong>
-INSIGHT: <1 sentence: what should change to score higher next time?>`;
+const VerdictSchema = z.object({
+  matched: z
+    .array(z.object({ expected: z.string(), produced: z.string() }))
+    .describe("Each expected capability that IS present in the produced set, paired with the produced concept that covers it."),
+  missing: z
+    .array(z.string())
+    .describe("Expected capabilities with NO adequate match in the produced set."),
+  spurious: z
+    .array(z.string())
+    .describe("Produced concepts that are noise — not real user-facing capabilities, or over-granular/implementation-named, or not in the expected set."),
+  reason: z.string().describe("1-3 sentences on the biggest gaps."),
+  insight: z.string().describe("1 sentence: what should change to recover the missing capabilities?"),
+});
 
-function parseVerdict(text: string): { score: number; reason: string; insight: string } {
-  const scoreMatch = text.match(/SCORE:\s*(0\.5|0|1)/i);
-  const reasonMatch = text.match(/REASON:\s*([\s\S]*?)(?=\nINSIGHT:|$)/i);
-  const insightMatch = text.match(/INSIGHT:\s*([\s\S]*)/i);
-  return {
-    score: scoreMatch ? parseFloat(scoreMatch[1]!) : 0,
-    reason: reasonMatch ? reasonMatch[1]!.trim().split("\n")[0]! : "Could not parse judge response",
-    insight: insightMatch ? insightMatch[1]!.trim().split("\n")[0]! : "",
-  };
+interface Verdict {
+  matched: Array<{ expected: string; produced: string }>;
+  missing: string[];
+  spurious: string[];
+  reason: string;
+  insight: string;
+}
+
+const BETA = 2; // weight recall this many times more than precision
+
+function fBeta(recall: number, precision: number): number {
+  const b2 = BETA * BETA;
+  const denom = b2 * precision + recall;
+  return denom === 0 ? 0 : ((1 + b2) * precision * recall) / denom;
 }
 
 export default defineStep({
   type: "eval/score",
   description:
-    "LLM-as-judge: score `actual` against `expected` using `rubric` criteria. Required config: actual, expected, rubric (rubric supplied by the calling workflow's `params` — the experiment surface). Optional: provider, model. Output: { score, reason, insight, markdown }.",
+    "Recall-based LLM-judge for concept sets: matches expected (gold) capabilities to produced concepts, computes a continuous recall-weighted score. Required config: actual, expected, rubric (rubric is the calling workflow's param — the experiment surface). Optional: provider, model. Output: { score, recall, precision, matched, missing, spurious, reason, insight, markdown }.",
   input: z.object({
     actual: z.string(),
     expected: z.string(),
@@ -49,8 +64,8 @@ export default defineStep({
     const provider = cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? "anthropic";
     const modelName = cfg.model ?? process.env["VEIN_LLM_MODEL"];
 
-    const { generateText } = await import("ai");
-    let model: Parameters<typeof generateText>[0]["model"];
+    const { generateObject } = await import("ai");
+    let model: any;
     switch (provider) {
       case "anthropic": {
         const { anthropic } = await import("@ai-sdk/anthropic");
@@ -68,21 +83,50 @@ export default defineStep({
 
     const prompt = `${cfg.rubric}
 
-# EXPECTED (gold standard)
+# EXPECTED (gold capabilities)
 ${cfg.expected}
 
-# ACTUAL (produced)
+# PRODUCED (what the workflow generated)
 ${cfg.actual}
 
-${FORMAT}`;
+Match each EXPECTED capability to a PRODUCED concept SEMANTICALLY (not by exact
+wording — a capability can be named differently). Then report:
+- matched:  expected capabilities that ARE covered (paired with the produced concept)
+- missing:  expected capabilities with no adequate match
+- spurious: produced concepts that are noise / not real capabilities / not expected
+Every expected capability must appear in exactly one of matched or missing.`;
 
-    const { text } = await generateText({ model, prompt });
-    const verdict = parseVerdict(text);
+    const { object } = await generateObject({ model, prompt, schema: VerdictSchema as any });
+    const v = object as Verdict;
 
-    const markdown = `**Score: ${verdict.score}**\n\n${verdict.reason}${
-      verdict.insight ? `\n\n_Insight: ${verdict.insight}_` : ""
-    }`;
+    const expectedTotal = v.matched.length + v.missing.length;
+    const producedTotal = v.matched.length + v.spurious.length;
+    const recall = expectedTotal === 0 ? 1 : v.matched.length / expectedTotal;
+    const precision = producedTotal === 0 ? 1 : v.matched.length / producedTotal;
+    const score = Math.round(fBeta(recall, precision) * 100) / 100;
 
-    return { ...verdict, markdown };
+    const pct = (n: number) => `${Math.round(n * 100)}%`;
+    const markdown = [
+      `**Score: ${score}**  (recall ${pct(recall)}, precision ${pct(precision)})`,
+      `Matched ${v.matched.length}/${expectedTotal} expected capabilities.`,
+      v.missing.length ? `\n**Missing:** ${v.missing.join(", ")}` : "",
+      v.spurious.length ? `**Spurious:** ${v.spurious.join(", ")}` : "",
+      `\n${v.reason}`,
+      v.insight ? `\n_Insight: ${v.insight}_` : "",
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    return {
+      score,
+      recall,
+      precision,
+      matched: v.matched,
+      missing: v.missing,
+      spurious: v.spurious,
+      reason: v.reason,
+      insight: v.insight,
+      markdown,
+    };
   },
 });

--- a/mcp/src/lab/eval/steps/score.ts
+++ b/mcp/src/lab/eval/steps/score.ts
@@ -1,15 +1,16 @@
 import { z, defineStep } from "vein";
 
 /**
- * Recall-oriented LLM-as-judge for concept sets. The judge MATCHES each
- * expected (gold) capability to a produced concept semantically and reports
- * matched / missing / spurious; the step then computes a continuous score
- * (recall-weighted F-beta) deterministically from those counts — so the number
- * is consistent and the gradient is informative for optimization.
+ * GENERIC recall-oriented LLM-as-judge. Domain-agnostic: it matches a PRODUCED
+ * set of items against an EXPECTED (gold) set and computes a continuous,
+ * recall-weighted score (F-beta) deterministically from the match counts — so
+ * the number is consistent and the gradient is informative for optimization.
  *
- * Pure mechanism: the matching criteria (WHAT counts as a match, what's
- * "spurious", naming standards) live in the `rubric` param (the experiment
- * surface). The step enforces the structured output contract + the scoring math.
+ * Nothing here is concepts-specific. WHAT counts as a match / what's "spurious"
+ * / naming standards all come from the `rubric` input (the experiment surface);
+ * the step only enforces the structured-output contract + the scoring math. An
+ * experiment supplies its own rubric (e.g. the concepts experiment ships a
+ * concept-quality rubric in `concepts-eval-score`).
  *
  * Self-contained: reaches the model via dynamic `import("ai")` (no services),
  * using structured output (`generateObject`).
@@ -21,15 +22,19 @@ import { z, defineStep } from "vein";
 const VerdictSchema = z.object({
   matched: z
     .array(z.object({ expected: z.string(), produced: z.string() }))
-    .describe("Each expected capability that IS present in the produced set, paired with the produced concept that covers it."),
+    .describe("Each EXPECTED item that IS present in the produced set, paired with the produced item that covers it."),
   missing: z
     .array(z.string())
-    .describe("Expected capabilities with NO adequate match in the produced set."),
+    .describe("EXPECTED items with NO adequate match in the produced set."),
   spurious: z
     .array(z.string())
-    .describe("Produced concepts that are noise — not real user-facing capabilities, or over-granular/implementation-named, or not in the expected set."),
-  reason: z.string().describe("1-3 sentences on the biggest gaps."),
-  insight: z.string().describe("1 sentence: what should change to recover the missing capabilities?"),
+    .describe("PRODUCED items that are noise — not a real item per the rubric, over-granular/implementation-named, or not in the expected set."),
+  reason: z.string().describe("1-3 sentences on the biggest gaps in THIS result (specifics are fine here)."),
+  insight: z
+    .string()
+    .describe(
+      "1 sentence: a GENERAL, domain-agnostic lesson about the GENERATOR (the prompt/workflow being evaluated) that would help on ANY input. Do NOT name this input's specific items or domain — generalize the failure into a transferable principle (e.g. 'the generator over-weights low-level/implementation items and under-weights top-level user-facing ones').",
+    ),
 });
 
 interface Verdict {
@@ -51,7 +56,7 @@ function fBeta(recall: number, precision: number): number {
 export default defineStep({
   type: "eval/score",
   description:
-    "Recall-based LLM-judge for concept sets: matches expected (gold) capabilities to produced concepts, computes a continuous recall-weighted score. Required config: actual, expected, rubric (rubric is the calling workflow's param — the experiment surface). Optional: provider, model. Output: { score, recall, precision, matched, missing, spurious, reason, insight, markdown }.",
+    "Generic recall-based LLM-judge: matches a produced set against an expected (gold) set and computes a continuous recall-weighted score. Domain-agnostic — all criteria live in the `rubric`. Required config: actual, expected, rubric. Optional: provider, model. Output: { score, recall, precision, matched, missing, spurious, reason, insight, markdown }.",
   input: z.object({
     actual: z.string(),
     expected: z.string(),
@@ -83,18 +88,22 @@ export default defineStep({
 
     const prompt = `${cfg.rubric}
 
-# EXPECTED (gold capabilities)
+# EXPECTED (gold)
 ${cfg.expected}
 
-# PRODUCED (what the workflow generated)
+# PRODUCED (what the generator produced)
 ${cfg.actual}
 
-Match each EXPECTED capability to a PRODUCED concept SEMANTICALLY (not by exact
-wording — a capability can be named differently). Then report:
-- matched:  expected capabilities that ARE covered (paired with the produced concept)
-- missing:  expected capabilities with no adequate match
-- spurious: produced concepts that are noise / not real capabilities / not expected
-Every expected capability must appear in exactly one of matched or missing.`;
+Match each EXPECTED item to a PRODUCED item SEMANTICALLY (not by exact wording —
+an item can be named differently). Then report:
+- matched:  expected items that ARE covered (paired with the produced item)
+- missing:  expected items with no adequate match
+- spurious: produced items that are noise / not real items / not expected
+Every expected item must appear in exactly one of matched or missing.
+
+For "insight", step back from THIS input: give one transferable, domain-agnostic
+lesson about the generator (never name this input's specific items or domain). It
+must read as advice that applies to any input.`;
 
     const { object } = await generateObject({ model, prompt, schema: VerdictSchema as any });
     const v = object as Verdict;
@@ -108,7 +117,7 @@ Every expected capability must appear in exactly one of matched or missing.`;
     const pct = (n: number) => `${Math.round(n * 100)}%`;
     const markdown = [
       `**Score: ${score}**  (recall ${pct(recall)}, precision ${pct(precision)})`,
-      `Matched ${v.matched.length}/${expectedTotal} expected capabilities.`,
+      `Matched ${v.matched.length}/${expectedTotal} expected items.`,
       v.missing.length ? `\n**Missing:** ${v.missing.join(", ")}` : "",
       v.spurious.length ? `**Spurious:** ${v.spurious.join(", ")}` : "",
       `\n${v.reason}`,

--- a/mcp/src/lab/eval/steps/score.ts
+++ b/mcp/src/lab/eval/steps/score.ts
@@ -1,0 +1,88 @@
+import { z, defineStep } from "vein";
+
+/**
+ * LLM-as-judge scorer. Compares an `actual` output against an `expected` gold
+ * standard using a `rubric` (the scoring criteria) and returns a structured
+ * verdict: { score, reason, insight }.
+ *
+ * Pure mechanism: the rubric (WHAT to weigh) is NOT baked in here — it's the
+ * experiment surface and lives in the calling workflow's `params` block (see
+ * `workflows/eval-score.yaml`), passed in via config. The step only enforces
+ * the strict SCORE/REASON/INSIGHT output contract so the result parses.
+ *
+ * Self-contained: like vein's core `llm` step, it reaches the model via a
+ * dynamic `import("ai")` — no services needed — so it's portable as a custom
+ * step on disk.
+ *
+ * Output: { score, reason, insight, markdown }.
+ */
+
+const FORMAT = `Respond in EXACTLY this format and nothing else:
+SCORE: <0 or 0.5 or 1>
+REASON: <1-3 sentences on what is right or wrong>
+INSIGHT: <1 sentence: what should change to score higher next time?>`;
+
+function parseVerdict(text: string): { score: number; reason: string; insight: string } {
+  const scoreMatch = text.match(/SCORE:\s*(0\.5|0|1)/i);
+  const reasonMatch = text.match(/REASON:\s*([\s\S]*?)(?=\nINSIGHT:|$)/i);
+  const insightMatch = text.match(/INSIGHT:\s*([\s\S]*)/i);
+  return {
+    score: scoreMatch ? parseFloat(scoreMatch[1]!) : 0,
+    reason: reasonMatch ? reasonMatch[1]!.trim().split("\n")[0]! : "Could not parse judge response",
+    insight: insightMatch ? insightMatch[1]!.trim().split("\n")[0]! : "",
+  };
+}
+
+export default defineStep({
+  type: "eval/score",
+  description:
+    "LLM-as-judge: score `actual` against `expected` using `rubric` criteria. Required config: actual, expected, rubric (rubric supplied by the calling workflow's `params` — the experiment surface). Optional: provider, model. Output: { score, reason, insight, markdown }.",
+  input: z.object({
+    actual: z.string(),
+    expected: z.string(),
+    rubric: z.string(),
+    provider: z.string().optional(),
+    model: z.string().optional(),
+  }),
+  output: z.any(),
+  async run(cfg) {
+    const provider = cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? "anthropic";
+    const modelName = cfg.model ?? process.env["VEIN_LLM_MODEL"];
+
+    const { generateText } = await import("ai");
+    let model: Parameters<typeof generateText>[0]["model"];
+    switch (provider) {
+      case "anthropic": {
+        const { anthropic } = await import("@ai-sdk/anthropic");
+        model = anthropic(modelName ?? "claude-sonnet-4-20250514");
+        break;
+      }
+      case "openai": {
+        const { openai } = await import("@ai-sdk/openai");
+        model = openai(modelName ?? "gpt-4o");
+        break;
+      }
+      default:
+        throw new Error(`Unknown LLM provider: "${provider}". Supported: anthropic, openai`);
+    }
+
+    const prompt = `${cfg.rubric}
+
+# EXPECTED (gold standard)
+${cfg.expected}
+
+# ACTUAL (produced)
+${cfg.actual}
+
+${FORMAT}`;
+
+    const { text } = await generateText({ model, prompt });
+    const verdict = parseVerdict(text);
+
+    const markdown = `**Score: ${verdict.score}**\n\n${verdict.reason}${
+      verdict.insight ? `\n\n_Insight: ${verdict.insight}_` : ""
+    }`;
+
+    return { ...verdict, markdown };
+  },
+});

--- a/mcp/src/lab/eval/workflows/eval-score.yaml
+++ b/mcp/src/lab/eval/workflows/eval-score.yaml
@@ -1,0 +1,45 @@
+name: eval-score
+# Score a produced artifact against an expected gold standard via LLM-as-judge.
+# Generic: pass `actual` (e.g. the `markdown` from a collect-for-eval run) and
+# `expected` (the gold markdown) as input. The scoring criteria live in the
+# `rubric` param below — the experiment surface. Output: { score, reason,
+# insight, markdown }.
+#
+# Input: { actual, expected }
+steps:
+  - id: judge
+    type: eval/score
+    config:
+      actual: "{{ input.actual }}"
+      expected: "{{ input.expected }}"
+      # The rubric (scoring criteria) lives in this workflow's `params` block
+      # below. Swap it per run via POST /run { params: { rubric } }, or edit
+      # the default to retune the measuring stick.
+      rubric: "{{ params.rubric }}"
+      # Optionally override the judge model (e.g. a stronger model for scoring):
+      # model: claude-opus-4-20250514
+
+# ── params: the rubric (the measuring stick) ────────────────────────────────
+params:
+  rubric: |-
+    You are scoring a produced set of software Concepts against an expected gold
+    set. Each Concept is a user-facing capability or business feature
+    (## Name + description).
+
+    Match produced Concepts to expected ones SEMANTICALLY, not by exact string.
+    Weigh:
+    - RECALL: what fraction of the expected capabilities are present?
+    - PRECISION: penalize junk, over-granular, or implementation-named concepts
+      (e.g. "Pusher WebSockets", "Redis Caching") that aren't real user-facing
+      capabilities.
+    - NAMING: capability-focused names are good ("Real-time Chat"); technology
+      names are bad ("Pusher WebSockets").
+    - DESCRIPTION: are the descriptions accurate and capability-focused?
+
+    Scoring:
+    - 1   = strong match: nearly all expected capabilities present, good names,
+            little noise.
+    - 0.5 = partial: the right shape but missing capabilities, noisy extras, or
+            poor (implementation-y) naming.
+    - 0   = wrong or missing: few/none of the expected capabilities, or mostly
+            noise.

--- a/mcp/src/lab/eval/workflows/eval-score.yaml
+++ b/mcp/src/lab/eval/workflows/eval-score.yaml
@@ -1,9 +1,10 @@
 name: eval-score
-# Score a produced artifact against an expected gold standard via LLM-as-judge.
-# Generic: pass `actual` (e.g. the `markdown` from a collect-for-eval run) and
-# `expected` (the gold markdown) as input. The scoring criteria live in the
-# `rubric` param below — the experiment surface. Output: { score, reason,
-# insight, markdown }.
+# Score a produced concept set against an expected gold set via recall-based
+# LLM matching. Pass `actual` (e.g. the `markdown` from a collect-for-eval run)
+# and `expected` (the gold markdown) as input. The matching CRITERIA live in
+# the `rubric` param below (the experiment surface); the step computes the
+# numeric score. Output: { score, recall, precision, matched, missing,
+# spurious, reason, insight, markdown }.
 #
 # Input: { actual, expected }
 steps:
@@ -12,34 +13,30 @@ steps:
     config:
       actual: "{{ input.actual }}"
       expected: "{{ input.expected }}"
-      # The rubric (scoring criteria) lives in this workflow's `params` block
+      # The rubric (matching criteria) lives in this workflow's `params` block
       # below. Swap it per run via POST /run { params: { rubric } }, or edit
       # the default to retune the measuring stick.
       rubric: "{{ params.rubric }}"
       # Optionally override the judge model (e.g. a stronger model for scoring):
       # model: claude-opus-4-20250514
 
-# ── params: the rubric (the measuring stick) ────────────────────────────────
+# ── params: the rubric (matching criteria) ──────────────────────────────────
+# The step does the scoring math (recall-weighted F-beta); this just tells the
+# judge HOW to decide what counts as a match / what's spurious.
 params:
   rubric: |-
-    You are scoring a produced set of software Concepts against an expected gold
-    set. Each Concept is a user-facing capability or business feature
-    (## Name + description).
+    You are matching a PRODUCED set of software Concepts against an EXPECTED gold
+    set. Each Concept is a user-facing capability or business feature (a name +
+    description). The goal is to recover the repo's core user-facing capabilities.
 
-    Match produced Concepts to expected ones SEMANTICALLY, not by exact string.
-    Weigh:
-    - RECALL: what fraction of the expected capabilities are present?
-    - PRECISION: penalize junk, over-granular, or implementation-named concepts
-      (e.g. "Pusher WebSockets", "Redis Caching") that aren't real user-facing
-      capabilities.
-    - NAMING: capability-focused names are good ("Real-time Chat"); technology
-      names are bad ("Pusher WebSockets").
-    - DESCRIPTION: are the descriptions accurate and capability-focused?
-
-    Scoring:
-    - 1   = strong match: nearly all expected capabilities present, good names,
-            little noise.
-    - 0.5 = partial: the right shape but missing capabilities, noisy extras, or
-            poor (implementation-y) naming.
-    - 0   = wrong or missing: few/none of the expected capabilities, or mostly
-            noise.
+    Matching rules:
+    - Match by CAPABILITY, semantically — not by exact wording. "Real-time Chat",
+      "Messaging", and "Live Chat" are the same capability. A poorly-named
+      produced concept (e.g. "Pusher WebSockets") still MATCHES "Real-time Chat"
+      if it clearly covers that capability — note the weak naming in `reason`.
+    - A produced concept is SPURIOUS if it is not a real user-facing capability
+      (infrastructure, generic UI, build tooling), is over-granular (a slice of a
+      larger capability already matched), or simply isn't in the expected set.
+    - Prefer recall: it is more important to cover every expected capability than
+      to be perfectly clean. Surface the MISSING capabilities clearly — those are
+      what the workflow needs to learn to find.

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -162,13 +162,24 @@ async function structureFinalAnswer(
     msgs.push({ role: "user", content: finalPrompt });
   }
 
-  // Add the assistant's answer and the structuring request
+  // Add the assistant's answer and the structuring request.
+  // IMPORTANT: this is a pure reformatting step, NOT a regeneration step.
+  // Without strict instructions the model "rephrases" opaque literals (file
+  // paths, ids, urls) into plausible-looking but fabricated values, causing
+  // the structured `content` to diverge from the free-text `final_answer`.
   msgs.push(
     { role: "assistant", content: finalAnswer },
     {
       role: "user",
       content:
-        "Great! Please rephrase your answer in the following JSON format: " +
+        "Reformat the answer above into the following JSON format. " +
+        "This is a formatting task ONLY — do not add, summarize, re-word, or invent anything.\n\n" +
+        "STRICT RULES:\n" +
+        "- Copy every value directly from the answer above. Do NOT generate new values.\n" +
+        "- File paths, URLs, IDs, names, and other literals MUST be copied character-for-character. " +
+        "Never normalize, guess, or substitute a 'typical-looking' value.\n" +
+        "- If a field's value is not explicitly present in the answer above, leave it empty/null rather than inventing one.\n\n" +
+        "JSON format:\n" +
         JSON.stringify(schema),
     }
   );

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -31,7 +31,7 @@ vein/
 │   ├── runner.ts          # execution engine: DAG (topological), retry, onError, control flow
 │   ├── store.ts           # RunStore interface + FileRunStore + MemoryRunStore
 │   ├── workspace.ts       # WorkspaceManager: versioning, _metadata.json, YAML loading
-│   ├── createVein.ts      # createVein() factory: Hono HTTP API + SSE run streaming + /chat + static serving; injectable registry/store/services
+│   ├── createVein.ts      # createVein() factory: Hono HTTP API + detached run launch + SSE run reattach (tail) + /chat + static serving; injectable registry/store/services
 │   ├── server.ts          # thin wrapper over createVein() (getApp/startServer) — default filesystem-backed server
 │   ├── auth.ts            # requireApiKey middleware + warnIfUnconfigured (VEIN_API_KEY shared secret)
 │   ├── index.ts           # barrel export — createVein (primary entry), createRegistry, coreRegistry, all types
@@ -249,6 +249,34 @@ later without breaking this contract — they'd be additive env vars
   `workflows/<name>/runs/<runId>/`. Run IDs are millisecond
   timestamps (not UUIDs) for natural sort order and easy
   pagination. Listing runs for a workflow is a single `readdir`.
+
+- **Runs launch detached; viewing is reattach-by-tail** (the
+  background-job model, `EVAL_SPEC.md` §8). `POST /workflows/:name/run`
+  (and `/:version/run`) does **not** stream — it kicks off
+  `runWorkflow` **without awaiting it in the request** (`launchDetached`
+  in `createVein.ts`) and returns `{ runId }` (202) immediately. The
+  run executes server-side and persists every event to the
+  append-only `events.jsonl`; its liveness is decoupled from any
+  connection (closing the client, proxy timeouts, etc. can't kill it).
+  To watch a run — live **or** after it finished — open
+  `GET /workflows/:name/runs/:runId/stream` (SSE). That endpoint calls
+  `FileRunStore.tailEvents`, which **tails the events file**: replay
+  from byte offset 0 → EOF (history), then follow appends (polling
+  `intervalMs`, default 250ms) until the terminal event
+  (`run.end`/`run.error`), then sends a final `done` carrying the
+  RunResult. Because the append-only log is the ordered source of
+  truth, the history→live join is **race-free** (read to EOF, follow
+  from EOF — no sequence numbers, no dedupe), and **one code path
+  serves completed and in-flight runs**. Pass an `AbortSignal` (wired
+  to `stream.onAbort` on client disconnect) to stop the tail early.
+  Streaming requires a `FileRunStore` (the tail reads the file);
+  `MemoryRunStore` runs still launch but the stream endpoint returns
+  501. **Crash caveat:** in-flight *execution* is in-memory, so a
+  crash mid-run loses the remaining work (the log up to the crash
+  survives); true resume is a later add. The web UI's
+  `api.runWorkflow` hides the two steps — it POSTs to launch, then
+  `streamRun(name, runId)` reattaches to the tail — so callers see the
+  same `(onEvent, → RunResult)` interface as before.
 
 - **`RunStore.append/finalize`** take `(workflow, runId, ...)`
   — the workflow name is the first param. `MemoryRunStore` keys

--- a/vein/EVAL_SPEC.md
+++ b/vein/EVAL_SPEC.md
@@ -1,361 +1,217 @@
-# Evals & Self-Improving Experiments — Spec
+# Evals & Self-Improving Workflows — Spec
 
-A design spec for turning vein into a platform for **evals** and
-**self-improving loops**: pin a goal, run a workflow against pinned
-examples, score the output against an expected gold standard, and let an
-optimizer evolve the workflow's tunable knobs (`params`) until the output
-is good.
+How vein supports **evals** and **self-improving loops**: define a goal, run a
+workflow, score its output against an expected gold standard, and iterate on
+the workflow until the output is good.
 
-This builds on `SPEC.md` (the engine) and reuses its existing primitives
-wherever possible. It is **not** a CLI — every operation is a first-class
-API endpoint, visible in the UI, and (later) drivable by the AI agent.
+Builds on `SPEC.md` (the engine). The guiding idea:
 
-> GOAL: AS SIMPLE AS POSSIBLE. **Everything is a workflow + its `params`.**
-> The dataset (expected gold), the rubric, and the candidate knobs are all
-> just `params` — which vein already stores, versions, and (now) edits in the
-> UI. We do **not** add new `Dataset`/`Rubric`/`Experiment` resource types.
-> The only new pieces are a couple of small **steps** (a collector and a
-> scorer) and one engine primitive (keyed param overrides).
+> **Everything is a workflow + its `params`.** The target pipeline, the
+> scorer, and the eval harness are all workflows; the dataset (expected gold),
+> the rubric, and the tunable prompts are all `params` — which vein already
+> stores, versions, and edits in the UI. There are **no** new
+> `Dataset`/`Rubric`/`Experiment` resource types. The eval is just a
+> **measurement substrate**: `run target → collect → score → a number`.
+> Whoever consumes that number (a human, the chat agent, or a thin loop) is
+> the "optimizer".
 
 ---
 
-## 0. Status (what's implemented)
+## 1. Status (what's built)
 
 | Piece | State |
 | --- | --- |
-| Keyed `paramOverrides` engine primitive (§3) | **done** (`runner.ts`, exposed on `/run` + `run()`) |
-| Params **visible + editable + persistable** in the UI (§4, §8) | **done** (`ParamsFlyout`; Publish writes params into the new version) |
-| Bootstrap prompt paramified (§6.1) | **done** (`bootstrap-then-process` `params`) |
-| `concepts/collect-for-eval` — run output = scoreable concept set (§5) | **done** (final step of `bootstrap-then-process`) |
-| `eval/score` step + `eval-score` workflow (rubric in `params`) (§5) | **done** (`mcp/src/lab/eval`) |
-| Snapshot capture/injection, namespacing + teardown (§6) | todo |
-| `eval/reflect` + orchestrator + optimize stream (§5) | todo |
-| Optimize UI: generations chart / diff / drill (§8) | todo |
-| Agent tools (§9) | todo |
+| Keyed `paramOverrides` engine primitive (§4) | **done** (`runner.ts`, on `/run` + `run()`) |
+| Params **visible + editable + persistable** in the UI (§3) | **done** (`ParamsFlyout`; Publish writes params into the new version) |
+| Bootstrap prompt paramified | **done** (`bootstrap-then-process` `params`) |
+| `concepts/collect-for-eval` — run output = scoreable concept set | **done** (final step of `bootstrap-then-process`) |
+| `eval/score` (recall-based) + `eval-score` workflow (§5) | **done** (`mcp/src/lab/eval`) |
+| `eval-concepts` — bootstrap-only eval loop (§6) | **done** (`mcp/src/lab/concepts`) |
+| Eval as a chat-agent capability (§7) | todo — the real "optimizer" |
+| Reproducible/isolated runs: snapshots + namespacing (§8) | todo |
+| Multi-repo dataset (`foreach` over `examples`) + thin param-sweep loop (§7) | todo |
+
+Manual eval works **today**: open `eval-concepts`, set the `expected` gold in
+the Params flyout, Run with a repo, read the score; edit the bootstrap prompt
+(`bootstrap-then-process` params or a `paramOverrides`), re-run.
 
 ---
 
-## 1. Motivation
+## 2. The model
 
-Two pipelines we want to make "perfect" by iterating on prompts, not code:
-
-1. **Concepts** (`mcp/src/lab/concepts`) — walk a repo's history and build
-   a knowledge graph of ~10 user-facing "Concepts". The goal is a good
-   **top-N concept set** per repo. Tunable surfaces: the bootstrap
-   exploration prompt and the per-change `decide` prompt.
-2. **Services agent** (`mcp/src/gitsee/agent`, services mode) — explore a
-   repo and emit a working `pm2.config.js` + `docker-compose.yml`. (A full
-   GEPA-style harness for this already existed at
-   `mcp/src/gitsee/agent/eval/` — this spec generalizes that pattern into
-   the platform. Not the v1 target, but the design must cover it.)
-
-Both reduce to the same shape:
-
-| Piece | Concepts | Services agent |
-| --- | --- | --- |
-| **Candidate** (what evolves) | bootstrap + decide prompts (`params`) | explorer + final_answer prompts |
-| **Dataset** | repos pinned at a rev + gold concept list | repos + gold pm2/compose files |
-| **Run** | run the target workflow with candidate params | run the agent with candidate prompts |
-| **Score** | judge: semantic recall/precision vs gold | judge: would the config work? |
-| **Reflect** | LLM proposes better params | LLM proposes better prompts |
-
-The framework is **target-agnostic**: it does not care how many prompts a
-target has or where they live, as long as they are exposed as `params`.
-
----
-
-## 2. Design decisions (settled)
-
-| # | Decision | Rationale |
-| --- | --- | --- |
-| D1 | **Thin orchestrator + everything-is-a-workflow.** `score`/`reflect` are vein workflows; the GEPA loop is thin engine code streamed via SSE. | Ports the proven harness; every sub-step is an inspectable run; no fragile new looping primitives. |
-| D2 | **No new resource types. Eval config = workflow `params`.** The rubric, the expected gold, and the dataset (`examples`) are `params` on an eval/experiment workflow. | `params` are already workspace-stored, versioned, and (now) UI-editable. **Changing a param IS a new workflow version** — exactly the persistence/versioning we'd otherwise rebuild. |
-| D3 | **Candidate scope = `params` only** (prompts/thresholds/selectors), as a **multi-scope union** across `{workflow, key}`. | Matches the existing "experiment surface"; smallest search space; covers multi-prompt targets. |
-| D4 | **Nested/scoped param override** is added to the engine (keyed by workflow name). | The tunable prompts live in subflows; per-run `params` don't propagate today. General; opt-in; back-compat. |
-| D5 | **Pin-by-snapshot** datasets. | Deterministic, offline, fast, cheap evals — no GitHub during optimization. |
-| D6 | **Holistic reflection** for credit assignment (start). | Simplest; reflector sees all prompts + insights and may change any. Component sub-rubrics / staged optimization can come later. |
-| D7 | **Human-driven first, agent-driven later.** | The agent layer is thin tool wrappers over the same endpoints; build them tool-friendly from day one. |
-| D8 | **Params are editable + persistable in the UI** (the `ParamsFlyout`); edits publish a new workflow version. | This is what makes "set up an eval in the UI" real without any new resource/storage/API. |
-
----
-
-## 3. New engine primitive: keyed param overrides
-
-Today (`runner.ts`): `executeFlow` seeds `params = { ...workflow.params,
-...paramsOverride }`, and the subflow call **does not** pass overrides
-down — subflows reset to their own `params`. This is deliberate isolation,
-but it means a candidate cannot reach a prompt that lives in a subflow
-(e.g. `concepts/decide` inside `process-change`, two levels below the
-entry workflow).
-
-**Add an opt-in, name-addressed override that travels the whole tree:**
-
-```ts
-runWorkflow(flow, input, registry, {
-  params,                                  // entry-flow only (unchanged)
-  paramOverrides: {                        // NEW — keyed by workflow name
-    "bootstrap-then-process": { bootstrapSystem, sizing },
-    "process-change":         { systemPrompt, guidelines },
-  },
-})
+```
+                 paramOverrides / new version
+                          │  (the candidate)
+                          ▼
+   repo ─► TARGET workflow ─► collect ─► { markdown, concepts }
+                                              │
+                expected gold (a param) ──►  SCORE ─► { score, missing, … }
 ```
 
-- In `executeFlow`, the scope becomes:
-  `{ ...workflow.params, ...(paramOverrides[workflow.name] ?? {}), ...(isEntry ? params : {}) }`
-- The subflow execution (`runner.ts` ~673) threads `paramOverrides`
-  recursively so it reaches every nested level.
-- **Back-compat:** flat `params` keeps meaning "entry flow"; `paramOverrides`
-  is additive and opt-in. Precedence: step `.default()` < flow `params`
-  default < `paramOverrides[name]` < entry `params`.
+- **Target** — the pipeline being improved (e.g. `bootstrap-then-process`).
+- **Collect** — a final step (`collect-for-eval`) turns graph state into the
+  scoreable run output. Without it the run records the wrong thing.
+- **Score** — `eval-score`, an LLM judge that matches produced vs expected.
+- **Candidate** — what changes between runs (see §4). Param tweak or a whole
+  new workflow version.
+- **Harness** — `eval-concepts` chains the above into one run that returns a
+  number (§6).
 
-This single primitive is also what makes **multi-scope candidates** free:
-a candidate is just a `paramOverrides` map spanning several workflows.
+Everything above is a workflow or a `param`. No new resource types.
 
 ---
 
-## 4. No new resources — eval config is `params`
+## 3. Eval config = `params` (no new resources)
 
-The earlier draft proposed `datasets/`, `rubrics/`, and `experiments/`
-resource types (storage + API + UI). We **dropped that**: vein's `params`
-already are the dynamic-state mechanism we need — workspace-stored, versioned,
-and now UI-editable. So the rubric, the expected gold, and the dataset all
-live as `params` on ordinary workflows.
+The rubric, the expected gold, and the dataset all live as `params` on
+ordinary workflows. **Changing a param = a new workflow version** — editing in
+the `ParamsFlyout` marks the workflow dirty; **Publish** writes the params into
+the next version's YAML (`POST /workflows/:name` already accepts
+`{ steps, params }`). So "setting up an eval in the UI" needs no new storage,
+API, or resource — just the editable Params flyout (done).
 
-> **Changing a param = a new workflow version.** Editing a param in the
-> `ParamsFlyout` marks the workflow dirty; **Publish** writes the params into
-> the next version's YAML (the existing `POST /workflows/:name` already
-> accepts `{ steps, params }`). No new storage, API, or resource type.
+- **Rubric** → the `rubric` param of `eval-score`.
+- **Expected gold** → an `expected` param (one repo) or an `examples` array
+  param (many), authored in the same markdown shape `collect-for-eval` emits.
 
-### 4.1 Rubric → a `param` of the scorer workflow
+---
 
-The rubric (the fixed measuring stick — WHAT to weigh) is the `rubric` param
-of `eval-score`. Editable in the UI; the optimizer never mutates it.
+## 4. The candidate: a workflow *version* (not just params)
 
-```yaml
-# eval-score.yaml (seeded)  —  input: { actual, expected }
-steps:
-  - id: judge
-    type: eval/score
-    config: { actual: "{{ input.actual }}", expected: "{{ input.expected }}", rubric: "{{ params.rubric }}" }
-params:
-  rubric: |-
-    Score produced Concepts vs the expected gold set. Match semantically, not
-    by string. Weigh RECALL / PRECISION / NAMING / DESCRIPTION. …
-```
+What an optimizer evolves is **a version of the target workflow**. Two kinds,
+on a spectrum:
 
-The `eval/score` **step** is pure mechanism: it appends the strict
-`SCORE / REASON / INSIGHT` contract and parses the verdict
-(`{ score, reason, insight, markdown }`). The `INSIGHT` feeds reflection.
+1. **Param tuning** (cheap, mechanical) — change prompt/threshold values for
+   known knobs. Reaches knobs at any depth via the keyed-override primitive:
 
-### 4.2 Dataset (expected gold) → a `param`
+   **`paramOverrides`** (`runner.ts`) — opt-in, name-addressed, threaded
+   recursively so it reaches a knob inside a nested subflow (e.g.
+   `concepts/decide` two levels down). `params` (flat) only hits the entry
+   flow; `paramOverrides[workflowName]` hits that flow at any depth.
+   ```jsonc
+   POST /workflows/eval-concepts/run
+   { "input": { "owner": "x", "repo": "y" },
+     "paramOverrides": { "bootstrap-then-process": { "bootstrapPrompt": "…" } } }
+   ```
 
-The "dataset" is just `params` too. For a single repo, the gold is an
-`expected` param; for several, an `examples` array param (each
-`{ input, expected }`). Authored/edited in the `ParamsFlyout` (JSON for the
-array), versioned on Publish.
+2. **Structural evolution** (the interesting one) — change the *shape* of the
+   workflow: add steps, new data sources, new tools. E.g. instead of only
+   reading code, bootstrap could fetch the last 200 PR titles, or inspect the
+   org's other repos, to recover historical context. A workflow can't author
+   itself — **this is inherently the agent's job** (§7). Each structural
+   variant is just a **new workflow version**, which versioning already
+   captures and the eval already scores.
 
-```yaml
-# an "experiment" workflow's params
-params:
-  rubric: |- …                       # the measuring stick
-  examples:
-    - input:    { owner: stakwork, repo: hive, rev: a1b2c3, until: "2025-09-01" }
-      expected: |
-        # Concepts: stakwork/hive
-        ## Real-time Chat
-        Users can …
-        ## Task Management
-        …
-```
+Param tuning is the degenerate case of structural evolution where only the
+params changed. Both reduce to "author a candidate version → eval it → keep
+the winner."
 
-`expected` is authored in the **same markdown shape** `collect-for-eval`
-emits, so scoring is apples-to-apples (semantic, so PR/commit counts don't
-matter). **Pin-by-snapshot (D5)** still applies for reproducibility — the
-pinned change-set is carried in the example's `input` (or a `snapshot` field)
-and injected into `fetch-changes`/`fetch-content`.
+---
 
-### 4.3 Experiment → a workflow whose params hold the dataset + rubric
+## 5. The scorer (recall-based)
 
-An "experiment" is an ordinary workflow that orchestrates one eval pass:
-`foreach` over `params.examples` → run the **target** (with the candidate's
-`paramOverrides`) → `collect-for-eval` → `eval-score` against that example's
-`expected`. The **candidate** (what the optimizer evolves) is the target's
-own `params`, addressed via keyed `paramOverrides` (§3) — *not* stored on the
-experiment; it's proposed per generation by reflection and promoted into the
-target's `params` defaults on a win.
-
-### 4.4 Generations (optimize history)
-
-The one place a small new artifact is still useful: the per-generation record
-the optimizer writes (candidate params tried, per-example scores, aggregate,
-reflection). Persist these under the experiment workflow's run storage
-(`runs/<ts>/gen-N/…`) — reusing the existing run store, not a new resource.
+`eval/score` is a self-contained LLM-judge step (dynamic `import("ai")`,
+structured output). The judge **matches** each expected capability to a
+produced concept semantically and reports `matched / missing / spurious`; the
+step computes a **continuous, recall-weighted** score (F-beta, β=2) from the
+counts — deterministic and informative as a gradient.
 
 ```jsonc
-// gen-3: { candidate, results:[{exampleId, score, reason, insight}], aggregate }
+// output
+{ "score": 0.62, "recall": 0.6, "precision": 0.75,
+  "matched":  [{ "expected": "Real-time Chat", "produced": "Messaging" }],
+  "missing":  ["Payment Processing", "Notifications"],
+  "spurious": ["Redis Caching"],
+  "reason": "…", "insight": "…", "markdown": "…" }
 ```
 
+The matching **criteria** (what counts as a match / spurious / naming
+standards) live in the `rubric` param; the **math** lives in the step. The
+`missing` list is the actionable signal — it's exactly what the next candidate
+must learn to recover.
+
 ---
 
-## 5. The optimize loop
+## 6. The harness: `eval-concepts`
 
-### 5.1 Two small workflows (everything-is-a-workflow, D1)
-
-- **`eval-score`** (built) — input `{ actual, expected }`, `rubric` in
-  `params`. The `eval/score` step is a self-contained LLM-judge (like vein's
-  core `llm` step, via dynamic `import("ai")`) that enforces the
-  `SCORE / REASON / INSIGHT` contract and returns
-  `{ score, reason, insight, markdown }`.
-- **`eval-reflect`** (todo) — input `{ candidate, results, history }`; one
-  `llm` step; output a new candidate (`paramOverrides`-shaped JSON over the
-  tunable keys). The reflection prompt is this workflow's own `params`, so
-  it is itself editable. Holistic (D6): it sees **all** prompts + insights
-  and may change any of them; given prior attempts so it doesn't repeat.
-
-### 5.2 The orchestrator (thin engine code, SSE-streamed)
+One workflow that runs the whole eval as a single scoreable run:
 
 ```
-optimize(experiment):
-  candidate = seed (from target's param defaults across all tunable scopes)
-  best = candidate; bestScore = -1; history = []
-  for gen in 0 .. budget.maxGenerations:
-    results = []
-    for example in dataset.examples:
-      ns = repoId + "#" + <expRun>/<gen>/<exampleId>          # isolation (§6)
-      run TARGET( { ...example.input, snapshot: example.snapshot, namespace: ns },
-                  paramOverrides = candidateToOverrides(candidate) )   # a real run
-      output = run experiment.output.extractor(ns)            # a real run
-      teardown(ns)                                            # delete graph nodes
-      s = run eval/score({ output, expected: example.expected, rubric })   # a real run
-      results.push({ exampleId, output, score: s })
-    aggregate = mean(results.score)
-    persist gen-N; emit SSE generation event; track best
-    if aggregate >= budget.perfectScore: break
-    candidate = run eval/reflect({ candidate, results, history })  # a real run
-    history.push(...)
-  persist summary
+reset    → clear the repo's concepts (so bootstrap re-runs fresh)
+produce  → bootstrap-then-process, lookbackDays: 0  (BOOTSTRAP ONLY, no PRs)
+score    → eval-score(actual = produce.markdown, expected = params.expected)
 ```
 
-Every `run …` is a normal `runWorkflow` call → persisted, inspectable in
-the existing run flyout/canvas. Only the outer loop (budget, best-tracking,
-reflection memory, early-stop) is engine code.
+`lookbackDays: 0` makes the checkpoint "now" so no PRs/commits are processed —
+isolating the bootstrap agent. `reset` is needed because the `is-new-repo`
+gate only bootstraps an empty repo. Output: `{ score, missing, … }`. The
+expected gold is the `expected` param.
 
 ---
 
-## 6. Stateful-target concerns (Concepts)
+## 7. The optimizer is the chat agent
 
-The Concepts target writes to Neo4j keyed by `repoId = owner/repo` rather
-than returning a value. Three mechanical requirements:
+vein already has a `ToolLoopAgent` (`src/ai/`) with `create_step`,
+`edit_step`, `create_workflow`, `run_workflow`. Because targets/scorers/
+datasets are all workflows + params, **the agent already has almost everything
+it needs** to be the optimizer:
 
-- **Output extraction (W4).** An `outputExtractor` step
-  (`concepts/collect-for-eval`) reads `getAllConcepts(namespacedRepoId)`
-  and returns `{ concepts }`, so the scorer always sees a uniform
-  `{ output, expected }`.
-- **Isolation (W3).** Add an optional `namespace` to the concepts workflow
-  input; steps compute
-  `repoId = namespace ? \`${owner}/${repo}#${namespace}\` : \`${owner}/${repo}\``.
-  Each candidate/generation/example run uses a distinct namespace so runs
-  never collide; **teardown** deletes nodes for that namespaced repoId
-  after scoring. Feasible: every storage method already takes a `repo` arg.
-- **Snapshot injection (D5).** `fetch-changes`/`fetch-content` read
-  `input.snapshot` when present (no GitHub).
+- read the goal + expected,
+- author a candidate (edit a prompt param, or author a new step/workflow
+  version — e.g. a `concepts/fetch-pr-titles` step using `ctx.services.octokit`),
+- run `eval-concepts`, read `{ score, missing, insight }`,
+- iterate, keeping the best version.
 
-### 6.1 Paramification (done)
+This is why we **don't** build a separate engine "GEPA orchestrator" as the
+primary path: a workflow can't restructure itself, but the agent can — and
+structural evolution (§4.2) is where the real gains are. The thin
+deterministic loop is only worth it as an optional add for **unattended param
+sweeps**, which the agent can even delegate.
 
-The bootstrap prompt was hardcoded in `bootstrap.ts` (`buildBootstrapPrompt`,
-the `systemOverride`). It is now lifted into `bootstrap-then-process`'s
-`params` (`bootstrapSystem` + `bootstrapPrompt`, with `{slot}` placeholders
-filled at runtime) and consumed by `concepts/bootstrap-explore` — mirroring
-`concepts/decide`. The candidate surface is now a clean union of `params`
-across the two workflows: `paramOverrides["bootstrap-then-process"]` (bootstrap)
-+ `paramOverrides["process-change"]` (decide).
+What's missing is small (todo):
+- a `run_eval` tool returning the score cleanly (vs parsing run output),
+- a system-prompt section teaching the agent the eval loop,
+- (later) a `promote`/`optimize` convenience for batch sweeps.
 
----
-
-## 7. API surface
-
-There are **no new resource endpoints** — datasets/rubrics/experiments are
-workflows + params, so they use the existing surface:
-
-| Method | Path | Purpose |
-| --- | --- | --- |
-| GET | `/workflows/:name/flow` | read a workflow incl. its `params` (done) |
-| POST | `/workflows/:name` | publish a new version with `{ steps, params }` — persists edited rubric/expected/examples (done) |
-| POST | `/workflows/:name/run` | run a target/experiment; accepts `params` **and** keyed `paramOverrides` (done) |
-
-The only genuinely new endpoints are for the optimize loop (todo):
-
-| Method | Path | Purpose |
-| --- | --- | --- |
-| POST | `/workflows/:name/optimize` | run the experiment workflow across `params.examples`, evolving the target's params; **SSE stream** of generation events |
-| POST | `/workflows/:name/promote` | write the winning candidate into the target's `params` defaults + publish a new version (reuses versioning) |
+Target UX: *open the chat, say "here's the repo and the 10 concepts I expect —
+make the workflow find them," and the agent iterates*, getting progressively
+more sophisticated about the workflow it builds.
 
 ---
 
-## 8. UI surface
+## 8. Reproducibility & isolation (todo)
 
-- **Setting up an eval = editing workflow params** (done). The `ParamsFlyout`
-  (topbar **Params** button) edits a workflow's `rubric` / `expected` /
-  `examples`; **Publish** persists them as a new version. No separate
-  Datasets/Rubrics/Experiments UI.
-- **Optimize view** (todo) — for an experiment workflow's optimize run:
-  - **score-over-generations** chart,
-  - **candidate diff** (params gen N vs N+1),
-  - **per-example drill** (output vs expected + judge reason/insight),
-  - **Promote winner** button.
-- Reuses the existing run flyout/canvas: each target/score/reflect run is a
-  normal run, openable from a generation.
+For tight/automated loops the eval runs must be cheap and non-colliding:
 
----
-
-## 9. Human-first / agent-later layering (D7)
-
-The chat agent already has `create_workflow` and `run_workflow` (with a
-`params` override) in `ai/tools.ts`. Because datasets/rubrics/experiments are
-just workflows + params, the agent mostly **already has what it needs** — it
-authors an experiment workflow and sets its `rubric`/`examples` params via
-`create_workflow`. The **agent layer (v2)** adds only:
-
-- `edit_workflow_params` (or reuse `create_workflow`) — set rubric/expected/examples
-- `optimize` + `promote` — drive and land the loop
-- `run_workflow` already accepts `paramOverrides` (done) for candidate trials
-
-plus a system-prompt section. No new resource machinery. A human says "make
-the concepts workflow produce a better top-10 set"; the agent authors the
-experiment workflow (params = examples + rubric) and runs `optimize`.
+- **Snapshots** — pin a dataset example's change-set so runs are deterministic
+  and offline (`fetch-changes`/`fetch-content` read an injected `snapshot`
+  instead of hitting GitHub). Today they only have a lower bound (the
+  checkpoint); a snapshot freezes the upper bound too.
+- **Namespacing + teardown** — concepts are keyed by `owner/repo` in Neo4j, so
+  parallel candidates collide. A per-run `namespace` (suffix the repoId) +
+  teardown isolates them. `eval-concepts` uses a coarse `reset` today, which
+  is enough for sequential single-repo tuning.
 
 ---
 
-## 10. Build order
+## 9. The open thesis
 
-| Phase | Scope | State |
-| --- | --- | --- |
-| **P0** | Engine: keyed `paramOverrides` (§3) | **done** |
-| **P1** | Params **visible + editable + persistable** in the UI (§4, §8) — the "set up an eval" surface (replaces the old Dataset/Rubric/Experiment resources) | **done** |
-| **P1b** | `collect-for-eval` (run output = concept set) + `eval-score` (scorer + rubric param) (§5) | **done**; bootstrap paramified (§6.1) **done** |
-| **P2** | Snapshot capture + injection seam; namespacing + teardown (§6) | todo — reproducible, isolated eval runs |
-| **P3** | An **experiment workflow** (foreach `examples` → target+collect+score) + `eval-reflect` + orchestrator + `/optimize` SSE (§5) | todo — the loop |
-| **P4** | Optimize UI (chart, diff, drill) + `/promote` (§7–8) | todo |
-| **P5** | Agent tools (§9) | todo |
-
-Manual eval works **today** (P0–P1b): run `bootstrap-then-process` (optionally
-with `paramOverrides`), copy the `result.markdown`, run `eval-score` with it +
-`expected`. P3 automates that across `params.examples`.
-
-First concrete experiment: **concepts prompt tuning** on
-`process-repo-chronological` (skip bootstrap initially to reduce variables;
-add it as a second tunable scope once the loop is green), `0/0.5/1`
-scoring, 1–2 pinned repos.
+The point of all this: **code-only bootstrap probably can't recover a repo's
+~10 core user-facing capabilities** — that needs historical context (PR
+titles, releases, org activity). The recall rubric will score code-only
+bootstrap low and name the `missing` capabilities, which is the signal that
+should push the agent to add history-aware steps. The eval turns "you need
+historical context" from an opinion into a **measurable, falsifiable** claim —
+and then drives building the workflow that fixes it.
 
 ---
 
-## 11. Open items (decide before/at build time)
+## 10. What's next
 
-- **Score granularity:** keep `0/0.5/1` to start; revisit continuous `0..1`
-  if the gradient is too coarse for reflection.
-- **Credit assignment:** holistic (D6) first; component sub-rubrics or
-  staged optimization later if multi-surface reflection plateaus.
-- **First target:** `process-repo-chronological` vs full
-  `bootstrap-then-process` (clone/ingest dependency). Start chronological.
-- **Concurrency:** examples run sequentially in v1 (cost + Neo4j
-  isolation simplicity); parallelize later via distinct namespaces.
+1. **First real run** of `eval-concepts` on a small repo (needs Neo4j +
+   GitHub token + LLM key) — validate the wiring and see a real score.
+2. **Agent eval capability** (§7): `run_eval` tool + prompt → the chat-driven
+   loop, including structural evolution.
+3. **Reproducibility** (§8): snapshots + namespacing for cheap, parallel runs.
+4. **Multi-repo + sweeps**: `examples` array param + an optional thin loop for
+   unattended param sweeps.

--- a/vein/EVAL_SPEC.md
+++ b/vein/EVAL_SPEC.md
@@ -10,8 +10,28 @@ This builds on `SPEC.md` (the engine) and reuses its existing primitives
 wherever possible. It is **not** a CLI — every operation is a first-class
 API endpoint, visible in the UI, and (later) drivable by the AI agent.
 
-> GOAL: AS SIMPLE AS POSSIBLE. Reuse runs, `params`, and versioning. Add
-> the smallest set of new concepts: **Dataset, Rubric, Experiment**.
+> GOAL: AS SIMPLE AS POSSIBLE. **Everything is a workflow + its `params`.**
+> The dataset (expected gold), the rubric, and the candidate knobs are all
+> just `params` — which vein already stores, versions, and (now) edits in the
+> UI. We do **not** add new `Dataset`/`Rubric`/`Experiment` resource types.
+> The only new pieces are a couple of small **steps** (a collector and a
+> scorer) and one engine primitive (keyed param overrides).
+
+---
+
+## 0. Status (what's implemented)
+
+| Piece | State |
+| --- | --- |
+| Keyed `paramOverrides` engine primitive (§3) | **done** (`runner.ts`, exposed on `/run` + `run()`) |
+| Params **visible + editable + persistable** in the UI (§4, §8) | **done** (`ParamsFlyout`; Publish writes params into the new version) |
+| Bootstrap prompt paramified (§6.1) | **done** (`bootstrap-then-process` `params`) |
+| `concepts/collect-for-eval` — run output = scoreable concept set (§5) | **done** (final step of `bootstrap-then-process`) |
+| `eval/score` step + `eval-score` workflow (rubric in `params`) (§5) | **done** (`mcp/src/lab/eval`) |
+| Snapshot capture/injection, namespacing + teardown (§6) | todo |
+| `eval/reflect` + orchestrator + optimize stream (§5) | todo |
+| Optimize UI: generations chart / diff / drill (§8) | todo |
+| Agent tools (§9) | todo |
 
 ---
 
@@ -49,12 +69,13 @@ target has or where they live, as long as they are exposed as `params`.
 | # | Decision | Rationale |
 | --- | --- | --- |
 | D1 | **Thin orchestrator + everything-is-a-workflow.** `score`/`reflect` are vein workflows; the GEPA loop is thin engine code streamed via SSE. | Ports the proven harness; every sub-step is an inspectable run; no fragile new looping primitives. |
-| D2 | **Resources live in the vein workspace**, versioned like workflows. | Consistent with how workflows/steps already work; one persistence model. |
+| D2 | **No new resource types. Eval config = workflow `params`.** The rubric, the expected gold, and the dataset (`examples`) are `params` on an eval/experiment workflow. | `params` are already workspace-stored, versioned, and (now) UI-editable. **Changing a param IS a new workflow version** — exactly the persistence/versioning we'd otherwise rebuild. |
 | D3 | **Candidate scope = `params` only** (prompts/thresholds/selectors), as a **multi-scope union** across `{workflow, key}`. | Matches the existing "experiment surface"; smallest search space; covers multi-prompt targets. |
 | D4 | **Nested/scoped param override** is added to the engine (keyed by workflow name). | The tunable prompts live in subflows; per-run `params` don't propagate today. General; opt-in; back-compat. |
 | D5 | **Pin-by-snapshot** datasets. | Deterministic, offline, fast, cheap evals — no GitHub during optimization. |
 | D6 | **Holistic reflection** for credit assignment (start). | Simplest; reflector sees all prompts + insights and may change any. Component sub-rubrics / staged optimization can come later. |
 | D7 | **Human-driven first, agent-driven later.** | The agent layer is thin tool wrappers over the same endpoints; build them tool-friendly from day one. |
+| D8 | **Params are editable + persistable in the UI** (the `ParamsFlyout`); edits publish a new workflow version. | This is what makes "set up an eval in the UI" real without any new resource/storage/API. |
 
 ---
 
@@ -92,143 +113,101 @@ a candidate is just a `paramOverrides` map spanning several workflows.
 
 ---
 
-## 4. Resources
+## 4. No new resources — eval config is `params`
 
-Stored in the workspace next to `workflows/` and `steps/`. JSON shapes are
-intentionally simple (tool-friendly for the future agent layer).
+The earlier draft proposed `datasets/`, `rubrics/`, and `experiments/`
+resource types (storage + API + UI). We **dropped that**: vein's `params`
+already are the dynamic-state mechanism we need — workspace-stored, versioned,
+and now UI-editable. So the rubric, the expected gold, and the dataset all
+live as `params` on ordinary workflows.
 
+> **Changing a param = a new workflow version.** Editing a param in the
+> `ParamsFlyout` marks the workflow dirty; **Publish** writes the params into
+> the next version's YAML (the existing `POST /workflows/:name` already
+> accepts `{ steps, params }`). No new storage, API, or resource type.
+
+### 4.1 Rubric → a `param` of the scorer workflow
+
+The rubric (the fixed measuring stick — WHAT to weigh) is the `rubric` param
+of `eval-score`. Editable in the UI; the optimizer never mutates it.
+
+```yaml
+# eval-score.yaml (seeded)  —  input: { actual, expected }
+steps:
+  - id: judge
+    type: eval/score
+    config: { actual: "{{ input.actual }}", expected: "{{ input.expected }}", rubric: "{{ params.rubric }}" }
+params:
+  rubric: |-
+    Score produced Concepts vs the expected gold set. Match semantically, not
+    by string. Weigh RECALL / PRECISION / NAMING / DESCRIPTION. …
 ```
-workspace/
-  workflows/   steps/                                   (exist)
-  datasets/<name>/
-     dataset.json                                       # metadata + example index
-     examples/<exampleId>/
-        input.json        # EXACTLY the target workflow's input
-        expected.json     # the gold label
-        snapshot.json     # captured change-set / fixtures (pin-by-snapshot)
-        notes.txt         # optional
-  rubrics/<name>.json                                   # judge prompt + scale
-  experiments/<name>.json                               # the binding + budget
-  experiments/<name>/runs/<ts>/
-     gen-<N>/{ candidate.json, results.json, aggregate } 
-     summary.json
+
+The `eval/score` **step** is pure mechanism: it appends the strict
+`SCORE / REASON / INSIGHT` contract and parses the verdict
+(`{ score, reason, insight, markdown }`). The `INSIGHT` feeds reflection.
+
+### 4.2 Dataset (expected gold) → a `param`
+
+The "dataset" is just `params` too. For a single repo, the gold is an
+`expected` param; for several, an `examples` array param (each
+`{ input, expected }`). Authored/edited in the `ParamsFlyout` (JSON for the
+array), versioned on Publish.
+
+```yaml
+# an "experiment" workflow's params
+params:
+  rubric: |- …                       # the measuring stick
+  examples:
+    - input:    { owner: stakwork, repo: hive, rev: a1b2c3, until: "2025-09-01" }
+      expected: |
+        # Concepts: stakwork/hive
+        ## Real-time Chat
+        Users can …
+        ## Task Management
+        …
 ```
 
-### 4.1 Dataset
+`expected` is authored in the **same markdown shape** `collect-for-eval`
+emits, so scoring is apples-to-apples (semantic, so PR/commit counts don't
+matter). **Pin-by-snapshot (D5)** still applies for reproducibility — the
+pinned change-set is carried in the example's `input` (or a `snapshot` field)
+and injected into `fetch-changes`/`fetch-content`.
 
-A reusable, re-labeled-rarely collection of **pinned examples**. Each
-example's `input` is exactly what the target workflow takes; `expected` is
-the human-authored gold; `snapshot` makes the run deterministic.
+### 4.3 Experiment → a workflow whose params hold the dataset + rubric
+
+An "experiment" is an ordinary workflow that orchestrates one eval pass:
+`foreach` over `params.examples` → run the **target** (with the candidate's
+`paramOverrides`) → `collect-for-eval` → `eval-score` against that example's
+`expected`. The **candidate** (what the optimizer evolves) is the target's
+own `params`, addressed via keyed `paramOverrides` (§3) — *not* stored on the
+experiment; it's proposed per generation by reflection and promoted into the
+target's `params` defaults on a win.
+
+### 4.4 Generations (optimize history)
+
+The one place a small new artifact is still useful: the per-generation record
+the optimizer writes (candidate params tried, per-example scores, aggregate,
+reflection). Persist these under the experiment workflow's run storage
+(`runs/<ts>/gen-N/…`) — reusing the existing run store, not a new resource.
 
 ```jsonc
-// datasets/concepts-goldset/dataset.json
-{
-  "name": "concepts-goldset",
-  "kind": "concepts",              // informal tag: compatible targets/rubrics
-  "examples": ["hive@a1b2c3"]
-}
-```
-```jsonc
-// datasets/concepts-goldset/examples/hive@a1b2c3/input.json
-{ "owner": "stakwork", "repo": "hive",
-  "rev": "a1b2c3d4",                       // pins the clone (working tree)
-  "until": "2025-09-01T00:00:00Z" }        // upper bound on the change-set
-```
-```jsonc
-// expected.json
-{ "concepts": [
-    { "name": "Real-time Chat",  "description": "Users can…" },
-    { "name": "Task Management", "description": "…" }
-    /* ~10 */ ] }
-```
-```jsonc
-// snapshot.json — captured once at label time; bypasses GitHub at eval time
-{ "changes": [ { "type": "pr", "id": "42", "data": { … }, "markdown": "…" }, … ] }
-```
-
-**Pin-by-snapshot (D5).** `fetch-changes` / `fetch-content` gain a seam:
-when `input.snapshot` is present, return it instead of calling GitHub. A
-**capture** workflow produces the snapshot from `{owner, repo, until}`.
-Note: today `fetch-changes` only has a *lower* bound (the checkpoint); the
-capture path introduces the upper bound (`until`) and freezes the result.
-
-### 4.2 Rubric
-
-The **fixed measuring stick** — how to turn `(output, expected)` into a
-score. It is a prompt (editable in the UI) but the optimizer **never
-mutates it**. Reusable across every experiment of the same `output_kind`.
-
-```jsonc
-// rubrics/concept-quality.json
-{
-  "name": "concept-quality",
-  "output_kind": "concepts",
-  "scale": [0, 0.5, 1],
-  "judgePrompt": "Score produced Concepts vs the expected gold set. Match \
-semantically, not by string. Weigh: RECALL (expected capabilities present), \
-PRECISION (penalize junk / over-granular / implementation-named concepts), \
-NAMING (capability-focused: 'Real-time Chat' good, 'Pusher WebSockets' bad), \
-DESCRIPTION accuracy. Output SCORE / REASON / INSIGHT.",
-  "aggregation": "mean"
-}
-```
-
-Score format (ported from the prior harness): `SCORE` (0 / 0.5 / 1) +
-`REASON` (what's right/wrong) + `INSIGHT` (one prompt-level suggestion).
-The `INSIGHT` is what feeds reflection.
-
-### 4.3 Experiment
-
-Binds a **target** workflow + **dataset** + **rubric** + the **candidate
-surface** + an **output extractor** + **isolation** + **budget**. This is
-the entity you press "Optimize" on.
-
-```jsonc
-// experiments/concepts-prompt-tuning.json
-{
-  "name": "concepts-prompt-tuning",
-  "target": "process-repo-chronological",     // workflow being optimized
-  "dataset": "concepts-goldset",
-  "rubric": "concept-quality",
-
-  "candidate": {                              // multi-scope param union (D3)
-    "tunable": [
-      { "scope": "bootstrap-then-process", "keys": ["bootstrapSystem","sizing"] },
-      { "scope": "process-change",         "keys": ["systemPrompt","guidelines"] }
-    ],
-    "seed": "from-workflow-defaults"
-  },
-
-  "output":    { "extractor": "concepts/collect-for-eval" }, // → { concepts }
-  "isolation": { "namespace": "per-run", "teardown": true },
-  "budget":    { "maxGenerations": 8, "perfectScore": 0.9 }
-}
-```
-
-### 4.4 ExperimentRun (generations)
-
-One `optimize` invocation produces a sequence of generations. This is
-exactly the `runs/gen-N/` artifact layout the prior harness wrote.
-
-```jsonc
-// experiments/<name>/runs/<ts>/gen-3/results.json
-[{ "exampleId": "hive@a1b2c3",
-   "output": { "concepts": [ … ] },
-   "score": 0.5, "reason": "…", "insight": "…" }]
-// .../gen-3/candidate.json     → the params tried this generation
-// .../summary.json             → { best_score, best_gen, history:[…] }
+// gen-3: { candidate, results:[{exampleId, score, reason, insight}], aggregate }
 ```
 
 ---
 
 ## 5. The optimize loop
 
-### 5.1 Two built-in workflows (everything-is-a-workflow, D1)
+### 5.1 Two small workflows (everything-is-a-workflow, D1)
 
-- **`eval/score`** — input `{ output, expected, rubric }`; one `llm` step
-  using `rubric.judgePrompt`; output `{ score, reason, insight }`.
-- **`eval/reflect`** — input `{ candidate, results, history }`; one `llm`
-  step; output a new candidate (`paramOverrides`-shaped JSON over the
+- **`eval-score`** (built) — input `{ actual, expected }`, `rubric` in
+  `params`. The `eval/score` step is a self-contained LLM-judge (like vein's
+  core `llm` step, via dynamic `import("ai")`) that enforces the
+  `SCORE / REASON / INSIGHT` contract and returns
+  `{ score, reason, insight, markdown }`.
+- **`eval-reflect`** (todo) — input `{ candidate, results, history }`; one
+  `llm` step; output a new candidate (`paramOverrides`-shaped JSON over the
   tunable keys). The reflection prompt is this workflow's own `params`, so
   it is itself editable. Holistic (D6): it sees **all** prompts + insights
   and may change any of them; given prior attempts so it doesn't repeat.
@@ -281,42 +260,47 @@ than returning a value. Three mechanical requirements:
 - **Snapshot injection (D5).** `fetch-changes`/`fetch-content` read
   `input.snapshot` when present (no GitHub).
 
-### 6.1 Prerequisite paramification
+### 6.1 Paramification (done)
 
-To make the bootstrap prompt tunable (it is currently hardcoded in
-`bootstrap.ts`: `buildBootstrapPrompt`, the `systemOverride`, sizing
-thresholds), lift those into `concepts/bootstrap-explore` config sourced
-from the workflow's `params`. `concepts/decide` is already paramified.
-After this, the candidate surface is a clean union of `params` across the
-two workflows.
+The bootstrap prompt was hardcoded in `bootstrap.ts` (`buildBootstrapPrompt`,
+the `systemOverride`). It is now lifted into `bootstrap-then-process`'s
+`params` (`bootstrapSystem` + `bootstrapPrompt`, with `{slot}` placeholders
+filled at runtime) and consumed by `concepts/bootstrap-explore` — mirroring
+`concepts/decide`. The candidate surface is now a clean union of `params`
+across the two workflows: `paramOverrides["bootstrap-then-process"]` (bootstrap)
++ `paramOverrides["process-change"]` (decide).
 
 ---
 
 ## 7. API surface
 
-Mirrors `/workflows`. All JSON in/out (tool-friendly).
+There are **no new resource endpoints** — datasets/rubrics/experiments are
+workflows + params, so they use the existing surface:
 
 | Method | Path | Purpose |
 | --- | --- | --- |
-| GET/POST | `/datasets`, `/datasets/:name` | list / read / create datasets |
-| POST | `/datasets/:name/capture` | run the capture flow → write a snapshot example |
-| GET/POST | `/rubrics`, `/rubrics/:name` | list / read / create rubrics |
-| GET/POST | `/experiments`, `/experiments/:name` | list / read / create experiments |
-| POST | `/experiments/:name/eval` | score current params once (no evolution) |
-| POST | `/experiments/:name/optimize` | **SSE stream** of generation events |
-| GET | `/experiments/:name/runs[/:ts]` | generation history |
-| POST | `/experiments/:name/promote` | write winning candidate into target `params` defaults + publish a new workflow version |
+| GET | `/workflows/:name/flow` | read a workflow incl. its `params` (done) |
+| POST | `/workflows/:name` | publish a new version with `{ steps, params }` — persists edited rubric/expected/examples (done) |
+| POST | `/workflows/:name/run` | run a target/experiment; accepts `params` **and** keyed `paramOverrides` (done) |
 
-`promote` closes the loop using the **existing** versioning machinery.
+The only genuinely new endpoints are for the optimize loop (todo):
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| POST | `/workflows/:name/optimize` | run the experiment workflow across `params.examples`, evolving the target's params; **SSE stream** of generation events |
+| POST | `/workflows/:name/promote` | write the winning candidate into the target's `params` defaults + publish a new version (reuses versioning) |
 
 ---
 
 ## 8. UI surface
 
-- New **Experiments** section in the sidebar (alongside Workflows/Steps).
-- Experiment detail:
+- **Setting up an eval = editing workflow params** (done). The `ParamsFlyout`
+  (topbar **Params** button) edits a workflow's `rubric` / `expected` /
+  `examples`; **Publish** persists them as a new version. No separate
+  Datasets/Rubrics/Experiments UI.
+- **Optimize view** (todo) — for an experiment workflow's optimize run:
   - **score-over-generations** chart,
-  - **candidate diff** viewer (params gen N vs N+1),
+  - **candidate diff** (params gen N vs N+1),
   - **per-example drill** (output vs expected + judge reason/insight),
   - **Promote winner** button.
 - Reuses the existing run flyout/canvas: each target/score/reflect run is a
@@ -326,37 +310,39 @@ Mirrors `/workflows`. All JSON in/out (tool-friendly).
 
 ## 9. Human-first / agent-later layering (D7)
 
-The chat agent already has `run_workflow` with a `params` override
-(`ai/tools.ts`), so it can do crude one-off trials today. The eval
-framework adds the substrate. The **agent layer (v2)** is then just thin
-tools over the §7 endpoints:
+The chat agent already has `create_workflow` and `run_workflow` (with a
+`params` override) in `ai/tools.ts`. Because datasets/rubrics/experiments are
+just workflows + params, the agent mostly **already has what it needs** — it
+authors an experiment workflow and sets its `rubric`/`examples` params via
+`create_workflow`. The **agent layer (v2)** adds only:
 
-- `create_dataset`, `capture_snapshot`
-- `create_rubric`
-- `create_experiment`
-- `run_experiment` (eval / optimize)
-- `get_experiment_run`
-- `promote`
+- `edit_workflow_params` (or reuse `create_workflow`) — set rubric/expected/examples
+- `optimize` + `promote` — drive and land the loop
+- `run_workflow` already accepts `paramOverrides` (done) for candidate trials
 
-plus a system-prompt section. No engine changes — the human flow and the
-agent flow call the same endpoints. A human says "make the concepts
-workflow produce a better top-10 set"; the agent builds the dataset/rubric/
-experiment and runs the optimization.
+plus a system-prompt section. No new resource machinery. A human says "make
+the concepts workflow produce a better top-10 set"; the agent authors the
+experiment workflow (params = examples + rubric) and runs `optimize`.
 
 ---
 
 ## 10. Build order
 
-| Phase | Scope | Notes |
+| Phase | Scope | State |
 | --- | --- | --- |
-| **P0** | Engine: keyed `paramOverrides` (§3) | Small, isolated, unit-testable in vein alone. |
-| **P1** | Dataset/Rubric/Experiment resources + storage + read API + UI lists | No loop yet. Establishes the data model. |
-| **P2** | Snapshot capture + injection seam; namespacing + teardown; paramify bootstrap (§6) | Concepts-specific prerequisite work. |
-| **P3** | `eval/score` + `eval/reflect` workflows + orchestrator + `/eval` + `/optimize` SSE (§5) | The actual loop. Ports the prior GEPA harness. |
-| **P4** | Optimize UI (chart, diff, drill) + `/promote` (§7–8) | Human-driven experience complete. |
-| **P5** | Agent tools (§9) | Agent-driven layer. |
+| **P0** | Engine: keyed `paramOverrides` (§3) | **done** |
+| **P1** | Params **visible + editable + persistable** in the UI (§4, §8) — the "set up an eval" surface (replaces the old Dataset/Rubric/Experiment resources) | **done** |
+| **P1b** | `collect-for-eval` (run output = concept set) + `eval-score` (scorer + rubric param) (§5) | **done**; bootstrap paramified (§6.1) **done** |
+| **P2** | Snapshot capture + injection seam; namespacing + teardown (§6) | todo — reproducible, isolated eval runs |
+| **P3** | An **experiment workflow** (foreach `examples` → target+collect+score) + `eval-reflect` + orchestrator + `/optimize` SSE (§5) | todo — the loop |
+| **P4** | Optimize UI (chart, diff, drill) + `/promote` (§7–8) | todo |
+| **P5** | Agent tools (§9) | todo |
 
-First concrete experiment: **`concepts-prompt-tuning`** on
+Manual eval works **today** (P0–P1b): run `bootstrap-then-process` (optionally
+with `paramOverrides`), copy the `result.markdown`, run `eval-score` with it +
+`expected`. P3 automates that across `params.examples`.
+
+First concrete experiment: **concepts prompt tuning** on
 `process-repo-chronological` (skip bootstrap initially to reduce variables;
 add it as a second tunable scope once the loop is green), `0/0.5/1`
 scoring, 1–2 pinned repos.

--- a/vein/EVAL_SPEC.md
+++ b/vein/EVAL_SPEC.md
@@ -27,9 +27,11 @@ Builds on `SPEC.md` (the engine). The guiding idea:
 | `concepts/collect-for-eval` — run output = scoreable concept set | **done** (final step of `bootstrap-then-process`) |
 | `eval/score` (recall-based) + `eval-score` workflow (§5) | **done** (`mcp/src/lab/eval`) |
 | `eval-concepts` — bootstrap-only eval loop (§6) | **done** (`mcp/src/lab/concepts`) |
-| Eval as a chat-agent capability (§7) | todo — the real "optimizer" |
-| Reproducible/isolated runs: snapshots + namespacing (§8) | todo |
-| Multi-repo dataset (`foreach` over `examples`) + thin param-sweep loop (§7) | todo |
+| First real run (recall 0.8) — surfaced the overfitting/insight problem | **done** |
+| Agent *builds* evals; background job *runs* them (§7) | todo |
+| Background-job model: detached runs + reattach (§8) | **done** (`launchDetached` + `FileRunStore.tailEvents` + `…/runs/:runId/stream`) |
+| Multi-repo dataset + train/val split + optimize loop (§4, §7) | todo |
+| Reproducible/isolated runs: snapshots + namespacing (§9) | todo |
 
 Manual eval works **today**: open `eval-concepts`, set the `expected` gold in
 the Params flyout, Run with a repo, read the score; edit the bootstrap prompt
@@ -149,37 +151,74 @@ expected gold is the `expected` param.
 
 ---
 
-## 7. The optimizer is the chat agent
+## 7. Who runs the loop: the agent *builds*, a background job *runs*
 
-vein already has a `ToolLoopAgent` (`src/ai/`) with `create_step`,
-`edit_step`, `create_workflow`, `run_workflow`. Because targets/scorers/
-datasets are all workflows + params, **the agent already has almost everything
-it needs** to be the optimizer:
+The chat agent should **build** evals, not **be** the loop. Two roles:
 
-- read the goal + expected,
-- author a candidate (edit a prompt param, or author a new step/workflow
-  version — e.g. a `concepts/fetch-pr-titles` step using `ctx.services.octokit`),
-- run `eval-concepts`, read `{ score, missing, insight }`,
-- iterate, keeping the best version.
+- **Agent = builder** (interactive, short-lived). Designs the experiment:
+  authors target-workflow variants, the dataset (`examples` param), the rubric,
+  the reflect prompt + its generalization rules, the train/val split. Uses tools
+  it largely already has (`create_workflow`, `create_step`, `edit_step`,
+  params). It can kick a run off and inspect results, but it is **not** the
+  thing sitting in the hot loop.
+- **Background optimize run = executor** (autonomous, runs for hours). Runs
+  `eval → reflect → select` over many candidates × many repos, persisting each
+  generation, decoupled from any chat session. `reflect` (the LLM proposing the
+  next param edit) runs **inside this job** — and per §4 it must see the
+  **multi-repo aggregate**, not one repo, or it overfits (the wrong-insight
+  problem).
 
-This is why we **don't** build a separate engine "GEPA orchestrator" as the
-primary path: a workflow can't restructure itself, but the agent can — and
-structural evolution (§4.2) is where the real gains are. The thin
-deterministic loop is only worth it as an optional add for **unattended param
-sweeps**, which the agent can even delegate.
+The orchestrator is thin, generic engine code that sequences workflow runs in a
+loop and tracks best-on-val; the *intelligence* lives in the artifacts the agent
+authored (rubric, reflect prompt, dataset). Every piece it runs is a workflow.
 
-What's missing is small (todo):
-- a `run_eval` tool returning the score cleanly (vs parsing run output),
-- a system-prompt section teaching the agent the eval loop,
-- (later) a `promote`/`optimize` convenience for batch sweeps.
+- **Param tuning** → fully autonomous in the background job ("go and go and go").
+- **Structural evolution** (authoring new steps/data sources) → stays
+  agent-interactive for now (a workflow can't write code); later, a headless
+  authoring-agent job.
 
-Target UX: *open the chat, say "here's the repo and the 10 concepts I expect —
-make the workflow find them," and the agent iterates*, getting progressively
-more sophisticated about the workflow it builds.
+Still todo: a `run_eval` tool (clean score for the agent) + a system-prompt
+section; and the background-job model (§8) the executor depends on.
 
 ---
 
-## 8. Reproducibility & isolation (todo)
+## 8. Background jobs: detached runs + reattach (engine prereq) — **done**
+
+A multi-hour optimize loop can't be a request-scoped run. Previously a run was
+launched by `POST /run` and streamed over that one request: it executes
+**server-side** and **persists every event to an append-only JSONL file**
+(durable, queryable after the fact) — but closing the connection, a server
+restart, or proxy timeouts made long runs fragile. The fix is an evolution of
+the existing run model, not a rewrite. **Shipped** as a clean cutover (the old
+streaming `POST /run` is gone):
+
+1. **Launch detached** — `POST /run` starts `runWorkflow` **without awaiting it
+   in the request** (`launchDetached` in `createVein.ts`) and returns
+   `{ runId }` (202) immediately. The run's liveness is decoupled from any
+   connection; there is no `onEvent` on the launch (all viewing is read back
+   from the persisted log).
+2. **Reattach (no client polling)** — `GET /workflows/:name/runs/:runId/stream`
+   (SSE) **tails the events file** via `FileRunStore.tailEvents`: replay offset
+   0 → EOF (history), then follow appends, stop + send final `done` on the
+   terminal event (`run.end`/`run.error`). The web UI's `api.runWorkflow`
+   chains the two (launch → `streamRun`) so callers keep the same interface.
+
+Why file-tail: the append-only log **is** the ordered source of truth, so the
+history→live join is naturally **race-free** (read to EOF, follow from EOF) — no
+sequence numbers, no dedupe. One code path serves completed *and* in-flight runs,
+it survives restarts, and it's process-agnostic. The only "polling" is the
+server noticing appends (`fs.watch` / a tiny interval) — invisible to the client.
+(An in-memory pub/sub is lower-latency but single-process and loses the live tail
+on restart; not worth it for vein's filesystem-first model.)
+
+**Restart-resume:** in-flight *execution* is in-memory, so a crash mid-run loses
+the remaining work; the persisted log up to the crash survives. True resume
+(re-pick an unfinished run) is a later add — for now a crashed optimize job is
+restarted from its last persisted generation.
+
+---
+
+## 9. Reproducibility & isolation (todo)
 
 For tight/automated loops the eval runs must be cheap and non-colliding:
 
@@ -194,7 +233,7 @@ For tight/automated loops the eval runs must be cheap and non-colliding:
 
 ---
 
-## 9. The open thesis
+## 10. The open thesis
 
 The point of all this: **code-only bootstrap probably can't recover a repo's
 ~10 core user-facing capabilities** — that needs historical context (PR
@@ -206,12 +245,15 @@ and then drives building the workflow that fixes it.
 
 ---
 
-## 10. What's next
+## 11. What's next
 
-1. **First real run** of `eval-concepts` on a small repo (needs Neo4j +
-   GitHub token + LLM key) — validate the wiring and see a real score.
-2. **Agent eval capability** (§7): `run_eval` tool + prompt → the chat-driven
-   loop, including structural evolution.
-3. **Reproducibility** (§8): snapshots + namespacing for cheap, parallel runs.
-4. **Multi-repo + sweeps**: `examples` array param + an optional thin loop for
-   unattended param sweeps.
+1. **First real run** of `eval-concepts` on a small repo — **done** (recall 0.8;
+   surfaced the overfitting/insight problem that motivates §4 + §7).
+2. **Multi-repo eval** — `examples` array param + a Level-2 batch eval, with a
+   train/val split (the structural fix for overfitting, §4/§7).
+3. **Background-job model (§8)** — detached launch + file-tail reattach.
+   **done.** The prerequisite for any long optimize run.
+4. **The optimize loop** — thin orchestrator: `eval across train → reflect
+   (generalizing) → keep best on val`, run as a background job; plus a `run_eval`
+   tool so the agent can build/inspect it.
+5. **Reproducibility (§9)** — snapshots + namespacing for cheap, parallel runs.

--- a/vein/EVAL_SPEC.md
+++ b/vein/EVAL_SPEC.md
@@ -25,15 +25,17 @@ Builds on `SPEC.md` (the engine). The guiding idea:
 | Params **visible + editable + persistable** in the UI (§3) | **done** (`ParamsFlyout`; Publish writes params into the new version) |
 | Bootstrap prompt paramified | **done** (`bootstrap-then-process` `params`) |
 | `concepts/collect-for-eval` — run output = scoreable concept set | **done** (final step of `bootstrap-then-process`) |
-| `eval/score` (recall-based) + `eval-score` workflow (§5) | **done** (`mcp/src/lab/eval`) |
-| `eval-concepts` — bootstrap-only eval loop (§6) | **done** (`mcp/src/lab/concepts`) |
+| `eval/score` (generic recall-based step) + `concepts-eval-score` workflow (§5) | **done** (step in `mcp/src/lab/eval`, workflow in `concepts`) |
+| `concepts-eval` — bootstrap-only eval loop (§6) | **done** (`mcp/src/lab/concepts`) |
 | First real run (recall 0.8) — surfaced the overfitting/insight problem | **done** |
-| Agent *builds* evals; background job *runs* them (§7) | todo |
 | Background-job model: detached runs + reattach (§8) | **done** (`launchDetached` + `FileRunStore.tailEvents` + `…/runs/:runId/stream`) |
-| Multi-repo dataset + train/val split + optimize loop (§4, §7) | todo |
+| `eval/reflect` — the "propose" step (param-changer, aggregate-aware) | **done** (`eval/reflect` + `concepts-eval-reflect` workflow) |
+| Optimize loop `eval→keep→reflect` as a detached job (§7, §11.4) | **done, single-repo** (`eval/optimize` + `concepts-optimize`; runs `concepts-eval` per generation via `paramOverrides`) |
+| Agent *builds* evals; background job *runs* them (§7) | partial (loop runs autonomously; agent-side `run_eval` tool + system prompt still todo) |
+| Multi-repo dataset + train/val split (§4, §11.2) — the real overfit fix | todo (reflect already takes a multi-repo `results[]`; needs the `examples[]` dataset + batch eval) |
 | Reproducible/isolated runs: snapshots + namespacing (§9) | todo |
 
-Manual eval works **today**: open `eval-concepts`, set the `expected` gold in
+Manual eval works **today**: open `concepts-eval`, set the `expected` gold in
 the Params flyout, Run with a repo, read the score; edit the bootstrap prompt
 (`bootstrap-then-process` params or a `paramOverrides`), re-run.
 
@@ -53,10 +55,10 @@ the Params flyout, Run with a repo, read the score; edit the bootstrap prompt
 - **Target** — the pipeline being improved (e.g. `bootstrap-then-process`).
 - **Collect** — a final step (`collect-for-eval`) turns graph state into the
   scoreable run output. Without it the run records the wrong thing.
-- **Score** — `eval-score`, an LLM judge that matches produced vs expected.
+- **Score** — `concepts-eval-score`, an LLM judge that matches produced vs expected.
 - **Candidate** — what changes between runs (see §4). Param tweak or a whole
   new workflow version.
-- **Harness** — `eval-concepts` chains the above into one run that returns a
+- **Harness** — `concepts-eval` chains the above into one run that returns a
   number (§6).
 
 Everything above is a workflow or a `param`. No new resource types.
@@ -72,9 +74,23 @@ the next version's YAML (`POST /workflows/:name` already accepts
 `{ steps, params }`). So "setting up an eval in the UI" needs no new storage,
 API, or resource — just the editable Params flyout (done).
 
-- **Rubric** → the `rubric` param of `eval-score`.
+- **Rubric** → the `rubric` param of `concepts-eval-score`.
 - **Expected gold** → an `expected` param (one repo) or an `examples` array
   param (many), authored in the same markdown shape `collect-for-eval` emits.
+
+**Naming convention (generic vs experiment).** The eval *mechanism* is
+domain-agnostic and reusable; the *config* is per-experiment. So:
+
+- **`eval/*` steps** — the generic primitives, no domain baked in:
+  `eval/score` (match produced↔expected by a `rubric`), `eval/reflect`
+  (propose a better prompt from the aggregate), `eval/optimize` (the loop).
+  Seeded once (`mcp/src/lab/eval`), reused by every experiment.
+- **`<experiment>-…` workflows** — wire those steps with the experiment's
+  rubric / task / dataset, and live with the experiment. The concepts
+  experiment ships `concepts-eval` (harness), `concepts-eval-score` (rubric),
+  `concepts-eval-reflect` (task+guidance), `concepts-optimize` (the wired loop)
+  in `mcp/src/lab/concepts/workflows`. A future experiment `foo` adds
+  `foo-eval`, `foo-eval-score`, … reusing the same `eval/*` steps.
 
 ---
 
@@ -91,7 +107,7 @@ on a spectrum:
    `concepts/decide` two levels down). `params` (flat) only hits the entry
    flow; `paramOverrides[workflowName]` hits that flow at any depth.
    ```jsonc
-   POST /workflows/eval-concepts/run
+   POST /workflows/concepts-eval/run
    { "input": { "owner": "x", "repo": "y" },
      "paramOverrides": { "bootstrap-then-process": { "bootstrapPrompt": "…" } } }
    ```
@@ -134,14 +150,14 @@ must learn to recover.
 
 ---
 
-## 6. The harness: `eval-concepts`
+## 6. The harness: `concepts-eval`
 
 One workflow that runs the whole eval as a single scoreable run:
 
 ```
 reset    → clear the repo's concepts (so bootstrap re-runs fresh)
 produce  → bootstrap-then-process, lookbackDays: 0  (BOOTSTRAP ONLY, no PRs)
-score    → eval-score(actual = produce.markdown, expected = params.expected)
+score    → concepts-eval-score(actual = produce.markdown, expected = params.expected)
 ```
 
 `lookbackDays: 0` makes the checkpoint "now" so no PRs/commits are processed —
@@ -228,7 +244,7 @@ For tight/automated loops the eval runs must be cheap and non-colliding:
   checkpoint); a snapshot freezes the upper bound too.
 - **Namespacing + teardown** — concepts are keyed by `owner/repo` in Neo4j, so
   parallel candidates collide. A per-run `namespace` (suffix the repoId) +
-  teardown isolates them. `eval-concepts` uses a coarse `reset` today, which
+  teardown isolates them. `concepts-eval` uses a coarse `reset` today, which
   is enough for sequential single-repo tuning.
 
 ---
@@ -247,13 +263,18 @@ and then drives building the workflow that fixes it.
 
 ## 11. What's next
 
-1. **First real run** of `eval-concepts` on a small repo — **done** (recall 0.8;
+1. **First real run** of `concepts-eval` on a small repo — **done** (recall 0.8;
    surfaced the overfitting/insight problem that motivates §4 + §7).
 2. **Multi-repo eval** — `examples` array param + a Level-2 batch eval, with a
    train/val split (the structural fix for overfitting, §4/§7).
 3. **Background-job model (§8)** — detached launch + file-tail reattach.
    **done.** The prerequisite for any long optimize run.
-4. **The optimize loop** — thin orchestrator: `eval across train → reflect
-   (generalizing) → keep best on val`, run as a background job; plus a `run_eval`
-   tool so the agent can build/inspect it.
+4. **The optimize loop** — `eval → keep best → reflect (generalizing) → repeat`,
+   built as the `eval/optimize` step inside the detached `concepts-optimize`
+   workflow (a background job, §8). **done for a single repo**; `eval/reflect`
+   already takes a multi-repo `results[]`, so generalizing across a train set
+   is unlocked once the dataset (item 2) lands. Still todo: best-on-**val** (vs
+   train), auto-**promote** the winner (write the param default + publish a new
+   version), and a `run_eval` tool + system-prompt section so the agent can
+   build/inspect it.
 5. **Reproducibility (§9)** — snapshots + namespacing for cheap, parallel runs.

--- a/vein/EVAL_SPEC.md
+++ b/vein/EVAL_SPEC.md
@@ -1,0 +1,375 @@
+# Evals & Self-Improving Experiments — Spec
+
+A design spec for turning vein into a platform for **evals** and
+**self-improving loops**: pin a goal, run a workflow against pinned
+examples, score the output against an expected gold standard, and let an
+optimizer evolve the workflow's tunable knobs (`params`) until the output
+is good.
+
+This builds on `SPEC.md` (the engine) and reuses its existing primitives
+wherever possible. It is **not** a CLI — every operation is a first-class
+API endpoint, visible in the UI, and (later) drivable by the AI agent.
+
+> GOAL: AS SIMPLE AS POSSIBLE. Reuse runs, `params`, and versioning. Add
+> the smallest set of new concepts: **Dataset, Rubric, Experiment**.
+
+---
+
+## 1. Motivation
+
+Two pipelines we want to make "perfect" by iterating on prompts, not code:
+
+1. **Concepts** (`mcp/src/lab/concepts`) — walk a repo's history and build
+   a knowledge graph of ~10 user-facing "Concepts". The goal is a good
+   **top-N concept set** per repo. Tunable surfaces: the bootstrap
+   exploration prompt and the per-change `decide` prompt.
+2. **Services agent** (`mcp/src/gitsee/agent`, services mode) — explore a
+   repo and emit a working `pm2.config.js` + `docker-compose.yml`. (A full
+   GEPA-style harness for this already existed at
+   `mcp/src/gitsee/agent/eval/` — this spec generalizes that pattern into
+   the platform. Not the v1 target, but the design must cover it.)
+
+Both reduce to the same shape:
+
+| Piece | Concepts | Services agent |
+| --- | --- | --- |
+| **Candidate** (what evolves) | bootstrap + decide prompts (`params`) | explorer + final_answer prompts |
+| **Dataset** | repos pinned at a rev + gold concept list | repos + gold pm2/compose files |
+| **Run** | run the target workflow with candidate params | run the agent with candidate prompts |
+| **Score** | judge: semantic recall/precision vs gold | judge: would the config work? |
+| **Reflect** | LLM proposes better params | LLM proposes better prompts |
+
+The framework is **target-agnostic**: it does not care how many prompts a
+target has or where they live, as long as they are exposed as `params`.
+
+---
+
+## 2. Design decisions (settled)
+
+| # | Decision | Rationale |
+| --- | --- | --- |
+| D1 | **Thin orchestrator + everything-is-a-workflow.** `score`/`reflect` are vein workflows; the GEPA loop is thin engine code streamed via SSE. | Ports the proven harness; every sub-step is an inspectable run; no fragile new looping primitives. |
+| D2 | **Resources live in the vein workspace**, versioned like workflows. | Consistent with how workflows/steps already work; one persistence model. |
+| D3 | **Candidate scope = `params` only** (prompts/thresholds/selectors), as a **multi-scope union** across `{workflow, key}`. | Matches the existing "experiment surface"; smallest search space; covers multi-prompt targets. |
+| D4 | **Nested/scoped param override** is added to the engine (keyed by workflow name). | The tunable prompts live in subflows; per-run `params` don't propagate today. General; opt-in; back-compat. |
+| D5 | **Pin-by-snapshot** datasets. | Deterministic, offline, fast, cheap evals — no GitHub during optimization. |
+| D6 | **Holistic reflection** for credit assignment (start). | Simplest; reflector sees all prompts + insights and may change any. Component sub-rubrics / staged optimization can come later. |
+| D7 | **Human-driven first, agent-driven later.** | The agent layer is thin tool wrappers over the same endpoints; build them tool-friendly from day one. |
+
+---
+
+## 3. New engine primitive: keyed param overrides
+
+Today (`runner.ts`): `executeFlow` seeds `params = { ...workflow.params,
+...paramsOverride }`, and the subflow call **does not** pass overrides
+down — subflows reset to their own `params`. This is deliberate isolation,
+but it means a candidate cannot reach a prompt that lives in a subflow
+(e.g. `concepts/decide` inside `process-change`, two levels below the
+entry workflow).
+
+**Add an opt-in, name-addressed override that travels the whole tree:**
+
+```ts
+runWorkflow(flow, input, registry, {
+  params,                                  // entry-flow only (unchanged)
+  paramOverrides: {                        // NEW — keyed by workflow name
+    "bootstrap-then-process": { bootstrapSystem, sizing },
+    "process-change":         { systemPrompt, guidelines },
+  },
+})
+```
+
+- In `executeFlow`, the scope becomes:
+  `{ ...workflow.params, ...(paramOverrides[workflow.name] ?? {}), ...(isEntry ? params : {}) }`
+- The subflow execution (`runner.ts` ~673) threads `paramOverrides`
+  recursively so it reaches every nested level.
+- **Back-compat:** flat `params` keeps meaning "entry flow"; `paramOverrides`
+  is additive and opt-in. Precedence: step `.default()` < flow `params`
+  default < `paramOverrides[name]` < entry `params`.
+
+This single primitive is also what makes **multi-scope candidates** free:
+a candidate is just a `paramOverrides` map spanning several workflows.
+
+---
+
+## 4. Resources
+
+Stored in the workspace next to `workflows/` and `steps/`. JSON shapes are
+intentionally simple (tool-friendly for the future agent layer).
+
+```
+workspace/
+  workflows/   steps/                                   (exist)
+  datasets/<name>/
+     dataset.json                                       # metadata + example index
+     examples/<exampleId>/
+        input.json        # EXACTLY the target workflow's input
+        expected.json     # the gold label
+        snapshot.json     # captured change-set / fixtures (pin-by-snapshot)
+        notes.txt         # optional
+  rubrics/<name>.json                                   # judge prompt + scale
+  experiments/<name>.json                               # the binding + budget
+  experiments/<name>/runs/<ts>/
+     gen-<N>/{ candidate.json, results.json, aggregate } 
+     summary.json
+```
+
+### 4.1 Dataset
+
+A reusable, re-labeled-rarely collection of **pinned examples**. Each
+example's `input` is exactly what the target workflow takes; `expected` is
+the human-authored gold; `snapshot` makes the run deterministic.
+
+```jsonc
+// datasets/concepts-goldset/dataset.json
+{
+  "name": "concepts-goldset",
+  "kind": "concepts",              // informal tag: compatible targets/rubrics
+  "examples": ["hive@a1b2c3"]
+}
+```
+```jsonc
+// datasets/concepts-goldset/examples/hive@a1b2c3/input.json
+{ "owner": "stakwork", "repo": "hive",
+  "rev": "a1b2c3d4",                       // pins the clone (working tree)
+  "until": "2025-09-01T00:00:00Z" }        // upper bound on the change-set
+```
+```jsonc
+// expected.json
+{ "concepts": [
+    { "name": "Real-time Chat",  "description": "Users can…" },
+    { "name": "Task Management", "description": "…" }
+    /* ~10 */ ] }
+```
+```jsonc
+// snapshot.json — captured once at label time; bypasses GitHub at eval time
+{ "changes": [ { "type": "pr", "id": "42", "data": { … }, "markdown": "…" }, … ] }
+```
+
+**Pin-by-snapshot (D5).** `fetch-changes` / `fetch-content` gain a seam:
+when `input.snapshot` is present, return it instead of calling GitHub. A
+**capture** workflow produces the snapshot from `{owner, repo, until}`.
+Note: today `fetch-changes` only has a *lower* bound (the checkpoint); the
+capture path introduces the upper bound (`until`) and freezes the result.
+
+### 4.2 Rubric
+
+The **fixed measuring stick** — how to turn `(output, expected)` into a
+score. It is a prompt (editable in the UI) but the optimizer **never
+mutates it**. Reusable across every experiment of the same `output_kind`.
+
+```jsonc
+// rubrics/concept-quality.json
+{
+  "name": "concept-quality",
+  "output_kind": "concepts",
+  "scale": [0, 0.5, 1],
+  "judgePrompt": "Score produced Concepts vs the expected gold set. Match \
+semantically, not by string. Weigh: RECALL (expected capabilities present), \
+PRECISION (penalize junk / over-granular / implementation-named concepts), \
+NAMING (capability-focused: 'Real-time Chat' good, 'Pusher WebSockets' bad), \
+DESCRIPTION accuracy. Output SCORE / REASON / INSIGHT.",
+  "aggregation": "mean"
+}
+```
+
+Score format (ported from the prior harness): `SCORE` (0 / 0.5 / 1) +
+`REASON` (what's right/wrong) + `INSIGHT` (one prompt-level suggestion).
+The `INSIGHT` is what feeds reflection.
+
+### 4.3 Experiment
+
+Binds a **target** workflow + **dataset** + **rubric** + the **candidate
+surface** + an **output extractor** + **isolation** + **budget**. This is
+the entity you press "Optimize" on.
+
+```jsonc
+// experiments/concepts-prompt-tuning.json
+{
+  "name": "concepts-prompt-tuning",
+  "target": "process-repo-chronological",     // workflow being optimized
+  "dataset": "concepts-goldset",
+  "rubric": "concept-quality",
+
+  "candidate": {                              // multi-scope param union (D3)
+    "tunable": [
+      { "scope": "bootstrap-then-process", "keys": ["bootstrapSystem","sizing"] },
+      { "scope": "process-change",         "keys": ["systemPrompt","guidelines"] }
+    ],
+    "seed": "from-workflow-defaults"
+  },
+
+  "output":    { "extractor": "concepts/collect-for-eval" }, // → { concepts }
+  "isolation": { "namespace": "per-run", "teardown": true },
+  "budget":    { "maxGenerations": 8, "perfectScore": 0.9 }
+}
+```
+
+### 4.4 ExperimentRun (generations)
+
+One `optimize` invocation produces a sequence of generations. This is
+exactly the `runs/gen-N/` artifact layout the prior harness wrote.
+
+```jsonc
+// experiments/<name>/runs/<ts>/gen-3/results.json
+[{ "exampleId": "hive@a1b2c3",
+   "output": { "concepts": [ … ] },
+   "score": 0.5, "reason": "…", "insight": "…" }]
+// .../gen-3/candidate.json     → the params tried this generation
+// .../summary.json             → { best_score, best_gen, history:[…] }
+```
+
+---
+
+## 5. The optimize loop
+
+### 5.1 Two built-in workflows (everything-is-a-workflow, D1)
+
+- **`eval/score`** — input `{ output, expected, rubric }`; one `llm` step
+  using `rubric.judgePrompt`; output `{ score, reason, insight }`.
+- **`eval/reflect`** — input `{ candidate, results, history }`; one `llm`
+  step; output a new candidate (`paramOverrides`-shaped JSON over the
+  tunable keys). The reflection prompt is this workflow's own `params`, so
+  it is itself editable. Holistic (D6): it sees **all** prompts + insights
+  and may change any of them; given prior attempts so it doesn't repeat.
+
+### 5.2 The orchestrator (thin engine code, SSE-streamed)
+
+```
+optimize(experiment):
+  candidate = seed (from target's param defaults across all tunable scopes)
+  best = candidate; bestScore = -1; history = []
+  for gen in 0 .. budget.maxGenerations:
+    results = []
+    for example in dataset.examples:
+      ns = repoId + "#" + <expRun>/<gen>/<exampleId>          # isolation (§6)
+      run TARGET( { ...example.input, snapshot: example.snapshot, namespace: ns },
+                  paramOverrides = candidateToOverrides(candidate) )   # a real run
+      output = run experiment.output.extractor(ns)            # a real run
+      teardown(ns)                                            # delete graph nodes
+      s = run eval/score({ output, expected: example.expected, rubric })   # a real run
+      results.push({ exampleId, output, score: s })
+    aggregate = mean(results.score)
+    persist gen-N; emit SSE generation event; track best
+    if aggregate >= budget.perfectScore: break
+    candidate = run eval/reflect({ candidate, results, history })  # a real run
+    history.push(...)
+  persist summary
+```
+
+Every `run …` is a normal `runWorkflow` call → persisted, inspectable in
+the existing run flyout/canvas. Only the outer loop (budget, best-tracking,
+reflection memory, early-stop) is engine code.
+
+---
+
+## 6. Stateful-target concerns (Concepts)
+
+The Concepts target writes to Neo4j keyed by `repoId = owner/repo` rather
+than returning a value. Three mechanical requirements:
+
+- **Output extraction (W4).** An `outputExtractor` step
+  (`concepts/collect-for-eval`) reads `getAllConcepts(namespacedRepoId)`
+  and returns `{ concepts }`, so the scorer always sees a uniform
+  `{ output, expected }`.
+- **Isolation (W3).** Add an optional `namespace` to the concepts workflow
+  input; steps compute
+  `repoId = namespace ? \`${owner}/${repo}#${namespace}\` : \`${owner}/${repo}\``.
+  Each candidate/generation/example run uses a distinct namespace so runs
+  never collide; **teardown** deletes nodes for that namespaced repoId
+  after scoring. Feasible: every storage method already takes a `repo` arg.
+- **Snapshot injection (D5).** `fetch-changes`/`fetch-content` read
+  `input.snapshot` when present (no GitHub).
+
+### 6.1 Prerequisite paramification
+
+To make the bootstrap prompt tunable (it is currently hardcoded in
+`bootstrap.ts`: `buildBootstrapPrompt`, the `systemOverride`, sizing
+thresholds), lift those into `concepts/bootstrap-explore` config sourced
+from the workflow's `params`. `concepts/decide` is already paramified.
+After this, the candidate surface is a clean union of `params` across the
+two workflows.
+
+---
+
+## 7. API surface
+
+Mirrors `/workflows`. All JSON in/out (tool-friendly).
+
+| Method | Path | Purpose |
+| --- | --- | --- |
+| GET/POST | `/datasets`, `/datasets/:name` | list / read / create datasets |
+| POST | `/datasets/:name/capture` | run the capture flow → write a snapshot example |
+| GET/POST | `/rubrics`, `/rubrics/:name` | list / read / create rubrics |
+| GET/POST | `/experiments`, `/experiments/:name` | list / read / create experiments |
+| POST | `/experiments/:name/eval` | score current params once (no evolution) |
+| POST | `/experiments/:name/optimize` | **SSE stream** of generation events |
+| GET | `/experiments/:name/runs[/:ts]` | generation history |
+| POST | `/experiments/:name/promote` | write winning candidate into target `params` defaults + publish a new workflow version |
+
+`promote` closes the loop using the **existing** versioning machinery.
+
+---
+
+## 8. UI surface
+
+- New **Experiments** section in the sidebar (alongside Workflows/Steps).
+- Experiment detail:
+  - **score-over-generations** chart,
+  - **candidate diff** viewer (params gen N vs N+1),
+  - **per-example drill** (output vs expected + judge reason/insight),
+  - **Promote winner** button.
+- Reuses the existing run flyout/canvas: each target/score/reflect run is a
+  normal run, openable from a generation.
+
+---
+
+## 9. Human-first / agent-later layering (D7)
+
+The chat agent already has `run_workflow` with a `params` override
+(`ai/tools.ts`), so it can do crude one-off trials today. The eval
+framework adds the substrate. The **agent layer (v2)** is then just thin
+tools over the §7 endpoints:
+
+- `create_dataset`, `capture_snapshot`
+- `create_rubric`
+- `create_experiment`
+- `run_experiment` (eval / optimize)
+- `get_experiment_run`
+- `promote`
+
+plus a system-prompt section. No engine changes — the human flow and the
+agent flow call the same endpoints. A human says "make the concepts
+workflow produce a better top-10 set"; the agent builds the dataset/rubric/
+experiment and runs the optimization.
+
+---
+
+## 10. Build order
+
+| Phase | Scope | Notes |
+| --- | --- | --- |
+| **P0** | Engine: keyed `paramOverrides` (§3) | Small, isolated, unit-testable in vein alone. |
+| **P1** | Dataset/Rubric/Experiment resources + storage + read API + UI lists | No loop yet. Establishes the data model. |
+| **P2** | Snapshot capture + injection seam; namespacing + teardown; paramify bootstrap (§6) | Concepts-specific prerequisite work. |
+| **P3** | `eval/score` + `eval/reflect` workflows + orchestrator + `/eval` + `/optimize` SSE (§5) | The actual loop. Ports the prior GEPA harness. |
+| **P4** | Optimize UI (chart, diff, drill) + `/promote` (§7–8) | Human-driven experience complete. |
+| **P5** | Agent tools (§9) | Agent-driven layer. |
+
+First concrete experiment: **`concepts-prompt-tuning`** on
+`process-repo-chronological` (skip bootstrap initially to reduce variables;
+add it as a second tunable scope once the loop is green), `0/0.5/1`
+scoring, 1–2 pinned repos.
+
+---
+
+## 11. Open items (decide before/at build time)
+
+- **Score granularity:** keep `0/0.5/1` to start; revisit continuous `0..1`
+  if the gradient is too coarse for reflection.
+- **Credit assignment:** holistic (D6) first; component sub-rubrics or
+  staged optimization later if multi-surface reflection plateaus.
+- **First target:** `process-repo-chronological` vs full
+  `bootstrap-then-process` (clone/ingest dependency). Start chronological.
+- **Concurrency:** examples run sequentially in v1 (cost + Neo4j
+  isolation simplicity); parallelize later via distinct namespaces.

--- a/vein/src/createVein.test.ts
+++ b/vein/src/createVein.test.ts
@@ -10,7 +10,7 @@ import { createVein } from "./createVein.js";
 import { createRegistry } from "./steps/registry.js";
 import { defineStep, flow, step } from "./core.js";
 import { WorkspaceManager } from "./workspace.js";
-import { MemoryRunStore } from "./store.js";
+import { MemoryRunStore, FileRunStore } from "./store.js";
 
 // ── createRegistry ─────────────────────────────────────────────────────────
 
@@ -328,14 +328,14 @@ describe("createVein", () => {
     assert.equal(ver2.active, v1);
   });
 
-  it("runs a registered workflow over HTTP via SSE", async () => {
+  it("launches a run detached over HTTP, returning a runId immediately", async () => {
     const ws = new WorkspaceManager(tempDir);
     await ws.publishWorkflow("echo-flow", "v1", {
       steps: [{ id: "g", type: "log", config: { message: "hi" } }],
     });
     const vein = await createVein({
       workspace: ws,
-      store: new MemoryRunStore(),
+      store: new FileRunStore(tempDir),
       serveUi: false,
       enableChat: false,
     });
@@ -344,11 +344,77 @@ describe("createVein", () => {
       headers: { "content-type": "application/json" },
       body: JSON.stringify({ input: {} }),
     });
+    // Detached: 202 + { runId }, no streamed body.
+    assert.equal(res.status, 202);
+    const { runId } = (await res.json()) as { runId: string };
+    assert.ok(runId, "should return a runId");
+    // Drain to completion so the background writes settle before teardown.
+    const drain = await vein.app.request(`/workflows/echo-flow/runs/${runId}/stream`);
+    await drain.text();
+  });
+
+  it("reattaches to a run via SSE tail (history + final done)", async () => {
+    const ws = new WorkspaceManager(tempDir);
+    await ws.publishWorkflow("echo-flow", "v1", {
+      steps: [{ id: "g", type: "log", config: { message: "hi" } }],
+    });
+    const vein = await createVein({
+      workspace: ws,
+      store: new FileRunStore(tempDir),
+      serveUi: false,
+      enableChat: false,
+    });
+
+    // Launch detached, then tail its log to completion.
+    const launch = await vein.app.request("/workflows/echo-flow/run", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ input: {} }),
+    });
+    const { runId } = (await launch.json()) as { runId: string };
+
+    const res = await vein.app.request(`/workflows/echo-flow/runs/${runId}/stream`);
     assert.equal(res.status, 200);
     const text = await res.text();
-    // SSE stream contains at least one event and a final done event.
+    assert.ok(text.includes("run.start"), "replays history");
+    assert.ok(text.includes("run.end"), "follows to the terminal event");
+    assert.ok(text.includes("event: done"), "sends a final done with the result");
+  });
+
+  it("streams a run reattached after it already finished", async () => {
+    const ws = new WorkspaceManager(tempDir);
+    await ws.publishWorkflow("echo-flow", "v1", {
+      steps: [{ id: "g", type: "log", config: { message: "hi" } }],
+    });
+    const vein = await createVein({
+      workspace: ws,
+      store: new FileRunStore(tempDir),
+      serveUi: false,
+      enableChat: false,
+    });
+
+    // Run to completion *first* (so the log is fully written), then attach.
+    const result = await vein.run("echo-flow", {});
+    assert.equal(result.status, "success");
+
+    const res = await vein.app.request(
+      `/workflows/echo-flow/runs/${result.runId}/stream`,
+    );
+    assert.equal(res.status, 200);
+    const text = await res.text();
     assert.ok(text.includes("run.start"));
     assert.ok(text.includes("event: done"));
+  });
+
+  it("refuses run streaming when the store is not a FileRunStore", async () => {
+    const vein = await createVein({
+      workspace: new WorkspaceManager(tempDir),
+      store: new MemoryRunStore(),
+      serveUi: false,
+      enableChat: false,
+    });
+    const res = await vein.app.request("/workflows/x/runs/123/stream");
+    assert.equal(res.status, 501);
   });
 
   it("rebuildRegistry is a no-op when the registry was injected", async () => {

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -110,6 +110,9 @@ export interface VeinRunOptions<TServices = unknown> {
   /** Per-run overrides for the workflow's `params` knobs (shallow-merged
    *  over the flow's `params` defaults). */
   params?: Record<string, unknown>;
+  /** Per-run overrides keyed by workflow name, applied at every level of the
+   *  execution tree (entry + nested subflows). See `RunOptions.paramOverrides`. */
+  paramOverrides?: Record<string, Record<string, unknown>>;
 }
 
 // ── Zod → field descriptors (UI helper, used by /steps/:type/schema) ──────
@@ -526,6 +529,7 @@ export async function createVein<TServices = unknown>(
     const body = await c.req.json<{
       input?: unknown;
       params?: Record<string, unknown>;
+      paramOverrides?: Record<string, Record<string, unknown>>;
       runId?: string;
     }>();
     let flow;
@@ -541,6 +545,7 @@ export async function createVein<TServices = unknown>(
         workspace,
         services,
         params: body.params,
+        paramOverrides: body.paramOverrides,
         onEvent: async (event) => {
           await stream.writeSSE({ data: JSON.stringify(event) });
         },
@@ -554,6 +559,7 @@ export async function createVein<TServices = unknown>(
     const body = await c.req.json<{
       input?: unknown;
       params?: Record<string, unknown>;
+      paramOverrides?: Record<string, Record<string, unknown>>;
       runId?: string;
     }>();
     let flow;
@@ -569,6 +575,7 @@ export async function createVein<TServices = unknown>(
         workspace,
         services,
         params: body.params,
+        paramOverrides: body.paramOverrides,
         onEvent: async (event) => {
           await stream.writeSSE({ data: JSON.stringify(event) });
         },
@@ -689,6 +696,7 @@ export async function createVein<TServices = unknown>(
       workspace,
       services: runOpts?.services ?? services,
       params: runOpts?.params,
+      paramOverrides: runOpts?.paramOverrides,
       onEvent: runOpts?.onEvent,
     });
   }

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 
 import type { Flow, StepRegistry, RunEvent, RunResult } from "./core.js";
 import type { RunStore } from "./store.js";
-import { FileRunStore } from "./store.js";
+import { FileRunStore, generateRunId } from "./store.js";
 import { WorkspaceManager } from "./workspace.js";
 import { buildRegistry, readStepSourceFromDisk } from "./steps/registry.js";
 import type { StepSources } from "./steps/registry.js";
@@ -326,6 +326,30 @@ export async function createVein<TServices = unknown>(
     return c.json(events);
   });
 
+  // Reattach to a run (live or completed) — SSE tail of its event log.
+  // Replays history from the start of the file, then follows appends until
+  // the terminal event, then sends a final `done` carrying the RunResult.
+  // One path serves in-flight and finished runs (see `FileRunStore.tailEvents`).
+  app.get("/workflows/:name/runs/:runId/stream", async (c) => {
+    const { name, runId } = c.req.param();
+    if (!(store instanceof FileRunStore)) {
+      return c.json({ error: "Run streaming requires a FileRunStore" }, 501);
+    }
+    return streamSSE(c, async (stream) => {
+      const ac = new AbortController();
+      stream.onAbort(() => ac.abort());
+      for await (const event of store.tailEvents(name, runId, { signal: ac.signal })) {
+        await stream.writeSSE({ data: JSON.stringify(event) });
+      }
+      if (ac.signal.aborted) return;
+      const summary = await store.getRunSummary(name, runId);
+      const result = summary
+        ? { runId, status: summary.status, output: summary.output, error: summary.error }
+        : { runId, status: "running" };
+      await stream.writeSSE({ event: "done", data: JSON.stringify(result) });
+    });
+  });
+
   app.get("/workflows/:name/flow", async (c) => {
     const name = c.req.param("name");
     try {
@@ -524,64 +548,62 @@ export async function createVein<TServices = unknown>(
 
   // ── Run workflows ────────────────────────────────────────────────────────
 
+  interface RunBody {
+    input?: unknown;
+    params?: Record<string, unknown>;
+    paramOverrides?: Record<string, Record<string, unknown>>;
+    runId?: string;
+  }
+
+  /**
+   * Launch a run **detached** (§8): kick off `runWorkflow` without awaiting it
+   * in the request and return the `runId` immediately. The run's liveness is
+   * decoupled from the connection — it executes server-side and persists every
+   * event to the store's append-only log, which `GET …/runs/:runId/stream`
+   * tails for live or after-the-fact viewing. `runWorkflow` finalizes its own
+   * errors into the log; the `.catch` is only a safety net for unexpected
+   * throws (e.g. a store write failure) so they don't become unhandled
+   * rejections.
+   */
+  function launchDetached(flow: Flow, body: RunBody): string {
+    const runId = body.runId ?? generateRunId();
+    void runWorkflow(flow, body.input ?? {}, registry, {
+      runId,
+      store,
+      workspace,
+      services,
+      params: body.params,
+      paramOverrides: body.paramOverrides,
+    }).catch((err) => {
+      console.error(`[run ${runId}] launch failed:`, err);
+    });
+    return runId;
+  }
+
   app.post("/workflows/:name/run", async (c) => {
     const name = c.req.param("name");
-    const body = await c.req.json<{
-      input?: unknown;
-      params?: Record<string, unknown>;
-      paramOverrides?: Record<string, Record<string, unknown>>;
-      runId?: string;
-    }>();
+    const body = await c.req.json<RunBody>();
     let flow;
     try {
       flow = await workspace.getWorkflow(name);
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 404);
     }
-    return streamSSE(c, async (stream) => {
-      const result = await runWorkflow(flow, body.input ?? {}, registry, {
-        runId: body.runId,
-        store,
-        workspace,
-        services,
-        params: body.params,
-        paramOverrides: body.paramOverrides,
-        onEvent: async (event) => {
-          await stream.writeSSE({ data: JSON.stringify(event) });
-        },
-      });
-      await stream.writeSSE({ event: "done", data: JSON.stringify(result) });
-    });
+    const runId = launchDetached(flow, body);
+    return c.json({ runId }, 202);
   });
 
   app.post("/workflows/:name/:version/run", async (c) => {
     const { name, version } = c.req.param();
-    const body = await c.req.json<{
-      input?: unknown;
-      params?: Record<string, unknown>;
-      paramOverrides?: Record<string, Record<string, unknown>>;
-      runId?: string;
-    }>();
+    const body = await c.req.json<RunBody>();
     let flow;
     try {
       flow = await workspace.getWorkflowVersion(name, version);
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 404);
     }
-    return streamSSE(c, async (stream) => {
-      const result = await runWorkflow(flow, body.input ?? {}, registry, {
-        runId: body.runId,
-        store,
-        workspace,
-        services,
-        params: body.params,
-        paramOverrides: body.paramOverrides,
-        onEvent: async (event) => {
-          await stream.writeSSE({ data: JSON.stringify(event) });
-        },
-      });
-      await stream.writeSSE({ event: "done", data: JSON.stringify(result) });
-    });
+    const runId = launchDetached(flow, body);
+    return c.json({ runId }, 202);
   });
 
   // ── Chat (AI workflow builder) ───────────────────────────────────────────

--- a/vein/src/integration.test.ts
+++ b/vein/src/integration.test.ts
@@ -280,6 +280,63 @@ describe("integration: complete workflow patterns", () => {
       doubled: 40,
     });
   });
+
+  it("keyed paramOverrides reach a nested subflow (flat params do not)", async () => {
+    // Child workflow with its own `params` default consumed via {{ params.* }}.
+    const child = flow("child-prompt", {
+      input: z.object({}),
+      params: { prompt: "CHILD_DEFAULT" },
+      steps: [step("emit", "echo", { used: "{{ params.prompt }}" })],
+    });
+
+    // Parent: call the child, then combine the child's resolved value with the
+    // parent's own param so the workflow output exposes BOTH.
+    const parent = flow("parent", {
+      input: z.object({}),
+      params: { prompt: "PARENT_DEFAULT" },
+      steps: [
+        step("call", "subflow", { workflow: "child-prompt", input: {} }),
+        step("combine", "echo", {
+          child: "{{ call.used }}",
+          entry: "{{ params.prompt }}",
+        }),
+      ],
+    });
+
+    const opts = { workspace: makeResolver({ "child-prompt": child }) };
+
+    // 1. Flat `params` only reaches the entry flow — the subflow keeps its default.
+    const flat = await runWorkflow(parent, {}, makeRegistry(), {
+      ...opts,
+      params: { prompt: "FLAT" },
+    });
+    assert.equal(flat.status, "success");
+    assert.equal((flat.output as any).entry, "FLAT"); // entry sees flat override
+    assert.equal((flat.output as any).child, "CHILD_DEFAULT"); // child unaffected
+
+    // 2. Keyed `paramOverrides` reach the named subflow at any depth.
+    const keyed = await runWorkflow(parent, {}, makeRegistry(), {
+      ...opts,
+      paramOverrides: { "child-prompt": { prompt: "KEYED" } },
+    });
+    assert.equal(keyed.status, "success");
+    assert.equal((keyed.output as any).child, "KEYED");
+    assert.equal((keyed.output as any).entry, "PARENT_DEFAULT"); // entry untouched
+
+    // 3. Both at once: keyed reaches child; for the entry flow, flat `params`
+    //    wins over a keyed override of the entry's own name.
+    const both = await runWorkflow(parent, {}, makeRegistry(), {
+      ...opts,
+      params: { prompt: "FLAT_ENTRY" },
+      paramOverrides: {
+        parent: { prompt: "KEYED_ENTRY" },
+        "child-prompt": { prompt: "KEYED_CHILD" },
+      },
+    });
+    assert.equal(both.status, "success");
+    assert.equal((both.output as any).child, "KEYED_CHILD");
+    assert.equal((both.output as any).entry, "FLAT_ENTRY");
+  });
 });
 
 // ── Integration: FileRunStore with runner ──────────────────────────────────

--- a/vein/src/runner.ts
+++ b/vein/src/runner.ts
@@ -39,6 +39,14 @@ export interface RunOptions<TServices = unknown> {
    *  subflows use their own `params` defaults. Exposed to step configs via
    *  `{{ params.* }}`. */
   params?: Record<string, unknown>;
+  /** Per-run overrides keyed by workflow name, applied at EVERY level of the
+   *  execution tree (entry flow + nested subflows), unlike `params` which only
+   *  reaches the entry flow. Use this to tune a knob that lives in a subflow
+   *  (e.g. a prompt in `process-change` invoked two levels down). For each
+   *  flow, `paramOverrides[flow.name]` is shallow-merged over that flow's
+   *  `params` defaults. Precedence: step `.default()` < flow `params` default
+   *  < `paramOverrides[name]` < (entry only) `params`. */
+  paramOverrides?: Record<string, Record<string, unknown>>;
 }
 
 /** Sentinel returned by steps that were skipped because their `when` didn't match. */
@@ -110,6 +118,7 @@ export async function runWorkflow<TServices = unknown>(
       opts?.workspace,
       services,
       opts?.params,
+      opts?.paramOverrides,
     );
 
     const finishedAt = new Date().toISOString();
@@ -174,10 +183,18 @@ async function executeFlow(
   workspace: SubflowResolver | undefined,
   services: unknown,
   paramsOverride?: Record<string, unknown>,
+  paramOverrides?: Record<string, Record<string, unknown>>,
 ): Promise<unknown> {
   // `params` = workflow defaults, shallow-merged with per-run overrides.
   // Exposed to step configs via `{{ params.* }}`. Distinct from `input`.
-  const params = { ...(workflow.params ?? {}), ...(paramsOverride ?? {}) };
+  //   - `paramOverrides[workflow.name]` applies at every level (entry + nested).
+  //   - `paramsOverride` (flat) is only passed for the entry flow.
+  // Precedence: flow defaults < keyed override < entry flat override.
+  const params = {
+    ...(workflow.params ?? {}),
+    ...(paramOverrides?.[workflow.name] ?? {}),
+    ...(paramsOverride ?? {}),
+  };
   const scope: Record<string, unknown> = { input, params };
   const steps = workflow.steps;
 
@@ -264,7 +281,7 @@ async function executeFlow(
     }
 
     const stepPath = `${basePath}/${s.id}`;
-    const output = await executeStep(s, scope, registry, runId, stepPath, emit, workspace, services);
+    const output = await executeStep(s, scope, registry, runId, stepPath, emit, workspace, services, paramOverrides);
     scope[s.id] = output;
     completed.add(s.id);
     pending.get(s.id)!.resolve(output);
@@ -292,6 +309,7 @@ async function executeStep(
   emit: EmitFn,
   workspace: SubflowResolver | undefined,
   services: unknown,
+  paramOverrides?: Record<string, Record<string, unknown>>,
 ): Promise<unknown> {
   const maxRetries = step.options?.retry?.max ?? 0;
   const retryDelay = step.options?.retry?.delayMs ?? 0;
@@ -350,6 +368,7 @@ async function executeStep(
         emit,
         workspace,
         services,
+        paramOverrides,
       );
 
       const durationMs = Date.now() - startTime;
@@ -384,6 +403,7 @@ async function executeStep(
               emit,
               workspace,
               services,
+              paramOverrides,
             );
             return fallbackOutput;
           } catch (fallbackErr) {
@@ -431,17 +451,18 @@ async function dispatchStep(
   emit: EmitFn,
   workspace: SubflowResolver | undefined,
   services: unknown,
+  paramOverrides?: Record<string, Record<string, unknown>>,
 ): Promise<unknown> {
   // Handle core control flow steps specially
   switch (step.type) {
     case "loop":
-      return executeLoop(step, resolvedConfig, scope, registry, runId, path, emit, workspace, services);
+      return executeLoop(step, resolvedConfig, scope, registry, runId, path, emit, workspace, services, paramOverrides);
 
     case "foreach":
-      return executeForeach(step, scope, registry, runId, path, emit, workspace, services);
+      return executeForeach(step, scope, registry, runId, path, emit, workspace, services, paramOverrides);
 
     case "subflow":
-      return executeSubflow(step, scope, registry, runId, path, emit, workspace, services);
+      return executeSubflow(step, scope, registry, runId, path, emit, workspace, services, paramOverrides);
 
     default: {
       // Look up in registry
@@ -480,6 +501,7 @@ async function executeLoop(
   emit: EmitFn,
   workspace: SubflowResolver | undefined,
   services: unknown,
+  paramOverrides?: Record<string, Record<string, unknown>>,
 ): Promise<unknown> {
   // Resolve scalar config values (but not `until` or `body` which need per-iteration resolution)
   const maxIterations = resolveConfig(step.config["maxIterations"], scope) as number;
@@ -516,6 +538,7 @@ async function executeLoop(
       emit,
       workspace,
       services,
+      paramOverrides,
     );
 
     await emit({
@@ -562,6 +585,7 @@ async function executeForeach(
   emit: EmitFn,
   workspace: SubflowResolver | undefined,
   services: unknown,
+  paramOverrides?: Record<string, Record<string, unknown>>,
 ): Promise<unknown> {
   // Resolve `items` once against the parent scope.
   const itemsResolved = resolveConfig(step.config["items"], scope);
@@ -619,6 +643,7 @@ async function executeForeach(
       emit,
       workspace,
       services,
+      paramOverrides,
     );
 
     await emit({
@@ -645,6 +670,7 @@ async function executeSubflow(
   emit: EmitFn,
   workspace: SubflowResolver | undefined,
   services: unknown,
+  paramOverrides?: Record<string, Record<string, unknown>>,
 ): Promise<unknown> {
   // Resolve workflow name, version, and input from parent scope
   const wfName = resolveConfig(step.config["workflow"], scope) as string;
@@ -670,7 +696,9 @@ async function executeSubflow(
   // Validate child flow input against its schema
   const validatedInput = childFlow.input.parse(childInput);
 
-  return executeFlow(childFlow, validatedInput, registry, runId, path, emit, workspace, services);
+  // Thread `paramOverrides` (but NOT the entry-only flat `paramsOverride`) into
+  // the child so a keyed override can reach knobs that live in this subflow.
+  return executeFlow(childFlow, validatedInput, registry, runId, path, emit, workspace, services, undefined, paramOverrides);
 }
 
 // ── Utilities ──────────────────────────────────────────────────────────────

--- a/vein/src/store.test.ts
+++ b/vein/src/store.test.ts
@@ -262,4 +262,84 @@ describe("FileRunStore", () => {
     assert.equal(events.length, 1);
     assert.deepEqual(events[0], evt);
   });
+
+  // ── tailEvents (background-job reattach, §8) ─────────────────────────────
+
+  const ev = (type: RunEvent["type"], runId: string): RunEvent => ({
+    ts: new Date().toISOString(),
+    runId,
+    path: WF,
+    type,
+  });
+
+  it("tailEvents drains a completed log then returns", async () => {
+    const store = new FileRunStore(tempDir);
+    await store.append(WF, "700", ev("run.start", "700"));
+    await store.append(WF, "700", ev("step.end", "700"));
+    await store.append(WF, "700", ev("run.end", "700"));
+
+    const seen: RunEvent[] = [];
+    for await (const e of store.tailEvents(WF, "700", { intervalMs: 10 })) {
+      seen.push(e);
+    }
+    assert.deepEqual(seen.map((e) => e.type), ["run.start", "step.end", "run.end"]);
+  });
+
+  it("tailEvents follows live appends until the terminal event", async () => {
+    const store = new FileRunStore(tempDir);
+    await store.append(WF, "800", ev("run.start", "800"));
+
+    const seen: RunEvent[] = [];
+    const consume = (async () => {
+      for await (const e of store.tailEvents(WF, "800", { intervalMs: 10 })) {
+        seen.push(e);
+      }
+    })();
+
+    // Append more events *after* the tail has started (live follow).
+    await new Promise((r) => setTimeout(r, 30));
+    await store.append(WF, "800", ev("step.start", "800"));
+    await new Promise((r) => setTimeout(r, 30));
+    await store.append(WF, "800", ev("run.end", "800"));
+
+    await consume; // resolves once the terminal event is reached
+    assert.deepEqual(seen.map((e) => e.type), ["run.start", "step.start", "run.end"]);
+  });
+
+  it("tailEvents waits for a not-yet-created log (race-free join)", async () => {
+    const store = new FileRunStore(tempDir);
+
+    const seen: RunEvent[] = [];
+    const consume = (async () => {
+      for await (const e of store.tailEvents(WF, "900", { intervalMs: 10 })) {
+        seen.push(e);
+      }
+    })();
+
+    // File doesn't exist yet when the tail starts; create it afterwards.
+    await new Promise((r) => setTimeout(r, 30));
+    await store.append(WF, "900", ev("run.start", "900"));
+    await store.append(WF, "900", ev("run.end", "900"));
+
+    await consume;
+    assert.deepEqual(seen.map((e) => e.type), ["run.start", "run.end"]);
+  });
+
+  it("tailEvents stops when its AbortSignal fires", async () => {
+    const store = new FileRunStore(tempDir);
+    await store.append(WF, "1000", ev("run.start", "1000")); // no terminal event
+
+    const ac = new AbortController();
+    const seen: RunEvent[] = [];
+    const consume = (async () => {
+      for await (const e of store.tailEvents(WF, "1000", { intervalMs: 10, signal: ac.signal })) {
+        seen.push(e);
+      }
+    })();
+
+    await new Promise((r) => setTimeout(r, 30));
+    ac.abort();
+    await consume; // must resolve despite no terminal event
+    assert.equal(seen[0]?.type, "run.start");
+  });
 });

--- a/vein/src/store.ts
+++ b/vein/src/store.ts
@@ -1,6 +1,13 @@
-import { mkdir, writeFile, appendFile, readdir, readFile } from "node:fs/promises";
+import { mkdir, writeFile, appendFile, readdir, readFile, open } from "node:fs/promises";
 import { join } from "node:path";
 import type { RunEvent, RunSummary } from "./core.js";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+/** A run is terminal once its log records a `run.end` or `run.error`. */
+function isTerminal(event: RunEvent): boolean {
+  return event.type === "run.end" || event.type === "run.error";
+}
 
 // ── Interface ──────────────────────────────────────────────────────────────
 
@@ -65,6 +72,72 @@ export class FileRunStore implements RunStore {
       return JSON.parse(raw) as RunSummary;
     } catch {
       return null;
+    }
+  }
+
+  /**
+   * Tail a run's event log: yield every event from the start of the file
+   * (history), then follow appends (live) until a terminal event
+   * (`run.end` / `run.error`) is seen, at which point the generator returns.
+   *
+   * The append-only log is the ordered source of truth, so the history→live
+   * join is naturally race-free: we read from a byte offset to EOF, then
+   * keep re-reading from the new offset. Partial trailing lines (a write
+   * caught mid-flush) are buffered until their newline arrives. One code path
+   * serves completed *and* in-flight runs — a completed run drains the file
+   * and returns immediately; a live run polls (`intervalMs`) for appends.
+   *
+   * The only "polling" is the server noticing appends — invisible to clients.
+   * Pass an `AbortSignal` (e.g. on client disconnect) to stop early.
+   */
+  async *tailEvents(
+    workflow: string,
+    runId: string,
+    opts: { intervalMs?: number; signal?: AbortSignal } = {},
+  ): AsyncGenerator<RunEvent> {
+    const file = join(this.runDir(workflow, runId), "events.jsonl");
+    const intervalMs = opts.intervalMs ?? 250;
+    const signal = opts.signal;
+    let offset = 0;
+    let leftover = "";
+
+    while (true) {
+      if (signal?.aborted) return;
+
+      let chunk = "";
+      try {
+        const fh = await open(file, "r");
+        try {
+          const { size } = await fh.stat();
+          if (size > offset) {
+            const buf = Buffer.alloc(size - offset);
+            await fh.read(buf, 0, buf.length, offset);
+            chunk = buf.toString("utf-8");
+            offset = size;
+          }
+        } finally {
+          await fh.close();
+        }
+      } catch {
+        // File not created yet (run just launched) — poll until it appears.
+      }
+
+      if (chunk) {
+        leftover += chunk;
+        const nl = leftover.lastIndexOf("\n");
+        if (nl >= 0) {
+          const complete = leftover.slice(0, nl);
+          leftover = leftover.slice(nl + 1);
+          for (const line of complete.split("\n")) {
+            if (!line) continue;
+            const event = JSON.parse(line) as RunEvent;
+            yield event;
+            if (isTerminal(event)) return;
+          }
+        }
+      }
+
+      await sleep(intervalMs);
     }
   }
 

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -117,8 +117,12 @@ export const getWorkflowYaml = async (name: string, version: string) => {
 };
 
 /**
- * Run a workflow via SSE. Calls `onEvent` for each event as it streams in.
- * Returns the final RunResult when the stream closes.
+ * Run a workflow. The launch is **detached** (§8): `POST …/run` starts the
+ * run server-side and returns `{ runId }` immediately, then we **reattach**
+ * to its event log via `GET …/runs/:runId/stream` (SSE tail). `onEvent` fires
+ * for each event (replayed history + live appends); the returned RunResult
+ * arrives on the terminal `done` event. The two-step launch+reattach is
+ * invisible to callers — same signature as a single streamed request.
  */
 export async function runWorkflow(
   name: string,
@@ -126,7 +130,7 @@ export async function runWorkflow(
   onEvent?: (event: RunEvent) => void,
   params?: Record<string, unknown>,
 ): Promise<any> {
-  const res = await fetch(`${BASE}/workflows/${name}/run`, {
+  const launch = await fetch(`${BASE}/workflows/${name}/run`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -134,7 +138,21 @@ export async function runWorkflow(
       ...(params && Object.keys(params).length > 0 ? { params } : {}),
     }),
   });
+  const { runId } = (await launch.json()) as { runId: string };
+  return streamRun(name, runId, onEvent);
+}
 
+/**
+ * Reattach to a run (live or completed) and stream its events. Tails the
+ * server's append-only log from the start, so callers see full history even
+ * when they attach late. Resolves to the final RunResult on `done`.
+ */
+export async function streamRun(
+  name: string,
+  runId: string,
+  onEvent?: (event: RunEvent) => void,
+): Promise<any> {
+  const res = await fetch(`${BASE}/workflows/${name}/runs/${runId}/stream`);
   const reader = res.body?.getReader();
   if (!reader) throw new Error("No response body");
 

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -130,7 +130,22 @@ export async function runWorkflow(
   onEvent?: (event: RunEvent) => void,
   params?: Record<string, unknown>,
 ): Promise<any> {
-  const launch = await fetch(`${BASE}/workflows/${name}/run`, {
+  const { runId } = await launchWorkflow(name, input, params);
+  return streamRun(name, runId, onEvent);
+}
+
+/**
+ * Launch a run **detached** (§8) and return its `runId` immediately — the run
+ * keeps executing server-side regardless of this connection. Callers that want
+ * to surface the run *before* it finishes (e.g. show it as "running" in a list)
+ * launch first, then `streamRun(name, runId)` to follow its events.
+ */
+export async function launchWorkflow(
+  name: string,
+  input: unknown,
+  params?: Record<string, unknown>,
+): Promise<{ runId: string }> {
+  const res = await fetch(`${BASE}/workflows/${name}/run`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -138,8 +153,7 @@ export async function runWorkflow(
       ...(params && Object.keys(params).length > 0 ? { params } : {}),
     }),
   });
-  const { runId } = (await launch.json()) as { runId: string };
-  return streamRun(name, runId, onEvent);
+  return (await res.json()) as { runId: string };
 }
 
 /**

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -72,15 +72,20 @@ export function App() {
   const [flyoutStepIndex, setFlyoutStepIndex] = useState<number | null>(null);
   const [showChat, setShowChat] = useState(false);
   const [runBindings, setRunBindings] = useState<ReturnType<typeof deriveInputBindings> | null>(null);
-  // The selected workflow's `params` defaults (tunable knobs), if any.
+  // The selected workflow's `params` defaults (tunable knobs). `wfParams` is
+  // the published baseline; `localParams` is the editable working copy. Editing
+  // a param and publishing = a new workflow version (params live in the YAML).
   const [wfParams, setWfParams] = useState<Record<string, unknown> | null>(null);
-  // Whether the read-only Params flyout is open.
+  const [localParams, setLocalParams] = useState<Record<string, unknown> | null>(null);
+  // Whether the Params flyout (editable) is open.
   const [showParams, setShowParams] = useState(false);
 
   const isDirty = useMemo(() => {
     if (!publishedSteps || !localSteps) return false;
-    return !deepEqual(normalizeSteps(publishedSteps), normalizeSteps(localSteps));
-  }, [publishedSteps, localSteps]);
+    const stepsDirty = !deepEqual(normalizeSteps(publishedSteps), normalizeSteps(localSteps));
+    const paramsDirty = !deepEqual(wfParams ?? {}, localParams ?? {});
+    return stepsDirty || paramsDirty;
+  }, [publishedSteps, localSteps, wfParams, localParams]);
 
   const activeVersion = workflows.find((w) => w.name === selectedWf)?.activeVersion;
 
@@ -178,6 +183,7 @@ export function App() {
       setPublishedSteps(null);
       setLocalSteps(null);
       setWfParams(null);
+      setLocalParams(null);
       setRuns([]);
       setFlyoutStepId(null);
       setFlyoutStepIndex(null);
@@ -188,6 +194,7 @@ export function App() {
       setPublishedSteps(steps);
       setLocalSteps(steps);
       setWfParams(flow.params ?? null);
+      setLocalParams(flow.params ?? null);
     }).catch(() => {
       setPublishedSteps(null);
       setLocalSteps(null);
@@ -304,7 +311,7 @@ export function App() {
     try {
       const { fields } = await api.getStepSchema(first.type);
       const bindings = deriveInputBindings(first, fields);
-      const hasParams = wfParams != null && Object.keys(wfParams).length > 0;
+      const hasParams = localParams != null && Object.keys(localParams).length > 0;
       if (bindings.length === 0 && !hasParams) {
         await submitRun({});
       } else {
@@ -314,7 +321,7 @@ export function App() {
       // If we can't load the schema, fall back to running with no input.
       await submitRun({});
     }
-  }, [selectedWf, localSteps, submitRun, wfParams]);
+  }, [selectedWf, localSteps, submitRun, localParams]);
 
   const handleCreate = useCallback(async (name: string, yamlStr: string, desc: string) => {
     // Server auto-suffixes on collision; navigate to the resolved name.
@@ -328,8 +335,9 @@ export function App() {
     if (!selectedWf || !localSteps || !activeVersion) return;
     const num = parseInt(activeVersion.replace(/^v/, ""), 10);
     const nextVersion = `v${(isNaN(num) ? 1 : num) + 1}`;
+    const hasParams = localParams != null && Object.keys(localParams).length > 0;
     const yamlStr = yaml.dump(
-      { name: selectedWf, steps: localSteps },
+      { name: selectedWf, steps: localSteps, ...(hasParams ? { params: localParams } : {}) },
       { lineWidth: 120, noRefs: true },
     );
     await api.publishWorkflowYaml(selectedWf, nextVersion, yamlStr);
@@ -338,7 +346,9 @@ export function App() {
     const steps = flow.steps as StepData[];
     setPublishedSteps(steps);
     setLocalSteps(steps);
-  }, [selectedWf, localSteps, activeVersion, refreshWorkflows]);
+    setWfParams(flow.params ?? null);
+    setLocalParams(flow.params ?? null);
+  }, [selectedWf, localSteps, localParams, activeVersion, refreshWorkflows]);
 
   // Clicking a node (body) always opens its flyout — leaf I/O, or a
   // container's aggregate I/O. Drilling into children is the arrow's job.
@@ -510,7 +520,7 @@ export function App() {
         </span>
         <div class="topbar-actions">
           {isDirty && <button class="btn btn-publish" onClick={handlePublish}>Publish</button>}
-          {selectedWf && wfParams && Object.keys(wfParams).length > 0 && (
+          {selectedWf && localParams && Object.keys(localParams).length > 0 && (
             <button
               class={`btn${showParams ? " is-active" : ""}`}
               onClick={() => { setShowParams((s) => !s); setFlyoutStepId(null); }}
@@ -523,7 +533,7 @@ export function App() {
                 <RunInputPopover
                   workflow={selectedWf}
                   bindings={runBindings}
-                  params={wfParams}
+                  params={localParams}
                   onSubmit={submitRun}
                   onClose={() => setRunBindings(null)}
                 />
@@ -614,9 +624,15 @@ export function App() {
         />
       )}
 
-      {/* Params flyout — read-only view of the workflow's tunable knobs */}
-      {showParams && selectedWf && wfParams && (
-        <ParamsFlyout workflow={selectedWf} params={wfParams} onClose={() => setShowParams(false)} />
+      {/* Params flyout — edit the workflow's tunable knobs; Publish persists
+          them as a new version (params live in the workflow YAML). */}
+      {showParams && selectedWf && localParams && (
+        <ParamsFlyout
+          workflow={selectedWf}
+          params={localParams}
+          onChange={setLocalParams}
+          onClose={() => setShowParams(false)}
+        />
       )}
 
       {/* Step flyout — operates on the current view (root or drilled child) */}

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useMemo } from "preact/hooks";
+import { useState, useEffect, useCallback, useMemo, useRef } from "preact/hooks";
 import { SystemCanvas } from "system-canvas-react";
 import type { CanvasData, CanvasNode, CanvasEdge } from "system-canvas";
 import type { AddNodeButtonRenderProps } from "system-canvas-react";
@@ -58,6 +58,9 @@ export function App() {
   const [selectedRun, setSelectedRun] = useState<string | null>(null);
   const [events, setEvents] = useState<api.RunEvent[]>([]);
   const [running, setRunning] = useState(false);
+  // True while an in-tab launched run is streaming live into `events`. Disarmed
+  // when the user navigates into another run, so the stream can't clobber it.
+  const liveStreamRef = useRef(false);
   const [loadError, setLoadError] = useState(false);
   // Run-view drill-down stack: each frame is a nested child execution. Each
   // carries the original event-path prefix it lives under, the child workflow
@@ -300,6 +303,7 @@ export function App() {
     setRunning(true);
     // Empty events + running → pending status overlay on all nodes immediately.
     setEvents([] as api.RunEvent[]);
+    liveStreamRef.current = true;
 
     try {
       // Detached launch (§8): we get the runId up front, so the run can surface
@@ -309,6 +313,9 @@ export function App() {
       const { runId } = await api.launchWorkflow(wf, input, params);
       let listedRunning = false;
       await api.streamRun(wf, runId, (event) => {
+        // If the user navigated into another run mid-stream (e.g. opened a
+        // generation's eval run), stop pushing this run's events over theirs.
+        if (!liveStreamRef.current) return;
         accumulated.push(event as RunEventData);
         setEvents([...accumulated] as api.RunEvent[]);
         // First event means the run's log exists on disk → `/runs` now returns
@@ -319,12 +326,24 @@ export function App() {
         }
       });
 
-      setSelectedRun(runId);
+      if (liveStreamRef.current) setSelectedRun(runId);
       await refreshRuns(wf);
     } finally {
+      liveStreamRef.current = false;
       setRunning(false);
     }
   }, [selectedWf, localSteps, refreshRuns]);
+
+  // Navigate into another workflow's run (from an Events-panel run-ref link).
+  // Disarm any in-tab live stream first so it doesn't clobber the target run's
+  // events (or yank us back when it finishes).
+  const openRun = useCallback((wf: string, runId: string) => {
+    liveStreamRef.current = false;
+    setRunning(false);
+    closeFlyout();
+    if (selectedWf !== wf) setSelectedWf(wf);
+    setSelectedRun(runId);
+  }, [selectedWf]);
 
   const handleRun = useCallback(async () => {
     if (!selectedWf || !localSteps || localSteps.length === 0) return;
@@ -625,7 +644,7 @@ export function App() {
 
       {/* Events panel + resize handle */}
       {events.length > 0 && <EventsResizer />}
-      {events.length > 0 && <EventsPanel events={events} />}
+      {events.length > 0 && <EventsPanel events={events} onOpenRun={openRun} />}
 
       {/* Create dialog */}
       {showCreate && <CreateDialog onClose={() => setShowCreate(false)} onCreate={handleCreate} />}

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -302,14 +302,24 @@ export function App() {
     setEvents([] as api.RunEvent[]);
 
     try {
-      const result = await api.runWorkflow(wf, input, (event) => {
+      // Detached launch (§8): we get the runId up front, so the run can surface
+      // in the sidebar as "running" while it's still executing. We don't select
+      // it yet — selecting fires an effect that refetches (and would clobber)
+      // the live events; we select on completion, as before.
+      const { runId } = await api.launchWorkflow(wf, input, params);
+      let listedRunning = false;
+      await api.streamRun(wf, runId, (event) => {
         accumulated.push(event as RunEventData);
         setEvents([...accumulated] as api.RunEvent[]);
-      }, params);
+        // First event means the run's log exists on disk → `/runs` now returns
+        // it (status "running", no run.json yet). Refresh once to show it live.
+        if (!listedRunning) {
+          listedRunning = true;
+          refreshRuns(wf);
+        }
+      });
 
-      if (result?.runId) {
-        setSelectedRun(result.runId);
-      }
+      setSelectedRun(runId);
       await refreshRuns(wf);
     } finally {
       setRunning(false);

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -68,6 +68,11 @@ export function App() {
   const [stepTypes, setStepTypes] = useState<StepTypeEntry[]>([]);
   const [publishedSteps, setPublishedSteps] = useState<StepData[] | null>(null);
   const [localSteps, setLocalSteps] = useState<StepData[] | null>(null);
+  // The workflow `localSteps` were actually loaded for. Until this matches
+  // `selectedWf`, the steps belong to the previously-selected workflow (the
+  // load is async), so the root canvas must not render with them — otherwise
+  // switching workflows briefly mounts/fits the canvas on the OLD content.
+  const [loadedWf, setLoadedWf] = useState<string | null>(null);
   const [flyoutStepId, setFlyoutStepId] = useState<string | null>(null);
   const [flyoutStepIndex, setFlyoutStepIndex] = useState<number | null>(null);
   const [showChat, setShowChat] = useState(false);
@@ -127,12 +132,15 @@ export function App() {
       };
     }
     if (!viewWorkflow || !viewSteps) return null;
+    // Root view: don't render until the steps belong to the selected workflow.
+    // (Drill frames carry their own already-loaded steps, so they're exempt.)
+    if (runDrill.length === 0 && loadedWf !== selectedWf) return null;
     const overlay = events.length > 0 || running;
     return flowToCanvas(
       { name: viewWorkflow, steps: viewSteps },
       overlay ? (viewEvents as RunEventData[]) : undefined,
     );
-  }, [loadError, selectedWf, viewWorkflow, viewSteps, viewEvents, events.length, running]);
+  }, [loadError, selectedWf, loadedWf, runDrill.length, viewWorkflow, viewSteps, viewEvents, events.length, running]);
 
   // Events for the flyout step (within the current view). Containers show
   // their own aggregate I/O here (subflow → child input/output; foreach →
@@ -182,6 +190,7 @@ export function App() {
     if (!selectedWf) {
       setPublishedSteps(null);
       setLocalSteps(null);
+      setLoadedWf(null);
       setWfParams(null);
       setLocalParams(null);
       setRuns([]);
@@ -193,11 +202,13 @@ export function App() {
       const steps = flow.steps as StepData[];
       setPublishedSteps(steps);
       setLocalSteps(steps);
+      setLoadedWf(selectedWf);
       setWfParams(flow.params ?? null);
       setLocalParams(flow.params ?? null);
     }).catch(() => {
       setPublishedSteps(null);
       setLocalSteps(null);
+      setLoadedWf(selectedWf);
       setLoadError(true);
     });
     refreshRuns(selectedWf);
@@ -573,6 +584,11 @@ export function App() {
         )}
         {canvas
           ? <SystemCanvas
+              // Remount when the viewed workflow changes so the canvas
+              // re-fits/re-centers on its content (the library's
+              // `autoFit="canvas-change"` only fires on sub-canvas
+              // navigation, not when we swap the root `canvas` prop).
+              key={viewWorkflow ?? "none"}
               panMode="trackpad"
               canvas={canvas}
               // A container node's ref arrow opens the referenced workflow

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -16,6 +16,7 @@ import { StepEditFlyout } from "./components/StepEditFlyout";
 import { EventsPanel } from "./components/EventsPanel";
 import { EventsResizer } from "./components/EventsResizer";
 import { StepRunFlyout } from "./components/StepRunFlyout";
+import { ParamsFlyout } from "./components/ParamsFlyout";
 import { RunInputPopover, deriveInputBindings } from "./components/RunInputPopover";
 
 // A nested run-execution the user has drilled into. `pathPrefix` is the
@@ -73,6 +74,8 @@ export function App() {
   const [runBindings, setRunBindings] = useState<ReturnType<typeof deriveInputBindings> | null>(null);
   // The selected workflow's `params` defaults (tunable knobs), if any.
   const [wfParams, setWfParams] = useState<Record<string, unknown> | null>(null);
+  // Whether the read-only Params flyout is open.
+  const [showParams, setShowParams] = useState(false);
 
   const isDirty = useMemo(() => {
     if (!publishedSteps || !localSteps) return false;
@@ -170,6 +173,7 @@ export function App() {
   useEffect(() => {
     setRunDrill([]);
     setLoadError(false);
+    setShowParams(false);
     if (!selectedWf) {
       setPublishedSteps(null);
       setLocalSteps(null);
@@ -342,6 +346,7 @@ export function App() {
     const stepId = node.customData?.stepId as string | undefined;
     const stepIndex = node.customData?.stepIndex as number | undefined;
     if (stepId == null) return;
+    setShowParams(false);
     setFlyoutStepId(stepId);
     setFlyoutStepIndex(stepIndex ?? null);
   }, []);
@@ -505,6 +510,12 @@ export function App() {
         </span>
         <div class="topbar-actions">
           {isDirty && <button class="btn btn-publish" onClick={handlePublish}>Publish</button>}
+          {selectedWf && wfParams && Object.keys(wfParams).length > 0 && (
+            <button
+              class={`btn${showParams ? " is-active" : ""}`}
+              onClick={() => { setShowParams((s) => !s); setFlyoutStepId(null); }}
+            >Params</button>
+          )}
           {selectedWf && (
             <div class="run-anchor">
               <button class="btn btn-primary" onClick={handleRun}>Run</button>
@@ -601,6 +612,11 @@ export function App() {
             setSelectedRun(runId);
           }}
         />
+      )}
+
+      {/* Params flyout — read-only view of the workflow's tunable knobs */}
+      {showParams && selectedWf && wfParams && (
+        <ParamsFlyout workflow={selectedWf} params={wfParams} onClose={() => setShowParams(false)} />
       )}
 
       {/* Step flyout — operates on the current view (root or drilled child) */}

--- a/vein/web/src/components/EventsPanel.tsx
+++ b/vein/web/src/components/EventsPanel.tsx
@@ -7,7 +7,34 @@ import yaml from "js-yaml";
 
 // ── Events Panel (expandable rows) ─────────────────────────────────────────
 
-export function EventsPanel(props: { events: api.RunEvent[] }) {
+interface RunRef {
+  label?: string;
+  workflow: string;
+  runId: string;
+}
+
+/** A step may attach pointers to related runs via `input.runs` / `output.runs`
+ *  (e.g. eval/optimize links each generation's eval & reflect runs). Collect
+ *  them so the panel can render "open run" links that drill into those logs. */
+function runRefs(evt: api.RunEvent): RunRef[] {
+  const out: RunRef[] = [];
+  for (const src of [evt.input, evt.output]) {
+    const runs = (src as { runs?: unknown } | null | undefined)?.runs;
+    if (!Array.isArray(runs)) continue;
+    for (const r of runs) {
+      if (r && typeof r.workflow === "string" && typeof r.runId === "string") {
+        out.push({ label: typeof r.label === "string" ? r.label : undefined, workflow: r.workflow, runId: r.runId });
+      }
+    }
+  }
+  return out;
+}
+
+export function EventsPanel(props: {
+  events: api.RunEvent[];
+  /** Navigate to another workflow's run (used by run-ref links). */
+  onOpenRun?: (workflow: string, runId: string) => void;
+}) {
   const [expanded, setExpanded] = useState<number | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
@@ -29,11 +56,22 @@ export function EventsPanel(props: { events: api.RunEvent[] }) {
       {props.events.map((evt, i) => {
         const hasData = evt.input != null || evt.output != null || evt.error != null;
         const isOpen = expanded === i;
+        const refs = props.onOpenRun ? runRefs(evt) : [];
         return (
           <div key={i} class="event-row">
             <div class="event-row-summary" onClick={() => hasData && setExpanded(isOpen ? null : i)}>
               <span class={`event-type event-type-${eventTone(evt.type)}`}>{evt.type}</span>
               <span class="event-path">{evt.path}</span>
+              {refs.map((r, j) => (
+                <button
+                  key={j}
+                  class="event-run-link"
+                  title={`Open ${r.workflow} / ${r.runId}`}
+                  onClick={(e) => { e.stopPropagation(); props.onOpenRun!(r.workflow, r.runId); }}
+                >
+                  ↗ {r.label ?? "open run"}
+                </button>
+              ))}
               <span class="event-duration">{evt.durationMs != null ? `${evt.durationMs}ms` : ""}</span>
             </div>
             {isOpen && (

--- a/vein/web/src/components/ParamsFlyout.tsx
+++ b/vein/web/src/components/ParamsFlyout.tsx
@@ -66,7 +66,7 @@ export function ParamsFlyout(props: {
           })
         )}
         <div class="flyout-section">
-          <span class="flyout-meta-value">Edits mark the workflow dirty — hit Publish to save as a new version.</span>
+          <span class="flyout-meta-value">Edits mark the workflow changed — hit Publish to save as a new version.</span>
         </div>
       </div>
     </div>

--- a/vein/web/src/components/ParamsFlyout.tsx
+++ b/vein/web/src/components/ParamsFlyout.tsx
@@ -1,22 +1,31 @@
-import { formatJson } from "../helpers";
 import { CloseIcon } from "../icons";
 import { FlyoutResizer } from "./FlyoutResizer";
 
-// ── Params Flyout (read-only) ──────────────────────────────────────────────
+// ── Params Flyout (editable) ───────────────────────────────────────────────
 //
-// Shows a workflow's `params` block — the tunable default knobs (prompts,
-// thresholds, sample sizes) referenced by step configs via {{ params.* }}.
-// These are otherwise invisible in the UI (they live at the workflow level,
-// not on any single step). String values (e.g. a big system prompt) render
-// in a scrollable <pre> so the full text is inspectable; non-strings render
-// as JSON. Per-run overrides still happen in the Run popover.
+// Edit a workflow's `params` block — the tunable default knobs (prompts,
+// rubrics, expected gold, thresholds) referenced by step configs via
+// {{ params.* }}. These live at the workflow level (not on any single step),
+// so they'd otherwise be invisible. Editing here marks the workflow dirty;
+// hitting Publish persists the params as a new workflow version (params are
+// part of the workflow YAML — changing a param IS a new version).
+//
+// String params edit as text; non-string params (objects/arrays, e.g. a
+// dataset `examples` list) edit as JSON and are parsed back on change (kept as
+// raw text while the JSON is mid-edit/invalid).
 
 export function ParamsFlyout(props: {
   workflow: string;
   params: Record<string, unknown>;
+  onChange: (next: Record<string, unknown>) => void;
   onClose: () => void;
 }) {
   const keys = Object.keys(props.params);
+
+  const update = (key: string, raw: string, isJson: boolean) => {
+    const value: unknown = isJson ? tryParseJson(raw) : raw;
+    props.onChange({ ...props.params, [key]: value });
+  };
 
   return (
     <div class="flyout">
@@ -36,19 +45,49 @@ export function ParamsFlyout(props: {
         ) : (
           keys.map((k) => {
             const v = props.params[k];
+            const isString = typeof v === "string";
+            const text = isString ? v : stringify(v);
+            const rows = Math.min(24, Math.max(3, text.split("\n").length + 1));
             return (
               <div class="flyout-section" key={k}>
-                <div class="flyout-section-title">{k}</div>
-                {typeof v === "string" ? (
-                  <pre class="flyout-json">{v}</pre>
-                ) : (
-                  <pre class="flyout-json">{formatJson(v)}</pre>
-                )}
+                <div class="flyout-section-title">
+                  {k}
+                  {!isString && <span class="param-type-tag">json</span>}
+                </div>
+                <textarea
+                  class="param-edit"
+                  rows={rows}
+                  value={text}
+                  spellcheck={false}
+                  onInput={(e) => update(k, (e.target as HTMLTextAreaElement).value, !isString)}
+                />
               </div>
             );
           })
         )}
+        <div class="flyout-section">
+          <span class="flyout-meta-value">Edits mark the workflow dirty — hit Publish to save as a new version.</span>
+        </div>
       </div>
     </div>
   );
+}
+
+function stringify(v: unknown): string {
+  if (v == null) return "";
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+/** Parse JSON, but fall back to the raw string while it's mid-edit/invalid so
+ *  the textarea stays usable (the user can keep typing). */
+function tryParseJson(raw: string): unknown {
+  try {
+    return JSON.parse(raw);
+  } catch {
+    return raw;
+  }
 }

--- a/vein/web/src/components/ParamsFlyout.tsx
+++ b/vein/web/src/components/ParamsFlyout.tsx
@@ -1,0 +1,54 @@
+import { formatJson } from "../helpers";
+import { CloseIcon } from "../icons";
+import { FlyoutResizer } from "./FlyoutResizer";
+
+// ── Params Flyout (read-only) ──────────────────────────────────────────────
+//
+// Shows a workflow's `params` block — the tunable default knobs (prompts,
+// thresholds, sample sizes) referenced by step configs via {{ params.* }}.
+// These are otherwise invisible in the UI (they live at the workflow level,
+// not on any single step). String values (e.g. a big system prompt) render
+// in a scrollable <pre> so the full text is inspectable; non-strings render
+// as JSON. Per-run overrides still happen in the Run popover.
+
+export function ParamsFlyout(props: {
+  workflow: string;
+  params: Record<string, unknown>;
+  onClose: () => void;
+}) {
+  const keys = Object.keys(props.params);
+
+  return (
+    <div class="flyout">
+      <FlyoutResizer />
+      <div class="flyout-header">
+        <div>
+          <div class="flyout-eyebrow">Params</div>
+          <div class="flyout-title">{props.workflow}</div>
+        </div>
+        <button class="flyout-close" onClick={props.onClose} aria-label="Close"><CloseIcon /></button>
+      </div>
+      <div class="flyout-body">
+        {keys.length === 0 ? (
+          <div class="flyout-section">
+            <span class="flyout-meta-value">This workflow has no params.</span>
+          </div>
+        ) : (
+          keys.map((k) => {
+            const v = props.params[k];
+            return (
+              <div class="flyout-section" key={k}>
+                <div class="flyout-section-title">{k}</div>
+                {typeof v === "string" ? (
+                  <pre class="flyout-json">{v}</pre>
+                ) : (
+                  <pre class="flyout-json">{formatJson(v)}</pre>
+                )}
+              </div>
+            );
+          })
+        )}
+      </div>
+    </div>
+  );
+}

--- a/vein/web/src/components/RunInputPopover.tsx
+++ b/vein/web/src/components/RunInputPopover.tsx
@@ -14,6 +14,24 @@ import type { StepData } from "../flow-to-canvas";
 /** Match `{{ input.<ident> }}` with optional whitespace, and nothing else. */
 const SINGLE_INPUT_RE = /^\s*\{\{\s*input\.([a-zA-Z_$][\w$]*)\s*\}\}\s*$/;
 
+/** Match every `input.<ident>` reference anywhere in a string (nested objects,
+ *  multi-segment templates, expressions). Used to surface input keys that a
+ *  flat single-template field check misses — e.g. a workflow that passes input
+ *  through a nested object like `eval/optimize`'s `evalInput: { owner, repo }`. */
+const ANY_INPUT_RE = /input\.([a-zA-Z_$][\w$]*)/g;
+
+/** Recursively collect distinct `input.X` keys referenced anywhere in a value. */
+function collectInputRefs(value: unknown, out: string[] = []): string[] {
+  if (typeof value === "string") {
+    for (const m of value.matchAll(ANY_INPUT_RE)) out.push(m[1]!);
+  } else if (Array.isArray(value)) {
+    for (const v of value) collectInputRefs(v, out);
+  } else if (value && typeof value === "object") {
+    for (const v of Object.values(value)) collectInputRefs(v, out);
+  }
+  return out;
+}
+
 interface InputBinding {
   /** Name of the input key the user supplies (e.g. "owner"). */
   inputKey: string;
@@ -32,6 +50,8 @@ export function deriveInputBindings(
   const bindings: InputBinding[] = [];
   const seen = new Set<string>();
 
+  // 1. Typed bindings: a config field whose value is exactly `{{ input.X }}`
+  //    borrows that field's schema descriptor (so number/enum widgets work).
   for (const field of fields) {
     const raw = step.config?.[field.name];
     if (typeof raw !== "string") continue;
@@ -44,6 +64,17 @@ export function deriveInputBindings(
       inputKey,
       field: { ...field, name: inputKey },
     });
+  }
+
+  // 2. Any other input refs anywhere in the config (nested objects, arrays,
+  //    multi-segment templates, expressions) — surfaced as plain string fields,
+  //    optional (we can't infer type/requiredness from a nested ref). Without
+  //    this, a workflow that passes input through a nested object never prompts
+  //    for those keys and runs with them undefined.
+  for (const inputKey of collectInputRefs(step.config)) {
+    if (seen.has(inputKey)) continue;
+    seen.add(inputKey);
+    bindings.push({ inputKey, field: { name: inputKey, kind: "string", required: false } });
   }
 
   return bindings;

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -589,6 +589,20 @@ body.is-resizing-flyout * {
   color: var(--text-dim);
   flex-shrink: 0;
 }
+.event-run-link {
+  flex-shrink: 0;
+  padding: 1px var(--sp-2);
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--accent);
+  font-size: 11px;
+  cursor: pointer;
+  white-space: nowrap;
+}
+.event-run-link:hover {
+  border-color: var(--accent);
+}
 .event-detail {
   padding: var(--sp-2) 0 var(--sp-3) 0;
 }

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -279,6 +279,10 @@ body.is-resizing-events * {
 .btn:hover {
   background: var(--surface);
 }
+.btn.is-active {
+  border-color: var(--accent);
+  color: var(--accent);
+}
 .btn-primary {
   background: var(--accent);
   border-color: var(--accent);

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -649,6 +649,34 @@ body.is-resizing-flyout * {
   border-color: rgba(248, 113, 113, 0.3);
   color: var(--danger);
 }
+.param-edit {
+  width: 100%;
+  box-sizing: border-box;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  padding: var(--sp-3);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text);
+  resize: vertical;
+}
+.param-edit:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+.param-type-tag {
+  margin-left: var(--sp-2);
+  padding: 0 6px;
+  border-radius: var(--r-sm);
+  background: var(--surface-2);
+  color: var(--text-dim);
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0;
+  text-transform: none;
+}
 .flyout-meta-row {
   display: flex;
   justify-content: space-between;


### PR DESCRIPTION
Foundation for **evals + self-improving loops** in vein, applied first to the
concepts (bootstrap) pipeline. Guiding idea: *everything is a workflow + its
`params`* — no new resource types. The eval is a measurement substrate
(`run target → collect → score → a number`); the chat agent (later) is the
optimizer.

See `vein/EVAL_SPEC.md` for the full design.

## What's in here

**Engine (vein)**
- **Keyed `paramOverrides`** (`runner.ts`) — opt-in, name-addressed per-run
  overrides threaded recursively, so a candidate can reach a knob inside a
  nested subflow (e.g. `concepts/decide` two levels down). Exposed on `/run`
  and `run()`. Back-compat; +1 test (299 pass).
- **Editable + persistable params UI** (`ParamsFlyout`) — surfaces a
  workflow's tunable params (prompts/rubric/expected gold); editing marks the
  workflow dirty and **Publish** persists them as a new version. This is the
  "set up an eval in the UI" surface.

**Concepts (lab)**
- Bootstrap prompt **paramified** out of `bootstrap.ts` into
  `bootstrap-then-process` params (visible/editable/tunable).
- `concepts/collect-for-eval` — final step makes the run output the scoreable
  concept set (`{ concepts, markdown }`), recorded + UI-rendered.
- `concepts/reset-repo` + **`eval-concepts`** workflow — a bootstrap-only eval
  loop: `reset → bootstrap-then-process (lookbackDays:0) → eval-score`, with
  the expected gold as a param.

**Eval machinery (lab)**
- `eval/score` — recall-based LLM judge: matches produced vs expected
  capabilities, returns `matched/missing/spurious`, step computes a continuous
  recall-weighted (F-beta) score. `eval-score` workflow holds the rubric as a
  tunable param.

## Status
Manual eval works end-to-end today (run `eval-concepts`, edit the bootstrap
prompt, re-run). Not yet runtime-verified (needs Neo4j + GitHub token + LLM
key).

## Next (per EVAL_SPEC §10)
1. First real run on a small repo.
2. Agent eval capability (`run_eval` tool + prompt) — the chat-driven loop,
   incl. structural workflow evolution.
3. Reproducibility: snapshots + namespacing.

## Checks
- vein: 299 tests pass.
- mcp + vein/web: typecheck clean (0 errors); web builds.