### PR TITLE
vein: adapter authoring loop — http/secrets services, record/replay, run_step

### DIFF
--- a/vein/package.json
+++ b/vein/package.json
@@ -22,7 +22,7 @@
     "build:web": "npm --prefix web run build",
     "dev": "npm run build:web && tsx --env-file=.env src/server.ts",
     "start": "node build/server.js",
-    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts"
+    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.81",

--- a/vein/plans/adapter-loop-followups.md
+++ b/vein/plans/adapter-loop-followups.md
@@ -1,0 +1,136 @@
+# Adapter loop — follow-ups
+
+Context: we shipped the "safe inner loop" for authoring integration adapters —
+the standard `http`/`secrets` capabilities (`capabilities.ts`), record/replay
+cassettes (`cassette.ts`), single-step running (`run-step.ts` + `POST
+/steps/:type/run` + the `run_step` agent tool), and routed the core `http` step
+through `ctx.services.http`. This doc tracks what we deliberately deferred.
+
+Status of the shipped slice: done, 372 tests green. Everything below is NOT yet
+built.
+
+---
+
+## 1. Credentials / secrets UI + store (the headline)
+
+**Why deferred:** the `secrets` *seam* is in (`ctx.services.secrets.get(name)`,
+env-backed by default), which is the part that costs nothing and future-proofs
+adapters. A real credential *system* is a big, security-sensitive subsystem whose
+requirements we'll only know after ~10 real adapters. Don't build the vault
+before the adapters that consume it.
+
+**What it needs (later):**
+- A `SecretsCapability` implementation backed by a real store (encrypted at rest)
+  instead of `process.env`. Swappable behind the existing interface — **zero
+  adapter changes** (same move as `RunStore`).
+- A UI to manage secrets: list which names exist, set/rotate a value, see which
+  steps reference which secret. Per-deployment scope first; per-publisher /
+  per-tenant later.
+- Wiring: inject the store-backed `secrets` into `createVein`'s services bag
+  (replacing/overriding the env default).
+- **Coupling already handled:** the cassette recorder scrubs secret VALUES (read
+  through `services.secrets`) to `{{secret:NAME}}`, so a real store doesn't change
+  the leak-free guarantee.
+- Open question: how does the chat agent obtain a credential to RECORD the first
+  live cassette? Probably a UI prompt ("this adapter needs STRIPE_KEY") rather
+  than the agent ever seeing the value. After the first record, replay needs no
+  creds, so this only matters once per integration.
+
+**Decision rule unchanged:** secrets always flow through `ctx.services.secrets`,
+never `process.env`, in adapter steps.
+
+---
+
+## 2. Cassette management UI
+
+**Why deferred:** the engine half (record/replay, persistence under
+`steps/_cassettes/<name>.json`) is enough to make the loop work via the agent
+tool + endpoint.
+
+**What it needs (later):**
+- View a step's cassette(s): the recorded `(key, args) → result` entries.
+- Delete / re-record a cassette (e.g. when the upstream API changed shape).
+- Multiple named scenarios per step (`cassetteName`) surfaced in the UI.
+- Show in the StepRunFlyout whether a run_step was live / recorded / replayed.
+
+---
+
+## 3. `run_step` in the web UI
+
+**Why deferred:** the agent uses the `run_step` tool and the `POST
+/steps/:type/run` endpoint is callable; the browser UI just doesn't expose a
+button yet.
+
+**What it needs:** (per AGENTS.md "adding an API endpoint")
+- `web/src/api.ts`: typed `runStep(type, { config, input, params, cassette })`.
+- A "Run this step" affordance in `StepEditFlyout` / the Add Step flow, with a
+  config editor and a record/replay toggle, showing `{ status, output, events }`.
+- `/steps` is already proxied by the Vite dev config, so no proxy change.
+
+---
+
+## 4. SDK allowlist (mostly a docs/convention item)
+
+**State:** already works — the registry loader does a bare dynamic `import()`,
+so an adapter CAN `import` a vendor SDK *if the host pre-installed it* (pro users
+consume vein as a lib and can add deps). The agent is told to prefer raw REST and
+only import a pre-installed package.
+
+**Optional later:** bake a curated allowlist (e.g. `stripe`, `@octokit/rest`)
+into the host `package.json` and surface it to the agent in the prompt. Note: an
+SDK does its own networking, so it bypasses `services.http` and is NOT cassette-
+recordable — prefer exposing such an SDK as a *service* if record/replay matters.
+
+---
+
+## 5. Verify mcp `/lab` with the new default services
+
+**Why:** `createVein` now auto-merges `standardServices()` (`{ http, secrets }`)
+into the default services bag (was `{}`). It's additive and consumer-overridable,
+and the one test asserting the old empty default was updated.
+
+**To do:** confirm mcp's `/lab` (which copies vein as a `file:../vein` dep and may
+introspect `vein.services`) still boots and behaves. Check for any code that
+assumed an empty default services bag.
+
+---
+
+## 6. Live agent end-to-end check
+
+**Why:** we tested the mechanics (runSingleStep, cassette, endpoint, core http
+rerouting) but NOT an actual LLM turn driving `create_step → run_step(record) →
+run_step(replay) → edit_step`.
+
+**To do:** one real chat run (needs `ANTHROPIC_API_KEY`): ask the agent to build
+an adapter for a public API, watch it use `ctx.services.http` (it can read
+`get_step("http")` as the reference) and the cassette loop. This is the real
+end-to-end validation of the feature.
+
+---
+
+## 7. Type safety for adapter authoring (the REAL win: typecheck-in-the-loop)
+
+**Rejected:** defaulting `defineStep`'s `TServices` to `VeinCapabilities` (so
+`ctx.services.http`/`secrets` type without annotation). It's a breaking type
+change for consumers — mcp lab steps cast `ctx.services as ConceptServices`, and
+`VeinCapabilities` (disjoint from those bags) makes that a `TS2352` ("convert to
+unknown first"). Marginal benefit anyway: the runner erases services to
+`unknown` (author-time only), `res.body` stays `unknown`, and custom steps load
+via tsx with NO typecheck — so the LLM gets zero benefit. Kept `unknown` default;
+`VeinCapabilities` is exported for OPT-IN annotation
+(`defineStep<"t", In, Out, VeinCapabilities>(…)`).
+
+**The actually-useful version:** add a **typecheck to `create_step` / `edit_step`**
+so the AGENT gets real diagnostics. After writing the source, compile it (e.g.
+`ts.transpileModule` won't catch type errors — need a real `Program` or
+`tsc --noEmit` against the file with a synthetic `services` type) and return any
+errors to the model so it can fix `ctx.services.htttp`, a wrong config field, or
+a bad return shape BEFORE publishing. This is the only path that gives the LLM
+type feedback (it can't get it from tsx at runtime). Pairs well with run_step:
+typecheck → run_step(record) → run_step(replay).
+
+## 8. Cassette matching robustness (only if needed)
+
+Current matching is exact `(key, stableJson(args))` with in-order consumption of
+repeated identical calls. Possible later needs: ignore volatile headers/fields,
+TTL / staleness, partial-arg matching. Don't build until a real adapter needs it.

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -103,7 +103,12 @@ Authoring custom steps (create_step / edit_step):
         return { /* output */ };
       },
     });
-- Do NOT import anything except "vein". All external capabilities (db, http/git clients, llm, …) come from ctx.services — a deployment-provided bag. If you're unsure what's on ctx.services, call get_step on an existing custom step to see how it uses ctx.services, and mirror that.
+- External capabilities come from ctx.services — a deployment-provided bag. Two standard capabilities are ALWAYS available:
+    - ctx.services.http(url, { method?, headers?, body?, query? }) — a fetch-like transport. Returns a PLAIN object { status, ok, headers, body } (body is parsed JSON when JSON). Use this for ALL network/API calls — NOT the global fetch. (It returns a serializable object so the call can be recorded/replayed by run_step's cassette, and it keeps secrets out of your code path.)
+    - ctx.services.secrets.get("ENV_NAME") — read an API key / token. Use this for ALL credentials — NOT process.env. (Secrets read this way are automatically scrubbed from recorded cassettes.)
+  So a typical REST adapter is: const key = await ctx.services.secrets.get("STRIPE_KEY"); const res = await ctx.services.http("https://api.stripe.com/v1/charges", { query: { customer: cfg.customer }, headers: { authorization: \`Bearer \${key}\` } }); return { charges: res.body.data };
+  The built-in "http" step is the canonical example — call get_step("http") to read its source and mirror how it uses ctx.services.http.
+- Prefer raw REST via ctx.services.http — you rarely need a vendor SDK (it's just a wrapper over REST, and an SDK does its own networking so it can't be recorded/replayed). Only import a package other than "vein" if the deployment has pre-installed it (a vendor SDK with gnarly auth); otherwise the step will fail to load. If you're unsure what else is on ctx.services, call get_step on an existing custom step and mirror how it uses ctx.services.
 - Keep the step's algorithm inline (that's the editable part). To change a prompt or heuristic in an existing step, call get_step to read it, then edit_step with the full updated source.
 
 Tools:
@@ -111,6 +116,7 @@ Tools:
 - search_steps("keywords"): keyword search across all step types.
 - get_step("<type>"): full schema + (for lib/custom) source code. Always call before using a type.
 - create_step / edit_step: author or revise a custom step (see above).
+- run_step("<type>", config?, input?, params?, cassette?, cassetteName?): run ONE step in isolation and get its output — the inner loop for authoring an adapter, no workflow needed. After create_step, call run_step to test it. Use cassette:"record" for the first live run (captures external calls to a fixture, secrets scrubbed), then cassette:"replay" to iterate offline (deterministic, no rate limits, no side effects) while you edit_step.
 - list_workflows(): list existing workflows (name, active version, versions, description). Check this before creating a new workflow or referencing one in a subflow.
 - get_workflow("<name>", version?): read an existing workflow's full YAML + version metadata. Call before editing, referencing, or reusing a workflow you didn't just write.
 - create_workflow / edit_workflow: publish a NEW workflow, or a new VERSION of an existing one. edit_workflow is for STRUCTURAL changes (add/remove steps, rewire depends, promote a winning params default). To merely try a different prompt/threshold value, do NOT publish a version — pass params to run_workflow (those are runs, not versions).
@@ -120,7 +126,7 @@ Tools:
 Workflow:
 1. Available step types are listed at the end of this prompt. Use search_steps only if you need to find something by keyword; use list_steps only to re-list after creating new custom steps.
 2. Call get_step for EVERY step type you will use. Each has a description with the exact YAML config format — you MUST read it before writing. Do not guess config fields.
-3. If a needed step doesn't exist, author it with create_step (or edit_step to revise one), then it's available by its type.
+3. If a needed step doesn't exist, author it with create_step (or edit_step to revise one), then it's available by its type. For a step that hits an external API, test it in isolation with run_step BEFORE wiring it into a workflow: run_step(type, config, cassette:"record") once to capture a fixture, then run_step(..., cassette:"replay") + edit_step to iterate offline until the output is right.
 4. Call create_workflow with the final YAML (or edit_workflow to publish a new version of an existing workflow — get_workflow to read it first).
 5. Call run_workflow with a sample input to test it. Report the result (success/error, output, or which step failed) to the user.
 6. To debug a failure or inspect prior behavior, use list_runs + get_run. To build on or reference existing workflows, use list_workflows + get_workflow first.

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -5,6 +5,7 @@ import type { RunEvent, RunSummary } from "../core.js";
 import { AiDeps } from "./prompts.js";
 import { lsSteps, searchSteps, readStepSource } from "./stepHelpers.js";
 import { zodToFields } from "./schemaHelpers.js";
+import { runSingleStep, cassettePath } from "../run-step.js";
 
 // The run-history read methods live on `FileRunStore`, not the base `RunStore`
 // interface (which is write-only: append/finalize). `MemoryRunStore` lacks them.
@@ -90,7 +91,7 @@ export function buildTools(deps: AiDeps) {
 
     create_step: tool({
       description:
-        "Author a NEW custom step type from TypeScript source. The code MUST be a self-contained vein step: the ONLY runtime import is `import { z, defineStep } from \"vein\"`, it `export default defineStep({ type, input, output, async run(cfg, ctx) {...} })`, and it reaches every external capability (db, http clients, llm, git, …) through `ctx.services` — never by importing other files. Use this only for step types that don't exist yet; use edit_step to change an existing one. Publishing as a new step creates version v1.",
+        "Author a NEW custom step type from TypeScript source. The code is a self-contained vein step: `import { z, defineStep } from \"vein\"` and `export default defineStep({ type, input, output, async run(cfg, ctx) {...} })`. Reach external capabilities through `ctx.services` — for network calls use `ctx.services.http(url, opts)` and for credentials `ctx.services.secrets.get(name)` (NOT the global fetch / process.env), so the step is recordable/replayable by run_step's cassette and secrets are scrubbed from fixtures. Call get_step(\"http\") to read the canonical ctx.services.http example. Prefer raw REST over vendor SDKs; only import a package other than \"vein\" if the deployment has pre-installed it. Use this only for step types that don't exist yet; use edit_step to change an existing one. Publishing as a new step creates version v1.",
       inputSchema: z.object({
         name: z
           .string()
@@ -340,6 +341,49 @@ export function buildTools(deps: AiDeps) {
         });
 
         return result;
+      },
+    }),
+
+    run_step: tool({
+      description:
+        "Run a SINGLE step in isolation with a given config + input, and return its output + events — WITHOUT wiring it into a workflow. This is the inner loop for authoring an adapter: create_step → run_step → edit_step → run_step until the output is right. " +
+        "Set cassette:'record' to run live AND capture the step's external service calls (http, etc.) to a reusable fixture (secrets are scrubbed); then cassette:'replay' to iterate OFFLINE against that fixture — deterministic, no rate limits, no cost, no side effects (so you don't, e.g., create a real charge on every test). " +
+        "Returns { status, output?, error?, events, recorded? }.",
+      inputSchema: z.object({
+        type: z.string().describe("Step type to run, e.g. 'stripe/list-charges' or 'http'."),
+        config: z
+          .record(z.any())
+          .optional()
+          .describe("The step's config (same shape as in a workflow). Templates like {{ input.* }} / {{ params.* }} are resolved."),
+        input: z
+          .any()
+          .optional()
+          .describe("Workflow input object, referenced in config via {{ input.* }}."),
+        params: z
+          .record(z.any())
+          .optional()
+          .describe("Params knobs, referenced via {{ params.* }}."),
+        cassette: z
+          .enum(["record", "replay"])
+          .optional()
+          .describe("record: run live + capture external calls to a fixture. replay: serve them from the fixture (offline). Omit for a plain live run."),
+        cassetteName: z
+          .string()
+          .optional()
+          .describe("Fixture name (defaults to the step type). Use distinct names to keep multiple scenarios per step."),
+      }),
+      execute: async ({ type, config, input, params, cassette, cassetteName }) => {
+        const registry = deps.registry;
+        if (!registry[type]) return { error: `Step type "${type}" not found` };
+        return runSingleStep(type, registry, deps.services, {
+          config,
+          input,
+          params,
+          workspace: deps.workspace,
+          ...(cassette
+            ? { cassette: { mode: cassette, path: cassettePath(deps.workspace.path, cassetteName ?? type) } }
+            : {}),
+        });
       },
     }),
 

--- a/vein/src/capabilities.ts
+++ b/vein/src/capabilities.ts
@@ -1,0 +1,179 @@
+/**
+ * Standard "capabilities" — the small, generic, host-owned services that
+ * LLM-authored adapter STEPS build on (see AGENTS.md "step vs service").
+ *
+ * An adapter step reaches the outside world through `ctx.services.http` (a
+ * fetch-like transport) and `ctx.services.secrets` (credential access), never
+ * the global `fetch` / `process.env` directly. Routing I/O through these two
+ * capabilities is what makes an adapter:
+ *   - **recordable** — `http` returns a PLAIN serializable object (a real
+ *     `fetch` Response can't be written to a cassette), so the record/replay
+ *     wrapper (`cassette.ts`) can capture and replay it; and
+ *   - **leak-free** — secrets flow through one boundary, so the recorder knows
+ *     exactly which values to scrub out of the cassette.
+ *
+ * These are the DEFAULT implementations the standard server injects. Consumers
+ * using vein as a library can spread them into — or override them within —
+ * their own typed services bag.
+ */
+
+// ── secrets ────────────────────────────────────────────────────────────────
+
+/** Credential access. The single boundary through which adapters read secrets
+ *  (API keys, tokens). Backed by `process.env` by default; swap the `source`
+ *  for a real secret store later without touching any adapter. */
+export interface SecretsCapability {
+  get(name: string): Promise<string | undefined>;
+}
+
+/** Build a secrets capability over a flat key→value source (defaults to
+ *  `process.env`). */
+export function secretsCapability(
+  source: Record<string, string | undefined> = process.env,
+): SecretsCapability {
+  return {
+    async get(name: string) {
+      return source[name];
+    },
+  };
+}
+
+// ── http ─────────────────────────────────────────────────────────────────
+
+export interface HttpRequestOptions {
+  method?: string;
+  headers?: Record<string, string>;
+  /** Request body. Objects are JSON-encoded (with a default
+   *  `content-type: application/json`); strings are sent as-is. */
+  body?: unknown;
+  /** Query params appended to the URL. */
+  query?: Record<string, string | number | boolean>;
+  /** Abort the request after this many milliseconds. */
+  timeout?: number;
+}
+
+/** A plain, fully-serializable HTTP response — deliberately NOT a `fetch`
+ *  Response, so it can be written to / replayed from a cassette. `body` is the
+ *  parsed JSON when the response is JSON, otherwise the raw text. */
+export interface HttpResponse {
+  status: number;
+  ok: boolean;
+  headers: Record<string, string>;
+  body: unknown;
+}
+
+/** Fetch-like transport. The blessed path for adapter network I/O. */
+export type HttpCapability = (
+  url: string,
+  opts?: HttpRequestOptions,
+) => Promise<HttpResponse>;
+
+/** Minimal shape of the global `fetch` we depend on — kept tiny so a fake can
+ *  be injected in tests without pulling in DOM lib types. */
+export type FetchLike = (
+  url: string,
+  init?: {
+    method?: string;
+    headers?: Record<string, string>;
+    body?: string;
+    signal?: AbortSignal;
+  },
+) => Promise<{
+  status: number;
+  ok: boolean;
+  headers: { forEach(cb: (value: string, key: string) => void): void };
+  text(): Promise<string>;
+}>;
+
+function appendQuery(
+  url: string,
+  query?: Record<string, string | number | boolean>,
+): string {
+  if (!query) return url;
+  const pairs = Object.entries(query).map(
+    ([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`,
+  );
+  if (!pairs.length) return url;
+  return url + (url.includes("?") ? "&" : "?") + pairs.join("&");
+}
+
+/** Build an http capability over a `fetch` implementation (defaults to the
+ *  global `fetch`). Encodes object bodies as JSON, parses JSON responses, and
+ *  returns a plain serializable {@link HttpResponse}. */
+export function httpCapability(
+  fetchImpl: FetchLike = globalThis.fetch as unknown as FetchLike,
+): HttpCapability {
+  if (typeof fetchImpl !== "function") {
+    throw new Error(
+      "httpCapability: no fetch available — pass a fetch implementation",
+    );
+  }
+  return async (url, opts = {}) => {
+    const headers: Record<string, string> = { ...(opts.headers ?? {}) };
+    let body: string | undefined;
+    if (opts.body !== undefined) {
+      if (typeof opts.body === "string") {
+        body = opts.body;
+      } else {
+        body = JSON.stringify(opts.body);
+        if (!hasHeader(headers, "content-type")) {
+          headers["content-type"] = "application/json";
+        }
+      }
+    }
+
+    const res = await fetchImpl(appendQuery(url, opts.query), {
+      method: opts.method ?? (opts.body !== undefined ? "POST" : "GET"),
+      headers,
+      body,
+      ...(opts.timeout ? { signal: AbortSignal.timeout(opts.timeout) } : {}),
+    });
+
+    const outHeaders: Record<string, string> = {};
+    res.headers.forEach((value, key) => {
+      outHeaders[key.toLowerCase()] = value;
+    });
+
+    const text = await res.text();
+    const isJson = (outHeaders["content-type"] ?? "").includes("application/json");
+    let parsed: unknown = text;
+    if (isJson || looksLikeJson(text)) {
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        parsed = text;
+      }
+    }
+
+    return { status: res.status, ok: res.ok, headers: outHeaders, body: parsed };
+  };
+}
+
+function hasHeader(headers: Record<string, string>, name: string): boolean {
+  return Object.keys(headers).some((k) => k.toLowerCase() === name);
+}
+
+function looksLikeJson(text: string): boolean {
+  const t = text.trim();
+  return t.startsWith("{") || t.startsWith("[");
+}
+
+// ── standard bag ───────────────────────────────────────────────────────────
+
+/** The standard capability shape adapters rely on. Consumers extend this with
+ *  their own typed services (graph store, llm client, …). */
+export interface VeinCapabilities {
+  http: HttpCapability;
+  secrets: SecretsCapability;
+}
+
+/** The default standard services bag: env-backed secrets + global-fetch http.
+ *  Injected by the standard server; override per environment as needed. */
+export function standardServices(
+  opts: { fetchImpl?: FetchLike; secretsSource?: Record<string, string | undefined> } = {},
+): VeinCapabilities {
+  return {
+    http: httpCapability(opts.fetchImpl),
+    secrets: secretsCapability(opts.secretsSource),
+  };
+}

--- a/vein/src/cassette.test.ts
+++ b/vein/src/cassette.test.ts
@@ -1,0 +1,182 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import {
+  httpCapability,
+  secretsCapability,
+  standardServices,
+  type FetchLike,
+} from "./capabilities.js";
+import {
+  withCassette,
+  emptyCassette,
+  type Cassette,
+} from "./cassette.js";
+
+// ── a fake fetch that records calls and returns canned responses ───────────
+
+function fakeFetch(
+  handler: (url: string, init: any) => { status?: number; headers?: Record<string, string>; body: unknown },
+): FetchLike & { calls: Array<{ url: string; init: any }> } {
+  const calls: Array<{ url: string; init: any }> = [];
+  const fn = (async (url: string, init: any = {}) => {
+    calls.push({ url, init });
+    const r = handler(url, init);
+    const headers = r.headers ?? { "content-type": "application/json" };
+    const text = typeof r.body === "string" ? r.body : JSON.stringify(r.body);
+    return {
+      status: r.status ?? 200,
+      ok: (r.status ?? 200) < 400,
+      headers: {
+        forEach(cb: (value: string, key: string) => void) {
+          for (const [k, v] of Object.entries(headers)) cb(v, k);
+        },
+      },
+      async text() {
+        return text;
+      },
+    };
+  }) as any;
+  fn.calls = calls;
+  return fn;
+}
+
+// ── capabilities ───────────────────────────────────────────────────────────
+
+describe("httpCapability", () => {
+  it("issues a GET and parses a JSON response into a plain object", async () => {
+    const f = fakeFetch((url) => {
+      assert.equal(url, "https://api.example.com/things?limit=2");
+      return { body: { data: [{ id: "a" }, { id: "b" }] } };
+    });
+    const http = httpCapability(f);
+    const res = await http("https://api.example.com/things", { query: { limit: 2 } });
+    assert.equal(res.status, 200);
+    assert.equal(res.ok, true);
+    assert.deepEqual(res.body, { data: [{ id: "a" }, { id: "b" }] });
+    assert.equal(f.calls[0]!.init.method, "GET");
+  });
+
+  it("JSON-encodes object bodies and defaults to POST", async () => {
+    const f = fakeFetch((_url, init) => {
+      assert.equal(init.method, "POST");
+      assert.equal(init.headers["content-type"], "application/json");
+      assert.deepEqual(JSON.parse(init.body), { name: "x" });
+      return { body: { ok: true } };
+    });
+    const http = httpCapability(f);
+    const res = await http("https://api.example.com/things", { body: { name: "x" } });
+    assert.deepEqual(res.body, { ok: true });
+  });
+});
+
+describe("secretsCapability", () => {
+  it("reads from the provided source", async () => {
+    const s = secretsCapability({ STRIPE_KEY: "sk_live_secret" });
+    assert.equal(await s.get("STRIPE_KEY"), "sk_live_secret");
+    assert.equal(await s.get("MISSING"), undefined);
+  });
+});
+
+// ── cassette: record then replay ───────────────────────────────────────────
+
+describe("withCassette record/replay", () => {
+  function stripeServices(fetchImpl: FetchLike) {
+    return standardServices({
+      fetchImpl,
+      secretsSource: { STRIPE_KEY: "sk_live_supersecret" },
+    });
+  }
+
+  // The adapter logic under test — calls secrets + http through services.
+  async function listCharges(services: ReturnType<typeof stripeServices>, customer: string) {
+    const key = await services.secrets.get("STRIPE_KEY");
+    const res = await services.http("https://api.stripe.com/v1/charges", {
+      query: { customer },
+      headers: { authorization: `Bearer ${key}` },
+    });
+    return (res.body as { data: Array<{ id: string }> }).data.map((c) => c.id);
+  }
+
+  it("records a live call, then replays it offline without hitting fetch", async () => {
+    const cassette = emptyCassette();
+
+    // 1. RECORD against the "real" API.
+    const liveFetch = fakeFetch(() => ({ body: { data: [{ id: "ch_1" }, { id: "ch_2" }] } }));
+    const recording = withCassette(stripeServices(liveFetch) as any, { mode: "record", cassette });
+    const recorded = await listCharges(recording as any, "cus_123");
+    assert.deepEqual(recorded, ["ch_1", "ch_2"]);
+    assert.equal(liveFetch.calls.length, 1);
+
+    // 2. REPLAY with a fetch that throws — proves no network is touched.
+    const deadFetch = fakeFetch(() => {
+      throw new Error("network should NOT be called during replay");
+    });
+    const replaying = withCassette(stripeServices(deadFetch) as any, { mode: "replay", cassette });
+    const replayed = await listCharges(replaying as any, "cus_123");
+    assert.deepEqual(replayed, ["ch_1", "ch_2"]);
+    assert.equal(deadFetch.calls.length, 0);
+  });
+
+  it("never writes the real secret to the cassette", async () => {
+    const cassette = emptyCassette();
+    const liveFetch = fakeFetch(() => ({ body: { data: [] } }));
+    const recording = withCassette(stripeServices(liveFetch) as any, { mode: "record", cassette });
+    await listCharges(recording as any, "cus_123");
+
+    const serialized = JSON.stringify(cassette);
+    assert.ok(!serialized.includes("sk_live_supersecret"), "secret leaked into cassette");
+    assert.ok(serialized.includes("{{secret:STRIPE_KEY}}"), "secret token missing");
+    // secrets.get itself is not recorded — only the http call is.
+    assert.equal(cassette.entries.length, 1);
+    assert.equal(cassette.entries[0]!.key, "http");
+  });
+
+  it("replay matches even with no real credentials present", async () => {
+    // Record with the real secret...
+    const cassette = emptyCassette();
+    const liveFetch = fakeFetch(() => ({ body: { data: [{ id: "ch_9" }] } }));
+    await listCharges(
+      withCassette(stripeServices(liveFetch) as any, { mode: "record", cassette }) as any,
+      "cus_x",
+    );
+
+    // ...replay in an environment where the secret is absent (undefined).
+    const credlessServices = standardServices({
+      fetchImpl: fakeFetch(() => {
+        throw new Error("no network in replay");
+      }),
+      secretsSource: {}, // STRIPE_KEY missing
+    });
+    const replaying = withCassette(credlessServices as any, { mode: "replay", cassette });
+    const out = await listCharges(replaying as any, "cus_x");
+    assert.deepEqual(out, ["ch_9"]);
+  });
+
+  it("walks repeated identical calls in recorded order (pagination)", async () => {
+    const cassette: Cassette = {
+      entries: [
+        { key: "http", args: ["https://x/feed", {}], result: { ok: 1 } },
+        { key: "http", args: ["https://x/feed", {}], result: { ok: 2 } },
+      ],
+    };
+    const services = withCassette(
+      standardServices({ fetchImpl: fakeFetch(() => ({ body: {} })) }) as any,
+      { mode: "replay", cassette },
+    );
+    const a = await (services as any).http("https://x/feed", {});
+    const b = await (services as any).http("https://x/feed", {});
+    assert.deepEqual(a, { ok: 1 });
+    assert.deepEqual(b, { ok: 2 });
+  });
+
+  it("throws a clear error when replay has no matching entry", async () => {
+    const services = withCassette(
+      standardServices({ fetchImpl: fakeFetch(() => ({ body: {} })) }) as any,
+      { mode: "replay", cassette: emptyCassette() },
+    );
+    await assert.rejects(
+      () => (services as any).http("https://x/missing", {}),
+      /no recorded call for "http"/,
+    );
+  });
+});

--- a/vein/src/cassette.ts
+++ b/vein/src/cassette.ts
@@ -1,0 +1,215 @@
+/**
+ * Record / replay for the services bag — the "safe inner loop" that lets the
+ * AI chat author an adapter and hammer on it OFFLINE: record once against the
+ * real world, then iterate against the recording (deterministic, no rate
+ * limits, no cost, no side effects).
+ *
+ * It works by wrapping the services bag (the seam every adapter already goes
+ * through — see `capabilities.ts`). In `record` mode each service call is run
+ * for real and its `(key, args) → result` captured; in `replay` mode the call
+ * is served from the recording by matching `(key, args)` instead of hitting the
+ * real service.
+ *
+ * **Secret hygiene.** Secrets enter through one boundary (`services.secrets`).
+ * The wrapper canonicalizes every secret VALUE to a stable token
+ * (`{{secret:NAME}}`) before anything is written to — or matched against — the
+ * cassette, so real keys never reach disk, and record↔replay still match even
+ * though replay has no real credentials.
+ */
+
+const SECRET_TOKEN = (name: string) => `{{secret:${name}}}`;
+
+/** One recorded service call. `args`/`result` are post-redaction (secret-safe). */
+export interface CassetteEntry {
+  /** `"<service>.<method>"`, or just `"<service>"` for a callable service. */
+  key: string;
+  args: unknown[];
+  result?: unknown;
+  /** Present instead of `result` when the recorded call threw. */
+  error?: string;
+}
+
+export interface Cassette {
+  entries: CassetteEntry[];
+}
+
+export type CassetteMode = "record" | "replay";
+
+export interface WithCassetteOptions {
+  mode: CassetteMode;
+  /** In `record` mode, entries are appended here. In `replay` mode, calls are
+   *  matched against these entries. */
+  cassette: Cassette;
+  /** Name of the service treated as the secrets boundary (its return values are
+   *  canonicalized to tokens and scrubbed from the cassette). Default
+   *  `"secrets"`; pass `null` to disable secret handling. */
+  secretsService?: string | null;
+}
+
+export function emptyCassette(): Cassette {
+  return { entries: [] };
+}
+
+/**
+ * Wrap a services bag with record/replay. Returns a structurally-identical bag
+ * (same call sites in adapter code) backed by the cassette per `mode`.
+ */
+export function withCassette<TServices extends Record<string, unknown>>(
+  services: TServices,
+  opts: WithCassetteOptions,
+): TServices {
+  const { mode, cassette } = opts;
+  const secretsService =
+    opts.secretsService === undefined ? "secrets" : opts.secretsService;
+
+  // name → real secret value, learned at the secrets boundary during record.
+  // Used to scrub real values out of recorded args/results.
+  const secretValues = new Map<string, string>();
+  // Indices already returned in replay, so repeated identical calls walk the
+  // recording in order (e.g. paginated GETs) instead of re-matching the first.
+  const consumed = new Set<number>();
+
+  const redact = (v: unknown): unknown => {
+    if (secretValues.size === 0) return v;
+    return deepReplace(v, (s) => {
+      let out = s;
+      for (const [name, value] of secretValues) {
+        if (value) out = out.split(value).join(SECRET_TOKEN(name));
+      }
+      return out;
+    });
+  };
+
+  /** Handle one wrapped call (non-secrets services). */
+  const handleCall = async (
+    key: string,
+    fn: (...a: unknown[]) => unknown,
+    args: unknown[],
+  ): Promise<unknown> => {
+    const redactedArgs = redact(args) as unknown[];
+    if (mode === "replay") {
+      const idx = cassette.entries.findIndex(
+        (e, i) =>
+          !consumed.has(i) && e.key === key && argsEqual(e.args, redactedArgs),
+      );
+      if (idx === -1) {
+        throw new Error(
+          `cassette replay: no recorded call for "${key}" with args ${stableJson(redactedArgs)}`,
+        );
+      }
+      consumed.add(idx);
+      const entry = cassette.entries[idx]!;
+      if (entry.error !== undefined) throw new Error(entry.error);
+      return entry.result;
+    }
+    // record
+    try {
+      const result = await fn(...args);
+      cassette.entries.push({ key, args: redactedArgs, result: redact(result) });
+      return result;
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      cassette.entries.push({ key, args: redactedArgs, error: message });
+      throw err;
+    }
+  };
+
+  /** The secrets boundary: NOT recorded. In record mode, learn name→value so it
+   *  can be scrubbed elsewhere; in replay mode, return the stable token so
+   *  downstream args carry tokens that match the recording. */
+  const wrapSecretsGet =
+    (realGet: (name: string) => Promise<string | undefined>) =>
+    async (name: string): Promise<string | undefined> => {
+      if (mode === "replay") return SECRET_TOKEN(name);
+      const value = await realGet(name);
+      if (typeof value === "string") secretValues.set(name, value);
+      return value;
+    };
+
+  const wrapService = (name: string, svc: unknown): unknown => {
+    const isSecrets = secretsService != null && name === secretsService;
+
+    if (typeof svc === "function") {
+      const fn = svc as (...a: unknown[]) => unknown;
+      return (...args: unknown[]) => handleCall(name, fn, args);
+    }
+    if (svc && typeof svc === "object") {
+      return new Proxy(svc as Record<string, unknown>, {
+        get(target, prop) {
+          const member = target[prop as string];
+          if (typeof member !== "function") return member;
+          const method = String(prop);
+          const bound = (member as (...a: unknown[]) => unknown).bind(target);
+          if (isSecrets && method === "get") {
+            return wrapSecretsGet(
+              bound as (name: string) => Promise<string | undefined>,
+            );
+          }
+          return (...args: unknown[]) =>
+            handleCall(`${name}.${method}`, bound, args);
+        },
+      });
+    }
+    return svc;
+  };
+
+  return new Proxy(services, {
+    get(target, prop) {
+      const name = String(prop);
+      const svc = target[prop as keyof TServices];
+      if (svc == null) return svc;
+      return wrapService(name, svc);
+    },
+  }) as TServices;
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────
+
+/** Recursively map every string in a JSON-like value through `fn`. */
+function deepReplace(v: unknown, fn: (s: string) => string): unknown {
+  if (typeof v === "string") return fn(v);
+  if (Array.isArray(v)) return v.map((x) => deepReplace(x, fn));
+  if (v && typeof v === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, val] of Object.entries(v)) out[k] = deepReplace(val, fn);
+    return out;
+  }
+  return v;
+}
+
+/** Deterministic JSON with sorted object keys, so arg comparison is stable. */
+function stableJson(v: unknown): string {
+  return JSON.stringify(v, (_k, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      const sorted: Record<string, unknown> = {};
+      for (const k of Object.keys(val).sort()) sorted[k] = (val as Record<string, unknown>)[k];
+      return sorted;
+    }
+    return val;
+  });
+}
+
+function argsEqual(a: unknown[], b: unknown[]): boolean {
+  return stableJson(a) === stableJson(b);
+}
+
+// ── persistence ──────────────────────────────────────────────────────────
+
+/** Load a cassette from disk, or an empty one if the file doesn't exist. */
+export async function loadCassette(path: string): Promise<Cassette> {
+  const { readFile } = await import("node:fs/promises");
+  try {
+    const parsed = JSON.parse(await readFile(path, "utf-8"));
+    return { entries: Array.isArray(parsed?.entries) ? parsed.entries : [] };
+  } catch {
+    return emptyCassette();
+  }
+}
+
+/** Persist a cassette to disk (pretty JSON, creating parent dirs). */
+export async function saveCassette(path: string, cassette: Cassette): Promise<void> {
+  const { writeFile, mkdir } = await import("node:fs/promises");
+  const { dirname } = await import("node:path");
+  await mkdir(dirname(path), { recursive: true });
+  await writeFile(path, JSON.stringify(cassette, null, 2));
+}

--- a/vein/src/core.ts
+++ b/vein/src/core.ts
@@ -9,6 +9,10 @@ import { z } from "zod";
  * in their own app and pass concrete implementations per environment
  * (e.g. Neo4j in prod, in-memory in tests). Steps that don't touch
  * services leave it as the default `unknown` and ignore `ctx.services`.
+ * An adapter that wants typed `http`/`secrets` can opt in by annotating
+ * `defineStep<"t", In, Out, VeinCapabilities>(…)` (import the type from
+ * "vein") — kept opt-in so it doesn't collide with consumer `ctx.services`
+ * casts (the standard server always provides `http`/`secrets` regardless).
  */
 export interface StepDef<
   TType extends string = string,

--- a/vein/src/createVein.test.ts
+++ b/vein/src/createVein.test.ts
@@ -109,7 +109,10 @@ describe("createVein", () => {
 
     assert.ok(vein.app, "app should be a Hono instance");
     assert.equal(vein.workspace.path, tempDir);
-    assert.deepEqual(vein.services, {}); // default services
+    // Default services provide the standard adapter capabilities out of the box.
+    const svc = vein.services as { http?: unknown; secrets?: unknown };
+    assert.equal(typeof svc.http, "function");
+    assert.equal(typeof svc.secrets, "object");
     const reg = vein.getRegistry();
     assert.ok("http" in reg);
   });
@@ -239,6 +242,30 @@ describe("createVein", () => {
     const body = (await res.json()) as { ok: boolean; stepCount: number };
     assert.equal(body.ok, true);
     assert.ok(body.stepCount > 0);
+  });
+
+  it("runs a single step via POST /steps/:type/run", async () => {
+    const vein = await createVein({
+      workspace: new WorkspaceManager(tempDir),
+      store: new MemoryRunStore(),
+      serveUi: false,
+      enableChat: false,
+    });
+    const res = await vein.app.request("/steps/log/run", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        config: { message: "hello {{ input.name }}" },
+        input: { name: "world" },
+      }),
+    });
+    assert.equal(res.status, 200);
+    const body = (await res.json()) as { status: string; output: unknown };
+    assert.equal(body.status, "success");
+    assert.equal(body.output, "hello world");
+
+    const missing = await vein.app.request("/steps/nope/run", { method: "POST" });
+    assert.equal(missing.status, 404);
   });
 
   it("exposes /steps with registered types", async () => {

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -23,6 +23,9 @@ import { buildRegistry, readStepSourceFromDisk } from "./steps/registry.js";
 import type { StepSources } from "./steps/registry.js";
 import { runWorkflow } from "./runner.js";
 import { requireApiKey, warnIfUnconfigured } from "./auth.js";
+import { standardServices } from "./capabilities.js";
+import { runSingleStep, cassettePath } from "./run-step.js";
+import type { CassetteMode } from "./cassette.js";
 
 // ── Public types ───────────────────────────────────────────────────────────
 
@@ -249,7 +252,14 @@ export async function createVein<TServices = unknown>(
   // restart / crash / cancellation) and is reported as "stale" rather than a
   // perpetual "running".
   const activeRuns = new Set<string>();
-  const services = (opts.services ?? ({} as TServices)) as TServices;
+  // Auto-provide the standard capabilities (http + secrets) every adapter step
+  // builds on, with the consumer's bag spread on top so they can override or
+  // extend any capability. This is what lets an LLM-authored adapter rely on
+  // `ctx.services.http` / `ctx.services.secrets` existing out of the box.
+  const services = {
+    ...(standardServices() as unknown as Record<string, unknown>),
+    ...((opts.services ?? {}) as Record<string, unknown>),
+  } as TServices;
   const serveUi = opts.serveUi ?? true;
   const enableChat = opts.enableChat ?? true;
   const chatStore: ChatStore =
@@ -680,6 +690,42 @@ export async function createVein<TServices = unknown>(
     }
     if (result.changed) await rebuildRegistry();
     return c.json({ ok: true, type: body.name, version: result.version, changed: result.changed }, 201);
+  });
+
+  // Run a SINGLE step in isolation (synchronous) — the adapter author's inner
+  // loop. Body: { config?, input?, params?, cassette?: "record"|"replay",
+  // cassetteName? }. With `cassette`, external `ctx.services` calls are recorded
+  // to / replayed from `steps/_cassettes/<name>.json` (secrets scrubbed), so the
+  // step can be iterated offline. Returns { status, output?, error?, events,
+  // recorded? }. Unlike workflow runs, this awaits and returns the result.
+  app.post("/steps/:type{.+}/run", async (c) => {
+    const type = c.req.param("type");
+    if (!registry[type]) return c.json({ error: `Step type "${type}" not found` }, 404);
+    const body = await c.req
+      .json<{
+        config?: Record<string, unknown>;
+        input?: unknown;
+        params?: Record<string, unknown>;
+        cassette?: CassetteMode;
+        cassetteName?: string;
+      }>()
+      .catch(() => ({}) as Record<string, never>);
+
+    const mode = body.cassette;
+    if (mode && mode !== "record" && mode !== "replay") {
+      return c.json({ error: `cassette must be "record" or "replay"` }, 400);
+    }
+
+    const result = await runSingleStep(type, registry, services, {
+      config: body.config,
+      input: body.input,
+      params: body.params,
+      workspace,
+      ...(mode
+        ? { cassette: { mode, path: cassettePath(workspace.path, body.cassetteName ?? type) } }
+        : {}),
+    });
+    return c.json(result);
   });
 
   app.delete("/steps", requireApiKey, async (c) => {

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -99,6 +99,39 @@ export {
   computeCost,
 } from "./pricing.js";
 
+// Standard capabilities — the http + secrets services adapter steps build on.
+export {
+  standardServices,
+  httpCapability,
+  secretsCapability,
+  type VeinCapabilities,
+  type HttpCapability,
+  type HttpRequestOptions,
+  type HttpResponse,
+  type SecretsCapability,
+  type FetchLike,
+} from "./capabilities.js";
+
+// Record/replay for the services bag (the adapter "safe inner loop").
+export {
+  withCassette,
+  emptyCassette,
+  loadCassette,
+  saveCassette,
+  type Cassette,
+  type CassetteEntry,
+  type CassetteMode,
+  type WithCassetteOptions,
+} from "./cassette.js";
+
+// Single-step runner (test one step in isolation, with optional cassette).
+export {
+  runSingleStep,
+  cassettePath,
+  type RunStepOptions,
+  type RunStepResult,
+} from "./run-step.js";
+
 // Vein factory — the primary entry point for library usage.
 export {
   createVein,

--- a/vein/src/run-step.test.ts
+++ b/vein/src/run-step.test.ts
@@ -1,0 +1,142 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { z } from "zod";
+import { defineStep, type StepRegistry } from "./core.js";
+import { coreRegistry } from "./steps/registry.js";
+import { runSingleStep, cassettePath } from "./run-step.js";
+import { standardServices, type FetchLike } from "./capabilities.js";
+
+// A fake fetch returning canned JSON, recording how many times it was called.
+function fakeFetch(
+  handler: (url: string, init: any) => unknown,
+): FetchLike & { count: number } {
+  const fn = (async (url: string, init: any = {}) => {
+    fn.count++;
+    const body = handler(url, init);
+    const text = JSON.stringify(body);
+    return {
+      status: 200,
+      ok: true,
+      headers: {
+        forEach(cb: (value: string, key: string) => void) {
+          cb("application/json", "content-type");
+        },
+      },
+      async text() {
+        return text;
+      },
+    };
+  }) as any;
+  fn.count = 0;
+  return fn;
+}
+
+// An adapter-style step: reads a secret + calls http through ctx.services.
+const listCharges = defineStep({
+  type: "stripe/list-charges",
+  input: z.object({ customer: z.string() }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const svc = ctx.services as ReturnType<typeof standardServices>;
+    const key = await svc.secrets.get("STRIPE_KEY");
+    const res = await svc.http("https://api.stripe.com/v1/charges", {
+      query: { customer: cfg.customer },
+      headers: { authorization: `Bearer ${key}` },
+    });
+    return { ids: (res.body as { data: Array<{ id: string }> }).data.map((c) => c.id) };
+  },
+});
+
+function registry(): StepRegistry {
+  return { "stripe/list-charges": listCharges } as StepRegistry;
+}
+
+describe("runSingleStep", () => {
+  it("runs a step in isolation and returns output + events", async () => {
+    const services = standardServices({
+      fetchImpl: fakeFetch(() => ({ data: [{ id: "ch_1" }] })),
+      secretsSource: { STRIPE_KEY: "sk_test" },
+    });
+    const res = await runSingleStep("stripe/list-charges", registry(), services, {
+      config: { customer: "{{ input.customer }}" },
+      input: { customer: "cus_1" },
+    });
+    assert.equal(res.status, "success");
+    assert.deepEqual(res.output, { ids: ["ch_1"] });
+    assert.ok(res.events.some((e) => e.type === "step.end"));
+  });
+
+  it("errors clearly for an unknown step type", async () => {
+    const res = await runSingleStep("nope", registry(), {});
+    assert.equal(res.status, "error");
+    assert.match(res.error!.message, /not found/);
+  });
+
+  it("records a fixture (secret scrubbed), then replays offline", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vein-cassette-"));
+    const path = cassettePath(dir, "stripe/list-charges");
+
+    // RECORD — live fetch hit once, fixture written.
+    const live = fakeFetch(() => ({ data: [{ id: "ch_7" }, { id: "ch_8" }] }));
+    const recRes = await runSingleStep(
+      "stripe/list-charges",
+      registry(),
+      standardServices({ fetchImpl: live, secretsSource: { STRIPE_KEY: "sk_live_secret" } }),
+      { config: { customer: "cus_42" }, cassette: { mode: "record", path } },
+    );
+    assert.equal(recRes.status, "success");
+    assert.deepEqual(recRes.output, { ids: ["ch_7", "ch_8"] });
+    assert.equal(live.count, 1);
+    assert.equal(recRes.recorded, 1); // one http call captured (secrets.get isn't recorded)
+
+    // Fixture on disk must not contain the real secret.
+    const raw = await readFile(path, "utf-8");
+    assert.ok(!raw.includes("sk_live_secret"), "secret leaked to cassette file");
+    assert.ok(raw.includes("{{secret:STRIPE_KEY}}"));
+
+    // REPLAY — fetch that throws proves no network is touched.
+    const dead = fakeFetch(() => {
+      throw new Error("network must not be called in replay");
+    });
+    const repRes = await runSingleStep(
+      "stripe/list-charges",
+      registry(),
+      standardServices({ fetchImpl: dead, secretsSource: {} }), // no creds present
+      { config: { customer: "cus_42" }, cassette: { mode: "replay", path } },
+    );
+    assert.equal(repRes.status, "success");
+    assert.deepEqual(repRes.output, { ids: ["ch_7", "ch_8"] });
+    assert.equal(dead.count, 0);
+  });
+
+  it("the built-in http step routes through services.http (so it's recordable)", async () => {
+    const dir = await mkdtemp(join(tmpdir(), "vein-http-"));
+    const path = cassettePath(dir, "http");
+
+    // RECORD — fake fetch behind services.http; the core http step uses it.
+    const live = fakeFetch(() => ({ hello: "world" }));
+    const rec = await runSingleStep("http", coreRegistry(), standardServices({ fetchImpl: live }), {
+      config: { url: "https://api.example.com/data" },
+      cassette: { mode: "record", path },
+    });
+    assert.equal(rec.status, "success");
+    assert.deepEqual(rec.output, { status: 200, body: { hello: "world" } });
+    assert.equal(rec.recorded, 1);
+    assert.equal(live.count, 1);
+
+    // REPLAY — offline, no network touched.
+    const dead = fakeFetch(() => {
+      throw new Error("no network in replay");
+    });
+    const rep = await runSingleStep("http", coreRegistry(), standardServices({ fetchImpl: dead }), {
+      config: { url: "https://api.example.com/data" },
+      cassette: { mode: "replay", path },
+    });
+    assert.equal(rep.status, "success");
+    assert.deepEqual(rep.output, { status: 200, body: { hello: "world" } });
+    assert.equal(dead.count, 0);
+  });
+});

--- a/vein/src/run-step.ts
+++ b/vein/src/run-step.ts
@@ -1,0 +1,109 @@
+import { z } from "zod";
+import type { Flow, StepRegistry, RunEvent, RunResult } from "./core.js";
+import { runWorkflow, type SubflowResolver } from "./runner.js";
+import { MemoryRunStore } from "./store.js";
+import {
+  withCassette,
+  loadCassette,
+  saveCassette,
+  type CassetteMode,
+} from "./cassette.js";
+
+/**
+ * Run a SINGLE step in isolation — the tight inner loop for authoring adapters.
+ *
+ * Unlike a workflow run (detached, launch+tail), this is synchronous: it wraps
+ * the step in an ad-hoc one-step flow, runs it to completion against an
+ * in-memory store, and returns the output + events directly — so the chat agent
+ * (or a developer) can author → run → fix without wiring anything into a
+ * workflow.
+ *
+ * With `cassette`, external service calls go through the record/replay wrapper:
+ *   - `record` — run live, capture every `ctx.services` call to the cassette
+ *     file (secrets scrubbed), so the next iteration can…
+ *   - `replay` — …serve those calls from the file: offline, deterministic, no
+ *     rate limits, no cost, no side effects.
+ */
+export interface RunStepOptions {
+  /** The step's config (same shape as a workflow step's `config`). Templates
+   *  like `{{ input.* }}` / `{{ params.* }}` are resolved. */
+  config?: Record<string, unknown>;
+  /** Workflow input, referenced in config via `{{ input.* }}`. */
+  input?: unknown;
+  /** Params knobs, referenced via `{{ params.* }}`. */
+  params?: Record<string, unknown>;
+  /** Record/replay external service calls against a cassette file. */
+  cassette?: { mode: CassetteMode; path: string };
+  /** Subflow resolver — only needed if the step itself is a `subflow`. */
+  workspace?: SubflowResolver;
+}
+
+export interface RunStepResult {
+  status: "success" | "error";
+  output?: unknown;
+  error?: { message: string; stack?: string };
+  /** Every event the step emitted (start/end/error, plus nested for containers). */
+  events: RunEvent[];
+  /** Number of recorded service calls (present when a cassette was used). */
+  recorded?: number;
+}
+
+export async function runSingleStep(
+  type: string,
+  registry: StepRegistry,
+  services: unknown,
+  opts: RunStepOptions = {},
+): Promise<RunStepResult> {
+  if (!registry[type]) {
+    return {
+      status: "error",
+      error: { message: `Step type "${type}" not found` },
+      events: [],
+    };
+  }
+
+  const flow: Flow = {
+    name: "__run_step__",
+    input: z.any(),
+    steps: [{ id: "step", type, config: opts.config ?? {} }],
+    ...(opts.params != null ? { params: opts.params } : {}),
+  };
+
+  const cassette = opts.cassette ? await loadCassette(opts.cassette.path) : null;
+  const runServices =
+    opts.cassette && cassette
+      ? withCassette(services as Record<string, unknown>, {
+          mode: opts.cassette.mode,
+          cassette,
+        })
+      : services;
+
+  const events: RunEvent[] = [];
+  const result: RunResult = await runWorkflow(flow, opts.input ?? {}, registry, {
+    store: new MemoryRunStore(),
+    services: runServices,
+    workspace: opts.workspace,
+    onEvent: (e) => {
+      events.push(e);
+    },
+  });
+
+  // Persist newly-captured calls only when recording.
+  if (opts.cassette?.mode === "record" && cassette) {
+    await saveCassette(opts.cassette.path, cassette);
+  }
+
+  return {
+    status: result.status,
+    output: result.output,
+    error: result.error,
+    events,
+    ...(cassette ? { recorded: cassette.entries.length } : {}),
+  };
+}
+
+/** Default on-disk location for a step's cassette, under the workspace. */
+export function cassettePath(workspacePath: string, name: string): string {
+  // `name` may contain slashes (namespaced step types) — they become subdirs.
+  return `${workspacePath}/steps/_cassettes/${name}.json`;
+}

--- a/vein/src/steps/core/http.ts
+++ b/vein/src/steps/core/http.ts
@@ -1,5 +1,6 @@
 import { z } from "zod";
 import { defineStep } from "../../core.js";
+import { httpCapability, type HttpCapability } from "../../capabilities.js";
 
 const EXAMPLE = `- id: fetch
   type: http
@@ -11,7 +12,10 @@ const EXAMPLE = `- id: fetch
 
 export default defineStep({
   type: "http",
-  description: `Make an HTTP request. Output: { status, body }.\n\n${EXAMPLE}`,
+  description:
+    `Make an HTTP request. Output: { status, body } (body is parsed JSON when the response is JSON, else text). Throws on a non-2xx response.\n\n` +
+    `This step is also the REFERENCE for authoring an adapter: it performs the request through ctx.services.http(url, opts) — NOT the global fetch — so its calls are recordable/replayable by run_step's cassette and credentials can be injected by the services bag. Read this step's source (get_step("http")) to see the exact ctx.services.http usage.\n\n` +
+    EXAMPLE,
   input: z.object({
     url: z.string(),
     method: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH"]).default("GET"),
@@ -20,33 +24,30 @@ export default defineStep({
     timeout: z.number().positive().optional(),
   }),
   output: z.any(),
-  async run(cfg) {
-    const res = await fetch(cfg.url, {
-      method: cfg.method,
-      body: cfg.body !== undefined ? JSON.stringify(cfg.body) : undefined,
-      headers: {
-        ...(cfg.body !== undefined
-          ? { "Content-Type": "application/json" }
-          : {}),
-        ...cfg.headers,
-      },
-      signal: cfg.timeout ? AbortSignal.timeout(cfg.timeout) : undefined,
-    });
+  async run(cfg, ctx) {
+    // Use the deployment's http capability so calls are recordable/replayable
+    // (run_step cassettes) and credentials/transport are swappable. Fall back to
+    // a global-fetch-backed capability when no services.http was injected (e.g. a
+    // bare `runWorkflow(..., { services: {} })`).
+    const http: HttpCapability =
+      (ctx.services as { http?: HttpCapability } | undefined)?.http ??
+      httpCapability();
 
-    let body: unknown;
-    const contentType = res.headers.get("content-type") ?? "";
-    if (contentType.includes("application/json")) {
-      body = await res.json();
-    } else {
-      body = await res.text();
-    }
+    const res = await http(cfg.url, {
+      method: cfg.method,
+      ...(cfg.headers ? { headers: cfg.headers } : {}),
+      ...(cfg.body !== undefined ? { body: cfg.body } : {}),
+      ...(cfg.timeout ? { timeout: cfg.timeout } : {}),
+    });
 
     if (!res.ok) {
       throw new Error(
-        `HTTP ${cfg.method} ${cfg.url} returned ${res.status}: ${typeof body === "string" ? body : JSON.stringify(body)}`,
+        `HTTP ${cfg.method} ${cfg.url} returned ${res.status}: ${
+          typeof res.body === "string" ? res.body : JSON.stringify(res.body)
+        }`,
       );
     }
 
-    return { status: res.status, body };
+    return { status: res.status, body: res.body };
   },
 });


### PR DESCRIPTION
## What

Adds the **safe inner loop** for authoring integration adapters in vein: the AI chat can author a step that hits an external API, test it in isolation, and iterate **offline** — no rate limits, no cost, no side effects, no leaked secrets.

The loop: `create_step` → `run_step(cassette: "record")` (one live call captures a fixture) → `run_step(cassette: "replay")` + `edit_step` (iterate offline) → publish → reference in a workflow.

## Changes

- **`capabilities.ts`** — standard `http(url, opts)` (fetch-like; returns a plain serializable `{ status, ok, headers, body }` so it's recordable) + `secrets.get(name)` (env-backed, injectable) + `standardServices()`.
- **`cassette.ts`** — record/replay wrapper over the services bag. Records real `ctx.services` calls; replays by arg-match (no network). Secret values read through `services.secrets` are canonicalized to `{{secret:NAME}}` before anything hits disk — keys never leak and record↔replay still match with no credentials present. Plus `load/saveCassette`.
- **`run-step.ts`** — `runSingleStep`: run one step in isolation (synchronous), optional cassette. Exposed as `POST /steps/:type/run` and the `run_step` agent tool.
- **`createVein.ts`** — auto-merge `standardServices()` into the default services bag (consumer services override). New `POST /steps/:type/run` endpoint.
- **`steps/core/http.ts`** — routed through `ctx.services.http` (preserving `{ status, body }` + throw-on-non-2xx + `timeout`), so the built-in `http` step is itself cassette-recordable and serves as the canonical adapter example (`get_step("http")`).
- **`ai/prompts.ts` + `ai/tools.ts`** — teach the agent to use `ctx.services.http`/`secrets` (not global `fetch`/`process.env`), the record→replay loop, and the SDK note; added the `run_step` tool.
- **`index.ts`** — export the new public API.
- **`plans/adapter-loop-followups.md`** — deferred work (secrets UI + store, cassette UI, `run_step` web UI, mcp `/lab` verification, typecheck-in-the-loop, etc.).

## Notes / behavior changes

- **Default services bag changed** from `{}` to `{ http, secrets }` (additive, consumer-overridable). The one test asserting the old empty default was updated. ⚠️ Worth confirming **mcp `/lab`** (copies vein as a dep) boots fine — it auto-merges now.
- Considered defaulting `defineStep`'s `TServices` to `VeinCapabilities` for typed `ctx.services.http`; **rejected** — it breaks the consumer `ctx.services as XServices` cast pattern (`TS2352`) for an author-time-only benefit the LLM can't use (tsx doesn't typecheck). `VeinCapabilities` is exported for opt-in annotation instead; the real fix (typecheck-in-the-loop) is in the plan doc.

## Not done (deferred, in the plan doc)

Secrets store + UI (only the seam is in), cassette management UI, `run_step` web UI button, a live end-to-end agent run, and mcp `/lab` verification.

## Testing

372 tests pass, clean typecheck. New offline tests cover the http/secrets capabilities, cassette record/replay + secret scrubbing + pagination ordering, `runSingleStep` (incl. the core http step now being recordable), and the `POST /steps/:type/run` endpoint.