### PR TITLE
vein: per-field copy buttons in run output

### DIFF
--- a/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-explore-services.yaml
@@ -79,21 +79,21 @@ params:
 
     Explore the repos to determine:
     - which repo is the runnable frontend (look for the app with a dev/start script, a web framework, an entrypoint);
-    - its package manager and the real install / build / dev commands (read the package manifest / lockfiles);
-    - the host and port it binds (it MUST bind 0.0.0.0 in the pod);
-    - the environment variables it needs — search for process.env. / ENV usage, .env.example, config files;
+    - its package manager and the real install / build / dev commands — read the package manifest / lockfiles AND verify executability by checking if binaries exist and scripts are runnable. For Go apps, prefer 'go run .' over pre-built binaries that may not exist. For database operations, prefer development commands (e.g. 'migrate dev') over production commands (e.g. 'migrate deploy') in local setups;
+    - the host and port it binds — it MUST bind 0.0.0.0 in the pod for external access, not localhost or 127.0.0.1. Verify HOST/HOSTNAME env vars are set to proper local binding addresses, not external URLs;
+    - ALL environment variables it needs — comprehensively search process.env usage, import statements, config file reads, .env files, and ANY hardcoded references to external services/APIs/databases. Look for API keys, database URLs, service endpoints, feature flags, authentication secrets, test commands, reset commands, and any variables referenced in startup scripts or configuration. Search broadly across multiple files and use patterns like TEST_*, RESET_*, *_API_KEY, *_URL, *_ENDPOINT;
     - whether it depends on sibling repos in the workspace that must be installed/built first (file: deps, workspace links);
-    - which backing services it TRULY needs to boot — usually just its database. Caches, queues, realtime, and cloud/third-party integrations should be mocked or disabled, not run as services;
+    - which backing services it TRULY needs to boot and render the frontend successfully — identify required databases, storage services, caches, queues, and authentication providers by tracing env var usage and dependencies. Ensure service credentials match between your configuration and the actual service definitions. Mock or disable optional services like analytics, monitoring, and non-critical integrations;
     - whether the repo has a mock / offline / dev mode (e.g. a USE_MOCKS or MOCK_* flag) that lets it boot without real external accounts — prefer enabling it over provisioning those services.
 
-    Use the fulltext_search tool to find env var usage, and bash to read package manifests, lockfiles, docker files, and cross-repo dependency links. You will output actual config files at the end, so find everything you need. Name the runnable pm2 service "frontend" no matter what.
+    PRIORITIZE A WORKING, RENDERING FRONTEND. Your primary goal is a setup that boots successfully AND renders the intended application UI with functional user interface elements, not just binding a port or showing placeholder text. Ensure start commands are correct and executable, host binding allows external access, required services are properly configured with matching credentials, database schemas are initialized correctly, and all critical environment variables are set with working values. Verify that persistent backend processes are properly managed through pm2 configuration, not just started in PRE_START_COMMAND.
 
-    EDITING THE REPO (local-first). You have a str_replace_based_edit_tool (view/create/str_replace/insert). Use it to make the workspace BOOT LOCALLY when a config change alone can't — e.g. flip a hardcoded cloud-only setting to a local one, enable a mock/offline flag in a config file, or MOVE a misplaced file into the place the framework expects (a classic case: a SQL migration committed at the repo root or meant to be pasted into a hosted dashboard, when the framework auto-applies migrations from a specific dir — move it there). Your edits are captured as a git diff and shipped as part of the setup (re-applied on a fresh clone), so:
+    Use the fulltext_search tool to find env var usage, API calls, and service dependencies, and bash to read package manifests, lockfiles, docker files, and cross-repo dependency links. You will output actual config files at the end, so find everything you need.
+
+    EDITING THE REPO (local-first). You have a str_replace_based_edit_tool (view/create/str_replace/insert). Use it to make the workspace BOOT LOCALLY when a config change alone can't — e.g. flip a hardcoded cloud-only setting to a local one, enable a mock/offline flag in a config file, fix incorrect host binding (change localhost to 0.0.0.0), or MOVE a misplaced file into the place the framework expects (a classic case: a SQL migration committed at the repo root or meant to be pasted into a hosted dashboard, when the framework auto-applies migrations from a specific dir — move it there). Your edits are captured as a git diff and shipped as part of the setup (re-applied on a fresh clone), so:
     - Make MINIMAL, surgical edits — only what's needed to boot locally. Don't refactor.
     - Put FILE changes in the repo (the diff captures them); put RUNTIME steps (reset the db, run migrations, seed) in PRE_START_COMMAND — do NOT do file-moving shell hacks inside PRE_START_COMMAND when an actual file move (a clean diff hunk) is clearer.
     - Prefer the repo's own mock/offline mode over editing when one exists.
-
-    Name the runnable pm2 service "frontend" no matter what.
   finalAnswer: |-
     Provide the final answer. YOU **MUST** CALL THIS TOOL AT THE END OF YOUR EXPLORATION.
 

--- a/vein/web/src/components/CopyButton.tsx
+++ b/vein/web/src/components/CopyButton.tsx
@@ -1,0 +1,34 @@
+import { useState } from "preact/hooks";
+import { CopyIcon, CheckIcon } from "../icons";
+
+// ── Copy-to-clipboard button ───────────────────────────────────────────────
+//
+// Writes the RAW value to the clipboard (no JSON escaping) — so a long string
+// field like an optimized prompt copies as clean multi-line text, not a quoted
+// `"...\n..."` blob. Shows a brief checkmark on success.
+
+export function CopyButton(props: { value: string; label?: string }) {
+  const [copied, setCopied] = useState(false);
+
+  const onCopy = async (e: Event) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(props.value);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard API unavailable (e.g. insecure context) — no-op.
+    }
+  };
+
+  return (
+    <button
+      class="copy-btn"
+      onClick={onCopy}
+      aria-label={props.label ?? "Copy"}
+      title={copied ? "Copied!" : "Copy"}
+    >
+      {copied ? <CheckIcon /> : <CopyIcon />}
+    </button>
+  );
+}

--- a/vein/web/src/components/EventsPanel.tsx
+++ b/vein/web/src/components/EventsPanel.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useRef } from "preact/hooks";
 import * as api from "../api";
-import { formatJson, eventTone, statusTone } from "../helpers";
+import { eventTone, statusTone } from "../helpers";
+import { ValueFields } from "./ValueFields";
 import { StepData } from "../flow-to-canvas";
 import { CloseIcon } from "../icons";
 import yaml from "js-yaml";
@@ -79,19 +80,19 @@ export function EventsPanel(props: {
                 {evt.input != null && (
                   <>
                     <div class="event-detail-label">Input</div>
-                    <pre class="event-detail-block">{formatJson(evt.input)}</pre>
+                    <ValueFields value={evt.input} blockClass="event-detail-block" />
                   </>
                 )}
                 {evt.output != null && (
                   <>
                     <div class="event-detail-label">Output</div>
-                    <pre class="event-detail-block">{formatJson(evt.output)}</pre>
+                    <ValueFields value={evt.output} blockClass="event-detail-block" />
                   </>
                 )}
                 {evt.error != null && (
                   <>
                     <div class="event-detail-label">Error</div>
-                    <pre class="event-detail-block tone-error">{formatJson(evt.error)}</pre>
+                    <ValueFields value={evt.error} blockClass="event-detail-block tone-error" />
                   </>
                 )}
               </div>

--- a/vein/web/src/components/StepRunFlyout.tsx
+++ b/vein/web/src/components/StepRunFlyout.tsx
@@ -3,6 +3,7 @@ import { StepData } from "../flow-to-canvas";
 import { formatJson, statusTone } from "../helpers";
 import { CloseIcon } from "../icons";
 import { Markdown, hasMarkdownField } from "./Markdown";
+import { ValueFields } from "./ValueFields";
 import { FlyoutResizer } from "./FlyoutResizer";
 import yaml from "js-yaml";
 
@@ -82,14 +83,14 @@ export function StepRunFlyout(props: {
                   <div class="flyout-markdown-wrap">
                     <Markdown source={markdown} class="md-compact" />
                   </div>
-                  {hasRest && <pre class="flyout-json flyout-json-after-md">{formatJson(rest)}</pre>}
+                  {hasRest && <div class="flyout-json-after-md"><ValueFields value={rest} /></div>}
                 </div>
               );
             }
             return (
               <div class="flyout-section">
                 <div class="flyout-section-title">Output</div>
-                <pre class="flyout-json">{formatJson(output)}</pre>
+                <ValueFields value={output} />
               </div>
             );
           })()}

--- a/vein/web/src/components/ValueFields.tsx
+++ b/vein/web/src/components/ValueFields.tsx
@@ -1,0 +1,40 @@
+import { formatJson, humanize } from "../helpers";
+import { CopyButton } from "./CopyButton";
+
+// ── Copyable value rendering ────────────────────────────────────────────────
+//
+// Renders a value with per-field copy buttons. A plain object becomes one row
+// per top-level field (so e.g. eval/optimize's `bestPrompt` copies on its own,
+// as clean unescaped text); anything else is a single copyable block.
+// `formatJson` returns strings RAW and pretty-prints everything else, and the
+// copy button writes that same text — so copying never yields JSON escapes.
+
+export function isPlainObject(v: unknown): v is Record<string, unknown> {
+  return typeof v === "object" && v !== null && !Array.isArray(v);
+}
+
+export function CopyBlock(props: { value: unknown; label?: string; blockClass?: string }) {
+  const text = formatJson(props.value);
+  return (
+    <div class="flyout-field">
+      <div class="flyout-field-head">
+        {props.label ? <span class="flyout-field-key">{humanize(props.label)}</span> : <span />}
+        <CopyButton value={text} label={props.label ? `Copy ${props.label}` : "Copy"} />
+      </div>
+      <pre class={props.blockClass ?? "flyout-json"}>{text}</pre>
+    </div>
+  );
+}
+
+export function ValueFields(props: { value: unknown; blockClass?: string }) {
+  if (isPlainObject(props.value)) {
+    return (
+      <div class="flyout-fields">
+        {Object.entries(props.value).map(([k, v]) => (
+          <CopyBlock key={k} label={k} value={v} blockClass={props.blockClass} />
+        ))}
+      </div>
+    );
+  }
+  return <CopyBlock value={props.value} blockClass={props.blockClass} />;
+}

--- a/vein/web/src/icons.tsx
+++ b/vein/web/src/icons.tsx
@@ -21,3 +21,42 @@ export function CloseIcon({ size = 14, ...rest }: IconProps) {
     </svg>
   );
 }
+
+export function CopyIcon({ size = 13, ...rest }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      {...rest}
+    >
+      <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
+      <path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1" />
+    </svg>
+  );
+}
+
+export function CheckIcon({ size = 13, ...rest }: IconProps) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+      {...rest}
+    >
+      <polyline points="20 6 9 17 4 12" />
+    </svg>
+  );
+}

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -670,6 +670,44 @@ body.is-resizing-flyout * {
   border-color: rgba(248, 113, 113, 0.3);
   color: var(--danger);
 }
+.flyout-fields {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+.flyout-field-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-2);
+  margin-bottom: var(--sp-1);
+  min-height: 18px;
+}
+.flyout-field-key {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-dim);
+  word-break: break-all;
+}
+.copy-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-sm);
+  background: var(--bg);
+  color: var(--text-dim);
+  cursor: pointer;
+  transition: color 0.12s, border-color 0.12s, background 0.12s;
+}
+.copy-btn:hover {
+  color: var(--text);
+  border-color: var(--text-dim);
+}
 .param-edit {
   width: 100%;
   box-sizing: border-box;


### PR DESCRIPTION
## What

Run results now render a plain-object output as **one copyable row per top-level field**, each with a copy button. Copying a string field (e.g. `eval/optimize`'s `bestPrompt`) yields clean, unescaped multi-line text instead of a JSON-escaped `"...\\n..."` blob.

Wired into both surfaces that show run output:
- **Step results flyout** (`StepRunFlyout`) — the Output section.
- **Events panel** (`EventsPanel`) — the expanded `run.end` row (Input / Output / Error).

### Changes
- `CopyButton.tsx` (new) — writes the **raw** value via `navigator.clipboard.writeText`; brief checkmark on success.
- `ValueFields.tsx` (new) — shared renderer: plain object → per-field `CopyBlock` rows; anything else → single copyable block. `blockClass` adapts the `<pre>` to each panel's styling. `formatJson` returns strings raw, so displayed text == copied text.
- `EventsPanel.tsx` / `StepRunFlyout.tsx` — use `ValueFields`.
- `icons.tsx` — `CopyIcon` + `CheckIcon`.
- `components.css` — `.flyout-fields` / `.flyout-field-head` / `.flyout-field-key` / `.copy-btn` (tight 4px inter-field gap).

Also promotes an optimized `gitsee-explore-services` `system` prompt.

## Why

Copying an optimized prompt out of the optimize run's output previously gave the JSON-escaped string. Per-field copy makes promoting a winner a one-click, paste-ready action.

## Test

`cd vein/web && npx tsc --noEmit && npx vite build` pass. Manual: open a `gitsee-optimize` run in `/lab`, expand `run.end`, copy `bestPrompt` → clean text.