### PR TITLE
vein/agent: raise bash tool timeout 15s → 10min

### DIFF
--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -477,12 +477,15 @@ export default defineStep({
       }),
       bash: tool({
         description:
-          "Execute a bash command inside the working dir. Use for listing dirs, reading files (cat/head), inspecting manifests/lockfiles/docker files, and anything the other tools don't cover.",
+          "Execute a bash command inside the working dir. Use for listing dirs, reading files (cat/head), inspecting manifests/lockfiles/docker files, running installs/builds, and anything the other tools don't cover. Long-running commands are allowed (up to a 10-minute timeout); a command that never exits (e.g. a dev server) will block until killed at the timeout.",
         inputSchema: z.object({ command: z.string().describe("The bash command to execute") }) as any,
         execute: async ({ command }: { command: string }) => {
           try {
             if (!existsSync(cfg.cwd)) return "Working directory does not exist";
-            return await runShell(command, cfg.cwd);
+            // 10-minute timeout so the agent can run real installs/builds (not just
+            // quick inspection). Note: a non-terminating process (a dev server)
+            // still blocks until killed at this timeout.
+            return await runShell(command, cfg.cwd, 600_000);
           } catch (e) {
             return `Command execution failed: ${e}`;
           }


### PR DESCRIPTION
## What

The core `agent` step's `bash` tool was capped at **15s**, only enough for quick inspection (cat/ls/read manifests). Raise it to **10 minutes** so the agent can run real `npm install` / build steps inside the working dir.

Scoped to the `bash` tool's call only — `runShell`'s default stays 15s, so `stakgraphSummary`'s explicit 15s call is unaffected.

## Why

gitsee's explorer (and any agent-step consumer) couldn't actually install/build a repo to inspect it — installs routinely exceed 15s and timed out. This is a prerequisite for any "boot/verify the setup" agent work.

## Caveats
- A **non-terminating** command (e.g. a dev server) now blocks until killed at the 10-min timeout — far longer than before. Agents should avoid starting long-lived servers via `bash`.
- Output is still capped at 10KB and truncated from the **start**, so a long build's trailing error may be cut off. A follow-up could bump `maxBytes` and keep the tail for the bash tool specifically.

## Test
`tsc` passes (`vein`); rebuilt + verified the timeout in the propagated `mcp/node_modules/vein` build.