### PR TITLE
gitsee: never produce empty output, clean reused clones, opt-in agent messages

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -64,8 +64,12 @@ the frontend running*, so the gold is the frontend's pm2 + the shared services.
 
 - `gitsee/steps/clone-workspace.ts` (`gitsee/clone-workspace`) — clones N repos
   as siblings under one workspace dir (idempotent, per-rev). Each repo may pin a
-  `rev`; `token` falls back to `GITHUB_TOKEN` env (private repos). Output
-  `{ workspacePath, repos }`. **The only gitsee-specific producer step.**
+  `rev`; `token` falls back to `GITHUB_TOKEN` env (private repos). `clean`
+  (default true) resets a REUSED clone to a pristine working tree
+  (`git reset --hard && git clean -fd`) so each run / optimizer generation starts
+  fresh — discarding the prior explore agent's edits + created files (keeps
+  gitignored `node_modules` for speed). Output `{ workspacePath, repos }`. **The
+  only gitsee-specific producer step.**
 - Exploration is the **core `agent` step** (`vein/src/steps/core/agent.ts`),
   pointed at `cwd = clone.workspacePath`. Its general tools (`repo_overview`,
   `fulltext_search`, `bash`, `str_replace_based_edit_tool` — view/create/edit

--- a/mcp/src/lab/gitsee/cleanup.ts
+++ b/mcp/src/lab/gitsee/cleanup.ts
@@ -1,4 +1,7 @@
 import { execSync } from "node:child_process";
+import { readdirSync, rmSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
 
 /**
  * Manual cleanup for a gitsee boot-gate run that was KILLED (no teardown ran).
@@ -48,6 +51,29 @@ if (ours.length) {
 sh("docker network prune -f");
 const vols = ids(sh(`docker volume ls -q --filter "name=supabase_"`));
 if (vols.length) sh(`docker volume rm ${vols.join(" ")}`);
+
+// 4. strip files verify-setup staged into each reused clone (pm2.config.js,
+//    docker-compose.yml, .pod-config) so a killed run doesn't leave a "prior
+//    attempt" that distracts the next explore agent.
+const labRoot = join(tmpdir(), "gitsee-lab");
+if (existsSync(labRoot)) {
+  for (const ws of readdirSync(labRoot)) {
+    const wsDir = join(labRoot, ws);
+    for (const f of ["pm2.config.js", "pm2.config.cjs", "docker-compose.yml"]) {
+      try {
+        rmSync(join(wsDir, f), { force: true });
+      } catch {
+        /* ignore */
+      }
+    }
+    try {
+      rmSync(join(wsDir, ".pod-config"), { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+  console.log(`[gitsee-cleanup] stripped staged config files from ${labRoot}/*`);
+}
 
 console.log("[gitsee-cleanup] done. Remaining containers:");
 console.log(sh("docker ps --format '{{.Names}}\\t{{.Ports}}'") || "(none)");

--- a/mcp/src/lab/gitsee/steps/clone-workspace.ts
+++ b/mcp/src/lab/gitsee/steps/clone-workspace.ts
@@ -39,7 +39,7 @@ function git(args: string[], cwd: string, timeoutMs = 120000): Promise<void> {
 export default defineStep({
   type: "gitsee/clone-workspace",
   description:
-    "Self-contained clone of a WORKSPACE (a set of repos cloned as siblings under one dir, like the pod's /workspaces/<repo>). No internal deps; needs `git`. Idempotent. Config: workspace (dir/label), repos ([{owner, repo, rev?}], rev pins a commit), token? (falls back to GITHUB_TOKEN env). Output: { workspacePath, repos }.",
+    "Self-contained clone of a WORKSPACE (a set of repos cloned as siblings under one dir, like the pod's /workspaces/<repo>). No internal deps; needs `git`. Idempotent. Config: workspace (dir/label), repos ([{owner, repo, rev?}], rev pins a commit), token? (falls back to GITHUB_TOKEN env), clean? (default true — `git reset --hard && git clean -fd` a reused clone so each run starts from a pristine working tree, discarding the prior agent's edits/new files; keeps gitignored node_modules). Output: { workspacePath, repos }.",
   input: z.object({
     workspace: z.string().describe("workspace name — the clone dir under the lab tmp root"),
     repos: z
@@ -53,6 +53,12 @@ export default defineStep({
       .min(1)
       .describe("the repos to clone as siblings; usually the frontend app + its local-dependency repos"),
     token: z.string().optional(),
+    clean: z
+      .boolean()
+      .default(true)
+      .describe(
+        "reset a REUSED clone to a pristine working tree (git reset --hard + git clean -fd) so each run/optimizer generation starts fresh — discards the prior explore agent's edits and any files it created. Keeps gitignored deps (node_modules) for speed; set false to preserve a dirty tree for debugging.",
+      ),
   }),
   output: z.any(),
   async run(cfg, ctx) {
@@ -70,6 +76,13 @@ export default defineStep({
 
       if (existsSync(join(dir, ".git"))) {
         console.log(`[gitsee] reusing existing clone at ${dir}`);
+        // Pristine slate: drop the prior explore agent's edits + untracked files
+        // (best-effort; keeps gitignored node_modules). Done before any rev
+        // checkout so a dirty tree can't block it.
+        if (cfg.clean) {
+          await git(["reset", "--hard"], dir).catch(() => {});
+          await git(["clean", "-fd"], dir).catch(() => {});
+        }
       } else {
         console.log(`[gitsee] cloning ${r.owner}/${r.repo}${rev ? " @ " + rev : ""} → ${dir}`);
         await git(["clone", "--depth", "1", url, dir], wsDir);

--- a/mcp/src/lab/gitsee/steps/verify-setup.ts
+++ b/mcp/src/lab/gitsee/steps/verify-setup.ts
@@ -1,6 +1,6 @@
 import { z, defineStep, usageFromResult, computeCost } from "vein";
 import { spawn } from "node:child_process";
-import { writeFileSync, readFileSync, mkdirSync, existsSync } from "node:fs";
+import { writeFileSync, readFileSync, mkdirSync, existsSync, rmSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import { createConnection } from "node:net";
@@ -573,6 +573,21 @@ export default defineStep({
           }
         } catch {
           /* ignore teardown errors */
+        }
+        // Remove the files WE staged so a REUSED clone isn't polluted next run —
+        // otherwise the next explore agent browses the workspace root, finds a
+        // prior attempt's pm2.config.js/compose, and burns its budget analyzing it.
+        for (const f of ["pm2.config.js", "docker-compose.yml", "pm2.config.cjs"]) {
+          try {
+            rmSync(join(wp, f), { force: true });
+          } catch {
+            /* ignore */
+          }
+        }
+        try {
+          rmSync(join(wp, ".pod-config"), { recursive: true, force: true });
+        } catch {
+          /* ignore */
         }
       } else {
         log("keepUp:true — leaving services + apps running");

--- a/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
@@ -57,9 +57,10 @@ steps:
 # ── params: the prompt experiment surface (workspace-aware, frontend-focused) ───
 params:
   model: claude-sonnet-4-6
-  # Agent step budget. Bigger for multi-repo workspaces; a forced final-answer
-  # turn (in the agent step) guarantees output even if this is exhausted.
-  maxSteps: 60
+  # Agent step budget. Generous for hard multi-repo workspaces (mikeoss, hive)
+  # that need a lot of exploration before producing; a forced final-answer turn
+  # (in the agent step) still guarantees output if even this is exhausted.
+  maxSteps: 200
   # The pod's base domain. Public URLs are https://<$POD_ID>[-<port>].<podDomain>.
   # Factored out here (single source of truth) and referenced via
   # {{ params.podDomain }} inside the finalAnswer contract below — vein resolves

--- a/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
@@ -34,6 +34,10 @@ steps:
       system: "{{ params.system }}"
       finalAnswer: "{{ params.finalAnswer }}"
       model: "{{ params.model }}"
+      # Multi-repo workspaces (mikeoss, hive) need a bigger budget to explore +
+      # produce. If the loop still runs out, the agent step forces a final-answer
+      # turn so we always get the two files (never an empty result).
+      maxSteps: "{{ params.maxSteps }}"
 
   # Capture the agent's repo edits (it may have patched files to make the
   # workspace boot local-first) as a replayable git diff — part of the
@@ -53,6 +57,9 @@ steps:
 # ── params: the prompt experiment surface (workspace-aware, frontend-focused) ───
 params:
   model: claude-sonnet-4-6
+  # Agent step budget. Bigger for multi-repo workspaces; a forced final-answer
+  # turn (in the agent step) guarantees output even if this is exhausted.
+  maxSteps: 60
   # The pod's base domain. Public URLs are https://<$POD_ID>[-<port>].<podDomain>.
   # Factored out here (single source of truth) and referenced via
   # {{ params.podDomain }} inside the finalAnswer contract below — vein resolves

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -391,8 +391,11 @@ later without breaking this contract — they'd be additive env vars
   `schema` to a JSON Schema → `Output.object`, read off `res.output`), or
   the final assistant text. Provider-direct (anthropic|openai), lazy-
   loaded; needs the provider key in env + `git`/`rg` on PATH. Returns
-  `{ result, object?, steps, messages }` — `messages` is the full session
-  (the seam for a future fork/sub-agent capability). Anything domain-
+  `{ result, object?, steps, usage, cost }`. The full session
+  (`messages`) is the seam for a future fork/sub-agent capability, but
+  it's **opt-in** (`returnMessages`, default false): it's huge and the
+  runner persists every step's output, so returning it by default bloats
+  `events.jsonl`/`run.json` and buries `result`. Anything domain-
   specific lives in the CALLER's prompts, not the step (e.g. mcp's
   `/lab` `gitsee-explore-services` wires `clone → agent`).
 

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -28,8 +28,10 @@ import { join, resolve, dirname, isAbsolute, sep } from "node:path";
  *
  * Provider-direct via the AI SDK (anthropic | openai), lazy-loaded. Needs the
  * provider's key in env (ANTHROPIC_API_KEY / OPENAI_API_KEY) and `git` + `rg` on
- * PATH for the repo tools. Output: { result, object?, steps, messages, usage,
- * cost } — `usage` is the aggregated token counts across the whole agent loop
+ * PATH for the repo tools. Output: { result, object?, steps, usage, cost }
+ * (+ `messages`, the full session, only when `returnMessages` is set — it's huge
+ * and persisted per step, so it's off by default). `usage` is the aggregated
+ * token counts across the whole agent loop
  * and `cost` is its dollar cost at the provider's rates (see ../../pricing.ts).
  */
 
@@ -380,7 +382,7 @@ export function textEdit(input: TextEditInput, cwd: string): string {
 export default defineStep({
   type: "agent",
   description:
-    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of tool names; empty = all), model?, provider? (anthropic|openai), maxSteps (default 40). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, messages }.",
+    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of tool names; empty = all), model?, provider? (anthropic|openai), maxSteps (default 40), returnMessages? (default false — the full session is huge + persisted per step). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, usage, cost } (+ messages when returnMessages).",
   input: z.object({
     cwd: z.string().describe("working directory the tools operate in"),
     system: z.string().describe("system prompt / agent persona"),
@@ -400,6 +402,12 @@ export default defineStep({
     model: z.string().optional(),
     provider: z.string().optional(),
     maxSteps: z.number().int().positive().default(40),
+    returnMessages: z
+      .boolean()
+      .default(false)
+      .describe(
+        "include the FULL tool-loop session (`messages`) in the output. Off by default — the session is huge and the runner persists every step's output, so returning it bloats events.jsonl/run.json and buries `result`. Turn on only for a fork/sub-agent that needs the transcript.",
+      ),
   }),
   output: z.any(),
   async run(cfg) {
@@ -574,7 +582,11 @@ export default defineStep({
     });
 
     const steps = res.steps ?? [];
+    // The full session is HUGE and the runner persists every step's output, so we
+    // only include it when explicitly asked (a future fork/sub-agent). Off by
+    // default keeps the explore step's persisted output to `{ result, steps, … }`.
     const messages = res.response?.messages ?? [];
+    const maybeMessages = cfg.returnMessages ? { messages } : {};
 
     // Token usage + cost across the WHOLE agent loop (totalUsage aggregates every
     // step; fall back to the final-step usage). `provider` drives the rate table.
@@ -587,7 +599,7 @@ export default defineStep({
     // Structured mode: return the typed object.
     if (useSchema) {
       console.log(`[agent] completed in ${Date.now() - startTime}ms (${steps.length} steps, structured)`);
-      return { result: res.text, object: res.output, steps: steps.length, messages, usage, cost };
+      return { result: res.text, object: res.output, steps: steps.length, ...maybeMessages, usage, cost };
     }
 
     // finalAnswer / text mode: extract the final_answer tool output, else last text.
@@ -617,6 +629,6 @@ export default defineStep({
     }
 
     console.log(`[agent] completed in ${Date.now() - startTime}ms (${steps.length} steps)`);
-    return { result: final, steps: steps.length, messages, usage, cost };
+    return { result: final, steps: steps.length, ...maybeMessages, usage, cost };
   },
 });

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import { defineStep } from "../../core.js";
-import { usageFromResult, computeCost } from "../../pricing.js";
+import { usageFromResult, computeCost, addUsage } from "../../pricing.js";
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { join, resolve, dirname, isAbsolute, sep } from "node:path";
@@ -411,7 +411,7 @@ export default defineStep({
   }),
   output: z.any(),
   async run(cfg) {
-    const { ToolLoopAgent, Output, tool, stepCountIs, hasToolCall, jsonSchema } = await import("ai");
+    const { ToolLoopAgent, Output, tool, stepCountIs, hasToolCall, jsonSchema, generateText } = await import("ai");
 
     const provider = cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? "anthropic";
     const modelName = cfg.model ?? process.env["VEIN_LLM_MODEL"];
@@ -590,8 +590,9 @@ export default defineStep({
 
     // Token usage + cost across the WHOLE agent loop (totalUsage aggregates every
     // step; fall back to the final-step usage). `provider` drives the rate table.
-    const usage = usageFromResult(res.totalUsage ?? res.usage);
-    const cost = computeCost(provider, usage);
+    // Mutable so a forced final-answer turn (below) can be folded in.
+    let usage = usageFromResult(res.totalUsage ?? res.usage);
+    let cost = computeCost(provider, usage);
     console.log(
       `[agent] tokens in:${usage.inputTokens} cacheRead:${usage.cacheReadTokens} cacheWrite:${usage.cacheWriteTokens} out:${usage.outputTokens} → $${cost.toFixed(4)}`,
     );
@@ -620,9 +621,37 @@ export default defineStep({
           break;
         }
       }
-      if (!final && lastText) {
-        console.warn("[agent] No final_answer tool call; using last reasoning text.");
-        final = `${lastText}\n\n(Note: model did not invoke final_answer; using last reasoning text.)`;
+      // The loop ended (almost always: hit maxSteps) WITHOUT calling final_answer,
+      // so we'd otherwise return a stray reasoning sentence and lose the whole
+      // (expensive) exploration. Salvage it: force ONE no-tools turn that must emit
+      // the final answer now, continuing the full session.
+      if (!final) {
+        console.warn("[agent] No final_answer tool call; forcing a final-answer turn.");
+        try {
+          const forced = await generateText({
+            model,
+            ...(providerOptions ? { providerOptions } : {}),
+            messages: [
+              ...(messages as any[]),
+              {
+                role: "user",
+                content: `You have used your entire exploration budget — do NOT call any tools. Using everything you learned above, produce the final answer NOW.\n\n${cfg.finalAnswer}`,
+              },
+            ],
+          });
+          const ft = (forced.text ?? "").trim();
+          if (ft) {
+            final = ft;
+            const fu = usageFromResult(forced.totalUsage ?? forced.usage);
+            usage = addUsage(usage, fu);
+            cost += computeCost(provider, fu);
+          }
+        } catch (e) {
+          console.warn("[agent] forced final-answer turn failed:", (e as Error).message);
+        }
+        if (!final && lastText) {
+          final = `${lastText}\n\n(Note: model did not invoke final_answer; using last reasoning text.)`;
+        }
       }
     } else {
       final = res.text || lastText;


### PR DESCRIPTION
Follow-ups to #1321 (which was squash-merged). These are the commits pushed after the merge point.

## Changes

**vein — `agent` step**
- **Forced final answer**: when the tool loop hits `maxSteps` WITHOUT calling `final_answer`, force one no-tools turn that must emit the final answer now (continuing the full session) — instead of returning a stray reasoning sentence and losing the whole exploration. The forced turn's tokens are folded into `usage`/`cost`. (Root cause of a mikeoss run that produced **no files at all**.)
- **`messages` is now opt-in** (`returnMessages`, default false). The full tool-loop session was returned by default and the runner persists every step's output, so a big exploration's persisted output was dominated by the transcript with `result` buried. Normal output is now lean `{ result, object?, steps, usage, cost }`.

**gitsee**
- `gitsee-explore-services`: `maxSteps` param (now **200**) for hard multi-repo workspaces (mikeoss/hive); forced-answer fallback still guarantees output.
- `clone-workspace`: **`clean` option (default true)** — `git reset --hard && git clean -fd` a reused clone so each run / optimizer generation starts from a pristine working tree (discards the prior explore agent's edits + created files; keeps gitignored `node_modules`). Runs before any rev checkout.
- `verify-setup` teardown + `cleanup.ts`: remove the `pm2.config.js` / `docker-compose.yml` / `.pod-config` we stage into the (reused) clone, so the next explore agent doesn't find a "prior attempt" at the workspace root and burn its budget analyzing our own files.

## Why
On mikeoss the explorer exhausted its 40-step budget — partly because it got distracted by a previous `verify` run's staged config files sitting in the reused clone — and returned only its last reasoning sentence, so `verify` got "no pm2.config.js in the produced output." These changes make the eval never emit empty output and keep each run isolated.

## Verified
vein typechecks + 346 tests pass; mcp typechecks clean.

Note: the captured repo-edit `git diff` is still stored per eval run (capture step output in that run's `run.json`); threading it into the optimizer's final output is a deliberate later follow-up.