### PR TITLE
lab/eval: optimizer memory + anchor reflection to best

### DIFF
--- a/mcp/src/lab/concepts/workflows/concepts-eval-reflect.yaml
+++ b/mcp/src/lab/concepts/workflows/concepts-eval-reflect.yaml
@@ -3,7 +3,8 @@ name: concepts-eval-reflect
 # the CONCEPT task framing + revision guidance, so the optimize loop can call it
 # to get an improved bootstrapPrompt from aggregated eval results.
 #
-# Input:  { prompt, results[ { score?, missing[], spurious[], insight? } ] }
+# Input:  { prompt, results[ { score?, missing[], spurious[], insight? } ],
+#           history?[ { gen?, score?, rationale?, prompt? } ] }
 # Output: { prompt, rationale }
 steps:
   - id: reflect
@@ -11,6 +12,9 @@ steps:
     config:
       prompt: "{{ input.prompt }}"
       results: "{{ input.results }}"
+      # Prior-generation trajectory (supplied by the optimize loop) → reflection
+      # gains memory across tries (follows the score trend, avoids regressions).
+      history: "{{ input.history }}"
       task: "{{ params.task }}"
       guidance: "{{ params.guidance }}"
 

--- a/mcp/src/lab/eval/steps/optimize.ts
+++ b/mcp/src/lab/eval/steps/optimize.ts
@@ -5,9 +5,15 @@ import { z, defineStep, type RunEvent, type TokenUsage, emptyUsage, addUsage, co
  * single step so the whole thing is one detached run (a "background job", §8):
  *
  *   eval  → score the current candidate prompt on the dataset
- *   keep  → track the best-scoring candidate so far
+ *   keep  → track the best-scoring candidate (prompt + its results) so far
  *   stop? → score ≥ threshold, or out of generations
- *   reflect → propose the next candidate (generalizing) and repeat
+ *   reflect → propose the next candidate, ANCHORED to the best (see below), and repeat
+ *
+ * ANCHOR + MEMORY: reflection builds the next candidate FROM the best-scoring
+ * prompt so far (not the latest, which may have regressed) — a hard guarantee we
+ * never keep editing a known-worse prompt — and is handed the FULL trajectory of
+ * prior generations (`history`: each prompt's mean score + the change rationale)
+ * so it follows the trend and won't re-propose a change that already regressed.
  *
  * Domain-agnostic: it tunes some `promptParam` on a `targetWorkflow` by running
  * an `evalWorkflow` (whose output has { score, missing, spurious, insight }) and
@@ -163,11 +169,20 @@ export default defineStep({
       gen: number;
       score: number; // mean across the dataset
       prompt: string;
+      rationale?: string; // why THIS gen's prompt was changed (prior reflection's rationale; undefined for gen 0)
       results: ExampleResult[];
       usage: TokenUsage; // gen total: every eval run + the reflection
       cost: number;
     }> = [];
-    let best = { gen: -1, prompt: candidate, score: -1 };
+    // The best-scoring candidate so far. We carry its OWN `results` so reflection
+    // can be ANCHORED to it (show best.prompt with the results best.prompt actually
+    // produced — coherent), instead of chaining off the latest (maybe-worse) gen.
+    let best: { gen: number; prompt: string; score: number; results: ExampleResult[] } = {
+      gen: -1,
+      prompt: candidate,
+      score: -1,
+      results: [],
+    };
 
     // Running totals across the WHOLE optimize run (all generations: every eval
     // run + every reflection). Surfaced in the final output as { totalCost,
@@ -245,10 +260,10 @@ export default defineStep({
         // `evalRunId` per example links to its full eval run (which nests the
         // bootstrap-then-process subflow — i.e. the bootstrap logs). The entry is
         // kept mutable so the reflection's tokens+$ can be added to it below.
-        const genEntry = { gen, score, prompt: candidate, results: evalRuns, usage: genUsage, cost: genCost };
+        const genEntry = { gen, score, prompt: candidate, rationale, results: evalRuns, usage: genUsage, cost: genCost };
         generations.push(genEntry);
 
-        if (score > best.score) best = { gen, prompt: candidate, score };
+        if (score > best.score) best = { gen, prompt: candidate, score, results: evalRuns };
 
         // One run ref per example so the UI can open each generation's evals.
         const runs: RunRef[] = evalRuns.map((r) => ({
@@ -275,18 +290,33 @@ export default defineStep({
         // "until it's satisfied": stop once good enough, or on the last generation.
         if (score >= cfg.threshold || gen === cfg.maxGenerations - 1) break;
 
-        // ── reflect → next candidate (generalizing ACROSS the dataset) ─────
-        // Pass the full per-example array so reflect optimizes for the COMMON
-        // failure modes, not one example's quirks.
+        // ── reflect → next candidate ───────────────────────────────────────
+        // ANCHOR TO BEST: build the next candidate FROM the best-scoring prompt so
+        // far — NOT the latest gen, which may have regressed. This is a hard
+        // structural guarantee that we never keep editing a known-worse prompt (and
+        // it sidesteps the fact that the `history` prompts are truncated, so the
+        // model couldn't faithfully reconstruct the best from them on its own). We
+        // pass best's OWN per-example results (coherent with best.prompt for "what
+        // produced the results below"), plus the FULL trajectory of every
+        // generation — including the just-eval'd one — as `history`, so reflection
+        // follows the score trend and won't re-propose a change that already
+        // regressed.
+        const history = generations.map((g) => ({
+          gen: g.gen,
+          score: g.score,
+          rationale: g.rationale,
+          prompt: g.prompt,
+        }));
         const reflectRun = await opt.run(cfg.reflectWorkflow, {
-          prompt: candidate,
-          results: evalRuns.map((r) => ({
+          prompt: best.prompt,
+          results: best.results.map((r) => ({
             label: r.label,
             score: r.score,
             missing: r.missing,
             spurious: r.spurious,
             insight: r.insight,
           })),
+          history,
         });
         if (reflectRun.status !== "success") {
           throw new Error(`reflect run failed: ${reflectRun.error?.message ?? "unknown"}`);

--- a/mcp/src/lab/eval/steps/reflect.ts
+++ b/mcp/src/lab/eval/steps/reflect.ts
@@ -19,6 +19,14 @@ import { z, defineStep, usageFromResult, computeCost } from "vein";
  * an ARRAY; the prompt is told to only make changes that help across ALL of
  * them and never encode a single example's specifics.
  *
+ * MEMORY across generations (optional `history`): without it, each reflection is
+ * memoryless — it only sees the CURRENT prompt + its results, so it can re-propose
+ * a change an earlier generation already tried and that LOWERED the score. When
+ * the optimize loop passes `history` (every prior generation's prompt excerpt +
+ * mean score + the rationale for that change), the reflector can follow the score
+ * trend and avoid re-treading rejected changes. Defaults to [] (back-compat: a
+ * memoryless single reflection still works).
+ *
  * Self-contained: reaches the model via dynamic `import("ai")` (no services),
  * structured output (`generateObject`). Output: { prompt, rationale, usage, cost }
  * — usage/cost are this reflection's own LLM tokens + dollar cost.
@@ -46,6 +54,27 @@ interface Proposal {
   prompt: string;
 }
 
+/** One prior generation in this optimize run — what was tried and how it scored. */
+const HistorySchema = z.object({
+  gen: z.number().optional().describe("the generation index (0-based)"),
+  score: z.number().optional().describe("that generation's mean score across the dataset"),
+  rationale: z.string().optional().describe("why that generation's prompt was changed (the prior reflection's rationale)"),
+  prompt: z.string().optional().describe("that generation's prompt (excerpted)"),
+});
+
+interface History {
+  gen?: number;
+  score?: number;
+  rationale?: string;
+  prompt?: string;
+}
+
+/** Cap a prompt excerpt so the history digest stays token-cheap. */
+function excerpt(s: string, max = 400): string {
+  const t = s.trim();
+  return t.length > max ? t.slice(0, max) + " […]" : t;
+}
+
 /** Explicit shape of a `results[]` entry — annotated so the aggregation
  *  callbacks below don't depend on zod inference flowing through
  *  `defineStep` (which widens to `any` when vein is consumed as built
@@ -65,6 +94,10 @@ export default defineStep({
   input: z.object({
     prompt: z.string().describe("the current candidate prompt being tuned"),
     results: z.array(ResultSchema).describe("per-example scoring results across the dataset (>=1; more = less overfit)"),
+    history: z
+      .array(HistorySchema)
+      .default([])
+      .describe("prior generations this optimize run (oldest→newest): each prompt's mean score + the rationale for its change, so reflection follows the score trend and avoids re-proposing changes that already regressed. Empty = memoryless (default)."),
     task: z.string().optional().describe("one line: what this prompt is supposed to accomplish (the domain framing)"),
     rubric: z.string().optional().describe("what a good output looks like (matching criteria / standards)"),
     guidance: z.string().optional().describe("meta-rules for how to revise (e.g. 'prefer broad names', 'never name a specific item')"),
@@ -113,13 +146,29 @@ export default defineStep({
         ? results.reduce((s: number, r: Result) => s + (r.score ?? 0), 0) / results.length
         : undefined;
 
+    // Trajectory of prior attempts (oldest→newest): what was changed + how it
+    // scored, so the model builds on improvements and avoids rejected changes.
+    const history = (cfg.history ?? []) as History[];
+    const historyDigest = history
+      .map((h: History, i: number) => {
+        const tag = h.gen != null ? `gen ${h.gen}` : `attempt ${i + 1}`;
+        const score = h.score != null ? ` — mean score ${Math.round(h.score * 100) / 100}` : "";
+        const why = h.rationale ? `\n  changed: ${h.rationale}` : "";
+        const ex = h.prompt ? `\n  prompt: ${excerpt(h.prompt)}` : "";
+        return `- ${tag}${score}${why}${ex}`;
+      })
+      .join("\n");
+    const historySection = history.length
+      ? `\n# PREVIOUS ATTEMPTS THIS RUN (oldest → newest)\nThe CURRENT PROMPT above is the BEST-scoring attempt so far — you are improving FROM it. Learn from this trajectory: build on changes that RAISED the mean score, and do NOT re-introduce a change that LOWERED it.\n${historyDigest}\n`
+      : "";
+
     const prompt = `You are optimizing a PROMPT. ${cfg.task ?? "The prompt produces a set of items that we score against a gold set for recall (did we recover the real items?) and precision (did we avoid noise?)."}
 
 # CURRENT PROMPT (what produced the results below)
 """
 ${cfg.prompt}
 """
-${cfg.rubric ? `\n# WHAT "GOOD" LOOKS LIKE (rubric)\n${cfg.rubric}\n` : ""}${cfg.guidance ? `\n# HOW TO REVISE (guidance)\n${cfg.guidance}\n` : ""}
+${cfg.rubric ? `\n# WHAT "GOOD" LOOKS LIKE (rubric)\n${cfg.rubric}\n` : ""}${cfg.guidance ? `\n# HOW TO REVISE (guidance)\n${cfg.guidance}\n` : ""}${historySection}
 # RESULTS ACROSS ${cfg.results.length} EXAMPLE(S)${meanScore != null ? ` — mean score ${Math.round(meanScore * 100) / 100}` : ""}
 ${digest}
 
@@ -129,7 +178,7 @@ these examples. Rules:
   examples. Never encode a single example's specific domain or missing item —
   encode the underlying PRINCIPLE instead.
 - Recall first: the biggest lever is recovering recurring 'missing' kinds.
-- Cut recurring 'spurious' kinds by sharpening the inclusion/exclusion criteria.
+- Cut recurring 'spurious' kinds by sharpening the inclusion/exclusion criteria.${historySection ? "\n- Use PREVIOUS ATTEMPTS: build on changes that raised the mean score; do NOT re-propose a change that already lowered it. Aim to beat the best score so far." : ""}
 - Preserve any {placeholder} tokens present in the current prompt verbatim.
 - Return the COMPLETE new prompt (not a diff).`;
 

--- a/mcp/src/lab/gitsee/workflows/gitsee-eval-reflect.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-eval-reflect.yaml
@@ -3,7 +3,8 @@ name: gitsee-eval-reflect
 # the SETUP task framing + revision guidance, so the optimize loop can get an
 # improved exploration prompt (`system`) from aggregated eval results.
 #
-# Input:  { prompt, results[ { score?, missing[], spurious[], insight? } ] }
+# Input:  { prompt, results[ { score?, missing[], spurious[], insight? } ],
+#           history?[ { gen?, score?, rationale?, prompt? } ] }
 # Output: { prompt, rationale }
 steps:
   - id: reflect
@@ -11,6 +12,10 @@ steps:
     config:
       prompt: "{{ input.prompt }}"
       results: "{{ input.results }}"
+      # Trajectory of prior generations (the optimize loop supplies it) so the
+      # reflector has memory across tries — follows the score trend, avoids
+      # re-proposing changes that already regressed.
+      history: "{{ input.history }}"
       task: "{{ params.task }}"
       guidance: "{{ params.guidance }}"
 


### PR DESCRIPTION
## Problem

The `eval/optimize` loop was **memoryless** and **greedy**:
- Each reflection saw only the *current* candidate prompt + its results — no record of what earlier generations tried or scored.
- The loop chained off the **latest** candidate (`candidate = proposal.prompt` unconditionally), even after a regression. `best` was only a high-water mark for the final output, never the search base.

So it could (a) re-propose a change a prior generation already tried and that *lowered* the score, and (b) drift away from the best prompt it ever found, spending generations editing a known-worse prompt.

## Fix (two complementary changes)

### 1. Memory — `history`
`eval/reflect` gains an optional `history` input: the full trajectory of prior generations (each prompt excerpt + mean score + the change rationale). Rendered as a `PREVIOUS ATTEMPTS` section with a rule to build on score-raising changes and not re-introduce regressions. Defaults to `[]` (back-compat — a memoryless single reflection still works).

### 2. Anchor to best
Reflection now builds the next candidate **from `best.prompt`** (with `best.results`, kept coherent for reflect's "CURRENT PROMPT — what produced the results below"), not the latest gen. A hard structural guarantee we never keep editing a known-worse prompt — and it sidesteps the fact that the `history` prompt excerpts are truncated (the model couldn't faithfully reconstruct the best from a snippet). `best` now carries its `results`; `history` includes all generations so the just-regressed attempt is still visible.

The two are complementary: anchoring fixes the *base*, history prevents *re-treading* changes already rejected from that base.

## Files
- `mcp/src/lab/eval/steps/reflect.ts` — `history` input + digest + rule.
- `mcp/src/lab/eval/steps/optimize.ts` — store `rationale`/`results` per gen; reflect from best + pass history.
- `mcp/src/lab/gitsee/workflows/gitsee-eval-reflect.yaml` + `concepts/workflows/concepts-eval-reflect.yaml` — `history` passthrough (shared loop).

## Test
`yarn tsc --noEmit` + `yarn build` pass. Behavior is back-compat for gen 0 (best == current) and for any reflect call without `history`.