### PR TITLE
vein: AI workflow tools + stale-run status

### DIFF
--- a/mcp/src/lab/gitsee/steps/clone-workspace.ts
+++ b/mcp/src/lab/gitsee/steps/clone-workspace.ts
@@ -1,7 +1,7 @@
 import { z, defineStep } from "vein";
 import { spawn } from "node:child_process";
 import { existsSync } from "node:fs";
-import { mkdir } from "node:fs/promises";
+import { mkdir, readdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 
@@ -39,7 +39,7 @@ function git(args: string[], cwd: string, timeoutMs = 120000): Promise<void> {
 export default defineStep({
   type: "gitsee/clone-workspace",
   description:
-    "Self-contained clone of a WORKSPACE (a set of repos cloned as siblings under one dir, like the pod's /workspaces/<repo>). No internal deps; needs `git`. Idempotent. Config: workspace (dir/label), repos ([{owner, repo, rev?}], rev pins a commit), token? (falls back to GITHUB_TOKEN env), clean? (default true — `git reset --hard && git clean -fd` a reused clone so each run starts from a pristine working tree, discarding the prior agent's edits/new files; keeps gitignored node_modules). Output: { workspacePath, repos }.",
+    "Self-contained clone of a WORKSPACE (a set of repos cloned as siblings under one dir, like the pod's /workspaces/<repo>). No internal deps; needs `git`. Idempotent. Config: workspace (dir/label), repos ([{owner, repo, rev?}], rev pins a commit), token? (falls back to GITHUB_TOKEN env), clean? (default true — `git reset --hard && git clean -fd` a reused clone so each run starts from a pristine working tree, discarding the prior agent's edits/new files (keeps gitignored node_modules); ALSO prunes stale sibling dirs no longer in `repos`). Output: { workspacePath, repos }.",
   input: z.object({
     workspace: z.string().describe("workspace name — the clone dir under the lab tmp root"),
     repos: z
@@ -57,7 +57,7 @@ export default defineStep({
       .boolean()
       .default(true)
       .describe(
-        "reset a REUSED clone to a pristine working tree (git reset --hard + git clean -fd) so each run/optimizer generation starts fresh — discards the prior explore agent's edits and any files it created. Keeps gitignored deps (node_modules) for speed; set false to preserve a dirty tree for debugging.",
+        "reset a REUSED clone to a pristine working tree (git reset --hard + git clean -fd) so each run/optimizer generation starts fresh — discards the prior explore agent's edits and any files it created. Keeps gitignored deps (node_modules) for speed. Also PRUNES stale sibling dirs in the reused workspace that aren't in the current `repos` list (e.g. a repo dropped from the dataset) so the explore agent can't pick an orphaned repo as the frontend. Set false to preserve a dirty tree for debugging.",
       ),
   }),
   output: z.any(),
@@ -93,6 +93,22 @@ export default defineStep({
         await git(["checkout", "FETCH_HEAD"], dir);
       }
       repos.push(r.repo);
+    }
+
+    // Prune STALE entries: anything in the reused workspace that isn't a repo in
+    // the current list — orphaned repo dirs (a repo dropped from the dataset) AND
+    // stray root files (e.g. a prior verify-setup's staged pm2.config.js /
+    // docker-compose.yml). The workspace should contain only the listed repo
+    // subdirs; otherwise the explore agent lists the workspace, sees the cruft,
+    // and may pick an orphaned repo as the "frontend" — the cross-version
+    // contamination bug.
+    if (cfg.clean) {
+      const keep = new Set(repos);
+      for (const entry of await readdir(wsDir, { withFileTypes: true })) {
+        if (keep.has(entry.name)) continue;
+        console.log(`[gitsee] pruning stale workspace entry ${join(wsDir, entry.name)}`);
+        await rm(join(wsDir, entry.name), { recursive: true, force: true }).catch(() => {});
+      }
     }
 
     console.log(`[gitsee] workspace "${cfg.workspace}" ready at ${wsDir} (${repos.length} repo(s): ${repos.join(", ")})`);

--- a/vein/src/ai-integration.test.ts
+++ b/vein/src/ai-integration.test.ts
@@ -9,7 +9,7 @@ import { z } from "zod";
 import { defineStep } from "./core.js";
 import { createRegistry } from "./steps/registry.js";
 import { WorkspaceManager } from "./workspace.js";
-import { MemoryRunStore } from "./store.js";
+import { MemoryRunStore, FileRunStore } from "./store.js";
 import { lsSteps, searchSteps, readStepSource } from "./ai/stepHelpers.js";
 import { buildSystem } from "./ai/prompts.js";
 import { buildTools } from "./ai/tools.js";
@@ -273,5 +273,162 @@ describe("AI create_step / edit_step tools", () => {
     assert.ok(c.error && /disabled/.test(c.error));
     const e = await tools.edit_step.execute({ type: "my/step", code: code(1) });
     assert.ok(e.error && /disabled/.test(e.error));
+  });
+});
+
+describe("AI list_workflows / get_workflow tools", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `vein-ai-wf-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  function makeDeps() {
+    const ws = new WorkspaceManager(tempDir);
+    return {
+      ws,
+      deps: {
+        workspace: ws,
+        registry: {} as any,
+        store: new MemoryRunStore(),
+        getRegistry: async () => ({} as any),
+      },
+    };
+  }
+
+  const wfYaml = (name: string) =>
+    `name: ${name}\nsteps:\n  - id: hello\n    type: log\n    config:\n      message: hi\n`;
+
+  it("list_workflows returns published workflows with versions", async () => {
+    const { ws, deps } = makeDeps();
+    await ws.createWorkflow("alpha", wfYaml("alpha"), "first one");
+    await ws.createWorkflow("beta", wfYaml("beta"));
+    const tools = buildTools(deps) as any;
+
+    const { workflows } = await tools.list_workflows.execute({});
+    const names = workflows.map((w: any) => w.name).sort();
+    assert.deepEqual(names, ["alpha", "beta"]);
+    const alpha = workflows.find((w: any) => w.name === "alpha");
+    assert.equal(alpha.activeVersion, "v1");
+    assert.deepEqual(alpha.versions, ["v1"]);
+    assert.equal(alpha.description, "first one");
+  });
+
+  it("get_workflow returns the active version's YAML + metadata", async () => {
+    const { ws, deps } = makeDeps();
+    await ws.createWorkflow("alpha", wfYaml("alpha"), "first one");
+    const tools = buildTools(deps) as any;
+
+    const res = await tools.get_workflow.execute({ name: "alpha" });
+    assert.equal(res.name, "alpha");
+    assert.equal(res.version, "v1");
+    assert.equal(res.activeVersion, "v1");
+    assert.ok(res.yaml.includes("type: log"));
+  });
+
+  it("get_workflow errors on unknown workflow and unknown version", async () => {
+    const { ws, deps } = makeDeps();
+    await ws.createWorkflow("alpha", wfYaml("alpha"));
+    const tools = buildTools(deps) as any;
+
+    const missing = await tools.get_workflow.execute({ name: "nope" });
+    assert.ok(missing.error && /not found/.test(missing.error));
+
+    const badVer = await tools.get_workflow.execute({ name: "alpha", version: "v9" });
+    assert.ok(badVer.error && /v9/.test(badVer.error));
+  });
+});
+
+describe("AI list_runs / get_run tools", () => {
+  let tempDir: string;
+
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `vein-ai-runs-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("list_runs + get_run surface run history and events from a FileRunStore", async () => {
+    const echo = defineStep({
+      type: "echo",
+      input: z.object({ msg: z.string() }),
+      output: z.any(),
+      async run(cfg: any) {
+        return { echoed: cfg.msg };
+      },
+    });
+    const registry = await createRegistry([echo]);
+    const ws = new WorkspaceManager(tempDir);
+    const store = new FileRunStore(tempDir);
+    const deps = {
+      workspace: ws,
+      registry,
+      store,
+      getRegistry: async () => registry,
+    };
+
+    await ws.createWorkflow(
+      "greeter",
+      `name: greeter\nsteps:\n  - id: say\n    type: echo\n    config:\n      msg: hello\n`,
+    );
+    const tools = buildTools(deps) as any;
+
+    const run = await tools.run_workflow.execute({ name: "greeter", input: {} });
+    assert.equal(run.status, "success");
+
+    const { runs } = await tools.list_runs.execute({ name: "greeter" });
+    assert.equal(runs.length, 1);
+    assert.equal(runs[0].runId, run.runId);
+    assert.equal(runs[0].status, "success");
+
+    // Slimmed events by default (no payloads).
+    const slim = await tools.get_run.execute({ name: "greeter", runId: run.runId });
+    assert.equal(slim.summary.status, "success");
+    assert.ok(slim.events.length > 0);
+    assert.ok(slim.events.every((e: any) => !("input" in e) && !("output" in e)));
+
+    // Full events include payloads.
+    const full = await tools.get_run.execute({
+      name: "greeter",
+      runId: run.runId,
+      fullEvents: true,
+    });
+    assert.ok(full.events.some((e: any) => e.output !== undefined));
+  });
+
+  it("get_run errors for an unknown run id", async () => {
+    const registry = await createRegistry([]);
+    const deps = {
+      workspace: new WorkspaceManager(tempDir),
+      registry,
+      store: new FileRunStore(tempDir),
+      getRegistry: async () => registry,
+    };
+    const tools = buildTools(deps) as any;
+    const res = await tools.get_run.execute({ name: "ghost", runId: "123" });
+    assert.ok(res.error && /not found/.test(res.error));
+  });
+
+  it("run-history tools degrade gracefully on a non-readable store", async () => {
+    const registry = await createRegistry([]);
+    const deps = {
+      workspace: new WorkspaceManager(tempDir),
+      registry,
+      store: new MemoryRunStore(),
+      getRegistry: async () => registry,
+    };
+    const tools = buildTools(deps) as any;
+    const list = await tools.list_runs.execute({ name: "x" });
+    assert.ok(list.error && /unavailable/.test(list.error));
+    const get = await tools.get_run.execute({ name: "x", runId: "1" });
+    assert.ok(get.error && /unavailable/.test(get.error));
   });
 });

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -111,13 +111,19 @@ Tools:
 - search_steps("keywords"): keyword search across all step types.
 - get_step("<type>"): full schema + (for lib/custom) source code. Always call before using a type.
 - create_step / edit_step: author or revise a custom step (see above).
+- list_workflows(): list existing workflows (name, active version, versions, description). Check this before creating a new workflow or referencing one in a subflow.
+- get_workflow("<name>", version?): read an existing workflow's full YAML + version metadata. Call before editing, referencing, or reusing a workflow you didn't just write.
+- create_workflow / edit_workflow: publish a NEW workflow, or a new VERSION of an existing one. edit_workflow is for STRUCTURAL changes (add/remove steps, rewire depends, promote a winning params default). To merely try a different prompt/threshold value, do NOT publish a version — pass params to run_workflow (those are runs, not versions).
+- list_runs("<name>", limit?): a workflow's past runs (newest first) with status/duration — for inspecting history or comparing experiment runs.
+- get_run("<name>", "<runId>", fullEvents?): one run's summary (input/output/error) + event log (slimmed by default; fullEvents:true for per-step payloads) — for debugging a failed run.
 
 Workflow:
 1. Available step types are listed at the end of this prompt. Use search_steps only if you need to find something by keyword; use list_steps only to re-list after creating new custom steps.
 2. Call get_step for EVERY step type you will use. Each has a description with the exact YAML config format — you MUST read it before writing. Do not guess config fields.
 3. If a needed step doesn't exist, author it with create_step (or edit_step to revise one), then it's available by its type.
-4. Call create_workflow with the final YAML.
+4. Call create_workflow with the final YAML (or edit_workflow to publish a new version of an existing workflow — get_workflow to read it first).
 5. Call run_workflow with a sample input to test it. Report the result (success/error, output, or which step failed) to the user.
+6. To debug a failure or inspect prior behavior, use list_runs + get_run. To build on or reference existing workflows, use list_workflows + get_workflow first.
 
 Be concise. Don't over-explain.`;
 

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -1,9 +1,43 @@
 import { z } from "zod";
 import { tool } from "ai";
 import { runWorkflow } from "../runner.js";
+import type { RunEvent, RunSummary } from "../core.js";
 import { AiDeps } from "./prompts.js";
 import { lsSteps, searchSteps, readStepSource } from "./stepHelpers.js";
 import { zodToFields } from "./schemaHelpers.js";
+
+// The run-history read methods live on `FileRunStore`, not the base `RunStore`
+// interface (which is write-only: append/finalize). `MemoryRunStore` lacks them.
+// Feature-detect so the run-history tools degrade gracefully on stores that
+// can't read back (they return an error rather than throwing).
+interface RunReadStore {
+  listRuns(workflow: string): Promise<string[]>;
+  getRunSummary(workflow: string, runId: string): Promise<RunSummary | null>;
+  getRunEvents(workflow: string, runId: string): Promise<RunEvent[]>;
+}
+
+function asReadStore(store: unknown): RunReadStore | null {
+  const s = store as Partial<RunReadStore> | undefined;
+  return s &&
+    typeof s.listRuns === "function" &&
+    typeof s.getRunSummary === "function" &&
+    typeof s.getRunEvents === "function"
+    ? (s as RunReadStore)
+    : null;
+}
+
+/** Drop bulky input/output payloads from an event so a run's event list stays
+ *  token-cheap; the agent can re-fetch a specific run's full events if needed. */
+function slimEvent(e: RunEvent) {
+  return {
+    type: e.type,
+    path: e.path,
+    ...(e.stepType ? { stepType: e.stepType } : {}),
+    ...(e.durationMs != null ? { durationMs: e.durationMs } : {}),
+    ...(e.iteration != null ? { iteration: e.iteration } : {}),
+    ...(e.error ? { error: e.error } : {}),
+  };
+}
 
 // ── Tools ──────────────────────────────────────────────────────────────────
 
@@ -145,10 +179,10 @@ export function buildTools(deps: AiDeps) {
 
     create_workflow: tool({
       description:
-        "Create and publish a new workflow from YAML. If the name already " +
+        "Create and publish a NEW workflow from YAML. If the name already " +
         "exists, a numeric suffix is appended (e.g. `send-email-2`). The " +
         "response includes the final name used. To publish a new version of " +
-        "an existing workflow, use `edit_workflow` (coming soon) instead.",
+        "an EXISTING workflow, use `edit_workflow` instead.",
       inputSchema: z.object({
         name: z.string().describe("Workflow name (kebab-case)"),
         yaml: z.string().describe("Full workflow YAML"),
@@ -168,6 +202,97 @@ export function buildTools(deps: AiDeps) {
           version,
           renamed: finalName !== name,
           requested: name,
+        };
+      },
+    }),
+
+    edit_workflow: tool({
+      description:
+        "Publish a NEW VERSION of an EXISTING workflow from YAML. Call " +
+        "get_workflow first to read the current source. Identical content is " +
+        "a no-op; a change increments the version (v1 → v2 → …) and activates " +
+        "it, retaining prior versions for rollback. Use this for STRUCTURAL " +
+        "changes (adding/removing steps, rewiring `depends`, or promoting a " +
+        "winning `params` default). To merely try a different prompt or " +
+        "threshold value, do NOT publish a version — pass `params` to " +
+        "run_workflow instead (those are runs, not versions).",
+      inputSchema: z.object({
+        name: z.string().describe("Existing workflow name to edit"),
+        yaml: z.string().describe("Full updated workflow YAML"),
+        description: z.string().optional(),
+      }),
+      execute: async ({ name, yaml, description }) => {
+        const exists = (await deps.workspace.listWorkflows()).some(
+          (w) => w.name === name,
+        );
+        if (!exists) {
+          return {
+            error: `Workflow "${name}" not found. Use create_workflow to author a new one.`,
+          };
+        }
+        let result;
+        try {
+          result = await deps.workspace.publishWorkflowByContent(
+            name,
+            yaml,
+            description,
+          );
+        } catch (err) {
+          return { error: err instanceof Error ? err.message : String(err) };
+        }
+        deps.registry = await deps.getRegistry();
+        return {
+          ok: true,
+          name,
+          version: result.version,
+          changed: result.changed,
+        };
+      },
+    }),
+
+    list_workflows: tool({
+      description:
+        "List all published workflows in the workspace, with each one's active version, all versions, and description. Use this to discover what workflows already exist before creating a new one or referencing one in a subflow.",
+      inputSchema: z.object({}),
+      execute: async () => {
+        const workflows = await deps.workspace.listWorkflows();
+        return { workflows };
+      },
+    }),
+
+    get_workflow: tool({
+      description:
+        "Get a published workflow's full YAML source plus its version metadata. Defaults to the active version; pass `version` for a specific one. Use this to read an existing workflow before editing, referencing it in a subflow, or running it.",
+      inputSchema: z.object({
+        name: z.string().describe("Workflow name"),
+        version: z
+          .string()
+          .optional()
+          .describe("Optional specific version. Defaults to the active version."),
+      }),
+      execute: async ({ name, version }) => {
+        const entry = (await deps.workspace.listWorkflows()).find(
+          (w) => w.name === name,
+        );
+        if (!entry) {
+          return { error: `Workflow "${name}" not found` };
+        }
+        const resolved = version ?? entry.activeVersion;
+        let yaml;
+        try {
+          yaml = await deps.workspace.getWorkflowSource(name, resolved);
+        } catch (err) {
+          return {
+            error: `Version "${resolved}" not found for "${name}". Available: ${entry.versions.join(", ")}`,
+          };
+        }
+        return {
+          name,
+          version: resolved,
+          activeVersion: entry.activeVersion,
+          versions: entry.versions,
+          description: entry.description,
+          yaml,
         };
       },
     }),
@@ -215,6 +340,78 @@ export function buildTools(deps: AiDeps) {
         });
 
         return result;
+      },
+    }),
+
+    list_runs: tool({
+      description:
+        "List past runs of a workflow (newest first), each with its status, duration, and timestamps. Use this to inspect a workflow's run history — e.g. to compare experiment runs or find a failing run. Then call get_run for a specific run's full input/output/events.",
+      inputSchema: z.object({
+        name: z.string().describe("Workflow name whose runs to list"),
+        limit: z
+          .number()
+          .int()
+          .positive()
+          .default(20)
+          .describe("Max number of recent runs to return (default 20)."),
+      }),
+      execute: async ({ name, limit }) => {
+        const store = asReadStore(deps.store);
+        if (!store) {
+          return {
+            error:
+              "Run history is unavailable (the run store does not support reading back runs).",
+          };
+        }
+        const ids = (await store.listRuns(name)).slice(0, limit);
+        const runs = await Promise.all(
+          ids.map(async (runId) => {
+            const s = await store.getRunSummary(name, runId);
+            return {
+              runId,
+              status: s?.status,
+              startedAt: s?.startedAt,
+              durationMs: s?.durationMs,
+              ...(s?.error ? { error: s.error } : {}),
+            };
+          }),
+        );
+        return { workflow: name, runs };
+      },
+    }),
+
+    get_run: tool({
+      description:
+        "Get a single run's details: its summary (input, output, status, error, duration) and its event log. By default the event log is slimmed (type/path/duration/error per step, no payloads) to stay token-cheap; set fullEvents:true to include each step's input/output. Use this to debug why a run failed or to read what each step produced.",
+      inputSchema: z.object({
+        name: z.string().describe("Workflow name"),
+        runId: z.string().describe("Run id (a millisecond timestamp, from list_runs)"),
+        fullEvents: z
+          .boolean()
+          .default(false)
+          .describe("Include full per-step input/output payloads in events (default false: slimmed)."),
+      }),
+      execute: async ({ name, runId, fullEvents }) => {
+        const store = asReadStore(deps.store);
+        if (!store) {
+          return {
+            error:
+              "Run history is unavailable (the run store does not support reading back runs).",
+          };
+        }
+        const [summary, rawEvents] = await Promise.all([
+          store.getRunSummary(name, runId),
+          store.getRunEvents(name, runId),
+        ]);
+        if (!summary && rawEvents.length === 0) {
+          return { error: `Run "${runId}" not found for workflow "${name}".` };
+        }
+        return {
+          workflow: name,
+          runId,
+          summary,
+          events: fullEvents ? rawEvents : rawEvents.map(slimEvent),
+        };
       },
     }),
   };

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -223,6 +223,12 @@ export async function createVein<TServices = unknown>(
 ): Promise<Vein<TServices>> {
   const workspace = opts.workspace ?? new WorkspaceManager();
   const store = opts.store ?? new FileRunStore(workspace.path);
+  // Run IDs currently executing **in this process** (keyed `${workflow}/${runId}`).
+  // Detached execution is in-memory, so a run with no `run.json` summary is only
+  // genuinely "running" if it's in this set; otherwise it never finalized (server
+  // restart / crash / cancellation) and is reported as "stale" rather than a
+  // perpetual "running".
+  const activeRuns = new Set<string>();
   const services = (opts.services ?? ({} as TServices)) as TServices;
   const serveUi = opts.serveUi ?? true;
   const enableChat = opts.enableChat ?? true;
@@ -329,7 +335,8 @@ export async function createVein<TServices = unknown>(
       if (summary) {
         runs.push(summary);
       } else {
-        runs.push({ runId, workflow: name, status: "running" });
+        const status = activeRuns.has(`${name}/${runId}`) ? "running" : "stale";
+        runs.push({ runId, workflow: name, status });
       }
     }
     return c.json(runs);
@@ -375,7 +382,7 @@ export async function createVein<TServices = unknown>(
       const summary = await store.getRunSummary(name, runId);
       const result = summary
         ? { runId, status: summary.status, output: summary.output, error: summary.error }
-        : { runId, status: "running" };
+        : { runId, status: activeRuns.has(`${name}/${runId}`) ? "running" : "stale" };
       await stream.writeSSE({ event: "done", data: JSON.stringify(result) });
     });
   });
@@ -597,6 +604,8 @@ export async function createVein<TServices = unknown>(
    */
   function launchDetached(flow: Flow, body: RunBody): string {
     const runId = body.runId ?? generateRunId();
+    const key = `${flow.name}/${runId}`;
+    activeRuns.add(key);
     void runWorkflow(flow, body.input ?? {}, registry, {
       runId,
       store,
@@ -604,9 +613,13 @@ export async function createVein<TServices = unknown>(
       services,
       params: body.params,
       paramOverrides: body.paramOverrides,
-    }).catch((err) => {
-      console.error(`[run ${runId}] launch failed:`, err);
-    });
+    })
+      .catch((err) => {
+        console.error(`[run ${runId}] launch failed:`, err);
+      })
+      .finally(() => {
+        activeRuns.delete(key);
+      });
     return runId;
   }
 

--- a/vein/web/src/helpers.ts
+++ b/vein/web/src/helpers.ts
@@ -48,7 +48,7 @@ export function deepEqual(a: unknown, b: unknown): boolean {
 export function statusTone(s: string) {
   if (s === "success") return "ok";
   if (s === "error") return "danger";
-  if (s === "skipped") return "muted";
+  if (s === "skipped" || s === "stale") return "muted";
   return "warning";
 }
 

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -161,12 +161,13 @@ body.is-resizing-events * {
 .sidebar-section {
   padding: var(--sp-2) 0;
   border-bottom: 1px solid var(--border);
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
 }
 .sidebar-section:last-child {
   border-bottom: none;
-  flex: 1;
-  display: flex;
-  flex-direction: column;
 }
 
 .section-title {
@@ -181,6 +182,7 @@ body.is-resizing-events * {
 .sidebar-scroll {
   overflow-y: auto;
   flex: 1;
+  min-height: 0;
 }
 
 /* ─── list items ─────────────────────────────────────────────── */


### PR DESCRIPTION
## Summary

Adds AI workflow-builder tools to vein, plus supporting fixes.

- **`edit_workflow` tool** — publishes a new version of an existing workflow from YAML via the existing `workspace.publishWorkflowByContent` (content-hash dedup, sequential `vN`, idempotent, rollback-retaining). Mirrors `edit_step`. Also fixes `create_workflow`'s stale "coming soon" note and documents the tool + version-vs-`params` guidance in the system prompt (structural changes → publish a version; prompt/threshold tweaks → `params` on `run_workflow`, which are runs not versions).
- **`list_workflows` / `get_workflow` / `list_runs` / `get_run` tools** — let the builder agent discover, read, and debug existing workflows and run history (run-history tools feature-detect a readable store and degrade gracefully).
- **Stale-run status** — `createVein` now tracks in-process runs (`activeRuns` set). A run with no `run.json` summary is reported `"stale"` (server restart/crash/cancel) instead of perpetually `"running"`; the web UI renders `"stale"` as a muted tone.
- **gitsee `clone-workspace`** — on a reused clone, prune stale sibling dirs/files no longer in the `repos` list, preventing the explore agent from picking an orphaned repo (cross-version contamination).
- **Sidebar CSS** — `min-height: 0` so the last section flexes/scrolls correctly.

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — 352 pass / 0 fail (includes new `list_workflows`/`get_workflow` integration tests)