### PR TITLE
gitsee: boot-gate eval + agent file editing

### DIFF
--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -410,13 +410,36 @@ export function getModel(
         ...(extraHeaders && { headers: extraHeaders }),
       });
       return anthropic(modelId);
-    case "google":
+    case "google": {
+      // Bifrost's native GenAI endpoint (/genai/v1beta) currently fails to
+      // resolve provider keys ("no keys found that support model: ..."),
+      // while its OpenAI-compatible endpoint (/openai/v1) serves the very
+      // same Gemini keys correctly. So when routing Google through a gateway
+      // (baseURL is present and suffixed with /genai/v1beta here), call the
+      // OpenAI-compat endpoint with a `gemini/`-prefixed model id instead.
+      // Direct (non-gateway) Google calls keep the native GenAI client.
+      if (baseURL) {
+        // Strip whatever provider suffix is present (/genai/v1beta normally,
+        // but be resilient to /anthropic/v1, /openai/v1, etc.) to recover the
+        // gateway root, then target the OpenAI-compat path.
+        const root = baseURL.replace(/\/(anthropic|openai|genai)\/v\d+[a-z]*\/?$/i, "");
+        const openaiCompatBase = `${root}/openai/v1`;
+        console.log(
+          `[gateway] routing google via OpenAI-compat ${openaiCompatBase} (model gemini/${modelId})`
+        );
+        const googleCompat = createOpenAI({
+          apiKey,
+          baseURL: openaiCompatBase,
+          ...(extraHeaders && { headers: extraHeaders }),
+        });
+        return googleCompat.chat(`gemini/${modelId}`);
+      }
       const google = createGoogleGenerativeAI({
         apiKey,
-        ...(baseURL && { baseURL }),
         ...(extraHeaders && { headers: extraHeaders }),
       });
       return google(modelId);
+    }
     case "openai":
       const openai = createOpenAI({
         apiKey,

--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -68,28 +68,75 @@ the frontend running*, so the gold is the frontend's pm2 + the shared services.
   `{ workspacePath, repos }`. **The only gitsee-specific producer step.**
 - Exploration is the **core `agent` step** (`vein/src/steps/core/agent.ts`),
   pointed at `cwd = clone.workspacePath`. Its general tools (`repo_overview`,
-  `fulltext_search`, `bash`, anthropic `web_search`, + `file_summary` — the
-  `stakgraph` AST CLI, only offered when `stakgraph` is on PATH) + the agent loop
+  `fulltext_search`, `bash`, `str_replace_based_edit_tool` — view/create/edit
+  files in the cloned workspace (lets the agent make a repo local-first, e.g.
+  flip a `USE_MOCKS` default or patch a hardcoded cloud URL), anthropic
+  `web_search`, + `file_summary` — the `stakgraph` AST CLI, only offered when
+  `stakgraph` is on PATH) + the agent loop
   live in vein core now — what was the old inlined `gitsee/explore-services` step
   (deleted). gitsee runs it in **`finalAnswer` (FILENAME text) mode**; the
   structured-`schema` mode is intentionally unused here for now. (For the
   `file_summary` tool, `stakgraph` must be on PATH; the agent falls back to
   `bash`/`cat` otherwise.)
-- `gitsee/workflows/gitsee-explore-services.yaml` — `clone → agent`; input
-  `{ workspace, repos: [{owner,repo,rev?}], token? }`; the `system`/`prompt`/
+- `gitsee/workflows/gitsee-explore-services.yaml` — `clone → agent → capture`;
+  input `{ workspace, repos: [{owner,repo,rev?}], token? }`; the `system`/`prompt`/
   `finalAnswer` prompts live in `params` (the experiment surface, frontend-
   focused). The agent injects a neutral working-dir listing, so the prompts
-  stay repo-agnostic (workspace framing moved into `params.system`).
+  stay repo-agnostic (workspace framing moved into `params.system`). The agent
+  MAY edit the cloned repos (via the core `str_replace_based_edit_tool`) to make
+  them boot local-first (move a misplaced migration, flip a mock flag, patch a
+  cloud-only URL); those edits are captured by the final `gitsee/capture-edits`
+  step as a replayable `git diff` and SHIPPED as part of the deliverable (output
+  `diff` + `changedRepos`, alongside the passed-through `result`/`usage`/`cost`).
+  The split: FILE changes go in the repo (the diff re-applies on a fresh pod
+  clone), RUNTIME steps (db reset/migrate/seed) go in `PRE_START_COMMAND` — so a
+  Supabase-style "move the migration + reset the db" becomes a clean diff hunk +
+  a clean PRE_START, not a file-shuffling shell hack. The agent also narrates its
+  edits in a `## CHANGES` section of the final answer (human-readable companion to
+  the diff). (`capture-edits` is the LAST step because a workflow's output is its
+  last step's output; it passes the agent's fields through so `produce.result`
+  etc. still resolve.)
+
+**The boot gate (`gitsee/verify-setup`) — the dominant eval signal.** A setup
+that doesn't actually *run* is a failure no matter how well its files match the
+gold, so the eval now RUNS the produced pair the pod way and proves the frontend
+loads. `gitsee/verify-setup.ts` (`gitsee/verify-setup`): stages the produced
+`pm2.config.js` + `docker-compose.yml` into the cloned workspace exactly where
+**staklink** looks (`<root>/pm2.config.js` + `<root>/.pod-config/.user-dockerfile/
+pm2.config.js`), rewriting the pod-absolute `cwd: /workspaces/<repo>` to the local
+clone root; `docker compose up -d --wait` for the backing services; boots the apps
+via **staklink** (`npx staklink start` → REBUILD→INSTALL→PRE_START→`pm2 start`→
+POST_START — pod-faithful; it does NOT run BUILD_COMMAND, so dev-mode boot is the
+target) or a pm2-free inline fallback (`useStaklink:false`); polls the frontend
+`PORT`; then loads `http://localhost:<port><checkPath>` in headless chromium
+(`@playwright/test`), screenshots to `<root>/.verify/render.png`, and **judges that
+screenshot with a VISION model** (`useVision`, anthropic, default on) — the real
+"did it render" signal, since an HTTP 200 + non-empty DOM still passes for a white
+screen or a styled error page. It asks the model whether the intended app UI
+rendered vs a blank/error/404-500 page; an HTTP-status + error-overlay heuristic is
+the fallback when vision is off or unavailable. Output `{ booted, rendered, port,
+httpStatus, title, reason, logs, screenshotPath, cost, usage }` (cost = the
+vision-judge tokens, folded into the eval total via `produce.cost + verify.cost`).
+Missing browsers degrade to a boot-only gate (`rendered:null`); `enabled:false`
+makes it a no-op (skip the gate in cheap sweeps). Needs `docker` + `git` on PATH, `npx playwright install chromium`
+for the render check, and (for `useStaklink`) network for `npx staklink`. **The
+agent can also EDIT the cloned repos** (via the core agent's
+`str_replace_based_edit_tool`) to make a repo local-first before this gate runs.
 
 **Eval/optimize stack** (mirrors `concepts-*`; reuses the generic `eval/*`
 steps EXCEPT scoring, which is gitsee-specific — see below). The gold is the
 **actual canonical pm2.config.js + docker-compose.yml pair** (produced vs gold
-is apples-to-apples).
+is apples-to-apples), but the **boot result dominates** (see below).
 
 Scoring is a **structured + hybrid** scorer (`gitsee/score-setup`), NOT the
-generic LLM `eval/score`. Both files are parseable, and the gold is the ANSWER
-KEY — so the dominant tier is **deterministic name set-diffs vs the gold**, which
-is why it stays repo-agnostic without understanding any dependency:
+generic LLM `eval/score`. The **dominant tier is now the boot gate**:
+`score-setup` takes `booted`/`rendered` from `gitsee/verify-setup` and clamps the
+file-shape score — `!booted` → ×0.15 (it didn't even run), booted-but-not-rendered
+→ ×0.5, booted+rendered → full. (Null/absent leaves the score untouched, so a
+verify-free run still works.) BELOW that gate, both files are parseable and the
+gold is the ANSWER KEY — so the file-shape score is **deterministic name set-diffs
+vs the gold**, which is why it stays repo-agnostic without understanding any
+dependency:
 - **env-key completeness** — `keys(produced pm2 env)` vs `keys(gold pm2 env)`,
   recall-weighted. Robust + general because the key NAME is dictated by the
   repo's code (`process.env.X`); a different name simply isn't read, so the
@@ -119,13 +166,18 @@ is why it stays repo-agnostic without understanding any dependency:
 matched, missing, spurious, reason, insight, markdown }` that `eval/optimize` +
 `eval/reflect` depend on.
 
-- `gitsee-eval` — harness: produce (subflow → `gitsee-explore-services`) →
-  score (subflow → `gitsee-eval-score`). No reset step (gitsee is stateless).
-  Input `{ label, repos, token?, expected? }` — `label` is the workspace name
-  (and the `eval: <label>` link); `expected` gold falls back to `params.expected`.
+- `gitsee-eval` — harness: clone (`gitsee/clone-workspace`) → produce (subflow →
+  `gitsee-explore-services`, re-clones the same idempotent path) → **verify**
+  (`gitsee/verify-setup` — the boot gate, using `clone.workspacePath`) → score
+  (subflow → `gitsee-eval-score`, threaded `booted`/`rendered`). No reset step
+  (gitsee is stateless). Input `{ label, repos, token?, expected? }` — `label` is
+  the workspace name (and the `eval: <label>` link); `expected` gold falls back to
+  `params.expected`. Boot-gate knobs in `params`: `verify` (default true — set
+  false for cheap docker-free sweeps), `checkPath`, `bootTimeoutMs`, `useStaklink`.
 - `gitsee-eval-score` — `gitsee/score-setup` + the matching policy in `params`
-  (`useLLM`, `ignoreEnvKeys`, the semantic-residue `rubric`). Strict env policy:
-  every gold env key is required (exempt noise keys via `ignoreEnvKeys`).
+  (`useLLM`, `ignoreEnvKeys`, the semantic-residue `rubric`); passes through the
+  `booted`/`rendered`/`bootReason` boot gate. Strict env policy: every gold env key
+  is required (exempt noise keys via `ignoreEnvKeys`).
 - `gitsee-eval-reflect` — `eval/reflect` + the setup task/guidance.
 - `gitsee-optimize` — `eval/optimize` loop. Tunes **`system`** (the explorer
   prompt), NOT `finalAnswer` (the hard pod contract). Cohort in `params.dataset`,
@@ -148,7 +200,10 @@ system-canvas / staklink). Add more workspaces for a stronger multi-example
 optimize (EVAL_SPEC §11.2).
 
 Needs `ANTHROPIC_API_KEY` + `git` + `rg` on PATH (Neo4j only for booting the
-lab, not for gitsee itself). Trigger:
+lab, not for gitsee itself). The **boot gate** additionally needs `docker` on
+PATH, `npx playwright install chromium` (browsers; otherwise the gate is
+boot-only), and network for `npx staklink` — set `params.verify=false` to skip it
+entirely. Trigger:
 `POST /lab/workflows/gitsee-explore-services/run` with
 `{ input: { workspace, repos: [{owner,repo,rev?}], token? } }`, or launch
 `gitsee-optimize` detached with `{ input: {} }`. Dev smoke harnesses (not

--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -123,6 +123,18 @@ for the render check, and (for `useStaklink`) network for `npx staklink`. **The
 agent can also EDIT the cloned repos** (via the core agent's
 `str_replace_based_edit_tool`) to make a repo local-first before this gate runs.
 
+**Teardown.** On a normal/errored finish the step's `finally` removes everything:
+`pm2 delete all`, `staklink stop`, `docker compose down -v`, AND — via a container
+SNAPSHOT taken just before boot — `docker rm -fv` of every container that appeared
+during the run. That snapshot-diff is what catches **app-spawned** stacks our
+compose file never declared: a `supabase start` CLI project (~12 `supabase_*`
+containers), a minio, etc. **But teardown only runs if the process finishes** —
+if you KILL the run (Ctrl-C / kill the optimize), the `finally` never fires and the
+booted stack is left up. Clean it with `npx tsx src/lab/gitsee/cleanup.ts`
+(removes the stale pm2 procs, supabase CLI stacks, and gitsee-lab compose
+projects; leaves Neo4j etc. alone). `keepUp:true` intentionally skips teardown for
+debugging.
+
 **Eval/optimize stack** (mirrors `concepts-*`; reuses the generic `eval/*`
 steps EXCEPT scoring, which is gitsee-specific — see below). The gold is the
 **actual canonical pm2.config.js + docker-compose.yml pair** (produced vs gold

--- a/mcp/src/lab/eval/steps/optimize.ts
+++ b/mcp/src/lab/eval/steps/optimize.ts
@@ -79,10 +79,35 @@ function labelFor(datum: unknown, i: number): string {
   return `example ${i + 1}`;
 }
 
+/** Map over `items` with a bounded number of in-flight calls, preserving order.
+ *  `limit <= 0` (or ≥ length) = unbounded (plain `Promise.all`, the default).
+ *  A limit of 1 serializes — needed when each eval has SIDE EFFECTS that don't
+ *  parallelize (e.g. gitsee's boot gate binds fixed host ports 3000/5432, a pm2
+ *  process named "frontend", and one staklink daemon — concurrent boots collide).
+ *  Rejection semantics match `Promise.all`: the first failure rejects. */
+async function mapLimit<T, R>(
+  items: T[],
+  limit: number,
+  fn: (item: T, i: number) => Promise<R>,
+): Promise<R[]> {
+  if (limit <= 0 || limit >= items.length) return Promise.all(items.map(fn));
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  const worker = async () => {
+    while (true) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]!, i);
+    }
+  };
+  await Promise.all(Array.from({ length: limit }, () => worker()));
+  return results;
+}
+
 export default defineStep({
   type: "eval/optimize",
   description:
-    "Generic self-improving loop: eval the candidate prompt over a DATASET → average the score → keep best → reflect a better one → repeat until mean score ≥ threshold or generations exhausted. Requires a `services.optimizer` capability. Config: evalWorkflow, evalInputs (array, the dataset; ≥1 entry), targetWorkflow, promptParam, reflectWorkflow, maxGenerations, threshold, prompt? (starting candidate, defaults to target's current value). Output: { bestScore, bestGen, bestPrompt, firstScore, totalCost, totalUsage, generations } — totalCost/totalUsage sum every eval (explorer agent + judge) + every reflection; each generation also carries its own cost/usage.",
+    "Generic self-improving loop: eval the candidate prompt over a DATASET → average the score → keep best → reflect a better one → repeat until mean score ≥ threshold or generations exhausted. Requires a `services.optimizer` capability. Config: evalWorkflow, evalInputs (array, the dataset; ≥1 entry), targetWorkflow, promptParam, reflectWorkflow, maxGenerations, threshold, prompt? (starting candidate, defaults to target's current value), concurrency? (0=unbounded parallel default; 1=serialize when evals have non-parallelizable side effects like a boot gate). Output: { bestScore, bestGen, bestPrompt, firstScore, totalCost, totalUsage, generations } — totalCost/totalUsage sum every eval (explorer agent + judge) + every reflection; each generation also carries its own cost/usage.",
   input: z.object({
     evalWorkflow: z.string().describe("workflow that scores a candidate; output must have { score, missing, spurious, insight }"),
     evalInputs: z.array(z.any()).min(1).describe("the dataset: inputs evaluated each generation and averaged (e.g. [{ owner, repo, expected }, ...]). Each entry's gold rides on the entry."),
@@ -92,6 +117,14 @@ export default defineStep({
     maxGenerations: z.number().int().positive().default(5),
     threshold: z.number().min(0).max(1).default(0.9),
     prompt: z.string().optional().describe("starting candidate; defaults to targetWorkflow's current promptParam value"),
+    concurrency: z
+      .number()
+      .int()
+      .min(0)
+      .default(0)
+      .describe(
+        "max dataset entries evaluated IN PARALLEL per generation. 0 = unbounded (default, back-compat). Set to 1 to SERIALIZE when each eval has non-parallelizable side effects (e.g. gitsee's boot gate binds fixed host ports / a shared pm2+staklink daemon — concurrent boots collide).",
+      ),
   }),
   output: z.any(),
   async run(cfg, ctx) {
@@ -175,27 +208,24 @@ export default defineStep({
         // Each example is its own run (so its own gold + logs); the candidate
         // prompt is injected into all of them via the same paramOverrides.
         const paramOverrides = { [cfg.targetWorkflow]: { [cfg.promptParam]: candidate } };
-        const evalRuns = await Promise.all(
-          dataset.map((datum, i) =>
-            opt.run(cfg.evalWorkflow, datum ?? {}, { paramOverrides }).then((run) => {
-              if (run.status !== "success") {
-                throw new Error(`eval run for "${labelFor(datum, i)}" failed: ${run.error?.message ?? "unknown"}`);
-              }
-              const out = (run.output ?? {}) as EvalOutput;
-              const result: ExampleResult = {
-                label: labelFor(datum, i),
-                score: out.score ?? 0,
-                missing: out.missing ?? [],
-                spurious: out.spurious ?? [],
-                insight: out.insight,
-                evalRunId: run.runId,
-                usage: coerceUsage(out.usage),
-                cost: typeof out.cost === "number" ? out.cost : 0,
-              };
-              return result;
-            }),
-          ),
-        );
+        const evalRuns = await mapLimit(dataset, cfg.concurrency, async (datum, i) => {
+          const run = await opt.run(cfg.evalWorkflow, datum ?? {}, { paramOverrides });
+          if (run.status !== "success") {
+            throw new Error(`eval run for "${labelFor(datum, i)}" failed: ${run.error?.message ?? "unknown"}`);
+          }
+          const out = (run.output ?? {}) as EvalOutput;
+          const result: ExampleResult = {
+            label: labelFor(datum, i),
+            score: out.score ?? 0,
+            missing: out.missing ?? [],
+            spurious: out.spurious ?? [],
+            insight: out.insight,
+            evalRunId: run.runId,
+            usage: coerceUsage(out.usage),
+            cost: typeof out.cost === "number" ? out.cost : 0,
+          };
+          return result;
+        });
 
         // The generation score = MEAN across the dataset (the overfitting fix).
         const score = evalRuns.reduce((s, r) => s + r.score, 0) / evalRuns.length;

--- a/mcp/src/lab/gitsee/cleanup.ts
+++ b/mcp/src/lab/gitsee/cleanup.ts
@@ -1,0 +1,53 @@
+import { execSync } from "node:child_process";
+
+/**
+ * Manual cleanup for a gitsee boot-gate run that was KILLED (no teardown ran).
+ * The verify-setup step tears down on a normal/errored finish, but if you stop
+ * the whole process (Ctrl-C, kill the optimize), its `finally` never runs and the
+ * booted stack is left up — a pm2 "frontend", our docker-compose services, and
+ * any app-spawned stack like a `supabase start` CLI project (12 containers) or a
+ * minio. This removes all of those. Leaves unrelated containers (Neo4j, etc.)
+ * alone — it only touches pm2, supabase CLI stacks, and compose projects rooted
+ * under the gitsee-lab tmp dir.
+ *
+ *   npx tsx src/lab/gitsee/cleanup.ts
+ */
+function sh(cmd: string): string {
+  try {
+    return execSync(cmd, { encoding: "utf-8", stdio: ["ignore", "pipe", "ignore"] });
+  } catch (e) {
+    return (e as { stdout?: Buffer }).stdout?.toString() ?? "";
+  }
+}
+
+const ids = (s: string) => s.split("\n").map((x) => x.trim()).filter(Boolean);
+
+console.log("[gitsee-cleanup] pm2 delete all");
+sh("npx -y pm2 delete all");
+
+// 1. supabase CLI stacks (started by the app via `supabase start`)
+const supa = ids(sh(`docker ps -aq --filter "label=com.supabase.cli.project"`));
+if (supa.length) {
+  console.log(`[gitsee-cleanup] removing ${supa.length} supabase container(s)`);
+  sh(`docker rm -fv ${supa.join(" ")}`);
+}
+
+// 2. compose projects rooted under the gitsee-lab tmp dir (our docker-compose.yml)
+const composeLines = sh(
+  `docker ps -a --format '{{.ID}}|{{.Label "com.docker.compose.project.working_dir"}}'`,
+)
+  .split("\n")
+  .filter(Boolean);
+const ours = composeLines.filter((l) => l.includes("gitsee-lab")).map((l) => l.split("|")[0]);
+if (ours.length) {
+  console.log(`[gitsee-cleanup] removing ${ours.length} gitsee compose container(s)`);
+  sh(`docker rm -fv ${ours.join(" ")}`);
+}
+
+// 3. prune the now-dangling networks/volumes those stacks created
+sh("docker network prune -f");
+const vols = ids(sh(`docker volume ls -q --filter "name=supabase_"`));
+if (vols.length) sh(`docker volume rm ${vols.join(" ")}`);
+
+console.log("[gitsee-cleanup] done. Remaining containers:");
+console.log(sh("docker ps --format '{{.Names}}\\t{{.Ports}}'") || "(none)");

--- a/mcp/src/lab/gitsee/seed.ts
+++ b/mcp/src/lab/gitsee/seed.ts
@@ -31,6 +31,13 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   // Structured scorer (replaces eval/score for gitsee-eval-score): parses the
   // pm2 + compose pair and scores by name set-diffs vs the gold + an LLM residue.
   { file: "score-setup.ts", type: "gitsee/score-setup" },
+  // Boot gate: actually runs the produced setup (compose up + staklink) and
+  // checks the frontend renders in headless chromium — the dominant eval signal.
+  { file: "verify-setup.ts", type: "gitsee/verify-setup" },
+  // Captures the agent's repo edits as a replayable git diff (part of the
+  // deliverable): the last step of gitsee-explore-services, passes the agent
+  // output through and adds `diff`.
+  { file: "capture-edits.ts", type: "gitsee/capture-edits" },
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));

--- a/mcp/src/lab/gitsee/steps/capture-edits.ts
+++ b/mcp/src/lab/gitsee/steps/capture-edits.ts
@@ -1,0 +1,102 @@
+import { z, defineStep } from "vein";
+import { spawn } from "node:child_process";
+import { existsSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * Capture the agent's REPO EDITS as a replayable `git diff` — the precise form of
+ * "what the agent changed to make this workspace boot local-first" (e.g. moving a
+ * misplaced Supabase migration into the framework's auto-migrations dir, flipping
+ * a USE_MOCKS default, patching a hardcoded cloud URL). The setup-profiler's
+ * deliverable is the pm2.config.js + docker-compose.yml PLUS this diff: in a
+ * fresh-cloned pod the diff is re-applied (`git apply`) so the loose working-tree
+ * edits survive, while runtime steps (db reset/migrate) stay in PRE_START_COMMAND.
+ *
+ * Runs as the LAST step of gitsee-explore-services and PASSES THROUGH the agent's
+ * `result`/`usage`/`cost`/`steps` (a workflow's output is its last step's output),
+ * so `produce.result`/`produce.usage`/`produce.cost` keep resolving and
+ * `produce.diff` is added. Captures the diff BEFORE any boot/install pollutes the
+ * tree (the explore clone is install-free, so the diff is pure source edits).
+ *
+ * Per repo (each git-repo subdir of workspacePath): `git add -A -N` (so NEW files
+ * the agent created show as additions) then `git diff`. Output `{ result, usage,
+ * cost, steps, diff, changedRepos, changed }`.
+ *
+ * Self-contained: imports only `vein` + Node builtins. Needs `git` on PATH.
+ */
+
+function git(args: string[], cwd: string, timeoutMs = 30000): Promise<string> {
+  return new Promise((resolve) => {
+    const child = spawn("git", args, { cwd, stdio: ["ignore", "pipe", "pipe"] });
+    let stdout = "";
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolve(stdout);
+    }, timeoutMs);
+    child.stdout?.on("data", (d) => (stdout += d.toString()));
+    child.on("close", () => {
+      clearTimeout(timer);
+      resolve(stdout);
+    });
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve(stdout);
+    });
+  });
+}
+
+/** Immediate subdirs of `cwd` that are git repos. */
+function listRepos(cwd: string): string[] {
+  if (!existsSync(cwd)) return [];
+  return readdirSync(cwd, { withFileTypes: true })
+    .filter((e) => e.isDirectory() && existsSync(join(cwd, e.name, ".git")))
+    .map((e) => e.name)
+    .sort();
+}
+
+export default defineStep({
+  type: "gitsee/capture-edits",
+  description:
+    "Capture the agent's repo edits as a replayable `git diff` per repo (the deliverable form of 'what it changed to boot local-first'). Runs `git add -A -N` + `git diff` in each git-repo subdir of workspacePath, BEFORE any install/boot pollutes the tree. Passes through the explorer agent's result/usage/cost/steps (so it can be the last step of gitsee-explore-services) and adds { diff, changedRepos, changed }. Config: workspacePath, result?, usage?, cost?, steps?, maxBytes? (default 60000). Needs `git`.",
+  input: z.object({
+    workspacePath: z.string().describe("dir containing the cloned repos as siblings"),
+    // Passthrough of the explorer agent's output (this is the last step, and a
+    // workflow's output is its last step's output).
+    result: z.string().optional(),
+    usage: z.any().optional(),
+    cost: z.number().optional(),
+    steps: z.number().optional(),
+    maxBytes: z.number().int().positive().default(60000).describe("cap on the combined diff size"),
+  }),
+  output: z.any(),
+  async run(cfg) {
+    const repos = listRepos(cfg.workspacePath);
+    const parts: string[] = [];
+    const changedRepos: string[] = [];
+    for (const repo of repos) {
+      const dir = join(cfg.workspacePath, repo);
+      // Intent-to-add so brand-new files show up as additions in the diff.
+      await git(["add", "-A", "-N"], dir);
+      const diff = await git(["diff"], dir);
+      if (diff.trim()) {
+        changedRepos.push(repo);
+        parts.push(`=== ${repo} ===\n${diff}`);
+      }
+    }
+    let diff = parts.join("\n\n");
+    if (diff.length > cfg.maxBytes) diff = diff.slice(0, cfg.maxBytes) + "\n\n[... diff truncated ...]";
+    if (changedRepos.length)
+      console.log(`[gitsee/capture-edits] captured edits in ${changedRepos.length} repo(s): ${changedRepos.join(", ")}`);
+
+    // Pass the explorer agent's fields through unchanged + add the diff.
+    return {
+      result: cfg.result,
+      usage: cfg.usage,
+      cost: cfg.cost,
+      steps: cfg.steps,
+      diff,
+      changedRepos,
+      changed: changedRepos.length > 0,
+    };
+  },
+});

--- a/mcp/src/lab/gitsee/steps/score-setup.ts
+++ b/mcp/src/lab/gitsee/steps/score-setup.ts
@@ -51,6 +51,15 @@ import yaml from "js-yaml";
 
 const BETA = 2; // weight recall this many times more than precision
 const SEM_FLOOR = 0.7; // the LLM tier can dock at most (1 - SEM_FLOOR) of the score
+// BOOT + RENDER (the screenshot) is the dominant signal — the real proof the
+// setup works. The file-shape set-diff is only a small residual hint: a setup
+// that booted AND rendered scores at least RENDER_FLOOR regardless of how its
+// files compare to the gold (so a non-boot-critical missing key or an extra
+// service barely moves it). Booted-but-broken-UI and non-boot are scaled down.
+const RENDER_FLOOR = 0.85; // a booted+rendered setup scores in [RENDER_FLOOR, 1]
+const RENDER_FAIL_MULT = 0.45; // booted but the page didn't render
+const RENDER_UNKNOWN_MULT = 0.6; // booted but render couldn't be judged (no browser)
+const NO_BOOT_MULT = 0.1; // did not boot at all
 
 function fBeta(recall: number, precision: number): number {
   const b2 = BETA * BETA;
@@ -252,7 +261,7 @@ ${cfg.actual}`;
 export default defineStep({
   type: "gitsee/score-setup",
   description:
-    "Structured + hybrid scorer for the gitsee setup-profiler. Deterministically parses a pm2.config.js (node:vm) + docker-compose.yml (js-yaml) pair out of both `actual` and `expected`, then scores by NAME set-diffs vs the gold: env-key completeness (RECALL-ONLY — extra env keys are not penalized) + compose service/image set (recall AND precision — extra services are over-provisioning) combined as a recall-weighted F-beta, β=2. An optional LLM tier judges only the semantic residue (start command, host-binding flag, cross-file cred consistency, service appropriateness) and is folded in as a bounded multiplier. Config: actual, expected, rubric? (semantic-judge rubric), useLLM? (default true), ignoreEnvKeys? (default []), provider?, model?. Output: { score, recall, precision, matched, missing, spurious, reason, insight, markdown }.",
+    "Scorer for the gitsee setup-profiler where BOOT + RENDER dominate. The booted+rendered screenshot verdict (from gitsee/verify-setup, via `booted`/`rendered`) is the headline signal: a booted+rendered setup scores in [0.85,1]; booted-but-broken and non-boot are scaled down hard. The file-shape set-diff is only a small residual hint — it deterministically parses the pm2.config.js (node:vm) + docker-compose.yml (js-yaml) pair from `actual`/`expected` and scores by NAME set-diffs vs the gold, RECALL-ONLY for BOTH env keys and services (extra keys AND extra services are NOT penalized — the boot gate is the arbiter), recall-weighted F-beta β=2, times an optional bounded LLM semantic tier. Config: actual, expected, booted?, rendered?, bootReason?, rubric?, useLLM? (default true), ignoreEnvKeys? (default []), provider?, model?. Output: { score, recall, precision, matched, missing, spurious, reason, insight, markdown }.",
   input: z.object({
     actual: z.string(),
     expected: z.string(),
@@ -265,6 +274,14 @@ export default defineStep({
     // tokens+$ into, so the output `usage`/`cost` is the full per-eval total.
     priorUsage: z.any().optional(),
     priorCost: z.number().optional(),
+    // DOMINANT BOOT GATE (from gitsee/verify-setup). A setup that doesn't boot is
+    // a failure regardless of file shape, so these clamp the score: !booted →
+    // heavy penalty, booted-but-not-rendered → medium. null/undefined (verify
+    // skipped) leaves the score untouched (back-compat). `rendered:null` means the
+    // browser couldn't run (no penalty) — boot alone gates.
+    booted: z.boolean().nullable().optional(),
+    rendered: z.boolean().nullable().optional(),
+    bootReason: z.string().optional(),
   }),
   output: z.any(),
   async run(cfg) {
@@ -306,13 +323,13 @@ export default defineStep({
       ...envDiff.missing.map((k) => `env:${k}`),
       ...svcDiff.missing.map((s) => `service:${s}`),
     ];
-    // ENV IS RECALL-ONLY: extra env keys are NOT penalized. They're almost always
-    // REAL keys the app reads (the gold is a minimal curated set, not the complete
-    // one), and an extra env var doesn't break a boot — so it must not drag the
-    // score or the reflect feedback. Only SERVICE over-provisioning is real harm
-    // (an unneeded redis/soketi container), so only spurious services count against
-    // precision. `envDiff.spurious` is kept for the markdown/detail (informational).
-    const spurious = [...svcDiff.spurious.map((s) => `service:${s}`)];
+    // BOTH ENV AND SERVICES ARE RECALL-ONLY: extra env keys AND extra services are
+    // NOT penalized. The gold is a minimal curated set, not the complete one, and
+    // the BOOT GATE is the real arbiter of correctness — if the produced setup
+    // boots and renders, an extra service (e.g. a redis the gold mocks) or extra
+    // env key did no harm. So precision is informational only; the spurious lists
+    // (env + service) are kept for the markdown/detail, not scored.
+    const spurious: string[] = [];
 
     const expectedTotal = matched.length + missingDet.length;
     const producedTotal = matched.length + spurious.length;
@@ -339,46 +356,93 @@ export default defineStep({
     const semanticScore = sem ? Math.max(0, Math.min(1, sem.semanticScore)) : 1;
     const semIssues = sem?.issues ?? [];
 
-    const score = Math.round(base * (SEM_FLOOR + (1 - SEM_FLOOR) * semanticScore) * 100) / 100;
+    // The file-shape score (recall-weighted F-beta × semantic) — now only a small
+    // RESIDUAL that nudges within the boot/render band.
+    const setupScore = base * (SEM_FLOOR + (1 - SEM_FLOOR) * semanticScore);
 
-    // missing (for reflect): deterministic gaps + unparseable + semantic issues
+    // ── BOOT + RENDER dominate ─────────────────────────────────────────────────
+    // The screenshot (did the real UI render?) is the headline signal. A
+    // booted+rendered setup scores in [RENDER_FLOOR, 1], with setupScore moving
+    // only the top (1 - RENDER_FLOOR). Booted-but-broken and non-boot are scaled
+    // down hard. `booted == null` (no verify in this run) → pure setupScore.
+    const renderedBand = RENDER_FLOOR + (1 - RENDER_FLOOR) * setupScore;
+    const bootGaps: string[] = [];
+    let raw: number;
+    if (cfg.booted == null) {
+      raw = setupScore; // no verify step — fall back to file-shape only
+    } else if (cfg.booted && cfg.rendered === true) {
+      raw = renderedBand; // ✅ the real thing
+    } else if (cfg.booted && (cfg.rendered === null || cfg.rendered === undefined)) {
+      raw = RENDER_UNKNOWN_MULT * renderedBand; // booted, render unjudged (no browser)
+    } else if (cfg.booted && cfg.rendered === false) {
+      raw = RENDER_FAIL_MULT * renderedBand;
+      bootGaps.push(`boot:booted but the page did not render${cfg.bootReason ? ` (${cfg.bootReason})` : ""}`);
+    } else {
+      raw = NO_BOOT_MULT * setupScore;
+      bootGaps.push(`boot:setup did not boot${cfg.bootReason ? ` (${cfg.bootReason})` : ""}`);
+    }
+
+    const score = Math.round(raw * 100) / 100;
+
+    // missing (for reflect): boot failures FIRST (dominant) + deterministic gaps +
+    // unparseable + semantic issues
     const missing = [
+      ...bootGaps,
       ...unparseable.map((u) => `parse:${u}`),
       ...missingDet,
       ...semIssues.map((i) => `semantic:${i}`),
     ];
 
     // ── insight + reason ──────────────────────────────────────────────────────
-    let insight = sem?.insight ?? "";
+    // Boot failure is the dominant signal, so it owns the insight when present.
+    let insight = "";
+    if (cfg.booted === false)
+      insight =
+        "the generated setup does not actually boot — prioritize a runnable config (correct install/start commands, real backing services, mock flags) over file completeness.";
+    else if (cfg.booted === true && cfg.rendered === false)
+      insight =
+        "the setup boots but the frontend does not render — check the start command, host-binding flag, and that required services/env are wired so the page actually loads.";
+    if (!insight) insight = sem?.insight ?? "";
     if (!insight) {
-      if (envDiff.missing.length)
-        insight = "the generator omits environment variables the app reads at runtime — enumerate every process.env key the code references before writing the config.";
-      else if (svcDiff.spurious.length)
-        insight = "the generator over-provisions services the app doesn't actually depend on — only declare backing services the code connects to.";
-      else if (svcDiff.missing.length)
-        insight = "the generator misses a required backing service — trace the app's data/connection dependencies to a compose service.";
-      else insight = "the generator produces a functionally complete setup; refine only the semantic details.";
+      if (svcDiff.missing.length)
+        insight = "the generator misses a required backing service the app needs to boot — trace the app's data/connection dependencies to a compose service.";
+      else if (envDiff.missing.length)
+        insight = "the generator omits an environment variable the gold sets — check whether the app reads it at boot (extra/missing non-critical keys don't matter if it boots+renders).";
+      else insight = "the generator produces a setup that boots and renders; refine only the semantic details.";
     }
 
     const reasonParts: string[] = [];
+    if (cfg.booted === false) reasonParts.push(`Did not boot${cfg.bootReason ? `: ${cfg.bootReason}` : ""}.`);
+    else if (cfg.booted === true && cfg.rendered === false)
+      reasonParts.push(`Booted but did not render${cfg.bootReason ? `: ${cfg.bootReason}` : ""}.`);
+    else if (cfg.booted === true && cfg.rendered === true) reasonParts.push("Booted and rendered. ✅");
     if (unparseable.length) reasonParts.push(`Unparseable: ${unparseable.join("; ")}.`);
-    if (envDiff.missing.length) reasonParts.push(`Missing env keys: ${envDiff.missing.join(", ")}.`);
     if (svcDiff.missing.length) reasonParts.push(`Missing services: ${svcDiff.missing.join(", ")}.`);
-    if (svcDiff.spurious.length) reasonParts.push(`Extra services: ${svcDiff.spurious.join(", ")}.`);
+    if (envDiff.missing.length) reasonParts.push(`Missing env keys (not boot-critical if it rendered): ${envDiff.missing.join(", ")}.`);
+    // Extra env keys + extra services are NOT defects (recall-only) — noted in the
+    // markdown only, never in the reason fed to reflect.
     if (semIssues.length) reasonParts.push(`Semantic: ${semIssues.join("; ")}.`);
     const reason = reasonParts.join(" ") || "Produced setup matches the gold's functional requirements.";
 
     // ── markdown breakdown ────────────────────────────────────────────────────
     const pct = (n: number) => `${Math.round(n * 100)}%`;
+    const bootBadge =
+      cfg.booted === false
+        ? ` — ⛔ DID NOT BOOT (×${NO_BOOT_MULT})`
+        : cfg.booted === true && cfg.rendered === false
+          ? ` — ⚠️ booted, no render (×${RENDER_FAIL_MULT})`
+          : cfg.booted === true && cfg.rendered === true
+            ? ` — ✅ booted & rendered`
+            : "";
     const markdown = [
-      `**Score: ${score}**  (recall ${pct(recall)}, precision ${pct(precision)}${cfg.useLLM ? `, semantic ${pct(semanticScore)}` : ""})`,
+      `**Score: ${score}**${bootBadge}  (file-shape residual ${Math.round(setupScore * 100) / 100}: recall ${pct(recall)}${cfg.useLLM ? `, semantic ${pct(semanticScore)}` : ""} — boot+render dominates)`,
       ``,
-      `- **env keys**: ${envDiff.matched.length}/${envExpected} matched (recall ${pct(envRecall)})` +
+      `- **env keys**: ${envDiff.matched.length}/${envExpected} matched (recall ${pct(envRecall)}, recall-only)` +
         (envDiff.missing.length ? ` — missing: ${envDiff.missing.join(", ")}` : ""),
-      `- **services**: ${svcDiff.matched.length}/${svcExpected} matched (recall ${pct(svcRecall)})` +
+      `- **services**: ${svcDiff.matched.length}/${svcExpected} matched (recall ${pct(svcRecall)}, recall-only)` +
         (svcDiff.missing.length ? ` — missing: ${svcDiff.missing.join(", ")}` : "") +
-        (svcDiff.spurious.length ? ` — extra: ${svcDiff.spurious.join(", ")}` : ""),
-      envDiff.spurious.length ? `- **extra env keys** (not penalized — env is recall-only): ${envDiff.spurious.join(", ")}` : "",
+        (svcDiff.spurious.length ? ` — extra (not penalized): ${svcDiff.spurious.join(", ")}` : ""),
+      envDiff.spurious.length ? `- **extra env keys** (not penalized — recall-only): ${envDiff.spurious.join(", ")}` : "",
       unparseable.length ? `- **parse errors**: ${unparseable.join("; ")}` : "",
       cfg.useLLM && semIssues.length ? `- **semantic issues**: ${semIssues.join("; ")}` : "",
       ``,

--- a/mcp/src/lab/gitsee/steps/verify-setup.ts
+++ b/mcp/src/lab/gitsee/steps/verify-setup.ts
@@ -1,0 +1,554 @@
+import { z, defineStep, usageFromResult, computeCost } from "vein";
+import { spawn } from "node:child_process";
+import { writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createConnection } from "node:net";
+import { openSync } from "node:fs";
+import vm from "node:vm";
+import yaml from "js-yaml";
+
+/**
+ * THE BOOT GATE for the gitsee setup-profiler. Takes the produced
+ * pm2.config.js + docker-compose.yml pair and ACTUALLY RUNS IT the way the pod
+ * does — then proves the frontend is reachable with a headless browser. This is
+ * the dominant eval signal: a setup that doesn't boot is a failure no matter how
+ * well its file shape matches the gold (see gitsee-eval / score-setup gate).
+ *
+ * Layout & runner are pod-faithful (see staklink/src/proxy/startup.ts):
+ *   - the workspace's repos are already cloned as siblings under `workspacePath`
+ *     (by gitsee/clone-workspace, which gitsee-eval runs first);
+ *   - we write the produced files where staklink looks: pm2.config.js at the
+ *     workspace root (staklink's findPm2Config search list) and at
+ *     `.pod-config/.user-dockerfile/pm2.config.js` (its top-priority path),
+ *     plus docker-compose.yml at the root;
+ *   - the produced pm2 `cwd: /workspaces/<repo>` is rewritten to
+ *     `<workspacePath>/<repo>` so it resolves locally (the chosen "clone into a
+ *     real workspaces dir + rewrite the cwd prefix" approach);
+ *   - `docker compose up -d --wait` brings up the backing services (DB, …);
+ *   - staklink boots the apps EXACTLY like prod: REBUILD → INSTALL → PRE_START →
+ *     pm2 start → POST_START. (It does NOT run BUILD_COMMAND — dev-mode boot is
+ *     the faithful target.) Set `useStaklink:false` for a pm2-free inline boot
+ *     (run the env commands + spawn the `script` directly) on CI hosts.
+ *
+ * Then we poll the frontend's PORT and load `http://localhost:<port><checkPath>`
+ * in headless chromium (via @playwright/test), asserting a non-error response
+ * and no framework error overlay, and capture a screenshot. Missing browsers
+ * degrade gracefully to a boot-only gate (`rendered: null`).
+ *
+ * Output: { booted, rendered, port, httpStatus, title, reason, logs,
+ *   screenshotPath }. `booted`/`rendered` feed score-setup's dominant gate.
+ *
+ * Self-contained: imports only `vein`, `@playwright/test` (lazy), and Node
+ * builtins. Needs `git` (clone, upstream), `docker` (compose), and — when
+ * `useStaklink` — network access for `npx staklink`. Playwright browsers must be
+ * installed (`npx playwright install chromium`) for the render check.
+ */
+
+// ── shell helpers ───────────────────────────────────────────────────────────
+
+interface ShResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/** Run a shell command, capture output, never reject (returns the exit code).
+ *  Mirrors staklink's runner env (CI=1, non-interactive) for parity. */
+function sh(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+  timeoutMs: number,
+): Promise<ShResult> {
+  return new Promise((resolve) => {
+    const child = spawn("sh", ["-c", command], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, CI: "1", DEBIAN_FRONTEND: "noninteractive", ...env },
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.stdout?.on("data", (d) => (stdout += d.toString()));
+    child.stderr?.on("data", (d) => (stderr += d.toString()));
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ code: -1, stdout, stderr: stderr + String(err), timedOut });
+    });
+  });
+}
+
+/** Poll a TCP port until something is listening (the app booted) or we time out. */
+function waitForPort(port: number, host: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve) => {
+    const attempt = () => {
+      const socket = createConnection({ port, host });
+      socket.setTimeout(2000);
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      const retry = () => {
+        socket.destroy();
+        if (Date.now() >= deadline) resolve(false);
+        else setTimeout(attempt, 1500);
+      };
+      socket.once("error", retry);
+      socket.once("timeout", retry);
+    };
+    attempt();
+  });
+}
+
+// ── booted-service logs ───────────────────────────────────────────────────────
+
+/** Grab the booted app's recent logs so we can check for fatal errors a
+ *  screenshot can't show. Tries the inline-boot log file, then pm2 (staklink
+ *  runs apps under pm2), then pm2's on-disk log files. Returns the TAIL. */
+async function captureAppLogs(wp: string, appName: string): Promise<string> {
+  const chunks: string[] = [];
+  const inlineLog = join(wp, ".verify", "app.log");
+  if (existsSync(inlineLog)) {
+    try {
+      chunks.push(readFileSync(inlineLog, "utf-8"));
+    } catch {
+      /* ignore */
+    }
+  }
+  const r = await sh(`npx -y pm2 logs ${appName} --nostream --lines 200`, wp, {}, 30000);
+  if (r.stdout.trim()) chunks.push(r.stdout);
+  const pm2dir = join(homedir(), ".pm2", "logs");
+  for (const f of [`${appName}-out.log`, `${appName}-error.log`]) {
+    const p = join(pm2dir, f);
+    if (existsSync(p)) {
+      try {
+        chunks.push(`--- ${f} ---\n${readFileSync(p, "utf-8")}`);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  const out = chunks.join("\n");
+  return out.length > 20000 ? out.slice(-20000) : out; // keep the tail
+}
+
+const LOG_ERROR_RE =
+  /(^|\b)(Error:|UnhandledPromiseRejection|unhandledRejection|uncaughtException|EADDRINUSE|ECONNREFUSED|Cannot find module|MODULE_NOT_FOUND|PrismaClientInitializationError|FATAL|panic:|Traceback \(most recent|errored|exited with code [1-9])/i;
+
+/** Obvious fatal-error lines in the logs (heuristic; the vision judge also reads
+ *  the logs and is authoritative when on). */
+function scanLogErrors(logs: string): string[] {
+  return logs
+    .split("\n")
+    .filter((l) => LOG_ERROR_RE.test(l))
+    .slice(0, 20);
+}
+
+// ── produced-file parsing (mirrors gitsee/score-setup) ────────────────────────
+
+interface TwoFiles {
+  pm2?: string;
+  compose?: string;
+}
+
+/** Split a "FILENAME: <name>\n```lang\n…\n```" doc into the pm2 + compose blocks. */
+function splitFiles(doc: string): TwoFiles {
+  const out: TwoFiles = {};
+  const re = /FILENAME:\s*([^\n]+?)\s*\n+```[a-zA-Z0-9]*\n([\s\S]*?)\n```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(doc)) !== null) {
+    const name = m[1].trim().toLowerCase();
+    const body = m[2];
+    if (name.includes("pm2")) out.pm2 ??= body;
+    else if (name.includes("compose")) out.compose ??= body;
+  }
+  return out;
+}
+
+/** Does the compose file declare any real services? A service-less compose (just
+ *  a network — the gitsee convention for "no backing services needed") must NOT
+ *  be `docker compose up`'d: that errors with "no service selected". */
+function hasComposeServices(text: string | undefined): boolean {
+  if (!text) return false;
+  try {
+    const doc = yaml.load(text) as { services?: Record<string, unknown> } | undefined;
+    return !!doc?.services && Object.keys(doc.services).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** A callable, infinitely-chainable no-op for sandboxed require() chains. */
+function callableStub(): unknown {
+  const fn = function () {
+    return stub;
+  };
+  const stub: unknown = new Proxy(fn, { get: () => stub, apply: () => stub });
+  return stub;
+}
+
+interface Pm2App {
+  name?: string;
+  script?: string;
+  args?: string;
+  cwd?: string;
+  env?: Record<string, unknown>;
+}
+
+/** Eval `module.exports = {...}` in a locked-down vm. Returns the apps, or null. */
+function parsePm2(code: string | undefined): Pm2App[] | null {
+  if (!code) return null;
+  const sandbox: Record<string, unknown> = {
+    module: { exports: {} },
+    require: () => callableStub(),
+    console: { log() {}, error() {}, warn() {}, info() {} },
+    process: { env: {} },
+  };
+  sandbox.exports = (sandbox.module as { exports: unknown }).exports;
+  try {
+    vm.createContext(sandbox);
+    vm.runInContext(code, sandbox, { timeout: 1000 });
+    const exported = (sandbox.module as { exports: unknown }).exports as { apps?: unknown };
+    return Array.isArray(exported?.apps) ? (exported.apps as Pm2App[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** The frontend app (named "frontend", else the first app) + its port. */
+function frontendApp(apps: Pm2App[]): { app: Pm2App; port: number } | null {
+  if (!apps.length) return null;
+  const app = apps.find((a) => a.name === "frontend") ?? apps[0];
+  const port = parseInt(String(app.env?.PORT ?? "3000"), 10) || 3000;
+  return { app, port };
+}
+
+// ── headless render check ─────────────────────────────────────────────────────
+
+interface RenderResult {
+  rendered: boolean | null; // null = could not run the browser (no boot-gate impact)
+  httpStatus?: number;
+  title?: string;
+  screenshotPath?: string;
+  note?: string;
+  usage?: ReturnType<typeof usageFromResult>;
+  cost?: number;
+}
+
+/** Vision judge: show the screenshot AND the booted service's log tail to a
+ *  multimodal model and ask whether the app rendered + booted cleanly. The
+ *  SCREENSHOT is weighted most heavily (the real "is it legit" signal — HTTP 200
+ *  + non-empty DOM isn't enough; a white screen or styled error page both pass
+ *  those); the LOGS catch fatal errors a screenshot can hide (crash loops,
+ *  module-not-found, DB connection refused). anthropic-only. Returns verdict +
+ *  call cost. */
+async function judgeRender(
+  pngPath: string,
+  url: string,
+  logs: string,
+  visionModel: string | undefined,
+): Promise<{ working: boolean; reason: string; usage: ReturnType<typeof usageFromResult>; cost: number }> {
+  const { generateObject } = await import("ai");
+  const { anthropic } = await import("@ai-sdk/anthropic");
+  const model = anthropic(visionModel ?? process.env["VEIN_LLM_MODEL"] ?? "claude-sonnet-4-6");
+  const schema = z.object({
+    working: z
+      .boolean()
+      .describe("true ONLY if the intended app UI rendered (a real, populated, styled page — a login/landing page counts) AND the logs show no fatal/repeating boot error; false for a blank/white page, an error overlay, a stack trace, an unstyled error, a 404/500/connection-error page, or logs showing a crash loop / fatal startup error."),
+    reason: z.string().describe("one short sentence: what the screenshot shows and whether the logs look clean."),
+  });
+  const image = readFileSync(pngPath);
+  const logTail = logs ? logs.slice(-8000) : "(no logs captured)";
+  const { object, usage: rawUsage } = await generateObject({
+    model: model as any,
+    schema: schema as any,
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `We just booted a web app locally for development at ${url}. Below is a full-page screenshot plus the TAIL of the booted server's logs. Did the app's intended UI render SUCCESSFULLY and boot cleanly?
+
+WEIGHT THE SCREENSHOT MOST HEAVILY. Treat as FAILURE: a blank/white page, a framework error overlay (Next.js/Vite/React), a stack trace, raw unstyled error text, a 404/500 page, or a "can't connect" page. Use the LOGS to catch fatal errors the screenshot can hide — a crash loop, uncaught exception, "Cannot find module", DB connection refused, or the process repeatedly errored/exited. A few warnings or a single non-fatal error line is FINE if the UI clearly rendered.
+
+SERVER LOGS (tail):
+${logTail}`,
+          },
+          { type: "image", image },
+        ],
+      },
+    ],
+  });
+  const usage = usageFromResult(rawUsage);
+  const o = object as { working: boolean; reason: string };
+  return { working: o.working, reason: o.reason, usage, cost: computeCost("anthropic", usage) };
+}
+
+/** Load the booted app in headless chromium, screenshot it, then judge whether it
+ *  actually rendered — by VISION model when available (the real signal), falling
+ *  back to HTTP-status + error-overlay heuristics. */
+async function renderCheck(
+  url: string,
+  screenshotDir: string,
+  timeoutMs: number,
+  logs: string,
+  vision: { use: boolean; model?: string },
+): Promise<RenderResult> {
+  let chromium: any;
+  try {
+    ({ chromium } = await import("@playwright/test"));
+  } catch (e) {
+    return { rendered: null, note: `playwright not available: ${(e as Error).message}` };
+  }
+  let browser: any;
+  try {
+    browser = await chromium.launch();
+  } catch (e) {
+    return { rendered: null, note: `could not launch chromium (browsers installed?): ${(e as Error).message}` };
+  }
+  try {
+    const page = await browser.newPage();
+    const resp = await page.goto(url, { waitUntil: "networkidle", timeout: timeoutMs }).catch(async () =>
+      page.goto(url, { waitUntil: "domcontentloaded", timeout: timeoutMs }),
+    );
+    const httpStatus = resp?.status();
+    const title = await page.title().catch(() => "");
+    const body = (await page.content().catch(() => "")) || "";
+    const logErr = scanLogErrors(logs);
+    const erroredHeuristic =
+      /nextjs__container_errors|__next-error|Application error: a (?:client|server)-side exception|Internal Server Error/i.test(
+        body,
+      ) || logErr.length > 0;
+    mkdirSync(screenshotDir, { recursive: true });
+    const screenshotPath = join(screenshotDir, "render.png");
+    await page.screenshot({ path: screenshotPath, fullPage: true }).catch(() => {});
+
+    // A hard HTTP error short-circuits to "not rendered".
+    if (httpStatus != null && httpStatus >= 400) {
+      return { rendered: false, httpStatus, title, screenshotPath, note: `HTTP ${httpStatus}` };
+    }
+
+    // The REAL signal: a vision model looks at the screenshot (+ the logs).
+    if (vision.use && existsSync(screenshotPath)) {
+      try {
+        const v = await judgeRender(screenshotPath, url, logs, vision.model);
+        return {
+          rendered: v.working,
+          httpStatus,
+          title,
+          screenshotPath,
+          note: `vision: ${v.reason}`,
+          usage: v.usage,
+          cost: v.cost,
+        };
+      } catch (e) {
+        // fall through to heuristic if the vision call fails (no key, etc.)
+        return {
+          rendered: !erroredHeuristic,
+          httpStatus,
+          title,
+          screenshotPath,
+          note: `vision judge failed (${(e as Error).message}); heuristic only`,
+        };
+      }
+    }
+
+    return {
+      rendered: !erroredHeuristic,
+      httpStatus,
+      title,
+      screenshotPath,
+      note: erroredHeuristic
+        ? `error overlay/crash detected${logErr.length ? ` (logs: ${logErr[0].trim().slice(0, 120)})` : ""}`
+        : "heuristic (vision off)",
+    };
+  } catch (e) {
+    return { rendered: false, note: `navigation failed: ${(e as Error).message}` };
+  } finally {
+    await browser.close().catch(() => {});
+  }
+}
+
+// ── step ──────────────────────────────────────────────────────────────────────
+
+export default defineStep({
+  type: "gitsee/verify-setup",
+  description:
+    "Boot gate for the gitsee setup-profiler: stages the produced pm2.config.js + docker-compose.yml into the cloned workspace the pod way (rewriting /workspaces/<repo> cwd to the local clone), `docker compose up -d --wait`, boots the apps via staklink (REBUILD→INSTALL→PRE_START→pm2 start→POST_START; no BUILD_COMMAND, mirroring prod) or an inline pm2-free fallback, polls the frontend PORT, then loads it in headless chromium, screenshots it, and JUDGES THE SCREENSHOT WITH A VISION MODEL (the real 'did it render' signal — HTTP 200 + a non-empty DOM isn't enough; a white screen or styled error page pass those) with an HTTP-status/error-overlay heuristic fallback. Tears down (pm2 delete all + compose down) unless keepUp. Config: workspacePath, setup (the two-file string), checkPath? (default /), bootTimeoutMs?, renderTimeoutMs?, useVision? (default true), visionModel?, useStaklink? (default true), bootCommand?, enabled? (default true), keepUp? (default false). Output: { booted, rendered, port, httpStatus, title, reason, logs, screenshotPath, cost, usage }.",
+  input: z.object({
+    workspacePath: z.string().describe("dir containing the cloned repos as siblings (from gitsee/clone-workspace)"),
+    setup: z.string().describe("the produced pm2.config.js + docker-compose.yml two-file string"),
+    checkPath: z.string().default("/").describe("path appended to http://localhost:<port> for the render check"),
+    bootTimeoutMs: z.number().int().positive().default(420000).describe("max wait for the frontend port to bind (install+build can be slow)"),
+    renderTimeoutMs: z.number().int().positive().default(30000),
+    useVision: z.boolean().default(true).describe("judge the screenshot with a vision model (the real 'did it render' signal); false = HTTP-status + error-overlay heuristics only"),
+    visionModel: z.string().optional().describe("anthropic vision model for the screenshot judge (default claude-sonnet-4-6)"),
+    useStaklink: z.boolean().default(true).describe("boot via `npx staklink start` (prod-faithful); false = inline pm2-free boot"),
+    bootCommand: z.string().default("npx -y staklink@latest start").describe("the staklink boot command (when useStaklink)"),
+    enabled: z.boolean().default(true).describe("false = no-op (returns booted:null) so the gate is skipped in cheap sweeps"),
+    keepUp: z.boolean().default(false).describe("skip teardown (leave compose + apps running for debugging)"),
+  }),
+  output: z.any(),
+  async run(cfg) {
+    const logs: string[] = [];
+    const log = (s: string) => {
+      console.log(`[gitsee/verify] ${s}`);
+      logs.push(s);
+    };
+    const result = (extra: Record<string, unknown>) => ({
+      booted: null as boolean | null,
+      rendered: null as boolean | null,
+      port: null as number | null,
+      // vision-judge token cost (0 when vision off / not reached); folded into the
+      // eval grand total by gitsee-eval (produce.cost + verify.cost).
+      cost: 0,
+      logs: logs.join("\n"),
+      ...extra,
+    });
+
+    if (!cfg.enabled) return result({ reason: "verify disabled (enabled:false)" });
+
+    const wp = cfg.workspacePath;
+    if (!existsSync(wp)) return result({ reason: `workspacePath does not exist: ${wp}` });
+
+    // 1. Parse + stage the produced files (pod layout).
+    const files = splitFiles(cfg.setup);
+    if (!files.pm2) return result({ booted: false, reason: "no pm2.config.js in the produced output" });
+
+    const apps = parsePm2(files.pm2);
+    if (!apps) return result({ booted: false, reason: "produced pm2.config.js did not parse" });
+    const fe = frontendApp(apps);
+    if (!fe) return result({ booted: false, reason: "no app found in pm2.config.js" });
+    const { app, port } = fe;
+
+    // Rewrite the pod-absolute cwd (/workspaces/<repo>) to the local clone root.
+    const pm2Local = files.pm2.replace(/\/workspaces\//g, `${wp}/`);
+    writeFileSync(join(wp, "pm2.config.js"), pm2Local);
+    mkdirSync(join(wp, ".pod-config", ".user-dockerfile"), { recursive: true });
+    writeFileSync(join(wp, ".pod-config", ".user-dockerfile", "pm2.config.js"), pm2Local);
+    if (files.compose) writeFileSync(join(wp, "docker-compose.yml"), files.compose);
+    log(`staged pm2.config.js (frontend port ${port}) + ${files.compose ? "docker-compose.yml" : "no compose"}`);
+
+    const appCwd = (app.cwd ?? "").replace(/\/workspaces\//g, `${wp}/`) || wp;
+    const appEnv: Record<string, string> = {};
+    for (const [k, v] of Object.entries(app.env ?? {})) appEnv[k] = String(v);
+
+    // A service-less compose (just a network) = "no backing services needed":
+    // skip compose entirely (docker compose up would error "no service selected").
+    const composeServices = hasComposeServices(files.compose);
+
+    let booted = false;
+    let reason = "";
+    try {
+      // 2. Backing services.
+      if (composeServices) {
+        log("docker compose up -d --wait …");
+        const up = await sh("docker compose up -d --wait", wp, {}, 300000);
+        if (up.code !== 0) {
+          // --wait fails if a container has no healthcheck; retry without it.
+          const up2 = await sh("docker compose up -d", wp, {}, 300000);
+          if (up2.code !== 0) {
+            log(`compose up failed: ${(up.stderr || up2.stderr).slice(0, 800)}`);
+            return result({ booted: false, port, reason: "docker compose up failed", screenshotPath: undefined });
+          }
+        }
+      } else {
+        log(files.compose ? "compose has no services — skipping compose up" : "no docker-compose.yml");
+      }
+
+      // 3. Boot the apps.
+      if (cfg.useStaklink) {
+        log(`booting via staklink: ${cfg.bootCommand}`);
+        // staklink launches a pm2-managed proxy that runs startup() (install →
+        // pre-start → pm2 start) in the background; we then poll the port.
+        const boot = await sh(cfg.bootCommand, wp, {}, 180000);
+        if (boot.code !== 0) log(`staklink start returned ${boot.code}: ${boot.stderr.slice(0, 600)}`);
+      } else {
+        // Inline pm2-free boot: run the env commands, then spawn the script.
+        for (const [key, cmd] of [
+          ["REBUILD_COMMAND", appEnv.REBUILD_COMMAND],
+          ["INSTALL_COMMAND", appEnv.INSTALL_COMMAND],
+          ["PRE_START_COMMAND", appEnv.PRE_START_COMMAND ?? appEnv.PRE_RUN_COMMAND],
+        ] as const) {
+          if (!cmd) continue;
+          log(`${key}: ${cmd}`);
+          const r = await sh(cmd, appCwd, appEnv, 600000);
+          if (r.code !== 0) log(`${key} exited ${r.code}: ${r.stderr.slice(0, 400)}`);
+        }
+        const script = [app.script, app.args].filter(Boolean).join(" ");
+        log(`spawning app: ${script} (cwd ${appCwd})`);
+        // Pipe the app's stdout/stderr to a log file so we can inspect it for
+        // boot errors (the staklink path uses pm2's logs instead).
+        mkdirSync(join(wp, ".verify"), { recursive: true });
+        const logFd = openSync(join(wp, ".verify", "app.log"), "w");
+        spawn("sh", ["-c", script], {
+          cwd: appCwd,
+          detached: true,
+          stdio: ["ignore", logFd, logFd],
+          env: { ...process.env, CI: "1", ...appEnv },
+        }).unref();
+      }
+
+      // 4. Wait for the port.
+      log(`waiting for port ${port} (timeout ${cfg.bootTimeoutMs}ms) …`);
+      booted = await waitForPort(port, "127.0.0.1", cfg.bootTimeoutMs);
+      reason = booted ? "frontend port bound" : `frontend port ${port} never bound within ${cfg.bootTimeoutMs}ms`;
+      log(reason);
+
+      // 5. Render check.
+      let render: RenderResult = { rendered: null };
+      let appLogs = "";
+      let logErrors: string[] = [];
+      if (booted) {
+        // Read the booted service's logs (so we catch fatal errors a screenshot
+        // can't show) and feed them to the judge alongside the screenshot.
+        appLogs = await captureAppLogs(wp, app.name ?? "frontend");
+        logErrors = scanLogErrors(appLogs);
+        if (logErrors.length) log(`log errors (heuristic): ${logErrors.length} line(s) — e.g. ${logErrors[0].trim().slice(0, 120)}`);
+        const url = `http://localhost:${port}${cfg.checkPath}`;
+        log(`render check: ${url}`);
+        render = await renderCheck(url, join(wp, ".verify"), cfg.renderTimeoutMs, appLogs, {
+          use: cfg.useVision,
+          model: cfg.visionModel,
+        });
+        log(`rendered=${render.rendered} status=${render.httpStatus ?? "?"} ${render.note ?? ""}`);
+      }
+
+      return result({
+        booted,
+        rendered: render.rendered,
+        port,
+        httpStatus: render.httpStatus,
+        title: render.title,
+        screenshotPath: render.screenshotPath,
+        cost: render.cost ?? 0,
+        usage: render.usage,
+        logErrors,
+        logsTail: appLogs.slice(-4000),
+        reason: render.note ? `${reason}; ${render.note}` : reason,
+      });
+    } finally {
+      // 6. Teardown.
+      if (!cfg.keepUp) {
+        log("teardown: pm2 delete all + docker compose down");
+        await sh("npx -y pm2 delete all", wp, {}, 60000).catch(() => {});
+        if (cfg.useStaklink) await sh(`${cfg.bootCommand.split(" ").slice(0, -1).join(" ")} stop`, wp, {}, 30000).catch(() => {});
+        if (composeServices) await sh("docker compose down -v", wp, {}, 120000).catch(() => {});
+      } else {
+        log("keepUp:true — leaving services + apps running");
+      }
+    }
+  },
+});

--- a/mcp/src/lab/gitsee/steps/verify-setup.ts
+++ b/mcp/src/lab/gitsee/steps/verify-setup.ts
@@ -88,6 +88,14 @@ function sh(
   });
 }
 
+/** All docker container IDs (running + stopped). Used to snapshot the container
+ *  set before boot so teardown can remove anything the app spun up (a `supabase
+ *  start` CLI stack, a minio, etc.) that our `docker compose down` never sees. */
+async function dockerContainerIds(): Promise<Set<string>> {
+  const r = await sh("docker ps -aq", process.cwd(), {}, 15000);
+  return new Set(r.stdout.split("\n").map((s) => s.trim()).filter(Boolean));
+}
+
 /** Poll a TCP port until something is listening (the app booted) or we time out. */
 function waitForPort(port: number, host: string, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs;
@@ -449,6 +457,11 @@ export default defineStep({
     // skip compose entirely (docker compose up would error "no service selected").
     const composeServices = hasComposeServices(files.compose);
 
+    // Snapshot the container set BEFORE boot, so teardown can force-remove
+    // everything that appeared during this run — including app-spawned stacks our
+    // compose file knows nothing about (a `supabase start` CLI project, a minio…).
+    const preBootContainers = await dockerContainerIds();
+
     let booted = false;
     let reason = "";
     try {
@@ -542,10 +555,25 @@ export default defineStep({
     } finally {
       // 6. Teardown.
       if (!cfg.keepUp) {
-        log("teardown: pm2 delete all + docker compose down");
+        log("teardown: pm2 delete all + docker compose down + remove app-spawned containers");
         await sh("npx -y pm2 delete all", wp, {}, 60000).catch(() => {});
         if (cfg.useStaklink) await sh(`${cfg.bootCommand.split(" ").slice(0, -1).join(" ")} stop`, wp, {}, 30000).catch(() => {});
         if (composeServices) await sh("docker compose down -v", wp, {}, 120000).catch(() => {});
+        // Force-remove anything that appeared since the pre-boot snapshot — this is
+        // what catches a `supabase start` stack / minio / any container the app
+        // started outside our compose file. `-v` also drops their anonymous volumes.
+        try {
+          const now = await dockerContainerIds();
+          const spawned = [...now].filter((id) => !preBootContainers.has(id));
+          if (spawned.length) {
+            log(`removing ${spawned.length} app-spawned container(s)`);
+            await sh(`docker rm -fv ${spawned.join(" ")}`, wp, {}, 120000).catch(() => {});
+            // best-effort prune of the now-dangling networks/volumes they created
+            await sh("docker network prune -f", wp, {}, 30000).catch(() => {});
+          }
+        } catch {
+          /* ignore teardown errors */
+        }
       } else {
         log("keepUp:true — leaving services + apps running");
       }

--- a/mcp/src/lab/gitsee/workflows/gitsee-eval-score.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-eval-score.yaml
@@ -12,8 +12,10 @@ name: gitsee-eval-score
 # mechanical + boot-critical — a set diff is sharper and lower-variance than
 # hoping a paragraph rubric makes the judge enumerate 15 keys.
 #
-# Input:  { actual, expected, usage?, cost? }   (each file = a "FILENAME: …" string;
-#          usage/cost = the upstream explorer agent's tokens+$, folded into the total)
+# Input:  { actual, expected, usage?, cost?, booted?, rendered?, bootReason? }
+#          (each file = a "FILENAME: …" string; usage/cost = the upstream explorer
+#          agent's tokens+$, folded into the total; booted/rendered = the dominant
+#          boot gate from gitsee/verify-setup)
 # Output: { score, recall, precision, matched, missing, spurious, reason, insight,
 #           markdown, usage, cost }
 #         (the eval/optimize + eval/reflect contract — preserved by score-setup —
@@ -37,6 +39,12 @@ steps:
       ignoreEnvKeys: "{{ params.ignoreEnvKeys }}"
       # The semantic-judge rubric (the experiment surface for the LLM tier).
       rubric: "{{ params.rubric }}"
+      # DOMINANT BOOT GATE: did the produced setup actually run + render (from
+      # gitsee/verify-setup)? !booted → heavy penalty, booted-but-not-rendered →
+      # medium. Null/absent (no verify step) leaves the file-shape score untouched.
+      booted: "{{ input.booted }}"
+      rendered: "{{ input.rendered }}"
+      bootReason: "{{ input.bootReason }}"
       # Optionally override the judge model:
       # model: claude-opus-4-20250514
 
@@ -83,11 +91,10 @@ params:
       pm2 env (e.g. a DATABASE_URL) are consistent with the corresponding compose
       service (same db name / user / password / host:port) — regardless of how
       either side is named.
-    - SERVICE APPROPRIATENESS: a backing service gets a real container ONLY if it
-      is a primary datastore the app can't boot without (the database). Caches,
-      queues, pub/sub, realtime (redis, soketi/pusher, etc.) and any cloud/third-
-      party service must be MOCKED or DISABLED, not containerized — flag any such
-      extra service in the produced compose as a defect (over-provisioning).
+    - SERVICE APPROPRIATENESS: do NOT flag EXTRA services as a defect — if the app
+      boots and renders, an extra backing service (e.g. a redis the gold mocks) did
+      no harm and is acceptable. Only flag a MISSING service the app genuinely
+      needs to boot. (Over-provisioning is no longer penalized.)
     - MOCK/OFFLINE MODE: when the repo supports a mock/offline mode (USE_MOCKS or
       similar), the produced pm2 env should enable it and use placeholder mock-*
       creds for external services rather than provisioning them.

--- a/mcp/src/lab/gitsee/workflows/gitsee-eval.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-eval.yaml
@@ -20,11 +20,22 @@ name: gitsee-eval
 # gitsee is stateless per run (it re-clones/re-explores), so unlike concepts-eval
 # there's no reset step — each run produces fresh output for the current prompt.
 steps:
-  # 1. Produce the setup files. The exploration prompt is tuned via
+  # 1. Clone the workspace FIRST so its path is in scope for the boot gate. The
+  #    produce subflow re-clones the SAME idempotent path (a no-op reuse), so this
+  #    costs nothing but hands `verify` the dir the produced config must run in.
+  - id: clone
+    type: gitsee/clone-workspace
+    config:
+      workspace: "{{ input.label }}"
+      repos: "{{ input.repos }}"
+      token: "{{ input.token }}"
+
+  # 2. Produce the setup files. The exploration prompt is tuned via
   #    gitsee-explore-services' `params.system`, or per run via
   #    paramOverrides: { "gitsee-explore-services": { system } }.
   - id: produce
     type: subflow
+    depends: clone
     config:
       workflow: gitsee-explore-services
       input:
@@ -34,9 +45,24 @@ steps:
     # subflow output = gitsee-explore-services' `explore` step = { result, steps }
     # `result` is the raw two-file (pm2.config.js + docker-compose.yml) string.
 
-  # 2. Score the produced files against the expected gold setup facts.
+  # 3. THE BOOT GATE: actually run the produced setup in the cloned workspace and
+  #    prove the frontend renders. `booted`/`rendered` dominate the score. Set
+  #    params.verify=false to skip (cheap deterministic-only sweeps).
+  - id: verify
+    type: gitsee/verify-setup
+    depends: produce
+    config:
+      workspacePath: "{{ clone.workspacePath }}"
+      setup: "{{ produce.result }}"
+      enabled: "{{ params.verify }}"
+      checkPath: "{{ params.checkPath }}"
+      bootTimeoutMs: "{{ params.bootTimeoutMs }}"
+      useStaklink: "{{ params.useStaklink }}"
+
+  # 4. Score the produced files against the gold, GATED by the boot result.
   - id: score
     type: subflow
+    depends: verify
     config:
       workflow: gitsee-eval-score
       input:
@@ -45,8 +71,13 @@ steps:
         expected: "{{ input.expected ? input.expected : params.expected }}"
         # Carry the explorer agent's token usage + cost through so the scorer can
         # fold in its own judge cost and surface a per-eval total (→ optimize).
+        # verify.cost = the screenshot vision-judge's tokens; add it in.
         usage: "{{ produce.usage }}"
-        cost: "{{ produce.cost }}"
+        cost: "{{ produce.cost + verify.cost }}"
+        # DOMINANT GATE: did the produced setup actually boot + render?
+        booted: "{{ verify.booted }}"
+        rendered: "{{ verify.rendered }}"
+        bootReason: "{{ verify.reason }}"
 
 # ── params: the gold OUTPUT (the canonical pm2.config.js + docker-compose.yml) ──
 # The gold is the ACTUAL known-good file pair for this repo — same shape the
@@ -56,6 +87,14 @@ steps:
 # functional equivalence is fine but deviations/omissions are penalized).
 # Default below is for heroku/node-js-getting-started (a simple Express app, no DB).
 params:
+  # ── boot-gate knobs (gitsee/verify-setup) ──────────────────────────────────
+  # verify=true makes the eval ACTUALLY run the produced setup and check the
+  # frontend renders — the dominant signal. Turn OFF for cheap, docker-free,
+  # deterministic-only sweeps (then the score is pure file-shape set-diff).
+  verify: true
+  checkPath: "/" # path appended to http://localhost:<port> for the render check
+  bootTimeoutMs: 420000 # install+build can be slow; allow plenty of headroom
+  useStaklink: true # boot the prod way (npx staklink start); false = inline boot
   expected: |-
     FILENAME: pm2.config.js
 

--- a/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
@@ -35,6 +35,21 @@ steps:
       finalAnswer: "{{ params.finalAnswer }}"
       model: "{{ params.model }}"
 
+  # Capture the agent's repo edits (it may have patched files to make the
+  # workspace boot local-first) as a replayable git diff — part of the
+  # deliverable. PASSES THROUGH the agent's result/usage/cost/steps (a workflow's
+  # output is its last step's output), so `explore`'s output is preserved AND
+  # `diff` is added. Captured before any install/boot pollutes the tree.
+  - id: capture
+    type: gitsee/capture-edits
+    depends: explore
+    config:
+      workspacePath: "{{ clone.workspacePath }}"
+      result: "{{ explore.result }}"
+      usage: "{{ explore.usage }}"
+      cost: "{{ explore.cost }}"
+      steps: "{{ explore.steps }}"
+
 # ── params: the prompt experiment surface (workspace-aware, frontend-focused) ───
 params:
   model: claude-sonnet-4-6
@@ -64,10 +79,19 @@ params:
     - whether the repo has a mock / offline / dev mode (e.g. a USE_MOCKS or MOCK_* flag) that lets it boot without real external accounts — prefer enabling it over provisioning those services.
 
     Use the fulltext_search tool to find env var usage, and bash to read package manifests, lockfiles, docker files, and cross-repo dependency links. You will output actual config files at the end, so find everything you need. Name the runnable pm2 service "frontend" no matter what.
+
+    EDITING THE REPO (local-first). You have a str_replace_based_edit_tool (view/create/str_replace/insert). Use it to make the workspace BOOT LOCALLY when a config change alone can't — e.g. flip a hardcoded cloud-only setting to a local one, enable a mock/offline flag in a config file, or MOVE a misplaced file into the place the framework expects (a classic case: a SQL migration committed at the repo root or meant to be pasted into a hosted dashboard, when the framework auto-applies migrations from a specific dir — move it there). Your edits are captured as a git diff and shipped as part of the setup (re-applied on a fresh clone), so:
+    - Make MINIMAL, surgical edits — only what's needed to boot locally. Don't refactor.
+    - Put FILE changes in the repo (the diff captures them); put RUNTIME steps (reset the db, run migrations, seed) in PRE_START_COMMAND — do NOT do file-moving shell hacks inside PRE_START_COMMAND when an actual file move (a clean diff hunk) is clearer.
+    - Prefer the repo's own mock/offline mode over editing when one exists.
+
+    Name the runnable pm2 service "frontend" no matter what.
   finalAnswer: |-
     Provide the final answer. YOU **MUST** CALL THIS TOOL AT THE END OF YOUR EXPLORATION.
 
     Return 2 files: a pm2.config.js and a docker-compose.yml. For each file, put "FILENAME: " followed by the filename (no markdown headers, just the plain filename), then the content in a fenced code block. YOU MUST RETURN BOTH FILES.
+
+    If you edited any repo files to make it boot local-first, add a short "## CHANGES" section AFTER the two files: a brief markdown list of what you changed and why (the exact git diff is captured automatically — this is the human-readable summary, not the patch). Omit the section if you made no repo edits.
 
     # Pod contract - mandatory
 

--- a/mcp/src/lab/gitsee/workflows/gitsee-optimize.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-optimize.yaml
@@ -38,6 +38,12 @@ steps:
       reflectWorkflow: gitsee-eval-reflect
       maxGenerations: "{{ params.maxGenerations }}"
       threshold: "{{ params.threshold }}"
+      # SERIALIZE the per-workspace evals: each one runs the BOOT GATE
+      # (gitsee/verify-setup), which binds fixed host ports (frontend :3000,
+      # postgres :5432), a pm2 process named "frontend", and the single staklink
+      # daemon — so concurrent boots would collide. 1 = one workspace booted at a
+      # time. (Raise only if you isolate ports/names per workspace.)
+      concurrency: "{{ params.concurrency }}"
 
 # ── params: the cohort (dataset of WORKSPACES) + the loop's stopping knobs ──
 # Each dataset entry is a WORKSPACE: { label, repos: [{ owner, repo, rev? }],
@@ -65,6 +71,10 @@ steps:
 params:
   maxGenerations: 4
   threshold: 0.9
+  # Serialize the boot gates (one workspace booted at a time) — concurrent boots
+  # collide on host ports 3000/5432, the pm2 "frontend" name, and the staklink
+  # daemon. A full run is 5 workspaces × maxGenerations boots, in series.
+  concurrency: 1
   dataset:
     # Single-repo workspace: a plain Express app, no DB.
     - label: heroku-node

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -379,9 +379,13 @@ later without breaking this contract — they'd be additive env vars
   workflow-*builder* chat above. It explores a working dir (`cwd`)
   with built-in general tools (`repo_overview` — adaptive, token-capped
   dir tree with build/dep/migration dirs collapsed; `fulltext_search`;
-  `bash`; + anthropic `web_search`; + `file_summary`, an AST structural
-  summary that's only registered when the `stakgraph` CLI is on PATH),
-  filterable via `toolFilter`, and returns one of three shapes: a
+  `bash`; `str_replace_based_edit_tool` — view/create/str_replace/insert
+  files, sandboxed to `cwd` (the anthropic provider-defined text-editor
+  tool, with a generic-`tool()` fallback for other providers; pure handler
+  `textEdit()` is unit-tested offline); + anthropic `web_search`; +
+  `file_summary`, an AST structural summary that's only registered when the
+  `stakgraph` CLI is on PATH), filterable via `toolFilter`, and returns one
+  of three shapes: a
   `final_answer` tool's
   text (set `finalAnswer` to its description), a STRUCTURED object (set
   `schema` to a JSON Schema → `Output.object`, read off `res.output`), or

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -1,7 +1,10 @@
-import { describe, it } from "node:test";
+import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { coreRegistry } from "../registry.js";
-import agent, { repoTree } from "./agent.js";
+import agent, { repoTree, textEdit } from "./agent.js";
 
 // These tests are OFFLINE: they exercise registration, the input schema, and the
 // config-validation guards in run() that fire BEFORE any model call. The actual
@@ -84,5 +87,78 @@ describe("repo_overview adaptive tree (repoTree)", () => {
     const files = ["a/b/c/d/e/f/g/h/i/j/deep.ts"];
     const { depth } = repoTree(files, { maxLines: 10000, maxDepth: 3 });
     assert.equal(depth, 3, "never deeper than maxDepth even with budget to spare");
+  });
+});
+
+describe("textEdit (str_replace_based_edit_tool handler)", () => {
+  let cwd: string;
+  beforeEach(() => {
+    cwd = mkdtempSync(join(tmpdir(), "vein-textedit-"));
+  });
+  afterEach(() => {
+    rmSync(cwd, { recursive: true, force: true });
+  });
+
+  it("views a file with 1-indexed line numbers", () => {
+    writeFileSync(join(cwd, "a.txt"), "one\ntwo\nthree");
+    const out = textEdit({ command: "view", path: "a.txt" }, cwd);
+    assert.equal(out, "1: one\n2: two\n3: three");
+  });
+
+  it("views a line range", () => {
+    writeFileSync(join(cwd, "a.txt"), "one\ntwo\nthree\nfour");
+    assert.equal(textEdit({ command: "view", path: "a.txt", view_range: [2, 3] }, cwd), "2: two\n3: three");
+    assert.equal(textEdit({ command: "view", path: "a.txt", view_range: [3, -1] }, cwd), "3: three\n4: four");
+  });
+
+  it("lists a directory on view", () => {
+    writeFileSync(join(cwd, "z.txt"), "");
+    writeFileSync(join(cwd, "a.txt"), "");
+    const out = textEdit({ command: "view", path: "." }, cwd);
+    assert.equal(out, "a.txt\nz.txt");
+  });
+
+  it("creates a new file (including nested dirs)", () => {
+    const out = textEdit({ command: "create", path: "sub/dir/new.txt", file_text: "hi" }, cwd);
+    assert.match(out, /Successfully created/);
+    assert.equal(readFileSync(join(cwd, "sub/dir/new.txt"), "utf-8"), "hi");
+  });
+
+  it("str_replace replaces exactly one match", () => {
+    writeFileSync(join(cwd, "a.txt"), "foo bar baz");
+    const out = textEdit({ command: "str_replace", path: "a.txt", old_str: "bar", new_str: "QUX" }, cwd);
+    assert.match(out, /Successfully replaced/);
+    assert.equal(readFileSync(join(cwd, "a.txt"), "utf-8"), "foo QUX baz");
+  });
+
+  it("str_replace refuses zero matches", () => {
+    writeFileSync(join(cwd, "a.txt"), "foo");
+    const out = textEdit({ command: "str_replace", path: "a.txt", old_str: "nope", new_str: "x" }, cwd);
+    assert.match(out, /No match found/);
+    assert.equal(readFileSync(join(cwd, "a.txt"), "utf-8"), "foo");
+  });
+
+  it("str_replace refuses multiple matches", () => {
+    writeFileSync(join(cwd, "a.txt"), "x x x");
+    const out = textEdit({ command: "str_replace", path: "a.txt", old_str: "x", new_str: "y" }, cwd);
+    assert.match(out, /Found 3 matches/);
+    assert.equal(readFileSync(join(cwd, "a.txt"), "utf-8"), "x x x");
+  });
+
+  it("inserts text after a line (0 = top of file)", () => {
+    writeFileSync(join(cwd, "a.txt"), "one\ntwo");
+    textEdit({ command: "insert", path: "a.txt", insert_line: 0, insert_text: "ZERO" }, cwd);
+    assert.equal(readFileSync(join(cwd, "a.txt"), "utf-8"), "ZERO\none\ntwo");
+  });
+
+  it("refuses paths that escape the working dir", () => {
+    writeFileSync(join(cwd, "a.txt"), "secret");
+    const out = textEdit({ command: "view", path: "../../../etc/passwd" }, cwd);
+    assert.match(out, /escapes the working directory/);
+  });
+
+  it("returns File not found for missing files", () => {
+    assert.match(textEdit({ command: "view", path: "nope.txt" }, cwd), /File not found/);
+    assert.ok(!existsSync(join(cwd, "nope.txt")));
   });
 });

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -2,8 +2,8 @@ import { z } from "zod";
 import { defineStep } from "../../core.js";
 import { usageFromResult, computeCost } from "../../pricing.js";
 import { spawn } from "node:child_process";
-import { existsSync, readdirSync } from "node:fs";
-import { join } from "node:path";
+import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { join, resolve, dirname, isAbsolute, sep } from "node:path";
 
 /**
  * Core AGENT step: a general tool-using agent loop (Vercel AI SDK
@@ -20,9 +20,11 @@ import { join } from "node:path";
  * optionally restrict the toolset with `toolFilter`. Anything domain-specific
  * (e.g. how to frame a particular workspace) lives in the CALLER's prompts.
  *
- * Built-in tools: repo_overview, file_summary, fulltext_search, bash, and
- * (anthropic only) web_search. `final_answer` is added automatically in
- * finalAnswer mode and is always available regardless of `toolFilter`.
+ * Built-in tools: repo_overview, file_summary, fulltext_search, bash,
+ * str_replace_based_edit_tool (view/create/str_replace/insert files, sandboxed
+ * to cwd), and (anthropic only) web_search. `final_answer` is added
+ * automatically in finalAnswer mode and is always available regardless of
+ * `toolFilter`.
  *
  * Provider-direct via the AI SDK (anthropic | openai), lazy-loaded. Needs the
  * provider's key in env (ANTHROPIC_API_KEY / OPENAI_API_KEY) and `git` + `rg` on
@@ -269,10 +271,116 @@ function buildPreamble(cwd: string): string {
   return `Working directory (${cwd}) contains:\n` + entries.map((e) => `- ${e}`).join("\n");
 }
 
+// ── file editing tool (str_replace_based_edit_tool) ────────────────────────────
+
+/** Max chars returned by a `view` before truncation. */
+const FILE_VIEW_MAX_CHARS = 200_000;
+
+/** The Anthropic text-editor tool's input shape (also used by the generic
+ *  fallback for non-anthropic providers). All commands operate on a path that
+ *  MUST resolve inside `cwd`. */
+export interface TextEditInput {
+  command: "view" | "create" | "str_replace" | "insert";
+  path: string;
+  file_text?: string;
+  insert_line?: number;
+  new_str?: string;
+  insert_text?: string;
+  old_str?: string;
+  view_range?: number[];
+}
+
+/** Resolve a tool-supplied path against `cwd` and refuse anything that escapes
+ *  it (directory-traversal / absolute-path guard). */
+function resolveInCwd(p: string, cwd: string): string {
+  const target = resolve(isAbsolute(p) ? p : join(cwd, p));
+  const root = resolve(cwd);
+  if (target !== root && !target.startsWith(root + sep)) {
+    throw new Error(`path "${p}" escapes the working directory`);
+  }
+  return target;
+}
+
+/**
+ * Pure handler for the str_replace-based text editor tool: view / create /
+ * str_replace / insert, sandboxed to `cwd`. Mirrors Anthropic's tool contract
+ * (1-indexed line numbers, exactly-one-match str_replace, `insert_line` 0 =
+ * top-of-file) so it backs both the provider-defined anthropic tool and the
+ * generic fallback. Returns a human-readable string (errors as `Error: …`).
+ */
+export function textEdit(input: TextEditInput, cwd: string): string {
+  let target: string;
+  try {
+    target = resolveInCwd(input.path, cwd);
+  } catch (e) {
+    return `Error: ${(e as Error).message}`;
+  }
+
+  switch (input.command) {
+    case "view": {
+      if (!existsSync(target)) return "Error: File not found";
+      if (statSync(target).isDirectory()) {
+        const entries = readdirSync(target, { withFileTypes: true })
+          .filter((e) => !e.name.startsWith("."))
+          .map((e) => (e.isDirectory() ? `${e.name}/` : e.name))
+          .sort();
+        return entries.length ? entries.join("\n") : "(empty directory)";
+      }
+      const lines = readFileSync(target, "utf-8").split("\n");
+      let start = 1;
+      let end = lines.length;
+      if (Array.isArray(input.view_range) && input.view_range.length === 2) {
+        start = Math.max(1, input.view_range[0]);
+        end = input.view_range[1] === -1 ? lines.length : input.view_range[1];
+      }
+      const out = lines
+        .slice(start - 1, end)
+        .map((l, i) => `${start + i}: ${l}`)
+        .join("\n");
+      return out.length > FILE_VIEW_MAX_CHARS
+        ? out.slice(0, FILE_VIEW_MAX_CHARS) + "\n\n[... output truncated ...]"
+        : out;
+    }
+
+    case "create": {
+      mkdirSync(dirname(target), { recursive: true });
+      writeFileSync(target, input.file_text ?? "");
+      return `Successfully created ${input.path}`;
+    }
+
+    case "str_replace": {
+      if (!existsSync(target)) return "Error: File not found";
+      const content = readFileSync(target, "utf-8");
+      const old = input.old_str ?? "";
+      const count = old ? content.split(old).length - 1 : 0;
+      if (count === 0)
+        return "Error: No match found for replacement. Please check your text and try again.";
+      if (count > 1)
+        return `Error: Found ${count} matches for replacement text. Please provide more context to make a unique match.`;
+      writeFileSync(target, content.replace(old, input.new_str ?? ""));
+      return "Successfully replaced text at exactly one location.";
+    }
+
+    case "insert": {
+      if (!existsSync(target)) return "Error: File not found";
+      const lines = readFileSync(target, "utf-8").split("\n");
+      const at = input.insert_line ?? 0;
+      if (at < 0 || at > lines.length)
+        return `Error: insert_line ${at} is out of range (0-${lines.length})`;
+      lines.splice(at, 0, input.insert_text ?? "");
+      writeFileSync(target, lines.join("\n"));
+      return `Successfully inserted text after line ${at}`;
+    }
+
+    default:
+      return `Error: unknown command "${(input as { command?: string }).command}"`;
+  }
+}
+
 export default defineStep({
   type: "agent",
   description:
-    "General tool-using agent (AI SDK ToolLoopAgent). Explores a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of tool names; empty = all), model?, provider? (anthropic|openai), maxSteps (default 40). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, messages }.",
+    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of tool names; empty = all), model?, provider? (anthropic|openai), maxSteps (default 40). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, messages }.",
   input: z.object({
     cwd: z.string().describe("working directory the tools operate in"),
     system: z.string().describe("system prompt / agent persona"),
@@ -308,12 +416,18 @@ export default defineStep({
     // cache hit across all forks). Same pattern as aieo's getProviderOptions.
     let model: any;
     let webSearchTool: any;
+    let textEditorTool: any;
     let providerOptions: any;
     switch (provider) {
       case "anthropic": {
         const { anthropic } = await import("@ai-sdk/anthropic");
         model = anthropic(modelName ?? "claude-sonnet-4-6");
-        webSearchTool = anthropic.tools.webSearch_20250305({ maxUses: 3 });
+        webSearchTool = anthropic.tools.webSearch_20260209({ maxUses: 3 });
+        // Provider-defined text editor (the model is specially trained on its
+        // schema); we supply the execute that performs the edit inside cfg.cwd.
+        textEditorTool = anthropic.tools.textEditor_20250728({
+          execute: async (input: TextEditInput) => textEdit(input, cfg.cwd),
+        });
         providerOptions = { anthropic: { cacheControl: { type: "ephemeral" } } };
         break;
       }
@@ -386,6 +500,31 @@ export default defineStep({
       });
     }
     if (webSearchTool) allTools.web_search = webSearchTool;
+
+    // File editing (str_replace_based_edit_tool): view/create/str_replace/insert,
+    // sandboxed to cfg.cwd. For anthropic use the provider-defined tool (the
+    // model is specially trained on it); other providers get an identical generic
+    // tool. The key MUST be `str_replace_based_edit_tool` for the anthropic case.
+    allTools.str_replace_based_edit_tool = textEditorTool
+      ? textEditorTool
+      : tool({
+          description:
+            "View and edit text files (sandboxed to the working dir). Commands: " +
+            '`view` (path, optional view_range [start,end]), `create` (path, file_text), ' +
+            "`str_replace` (path, old_str must match EXACTLY once, new_str), " +
+            "`insert` (path, insert_line — 0 = top of file, insert_text).",
+          inputSchema: z.object({
+            command: z.enum(["view", "create", "str_replace", "insert"]),
+            path: z.string(),
+            file_text: z.string().optional(),
+            insert_line: z.number().int().optional(),
+            new_str: z.string().optional(),
+            insert_text: z.string().optional(),
+            old_str: z.string().optional(),
+            view_range: z.array(z.number().int()).optional(),
+          }) as any,
+          execute: async (input: TextEditInput) => textEdit(input, cfg.cwd),
+        });
 
     // Apply toolFilter (empty = all). Unknown names are ignored.
     const filter = cfg.toolFilter ?? [];


### PR DESCRIPTION
## What

Makes the gitsee setup-profiler eval **actually run the produced setup and prove the frontend renders**, instead of only diffing the produced `pm2.config.js` + `docker-compose.yml` against a gold answer key. The screenshot (+ booted-service logs) judged by a vision model is now the dominant signal.

Also gives the explorer agent the ability to **edit repos** (to make them boot local-first), captured as a replayable diff.

## Changes

**vein — `agent` core step**
- New `str_replace_based_edit_tool` (view/create/str_replace/insert), sandboxed to `cwd`. Anthropic uses the provider-defined `textEditor_20250728`; other providers get an identical generic tool. Pure `textEdit()` helper + 10 offline unit tests.

**gitsee — the boot gate (`gitsee/verify-setup`, new)**
- Stages the produced files the pod way (`<root>/pm2.config.js` + `.pod-config/.user-dockerfile/`, rewriting `/workspaces/<repo>` cwd to the local clone), `docker compose up -d --wait` (skipped when the compose has no services), boots via **staklink** (`npx staklink start` → REBUILD→INSTALL→PRE_START→pm2 start→POST_START; no BUILD_COMMAND, dev-mode boot) or an inline pm2-free fallback, polls the frontend port.
- Screenshots in headless chromium and **judges the screenshot + booted-service log tail with a vision model** — HTTP 200 + non-empty DOM isn't enough; a white screen or styled error page both pass those. Heuristic (HTTP status + error overlay + log crash signatures) is the fallback when vision is off/unavailable.

**gitsee — scoring (`gitsee/score-setup`)**
- **Boot + render dominate**: a booted+rendered setup scores in `[0.85, 1]`; the gold set-diff is a 15% residual hint. Booted-but-broken-UI ×0.45, non-boot ×0.1.
- Env keys **and** services are now **recall-only** — extra keys/services (e.g. a redis the gold mocks) are not penalized; the boot gate is the arbiter.

**gitsee — repo-edit capture (`gitsee/capture-edits`, new)**
- Captures the agent's repo edits as a replayable `git diff` per repo (the deliverable form of "what it changed to boot local-first"), as the last step of `gitsee-explore-services` (passes the agent output through, so `produce.result`/`usage`/`cost` still resolve).

**Wiring + docs**
- `gitsee-eval`: `clone → produce → verify → score`, threading `booted`/`rendered` into the score and folding the vision-judge cost into the eval total (`produce.cost + verify.cost`).
- Updated explore prompts (license repo edits + `## CHANGES` narration), the semantic rubric (stop flagging extra services), and `vein`/`lab` AGENTS docs.

## Verified end-to-end (local, real keys + docker + chromium)

- `heroku-node` (Express): booted + vision-approved landing page → ~0.96.
- `hive` (Next.js + Postgres + Prisma + 3 sibling repos, `USE_MOCKS=true`): compose Postgres up, `prisma migrate` in PRE_START, `next dev` host-bound, vision confirmed a real Hive sign-in page, logs read (a non-fatal API DB error correctly ruled non-blocking) → **0.98**.

mcp typechecks clean; vein test suite passes (356 tests).

## Notes / follow-ups

- Boot gate needs `docker` + `npx playwright install chromium` + network for `npx staklink` on the eval host; `params.verify=false` skips it for cheap deterministic sweeps.
- In prod the captured diff would need a `git apply` after fresh clone to reproduce loose repo edits (downstream pod-provisioning concern, not in this PR).
- `staklink start` resolves its workspace root via `/workspaces`-if-exists else cwd; fine where `/workspaces` is absent or is the workspace, otherwise prefer `useStaklink:false`.