### PR TITLE
vein: promote a run output to a target param (diff + apply)

### DIFF
--- a/mcp/src/lab/gitsee/workflows/gitsee-optimize.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-optimize.yaml
@@ -45,6 +45,17 @@ steps:
       # time. (Raise only if you isolate ports/names per workspace.)
       concurrency: "{{ params.concurrency }}"
 
+# ── promote: the winning prompt → the explorer's `system` param ─────────────
+# Declarative + INERT: this just tells the UI that after a run, `output.bestPrompt`
+# is a value worth promoting into gitsee-explore-services' `system` param default.
+# It writes NOTHING on its own — the UI shows a diff (current system prompt vs this
+# run's bestPrompt) and only writes + publishes a new gitsee-explore-services
+# version when you review it and click Apply.
+promotes:
+  - from: bestPrompt
+    to: gitsee-explore-services.system
+    label: Explorer system prompt
+
 # ── params: the cohort (dataset of WORKSPACES) + the loop's stopping knobs ──
 # Each dataset entry is a WORKSPACE: { label, repos: [{ owner, repo, rev? }],
 # token?, expected }.

--- a/vein/src/core.ts
+++ b/vein/src/core.ts
@@ -65,6 +65,30 @@ export interface Step {
   options?: StepOptions;
 }
 
+/**
+ * A declared mapping from a value in THIS workflow's run output to a `param`
+ * default on a (possibly different) target workflow — the "promote a winner"
+ * surface (Tier 2). After a run, the UI resolves each spec against the run's
+ * output and offers a one-click "promote": write the resolved value into the
+ * target's `params[param]` default and publish a new version. Fully generic —
+ * nothing keys off a specific output name; the optimize loop just declares
+ * `from: bestPrompt`, `to: <targetWorkflow>.<promptParam>`.
+ *
+ * Inert by itself: declaring a promote NEVER writes anything. Promotion is a
+ * human-reviewed action (see the diff, click Apply); only then is the target's
+ * param overwritten + a new version published.
+ */
+export interface PromoteSpec {
+  /** Dotted path into this workflow's run output (e.g. `bestPrompt`,
+   *  `best.prompt`, `results[0].prompt`). */
+  from: string;
+  /** Destination as `"<workflow>.<param>"` — the param default to overwrite.
+   *  Split on the FIRST dot (workflow names contain no dots). */
+  to: string;
+  /** Optional human label for the UI (defaults to the `to` string). */
+  label?: string;
+}
+
 /** A workflow (flow) definition. */
 export interface Flow {
   name: string;
@@ -77,6 +101,10 @@ export interface Flow {
    *  `RunOptions.params`). Override precedence: run override > these
    *  defaults. Omit for workflows with no knobs. */
   params?: Record<string, unknown>;
+  /** Declared "promote a run output → a target param default" mappings.
+   *  Resolved against a run's output by the UI to offer one-click promotion
+   *  of a winning value (e.g. an optimize loop's `bestPrompt`). */
+  promotes?: PromoteSpec[];
 }
 
 /** Run event types for the JSONL log. */

--- a/vein/src/createVein.test.ts
+++ b/vein/src/createVein.test.ts
@@ -461,4 +461,81 @@ describe("createVein", () => {
     const res = await vein.app.request("/workflows/mem-test/runs");
     assert.equal(res.status, 501);
   });
+
+  it("resolves + applies a declared promotion (run output → target param)", async () => {
+    const ws = new WorkspaceManager(tempDir);
+    // Target workflow whose `system` param we'll promote into.
+    await ws.publishWorkflow("target", "v1", {
+      steps: [{ id: "g", type: "log", config: { message: "{{ params.system }}" } }],
+      params: { system: "old" },
+    });
+    // Optimizer workflow: emits `{ bestPrompt }` and declares a promote to target.
+    await ws.publishWorkflow("opt", "v1", {
+      steps: [{ id: "best", type: "emit", config: {} }],
+      promotes: [{ from: "bestPrompt", to: "target.system", label: "Sys" }],
+    });
+
+    const emit = defineStep({
+      type: "emit",
+      input: z.object({}),
+      output: z.any(),
+      async run() {
+        return { bestPrompt: "new winner" };
+      },
+    });
+
+    const vein = await createVein({
+      workspace: ws,
+      registry: await createRegistry([emit]),
+      store: new FileRunStore(tempDir),
+      serveUi: false,
+      enableChat: false,
+    });
+
+    const result = await vein.run("opt", {});
+    assert.equal(result.status, "success");
+
+    // GET promotions resolves the run-output value + the target's current value.
+    const pRes = await vein.app.request(`/workflows/opt/runs/${result.runId}/promotions`);
+    assert.equal(pRes.status, 200);
+    const proms = (await pRes.json()) as any[];
+    assert.equal(proms.length, 1);
+    assert.equal(proms[0].value, "new winner");
+    assert.equal(proms[0].current, "old");
+    assert.equal(proms[0].target.workflow, "target");
+    assert.equal(proms[0].target.param, "system");
+    assert.equal(proms[0].resolved, true);
+
+    // POST promote writes it + publishes a new target version.
+    const applyRes = await vein.app.request(`/workflows/opt/runs/${result.runId}/promote`, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ to: "target.system" }),
+    });
+    assert.equal(applyRes.status, 200);
+    const applied = (await applyRes.json()) as any;
+    assert.equal(applied.version, "v2");
+    assert.equal(applied.before, "old");
+    assert.equal(applied.after, "new winner");
+
+    const flow = await ws.getWorkflow("target");
+    assert.equal(flow.params?.["system"], "new winner");
+  });
+
+  it("returns [] promotions when the workflow declares none", async () => {
+    const ws = new WorkspaceManager(tempDir);
+    await ws.publishWorkflow("plain", "v1", {
+      steps: [{ id: "g", type: "log", config: { message: "hi" } }],
+    });
+    const vein = await createVein({
+      workspace: ws,
+      store: new FileRunStore(tempDir),
+      serveUi: false,
+      enableChat: false,
+    });
+    const result = await vein.run("plain", {});
+    const pRes = await vein.app.request(`/workflows/plain/runs/${result.runId}/promotions`);
+    assert.equal(pRes.status, 200);
+    assert.deepEqual(await pRes.json(), []);
+  });
 });

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -153,6 +153,26 @@ function zodToFields(schema: z.ZodTypeAny): FieldDesc[] {
   return Object.entries(shape).map(([name, s]) => describeField(name, s as z.ZodTypeAny));
 }
 
+/** Resolve a dotted/bracketed path (`a.b`, `a[0].b`) into a nested value.
+ *  Used to pull a promote spec's `from` value out of a run's output. */
+function getByPath(obj: unknown, path: string): unknown {
+  if (!path) return obj;
+  const parts = path.replace(/\[(\d+)\]/g, ".$1").split(".").filter(Boolean);
+  let cur: unknown = obj;
+  for (const p of parts) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+/** Split a promote spec's `to` ("<workflow>.<param>") on the FIRST dot. */
+function parsePromoteTarget(to: string): { workflow: string; param: string } | null {
+  const dot = to.indexOf(".");
+  if (dot <= 0 || dot >= to.length - 1) return null;
+  return { workflow: to.slice(0, dot), param: to.slice(dot + 1) };
+}
+
 function getObjectShape(s: z.ZodTypeAny): Record<string, z.ZodTypeAny> | null {
   const def = s._def;
   if (def.typeName === "ZodObject") return (def as any).shape();
@@ -387,6 +407,106 @@ export async function createVein<TServices = unknown>(
     });
   });
 
+  // Resolve this workflow's declared `promotes` against a run's OUTPUT — the
+  // review surface for "promote a winner". For each spec: the resolved value
+  // from the run output (`value`) and the target param's CURRENT default
+  // (`current`), so the UI can diff current → value. Pure read; nothing is
+  // written until the human POSTs to `/promote`.
+  app.get("/workflows/:name/runs/:runId/promotions", async (c) => {
+    const { name, runId } = c.req.param();
+    if (!(store instanceof FileRunStore)) {
+      return c.json({ error: "Promotions require a FileRunStore" }, 501);
+    }
+    let flow: Flow;
+    try {
+      flow = await workspace.getWorkflow(name);
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 404);
+    }
+    const specs = flow.promotes ?? [];
+    if (specs.length === 0) return c.json([]);
+
+    const summary = await store.getRunSummary(name, runId);
+    if (!summary) {
+      return c.json({ error: `Run "${runId}" not found for workflow "${name}"` }, 404);
+    }
+    const output = summary.output;
+
+    const promotions = [];
+    for (const spec of specs) {
+      const target = parsePromoteTarget(spec.to);
+      if (!target) continue;
+      const value = getByPath(output, spec.from);
+      let current: unknown = undefined;
+      try {
+        current = (await workspace.getWorkflow(target.workflow)).params?.[target.param];
+      } catch {
+        current = undefined; // target workflow may not exist yet
+      }
+      promotions.push({
+        from: spec.from,
+        to: spec.to,
+        target,
+        label: spec.label ?? spec.to,
+        value,
+        current,
+        resolved: value !== undefined,
+      });
+    }
+    return c.json(promotions);
+  });
+
+  // Apply a single declared promotion (human-approved): resolve the run output
+  // value for the spec whose `to` === body.to, write it to the target's param
+  // default, publish a new version, and rebuild the registry. Returns the new
+  // version + before/after.
+  app.post("/workflows/:name/runs/:runId/promote", async (c) => {
+    const { name, runId } = c.req.param();
+    if (!(store instanceof FileRunStore)) {
+      return c.json({ error: "Promotions require a FileRunStore" }, 501);
+    }
+    const body = await c.req.json<{ to?: string }>();
+    if (!body.to) return c.json({ error: "to is required" }, 400);
+
+    let flow: Flow;
+    try {
+      flow = await workspace.getWorkflow(name);
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 404);
+    }
+    const spec = (flow.promotes ?? []).find((s) => s.to === body.to);
+    if (!spec) {
+      return c.json({ error: `No promote spec with to="${body.to}" on workflow "${name}"` }, 404);
+    }
+    const target = parsePromoteTarget(spec.to);
+    if (!target) return c.json({ error: `Invalid promote target "${spec.to}"` }, 400);
+
+    const summary = await store.getRunSummary(name, runId);
+    if (!summary) {
+      return c.json({ error: `Run "${runId}" not found for workflow "${name}"` }, 404);
+    }
+    const value = getByPath(summary.output, spec.from);
+    if (value === undefined) {
+      return c.json({ error: `Promote value at "${spec.from}" is undefined in this run's output` }, 422);
+    }
+
+    let result;
+    try {
+      result = await workspace.setParam(target.workflow, target.param, value);
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
+    }
+    await rebuildRegistry();
+    return c.json({
+      ok: true,
+      workflow: target.workflow,
+      param: target.param,
+      version: result.version,
+      before: result.before,
+      after: result.after,
+    });
+  });
+
   app.get("/workflows/:name/flow", async (c) => {
     const name = c.req.param("name");
     try {
@@ -395,6 +515,7 @@ export async function createVein<TServices = unknown>(
         name: flow.name,
         steps: flow.steps,
         ...(flow.params != null ? { params: flow.params } : {}),
+        ...(flow.promotes != null ? { promotes: flow.promotes } : {}),
       });
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 404);

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -11,6 +11,7 @@ export {
   step,
   defineStep,
   type Flow,
+  type PromoteSpec,
   type Step,
   type StepDef,
   type AnyStepDef,

--- a/vein/src/workspace.test.ts
+++ b/vein/src/workspace.test.ts
@@ -653,6 +653,75 @@ describe("WorkspaceManager", () => {
 
   // ── path property ──────────────────────────────────────────────────────
 
+  describe("promotes + setParam", () => {
+    const PROMOTE_YAML = `name: opt
+steps:
+  - id: run
+    type: log
+    config:
+      message: "{{ params.prompt }}"
+promotes:
+  - from: bestPrompt
+    to: target.system
+    label: System prompt
+params:
+  prompt: hello
+`;
+
+    it("loads the promotes block on the flow", async () => {
+      await ws.publishWorkflow("opt", "v1", PROMOTE_YAML);
+      const flow = await ws.getWorkflow("opt");
+      assert.deepEqual(flow.promotes, [
+        { from: "bestPrompt", to: "target.system", label: "System prompt" },
+      ]);
+    });
+
+    it("round-trips promotes through a steps/params publish", async () => {
+      await ws.publishWorkflow("opt", "v1", {
+        steps: [{ id: "run", type: "log", config: { message: "x" } }],
+        params: { prompt: "hello" },
+        promotes: [{ from: "bestPrompt", to: "target.system" }],
+      });
+      const flow = await ws.getWorkflow("opt");
+      assert.deepEqual(flow.promotes, [{ from: "bestPrompt", to: "target.system" }]);
+    });
+
+    it("setParam overwrites one param + publishes the next version", async () => {
+      await ws.publishWorkflow("target", "v1", {
+        steps: [{ id: "run", type: "log", config: { message: "{{ params.system }}" } }],
+        params: { system: "old prompt", other: "keep" },
+      });
+      const res = await ws.setParam("target", "system", "new prompt");
+      assert.equal(res.version, "v2");
+      assert.equal(res.before, "old prompt");
+      assert.equal(res.after, "new prompt");
+
+      const flow = await ws.getWorkflow("target");
+      assert.equal(flow.params?.["system"], "new prompt");
+      // Other params survive.
+      assert.equal(flow.params?.["other"], "keep");
+      // New version is active.
+      const meta = JSON.parse(
+        await readFile(join(tempDir, "workflows", "target", "_metadata.json"), "utf-8"),
+      );
+      assert.equal(meta.active, "v2");
+    });
+
+    it("setParam preserves the promotes block across versions", async () => {
+      await ws.publishWorkflow("target", "v1", PROMOTE_YAML.replace("name: opt", "name: target"));
+      await ws.setParam("target", "prompt", "world");
+      const flow = await ws.getWorkflow("target");
+      assert.equal(flow.params?.["prompt"], "world");
+      assert.deepEqual(flow.promotes, [
+        { from: "bestPrompt", to: "target.system", label: "System prompt" },
+      ]);
+    });
+
+    it("setParam throws on an unknown workflow", async () => {
+      await assert.rejects(() => ws.setParam("nope", "x", 1), /not found/);
+    });
+  });
+
   describe("path property", () => {
     it("returns the workspace root path", () => {
       assert.equal(ws.path, tempDir);

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -180,6 +180,7 @@ export class WorkspaceManager {
       // Resolve param-to-param references (`{{ params.* }}` nested inside another
       // param) once at load, so a shared value can be factored into one knob.
       ...(data.params != null ? { params: resolveParamSelfReferences(data.params) } : {}),
+      ...(Array.isArray(data.promotes) ? { promotes: data.promotes } : {}),
     };
   }
 
@@ -223,7 +224,7 @@ export class WorkspaceManager {
   async publishWorkflow(
     name: string,
     version: string,
-    content: { steps: any[]; params?: Record<string, unknown> } | string,
+    content: { steps: any[]; params?: Record<string, unknown>; promotes?: unknown[] } | string,
     description?: string,
   ): Promise<void> {
     const dir = join(this.root, "workflows", name);
@@ -238,6 +239,7 @@ export class WorkspaceManager {
               name,
               steps: content.steps,
               ...(content.params != null ? { params: content.params } : {}),
+              ...(content.promotes != null ? { promotes: content.promotes } : {}),
             },
             { lineWidth: 120, noRefs: true },
           );
@@ -282,6 +284,40 @@ export class WorkspaceManager {
       JSON.stringify(meta, null, 2),
       "utf-8",
     );
+  }
+
+  /**
+   * GENERIC promote primitive: set ONE `param` default on a workflow and
+   * publish it as the next sequential version (`vN+1`). Reads the active
+   * version's raw YAML and round-trips the WHOLE object (so `steps`, other
+   * `params`, and any `promotes` block survive), overwriting only
+   * `params[param]`. Returns the new version id plus the `before`/`after`
+   * values (the diff surface). This is what "promote a winner" calls once a
+   * human approves — nothing here is automatic.
+   */
+  async setParam(
+    name: string,
+    param: string,
+    value: unknown,
+  ): Promise<{ version: string; before: unknown; after: unknown }> {
+    const meta = await this.readWorkflowMetadata(name);
+    if (!meta) throw new Error(`Workflow "${name}" not found`);
+
+    const raw = await this.getWorkflowSource(name, meta.active);
+    const obj = (yaml.load(raw) as Record<string, unknown>) ?? {};
+    if (!obj["name"]) obj["name"] = name;
+    const params =
+      obj["params"] && typeof obj["params"] === "object"
+        ? (obj["params"] as Record<string, unknown>)
+        : {};
+    const before = params[param];
+    params[param] = value;
+    obj["params"] = params;
+
+    const yamlStr = yaml.dump(obj, { lineWidth: 120, noRefs: true });
+    const next = nextVersionLabel(Object.keys(meta.versions));
+    await this.publishWorkflow(name, next, yamlStr);
+    return { version: next, before, after: value };
   }
 
   /**

--- a/vein/web/package.json
+++ b/vein/web/package.json
@@ -11,13 +11,16 @@
   "dependencies": {
     "@codemirror/lang-yaml": "^6.1.3",
     "codemirror": "^6.0.2",
+    "diff": "^5.2.0",
     "js-yaml": "^4.1.1",
     "preact": "^10.28.0",
+    "react-diff-view": "^3.2.1",
     "system-canvas": "^0.2.36",
     "system-canvas-react": "^0.2.36"
   },
   "devDependencies": {
     "@preact/preset-vite": "^2.9.0",
+    "@types/diff": "^5.2.3",
     "typescript": "^5.9.0",
     "vite": "^6.3.0"
   }

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -56,11 +56,19 @@ export const getWorkflowCode = async (name: string, version: string) => {
   return res.text();
 };
 
+export interface PromoteSpec {
+  from: string;
+  to: string;
+  label?: string;
+}
+
 export interface FlowDef {
   name: string;
   steps: { id: string; type: string; config: Record<string, any>; options?: any }[];
   /** Tunable default knobs (prompts, thresholds, …), overridable per run. */
   params?: Record<string, unknown>;
+  /** Declared "promote a run output → a target param default" mappings. */
+  promotes?: PromoteSpec[];
 }
 
 export const getWorkflowFlow = (name: string) =>
@@ -271,6 +279,41 @@ export const getRun = (workflow: string, runId: string) =>
 
 export const getRunEvents = (workflow: string, runId: string) =>
   fetchJSON<RunEvent[]>(`/workflows/${workflow}/runs/${runId}/events`);
+
+// ── Promotions (promote a run output → a target workflow's param) ───────────
+
+/** A declared promotion resolved against a specific run's output. `value` is
+ *  what would be written; `current` is the target param's existing default. */
+export interface Promotion {
+  from: string;
+  to: string;
+  target: { workflow: string; param: string };
+  label: string;
+  value: unknown;
+  current: unknown;
+  resolved: boolean;
+}
+
+export interface PromoteResult {
+  ok: true;
+  workflow: string;
+  param: string;
+  version: string;
+  before: unknown;
+  after: unknown;
+}
+
+/** Resolve a run's declared promotions (pure read — nothing is written). */
+export const getPromotions = (workflow: string, runId: string) =>
+  fetchJSON<Promotion[]>(`/workflows/${workflow}/runs/${runId}/promotions`);
+
+/** Apply one promotion (human-approved): writes the target param + publishes
+ *  a new version. `to` identifies which declared spec to apply. */
+export const promote = (workflow: string, runId: string, to: string) =>
+  fetchJSON<PromoteResult>(`/workflows/${workflow}/runs/${runId}/promote`, {
+    method: "POST",
+    body: JSON.stringify({ to }),
+  });
 
 // ── Chat (AI workflow builder) ─────────────────────────────────────────────
 //

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -17,6 +17,7 @@ import { EventsPanel } from "./components/EventsPanel";
 import { EventsResizer } from "./components/EventsResizer";
 import { StepRunFlyout } from "./components/StepRunFlyout";
 import { ParamsFlyout } from "./components/ParamsFlyout";
+import { PromoteFlyout } from "./components/PromoteFlyout";
 import { RunInputPopover, deriveInputBindings } from "./components/RunInputPopover";
 
 // A nested run-execution the user has drilled into. `pathPrefix` is the
@@ -87,6 +88,10 @@ export function App() {
   const [localParams, setLocalParams] = useState<Record<string, unknown> | null>(null);
   // Whether the Params flyout (editable) is open.
   const [showParams, setShowParams] = useState(false);
+  // Declared promotions resolved against the selected run's output (the
+  // "promote a winner" review surface) + whether its flyout is open.
+  const [promotions, setPromotions] = useState<api.Promotion[]>([]);
+  const [showPromote, setShowPromote] = useState(false);
   // Whether every structured param currently parses (the flyout reports this);
   // an invalid YAML param blocks Publish while the flyout is open.
   const [paramsValid, setParamsValid] = useState(true);
@@ -239,6 +244,18 @@ export function App() {
       setEvents(evts);
     }).catch(console.error);
   }, [selectedRun]);
+
+  // Resolve the selected run's declared promotions (a winning value → a target
+  // param). Drives the topbar Promote button + flyout. Empty unless the
+  // workflow declares `promotes` and the run output resolves them.
+  useEffect(() => {
+    setShowPromote(false);
+    setPromotions([]);
+    if (!selectedRun || !selectedWf) return;
+    api.getPromotions(selectedWf, selectedRun)
+      .then(setPromotions)
+      .catch(() => setPromotions([]));
+  }, [selectedWf, selectedRun]);
 
   // A container node's ref arrow means "open this workflow" — go-to-definition.
   // We switch the selected workflow rather than drilling into an inline
@@ -406,6 +423,7 @@ export function App() {
     const stepIndex = node.customData?.stepIndex as number | undefined;
     if (stepId == null) return;
     setShowParams(false);
+    setShowPromote(false);
     setFlyoutStepId(stepId);
     setFlyoutStepIndex(stepIndex ?? null);
   }, []);
@@ -569,10 +587,16 @@ export function App() {
         </span>
         <div class="topbar-actions">
           {isDirty && <button class="btn btn-publish" disabled={showParams && !paramsValid} onClick={handlePublish}>Publish</button>}
+          {isRunView && promotions.length > 0 && (
+            <button
+              class={`btn${showPromote ? " is-active" : ""}`}
+              onClick={() => { setShowPromote((s) => !s); setShowParams(false); closeFlyout(); }}
+            >Promote</button>
+          )}
           {selectedWf && localParams && Object.keys(localParams).length > 0 && (
             <button
               class={`btn${showParams ? " is-active" : ""}`}
-              onClick={() => { setShowParams((s) => !s); setFlyoutStepId(null); }}
+              onClick={() => { setShowParams((s) => !s); setShowPromote(false); setFlyoutStepId(null); }}
             >Params</button>
           )}
           {selectedWf && (
@@ -688,6 +712,18 @@ export function App() {
           onChange={setLocalParams}
           onValidChange={setParamsValid}
           onClose={() => setShowParams(false)}
+        />
+      )}
+
+      {/* Promote flyout — review + apply a run's declared promotions. */}
+      {showPromote && selectedWf && selectedRun && promotions.length > 0 && (
+        <PromoteFlyout
+          key={`${selectedWf}/${selectedRun}`}
+          workflow={selectedWf}
+          runId={selectedRun}
+          promotions={promotions}
+          onClose={() => setShowPromote(false)}
+          onPromoted={() => { refreshWorkflows(); }}
         />
       )}
 

--- a/vein/web/src/components/PromoteFlyout.tsx
+++ b/vein/web/src/components/PromoteFlyout.tsx
@@ -1,0 +1,158 @@
+import { useState } from "preact/hooks";
+import { structuredPatch } from "diff";
+import { parseDiff, Diff, Hunk, type HunkData } from "react-diff-view";
+import "react-diff-view/style/index.css";
+import * as api from "../api";
+import { CloseIcon } from "../icons";
+import { FlyoutResizer } from "./FlyoutResizer";
+
+// ── Promote Flyout ──────────────────────────────────────────────────────────
+//
+// The human-review surface for "promote a winner". A workflow declares
+// `promotes: [{ from, to }]` in its YAML; after a run we resolve each spec
+// against the run's OUTPUT and show, per promotion, a DIFF of the target
+// param's current default → the value this run produced. Nothing is written
+// until the user clicks Apply (which writes the param + publishes a new version
+// of the target workflow). Declaring a promote is inert; promotion is a click.
+
+function toText(v: unknown): string {
+  if (v == null) return "";
+  if (typeof v === "string") return v;
+  try {
+    return JSON.stringify(v, null, 2);
+  } catch {
+    return String(v);
+  }
+}
+
+// Build a git-style unified diff. gitdiff-parser (react-diff-view's parseDiff)
+// needs the `diff --git` + `---`/`+++` headers; jsdiff's createTwoFilesPatch
+// preamble (the `===` separator + tab-suffixed names) trips it, so we format
+// from structuredPatch ourselves.
+function buildPatch(a: string, b: string): string {
+  const sp = structuredPatch("value", "value", a, b, "", "", { context: 3 });
+  if (sp.hunks.length === 0) return "";
+  let txt = "diff --git a/value b/value\n--- a/value\n+++ b/value\n";
+  for (const h of sp.hunks) {
+    txt += `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@\n`;
+    txt += h.lines.join("\n") + "\n";
+  }
+  return txt;
+}
+
+function DiffBlock(props: { before: unknown; after: unknown }) {
+  const a = toText(props.before);
+  const b = toText(props.after);
+  const patch = buildPatch(a, b);
+  const files = patch ? parseDiff(patch, { nearbySequences: "zip" }) : [];
+  const file = files[0];
+  if (!file || file.hunks.length === 0) {
+    return <div class="promote-nodiff">No change — this run's value matches the current default.</div>;
+  }
+  return (
+    <div class="promote-diff">
+      <Diff viewType="unified" diffType={file.type} hunks={file.hunks}>
+        {(hunks: HunkData[]) => hunks.map((h) => <Hunk key={h.content} hunk={h} />)}
+      </Diff>
+    </div>
+  );
+}
+
+function PromotionRow(props: {
+  workflow: string;
+  runId: string;
+  promotion: api.Promotion;
+  onPromoted: (r: api.PromoteResult) => void;
+}) {
+  const { promotion: p } = props;
+  const [busy, setBusy] = useState(false);
+  const [done, setDone] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const apply = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await api.promote(props.workflow, props.runId, p.to);
+      setDone(res.version);
+      props.onPromoted(res);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div class="flyout-section promote-row">
+      <div class="flyout-section-title">{p.label}</div>
+      <div class="promote-target">
+        <span class="promote-arrow">→</span>
+        <code>{p.target.workflow}</code>.<code>{p.target.param}</code>
+        <span class="promote-from">from output.{p.from}</span>
+      </div>
+
+      {!p.resolved ? (
+        <div class="promote-nodiff promote-unresolved">
+          This run's output has no value at <code>{p.from}</code> — nothing to promote.
+        </div>
+      ) : (
+        <DiffBlock before={p.current} after={p.value} />
+      )}
+
+      <div class="promote-actions">
+        {done ? (
+          <span class="badge badge-ok">promoted → {done}</span>
+        ) : (
+          <button
+            class="btn btn-publish"
+            disabled={busy || !p.resolved}
+            onClick={apply}
+          >
+            {busy ? "Promoting…" : "Apply"}
+          </button>
+        )}
+      </div>
+      {error && <pre class="flyout-json tone-error">{error}</pre>}
+    </div>
+  );
+}
+
+export function PromoteFlyout(props: {
+  workflow: string;
+  runId: string;
+  promotions: api.Promotion[];
+  onClose: () => void;
+  onPromoted: (r: api.PromoteResult) => void;
+}) {
+  return (
+    <div class="flyout">
+      <FlyoutResizer />
+      <div class="flyout-header">
+        <div>
+          <div class="flyout-eyebrow">Promote</div>
+          <div class="flyout-title">{props.workflow}</div>
+        </div>
+        <button class="flyout-close" onClick={props.onClose} aria-label="Close"><CloseIcon /></button>
+      </div>
+      <div class="flyout-body">
+        <div class="flyout-section">
+          <span class="flyout-meta-value">
+            Promote a value from this run into a target workflow's param default.
+            Review the diff, then Apply to publish a new version. Nothing is
+            written until you click Apply.
+          </span>
+        </div>
+        {props.promotions.map((p) => (
+          <PromotionRow
+            key={p.to}
+            workflow={props.workflow}
+            runId={props.runId}
+            promotion={p}
+            onPromoted={props.onPromoted}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -1010,6 +1010,56 @@ body.is-resizing-flyout * {
   padding: var(--sp-6) 0;
 }
 
+.chat-history-btn.is-active {
+  color: var(--text);
+  border-color: var(--border-strong);
+  background: rgba(255, 255, 255, 0.04);
+}
+
+.chat-history {
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--sp-2) var(--sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+
+.chat-history-item {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  width: 100%;
+  text-align: left;
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--r-sm);
+  padding: var(--sp-2) var(--sp-3);
+  cursor: pointer;
+  color: var(--text);
+  font-size: 13px;
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.chat-history-item:hover {
+  background: var(--surface-2);
+  border-color: var(--border);
+}
+.chat-history-item.is-current {
+  border-color: var(--accent);
+}
+.chat-history-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  flex: 1;
+}
+.chat-history-time {
+  color: var(--text-dim);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
 .chat-msg {
   max-width: 92%;
   font-size: 13px;
@@ -1303,4 +1353,72 @@ body.is-resizing-flyout * {
 
 .md-view strong { font-weight: 600; color: var(--text); }
 .md-view em { font-style: italic; }
+
+/* ── Promote flyout ──────────────────────────────────────────────────────── */
+.promote-row { border-top: 1px solid var(--border); padding-top: var(--sp-3); }
+.promote-target {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: var(--sp-1);
+  font-size: 12px;
+  color: var(--text-muted);
+  margin-bottom: var(--sp-2);
+}
+.promote-target code {
+  color: var(--accent-strong);
+  background: var(--surface-2);
+  padding: 1px 5px;
+  border-radius: var(--r-sm);
+  font-size: 11px;
+}
+.promote-arrow { color: var(--text-dim); }
+.promote-from { color: var(--text-dim); font-size: 11px; margin-left: var(--sp-2); }
+.promote-actions { margin-top: var(--sp-2); }
+.promote-nodiff {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--bg);
+  border: 1px dashed var(--border);
+  border-radius: var(--r-md);
+}
+.promote-unresolved { color: var(--warning); border-color: rgba(251, 191, 36, 0.3); }
+
+/* react-diff-view, themed onto the midnight palette (the lib ships light). */
+.promote-diff {
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  overflow: auto;
+  max-height: 360px;
+  background: var(--bg);
+}
+.promote-diff .diff {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  line-height: 1.5;
+  background: var(--bg);
+  color: var(--text);
+  border-collapse: collapse;
+  width: 100%;
+}
+.promote-diff .diff-gutter {
+  color: var(--text-dim);
+  background: var(--surface);
+  padding: 0 var(--sp-2);
+  text-align: right;
+  min-width: 32px;
+}
+.promote-diff .diff-code { padding: 0 var(--sp-3); white-space: pre-wrap; word-break: break-word; }
+.promote-diff .diff-code-insert,
+.promote-diff .diff-gutter-insert { background: rgba(34, 197, 94, 0.14); }
+.promote-diff .diff-code-delete,
+.promote-diff .diff-gutter-delete { background: rgba(248, 113, 113, 0.14); }
+.promote-diff .diff-code-insert { color: #b9f0c9; }
+.promote-diff .diff-code-delete { color: #f7c0c0; }
+.promote-diff .diff-hunk-header {
+  background: var(--surface-2);
+  color: var(--text-dim);
+  font-size: 11px;
+}
 

--- a/vein/web/vite.config.ts
+++ b/vein/web/vite.config.ts
@@ -18,6 +18,15 @@ export default defineConfig({
   // the SPA at a trailing-slash path so relative assets resolve correctly.
   base: "./",
   plugins: [preact()],
+  // react-diff-view is a React lib — alias React onto preact/compat so it
+  // runs under Preact (the rest of the app stays vanilla Preact).
+  resolve: {
+    alias: {
+      react: "preact/compat",
+      "react-dom": "preact/compat",
+      "react/jsx-runtime": "preact/jsx-runtime",
+    },
+  },
   server: {
     port: 5173,
     proxy: {


### PR DESCRIPTION
## What

Closes the optimize loop. Today, promoting a winning result means digging through a run's `run.json`, finding a value buried in escaped JSON (e.g. `bestPrompt`), copy-pasting it into a workflow's `params` default, and publishing a new version by hand. This adds a declarative, **review-first** promotion path with a diff viewer.

A workflow declares what's promotable in its YAML:

```yaml
promotes:
  - from: bestPrompt                    # dotted path into THIS run's output
    to: gitsee-explore-services.system  # <targetWorkflow>.<param>
    label: Explorer system prompt
```

After a run, the UI resolves each spec against the run output and shows a **Promote** button (run view, topbar). The flyout renders a unified diff of the target param's **current default → this run's value**; clicking **Apply** writes the param and publishes a new version of the target workflow.

It's generic — nothing keys off `bestPrompt`; any workflow declares its own `from`/`to`. And it's inert until a human clicks: declaring a promote writes nothing.

## How

- **core**: `PromoteSpec` type + `Flow.promotes` (exported from the barrel).
- **workspace**: parse/round-trip `promotes`; new generic primitive `setParam(name, param, value)` — overwrite one param (preserving `steps`/other params/`promotes`) and publish the next `vN`, returning `{ version, before, after }`.
- **createVein**: `GET /workflows/:name/runs/:runId/promotions` (resolve each spec's value + the target's current value, for diffing) and `POST /workflows/:name/runs/:runId/promote` (apply, human-approved); `promotes` included in `/flow`.
- **web**: `PromoteFlyout` using `react-diff-view` (aliased onto `preact/compat`), themed onto the midnight palette; topbar button wired into the run view.
- **lab**: `gitsee-optimize` declares `bestPrompt → gitsee-explore-services.system`.

## Testing

- `npm test` in `vein/` — 361 pass (added `setParam` + promotions resolve/apply round-trip).
- `tsc --noEmit` + `vite build` clean for engine and web.
- Verified end-to-end against the running `/lab` instance: `/promotions` resolves the winning prompt vs the current default and the diff renders.

## Notes

- Diff renderer is `react-diff-view` via a `preact/compat` alias (matches the approach used in hive's `diff.tsx`). It needs a git-style unified diff, built from jsdiff's `structuredPatch`.
- Deliberately out of scope: an AI-chat `promote_param` tool and any auto-promote — the `setParam` primitive is in place if we want those later.
- vein is a copied `file:` dep in mcp; `/lab` picks this up after `yarn refresh-vein`.