### PR TITLE
vein: secrets store + UI, google drive step, authoring robustness

### DIFF
--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -35,17 +35,18 @@ vein/
 │   ├── createVein.ts      # createVein() factory: Hono HTTP API + detached run launch + SSE run reattach (tail) + detached /chat (launch+reattach) + static serving; injectable registry/store/chatStore/services
 │   ├── server.ts          # thin wrapper over createVein() (getApp/startServer) — default filesystem-backed server
 │   ├── auth.ts            # requireApiKey middleware + warnIfUnconfigured (VEIN_API_KEY shared secret)
+│   ├── secret-store.ts    # SecretStore iface + FileSecretStore (AES-256-GCM, VEIN_SECRET_KEY) + MemorySecretStore — backs ctx.services.secrets + /secrets endpoints
 │   ├── index.ts           # barrel export — createVein (primary entry), createRegistry, coreRegistry, all types
 │   ├── steps/
 │   │   ├── core/          # 9 built-in steps: http, log, if, loop, foreach, subflow, llm, agent, wait (static import)
-│   │   ├── lib/           # built-in domain integrations (github/fetch-pr, ...) — dynamic import
+│   │   ├── lib/           # built-in domain integrations (github/fetch-pr, ...) — file dynamic-imported at build; heavy SDKs lazy-imported in run() (see "Lib step dependency convention")
 │   │   └── registry.ts    # auto-discovery: buildRegistry() core (static) + lib (dynamic) + workspace custom/ (dynamic); createRegistry() for in-code steps
 │   ├── ai/                # AI workflow-builder backend (used by POST /chat)
 │   │   ├── index.ts       # barrel export
-│   │   ├── prompts.ts     # SYSTEM prompt + buildSystem(deps) (pre-seeds steps tree); AiDeps now carries `services`
+│   │   ├── prompts.ts     # SYSTEM prompt + buildSystem(deps) (pre-seeds steps tree); AiDeps carries `services` + `secrets` (read-only names)
 │   │   ├── tools.ts       # buildTools(deps): list_steps, search_steps, get_step,
-│   │   │                  #                   create_step, edit_step, create_workflow,
-│   │   │                  #                   run_workflow (threads ctx.services)
+│   │   │                  #                   list_secrets (NAMES only), create_step, edit_step,
+│   │   │                  #                   create_workflow, run_workflow (threads ctx.services)
 │   │   ├── stepHelpers.ts # lsSteps / searchSteps / readStepSource (filesystem-style browser)
 │   │   └── schemaHelpers.ts # Zod → FieldDesc[] (for get_step schema rendering)
 │   └── *.test.ts          # 298 tests across 12 files
@@ -70,6 +71,7 @@ vein/
         │   ├── EventsResizer.tsx     # drag handle for events panel height
         │   ├── Markdown.tsx          # tiny markdown renderer for chat output
         │   ├── RunInputPopover.tsx   # input-payload editor when triggering a run
+        │   ├── SecretsDialog.tsx     # manage deployment secrets (write-only values; names+meta listed)
         │   ├── StepEditFlyout.tsx    # edit step (id / type / config / depends / options)
         │   ├── StepRunFlyout.tsx     # view a step's run I/O (leaf: input/output; container: aggregate summary)
         │   └── FlyoutResizer.tsx     # drag handle for flyout width
@@ -104,6 +106,7 @@ cd vein && npm run dev        # serves API + UI on :3000
 | `VEIN_WORKSPACE`    | `./workspace`  | Persistent volume for workflows/runs |
 | `VEIN_PORT`         | `3000`         | HTTP server port                     |
 | `VEIN_API_KEY`      | (unset)        | Deployment-scoped shared secret. See "Auth" below. |
+| `VEIN_SECRET_KEY`   | (unset)        | Encryption key for the secret store (AES-256-GCM). Unset → a default dev key + one-time warning (obfuscated, not secure). See "Secrets". |
 | `VEIN_LLM_PROVIDER` | `anthropic`    | Default LLM provider for llm step    |
 | `VEIN_LLM_MODEL`    | (per-provider) | Override model name                  |
 | `VEIN_CHAT_MODEL`   | `claude-sonnet-4-20250514` | Anthropic model for the AI-builder chat agent |
@@ -132,17 +135,84 @@ This is sufficient when both services live in the same trust domain
 later without breaking this contract — they'd be additive env vars
 (`VEIN_API_KEY_<NAMESPACE>`) checked in addition to the shared key.
 
+## Secrets
+
+Steps reach credentials through one boundary — `ctx.services.secrets.get("NAME")`
+— never `process.env` directly. That boundary is backed by a **deployment-scoped
+secret store** (`src/secret-store.ts`) so credentials can be managed from the UI
+instead of baked into env at deploy time.
+
+- **Store:** `SecretStore` interface (parallel to `RunStore`/`ChatStore`).
+  Default `FileSecretStore` persists `<workspace>/secrets.json`, **encrypted at
+  rest** (AES-256-GCM, key derived from `VEIN_SECRET_KEY`). `MemorySecretStore`
+  for tests / in-memory deployments. The default `secrets` capability reads the
+  store first, then falls back to `process.env` (so existing env-provided keys
+  keep working). Injectable via `createVein({ secretStore })`.
+
+- **Scope is deployment-global**, NOT per-user — matching the `VEIN_API_KEY`
+  single-trust-domain model. (Per-user secrets would need an identity model vein
+  doesn't have.)
+
+- **Endpoints** (gated by `VEIN_API_KEY`, permissive in dev): `GET /secrets`
+  returns **names + metadata only — never values** (write-only credentials);
+  `PUT /secrets/:name { value }` creates/overwrites; `DELETE /secrets/:name`.
+  If the consumer injects their own `services.secrets`, these return **501**
+  (vein doesn't own that store).
+
+- **UI:** the topbar **Secrets** button opens `SecretsDialog` — list (names +
+  "updated" date), add (name + value, value can be multi-line e.g. a
+  service-account JSON), delete. The stored value is never sent back to the
+  browser. The UI assumes dev / same-trust-domain (no `Authorization` header),
+  exactly like the existing `/steps` mutations.
+
+- **`VEIN_SECRET_KEY`:** set it in production. Unset → values are encrypted with
+  a fixed dev key and a one-time warning logs (obfuscation, not real security).
+
+- **AI builder access:** the chat agent has a read-only `list_secrets` tool
+  (names + metadata only — never values) so it can reference existing
+  credentials when authoring steps and prompt the user to add missing ones. It
+  has no write access; adding/removing secrets stays a human action.
+
+- **No OAuth.** This is a paste-a-key / service-account store by design. For
+  Google Drive, paste a **service-account JSON** as `GOOGLE_SERVICE_ACCOUNT_JSON`
+  (no expiry, no refresh) — far simpler than an OAuth flow for a server-side
+  engine. If interactive per-end-user OAuth is ever needed, the **host app**
+  (mcp) should own the OAuth dance and deposit/refresh tokens *into* this store;
+  vein's `secrets` capability stays generic and provider-agnostic.
+
+## Lib step credentials
+
+Lib steps read credentials through the secrets capability, with explicit step
+config taking precedence:
+
+```ts
+const token = cfg.token ?? (await ctx?.services?.secrets?.get("GITHUB_TOKEN"));
+```
+
+- **`cfg.<field>` wins** (a workflow can pass a token via `{{ input.x }}`),
+  otherwise fall through to the managed secret store / env.
+- Type `ctx` as `StepContext<VeinCapabilities>` (import both from the relative
+  `core.js` / `capabilities.js`) so `ctx.services.secrets` is typed. Use
+  optional chaining — a bare `runWorkflow` without a services bag has no
+  `secrets`.
+- This also gets the step **cassette scrubbing for free**: every value read
+  through `secrets.get()` is scrubbed from recorded fixtures.
+- `github/fetch-pr` (`GITHUB_TOKEN`) and `gdrive/export-file`
+  (`GOOGLE_ACCESS_TOKEN` or `GOOGLE_SERVICE_ACCOUNT_JSON`) are the reference
+  examples.
+
 ## Key concepts
 
 - **`createVein()` is the primary entry point** (`src/createVein.ts`).
   It builds a configured instance — Hono `app`, `workspace`, `store`,
   `services`, plus `run()`/`listen()`/`rebuildRegistry()` helpers — and
-  mounts every route (`/workflows`, `/steps`, `/chat` + `/chats`,
-  `/health`, static UI). Everything is injectable via `VeinOptions`:
-  pass your own `registry` (disables filesystem step discovery +
-  publishing), `store` (e.g. `MemoryRunStore`), `chatStore`, `services`
-  bag, or toggle `serveUi`/`enableChat`. `server.ts` is a thin wrapper
-  (`getApp`/`startServer`) over `createVein()` with filesystem defaults.
+  mounts every route (`/workflows`, `/steps`, `/secrets`, `/chat` +
+  `/chats`, `/health`, static UI). Everything is injectable via
+  `VeinOptions`: pass your own `registry` (disables filesystem step
+  discovery + publishing), `store` (e.g. `MemoryRunStore`), `chatStore`,
+  `secretStore`, `services` bag, or toggle `serveUi`/`enableChat`.
+  `server.ts` is a thin wrapper (`getApp`/`startServer`) over
+  `createVein()` with filesystem defaults.
 
 - **`services` bag** is a consumer-defined capabilities object exposed to
   every step via `ctx.services` (typed by `defineStep`, untyped at
@@ -155,6 +225,9 @@ later without breaking this contract — they'd be additive env vars
   layered on core + lib (no filesystem custom/ discovery) — the
   library-usage counterpart to `buildRegistry(workspacePath)`. User
   steps may shadow core/lib steps (with a warning); duplicates throw.
+  Like `buildRegistry`, it imports every lib step *file* at build time
+  (cheap: schema + metadata only) — heavy SDK deps load lazily in `run()`
+  per the "Lib step dependency convention".
 
 - **Workflows are YAML**. One format everywhere — no `.ts` workflows,
   no JSON workflows. The API accepts either a `steps` array (server
@@ -204,6 +277,25 @@ later without breaking this contract — they'd be additive env vars
   `/g` regex. `resolveTemplate` uses a non-regex check
   (`indexOf("{{")`) for the single-expression fast path to avoid
   the greedy backtracking bug with multi-segment templates.
+
+- **Templates must be quoted in YAML.** A value starting with `{{`
+  is parsed by YAML as a flow-mapping, so `pull_number: {{ input.x }}`
+  silently becomes an object (`{ "[object Object]": null }`) → the step
+  fails with a baffling "expected number, received object". Always write
+  `pull_number: "{{ input.x }}"`. A sole `"{{ expr }}"` still preserves
+  the value's real type (number stays number). `publishWorkflow`
+  **lints for this** (`workspace.ts:assertValidWorkflowYaml`, detects the
+  parsed `[object Object]` corruption signature — so it doesn't
+  false-positive on `{{ }}` inside block-scalar message bodies) and throws
+  an actionable error instead of writing a broken workflow. The AI builder's
+  system prompt also carries the quoting rule.
+
+- **AI tool args may arrive as JSON strings.** LLMs sometimes pass an
+  object-valued tool arg (e.g. `run_workflow`'s `input`) as a JSON
+  *string*; the template engine then sees a string and `{{ input.* }}`
+  resolves to `undefined`. `buildTools` (`ai/tools.ts:coerceJsonArg`)
+  defensively `JSON.parse`s string args that look like objects/arrays for
+  `run_workflow` + `run_step` (`input`/`params`/`config`).
 
 - **`_metadata.json`** in each workflow dir tracks versions and the
   active version. In `steps/custom/_metadata.json` it tracks
@@ -344,6 +436,17 @@ later without breaking this contract — they'd be additive env vars
   prompt is built per-request by `buildSystem(deps)` (pre-seeds the
   steps tree).
 
+- **`list_secrets` tool** (`AiDeps.secrets`). The agent can list the
+  **names** of available credentials (never values — it's the same
+  names-only view as `GET /secrets`) so when it authors a step it
+  references an existing secret name in `ctx.services.secrets.get("NAME")`
+  rather than guessing, and tells the user which secret to add when one
+  is missing. Deliberately **read-only**: the agent has no
+  set/delete — writing a value through the model would defeat the
+  write-only design, and adding a secret is a human action. Wired only
+  when vein owns the secret store (absent when the consumer injected
+  their own `services.secrets`; the tool then returns an error).
+
 - **Chat is a detached background job** (`src/chat-store.ts`), NOT a
   connection-bound stream — the same launch+reattach model as runs
   (§8). `POST /chat { chatId?, message }` appends the user message,
@@ -461,6 +564,68 @@ later without breaking this contract — they'd be additive env vars
 5. Write tests in the appropriate test file.
 6. Run `npm test` and `cd web && npx tsc --noEmit && npx vite build`.
 
+## When adding a lib step (domain integration)
+
+Lib steps (`src/steps/lib/<namespace>/<name>.ts`) are engine-shipped
+domain integrations (github, slack, google-docs, dropbox, …). They're
+auto-discovered by `buildRegistry()`/`createRegistry()` — no manual
+registration — but they follow a strict **dependency convention** so
+adding a hundred adapters doesn't bloat every consumer's startup.
+
+### Lib step dependency convention
+
+**Rule: schema + metadata at module top level; heavy SDKs `await import()`-ed
+INSIDE `run()`.**
+
+```ts
+import { z } from "zod";                       // ✅ light, already a core dep
+import { defineStep } from "../../../core.js"; // ✅ engine
+// ❌ NEVER: import { Octokit } from "@octokit/rest";  (top-level heavy SDK)
+
+export default defineStep({
+  type: "github/fetch-pr",
+  description: "...",
+  input: z.object({ /* ... */ }),   // top level — needed by /steps + UI
+  output: z.object({ /* ... */ }),
+  async run(cfg) {
+    const { Octokit } = await import("@octokit/rest"); // ✅ lazy, first-use only
+    const octokit = new Octokit(/* ... */);
+    // ...
+  },
+});
+```
+
+**Why.** `loadStepsFrom(LIB_DIR)` does `await import()` on *every* lib
+file at registry-build time (which `createVein()` does eagerly at
+construction). A **top-level** `import` of an SDK therefore loads that
+SDK at startup for **every** consumer — even ones that never use the
+step. Moving the SDK import into `run()` keeps registry-build cheap (only
+schema + metadata execute), so the SDK only loads the first time its step
+actually runs. This is the "monolith, lazy-loaded" model (same shape as
+n8n's node catalog): all adapter code ships in vein, but unused SDKs are
+never *loaded* — though they are still *installed* in `node_modules`
+(an in-tree integration's deps are unavoidably listed in
+`vein/package.json`). If install footprint ever becomes the problem,
+split heavy adapters into companion packages registered via
+`createRegistry([...])`; the lazy-in-`run()` pattern is forward-compatible
+with that move.
+
+**Checklist for a new lib step:**
+1. Create `src/steps/lib/<namespace>/<name>.ts` with a `defineStep()`
+   default export. Use a `<namespace>/<name>` type (e.g. `slack/post-message`).
+2. Keep ALL `import`s at the top light (zod, core, sibling `_helpers`).
+   `await import()` every third-party SDK inside `run()`.
+3. Add the SDK to `vein/package.json` dependencies.
+4. Read credentials via `cfg.<field> ?? await ctx?.services?.secrets?.get("NAME")`
+   (type `ctx` as `StepContext<VeinCapabilities>`) — never `process.env`
+   directly. See "Lib step credentials".
+5. Shared helpers go in a leading-underscore file (`lib/<ns>/_shared.ts`) —
+   imported by siblings, skipped by registry discovery.
+6. Add a `STEP_COLORS` entry in `web/src/flow-to-canvas.ts` if you want a
+   distinct node color (optional; the Add Step dialog discovers the type
+   regardless via `/steps`).
+7. Write tests; run `npm test` and `cd web && npx tsc --noEmit && npx vite build`.
+
 ## When adding an API endpoint
 
 1. Add the route in `src/createVein.ts` (inside the `createVein()`
@@ -470,7 +635,7 @@ later without breaking this contract — they'd be additive env vars
 2. Add the typed function in `web/src/api.ts`.
 3. Wire it into `web/src/app.tsx`.
 4. The Vite dev proxy in `web/vite.config.ts` only proxies known
-   prefixes (`/workflows`, `/steps`, `/chat`, `/health`). Runs are
+   prefixes (`/workflows`, `/steps`, `/secrets`, `/chat`, `/health`). Runs are
    under `/workflows/` and chat reattach under `/chat/` so they're
    already proxied. SSE responses get `cache-control: no-cache` +
    `x-accel-buffering: no` injected by the shared `sseConfigure` —

--- a/vein/package.json
+++ b/vein/package.json
@@ -22,11 +22,12 @@
     "build:web": "npm --prefix web run build",
     "dev": "npm run build:web && tsx --env-file=.env src/server.ts",
     "start": "node build/server.js",
-    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts"
+    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.81",
     "@ai-sdk/openai": "^3.0.67",
+    "@googleapis/drive": "^20.2.0",
     "@hono/node-server": "^2.0.4",
     "@octokit/rest": "^22.0.1",
     "ai": "^6.0.196",

--- a/vein/src/ai-integration.test.ts
+++ b/vein/src/ai-integration.test.ts
@@ -10,6 +10,7 @@ import { defineStep } from "./core.js";
 import { createRegistry } from "./steps/registry.js";
 import { WorkspaceManager } from "./workspace.js";
 import { MemoryRunStore, FileRunStore } from "./store.js";
+import { MemorySecretStore } from "./secret-store.js";
 import { lsSteps, searchSteps, readStepSource } from "./ai/stepHelpers.js";
 import { buildSystem } from "./ai/prompts.js";
 import { buildTools } from "./ai/tools.js";
@@ -430,5 +431,95 @@ describe("AI list_runs / get_run tools", () => {
     assert.ok(list.error && /unavailable/.test(list.error));
     const get = await tools.get_run.execute({ name: "x", runId: "1" });
     assert.ok(get.error && /unavailable/.test(get.error));
+  });
+});
+
+// ── run_workflow coerces a stringified input ────────────────────────────────
+
+describe("AI run_workflow tool: stringified input coercion", () => {
+  let tempDir: string;
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `vein-ai-runwf-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("parses an input passed as a JSON string so {{ input.* }} resolves", async () => {
+    const echo = defineStep({
+      type: "echo",
+      input: z.any(),
+      output: z.any(),
+      async run(cfg) {
+        return cfg;
+      },
+    });
+    const registry = await createRegistry([echo]);
+    const ws = new WorkspaceManager(tempDir);
+    await ws.publishWorkflow("echo-wf", "v1", {
+      steps: [
+        { id: "a", type: "echo", config: { owner: "{{ input.owner }}", pull_number: "{{ input.pull_number }}" } },
+      ],
+    });
+
+    const deps = {
+      workspace: ws,
+      registry,
+      store: new MemoryRunStore(),
+      getRegistry: async () => registry,
+    };
+    const tools = buildTools(deps) as any;
+
+    // The model passes input as a JSON STRING (the exact bug from the logs).
+    const res = await tools.run_workflow.execute({
+      name: "echo-wf",
+      input: '{ "owner": "vercel", "pull_number": 1234 }',
+    });
+
+    assert.equal(res.status, "success");
+    assert.equal(res.output.owner, "vercel");
+    assert.equal(res.output.pull_number, 1234);
+    assert.equal(typeof res.output.pull_number, "number");
+  });
+});
+
+// ── list_secrets tool ────────────────────────────────────────────────────────
+
+describe("AI list_secrets tool", () => {
+  function makeDeps(secrets?: MemorySecretStore) {
+    const registry = {} as any;
+    return {
+      workspace: {} as any,
+      registry,
+      store: new MemoryRunStore(),
+      getRegistry: async () => registry,
+      secrets,
+    };
+  }
+
+  it("returns secret NAMES + updatedAt, never values", async () => {
+    const store = new MemorySecretStore();
+    await store.set("GITHUB_TOKEN", "ghp_superSecret");
+    await store.set("GOOGLE_SERVICE_ACCOUNT_JSON", '{"private_key":"xyz"}');
+
+    const tools = buildTools(makeDeps(store)) as any;
+    const res = await tools.list_secrets.execute({});
+
+    assert.deepEqual(
+      res.secrets.map((s: { name: string }) => s.name).sort(),
+      ["GITHUB_TOKEN", "GOOGLE_SERVICE_ACCOUNT_JSON"],
+    );
+    // The agent must never see values.
+    const blob = JSON.stringify(res);
+    assert.ok(!blob.includes("ghp_superSecret"));
+    assert.ok(!blob.includes("private_key"));
+    assert.ok(res.secrets.every((s: { updatedAt?: string }) => typeof s.updatedAt === "string"));
+  });
+
+  it("degrades gracefully when no secret store is wired", async () => {
+    const tools = buildTools(makeDeps(undefined)) as any;
+    const res = await tools.list_secrets.execute({});
+    assert.ok(res.error && /not available/.test(res.error));
   });
 });

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -1,6 +1,7 @@
 import type { StepRegistry } from "../core.js";
 import type { WorkspaceManager } from "../workspace.js";
 import type { RunStore } from "../store.js";
+import type { SecretInfo } from "../secret-store.js";
 import { lsSteps } from "./stepHelpers.js";
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -18,6 +19,11 @@ export interface AiDeps {
    *  LLM, the optimize loop's `optimizer`, …). Without it, the agent could
    *  only run service-free core/lib workflows. */
   services?: unknown;
+  /** Read-only view of the deployment's secret store (NAMES + metadata only —
+   *  never values) so the agent can reference existing credentials when
+   *  authoring steps and tell the user which to add. Optional: the
+   *  `list_secrets` tool degrades gracefully when absent. */
+  secrets?: { list(): Promise<SecretInfo[]> };
 }
 
 // ── System prompt ──────────────────────────────────────────────────────────
@@ -42,6 +48,7 @@ Rules:
 - Steps run sequentially by default (each depends on the previous).
 - Use "depends" to control ordering. depends: [] means run immediately (parallel).
 - Use {{ }} templates to reference previous step outputs or the workflow's input payload, e.g. {{ fetch.body.name }} or {{ input.url }} (where "input" is the object passed to run_workflow; you choose its shape).
+- ALWAYS WRAP TEMPLATE VALUES IN QUOTES. A YAML value that starts with "{{" is otherwise parsed as an object, not a string — e.g. \`pull_number: {{ input.pull_number }}\` silently becomes an object and the step fails with "expected number, received object". Write \`pull_number: "{{ input.pull_number }}"\`. A sole \`"{{ expr }}"\` still preserves the value's real type (a number stays a number) — so quoting does NOT turn a number into a string.
 - Use === for equality in expressions, not ==.
 
 Branching (if):
@@ -105,7 +112,7 @@ Authoring custom steps (create_step / edit_step):
     });
 - External capabilities come from ctx.services — a deployment-provided bag. Two standard capabilities are ALWAYS available:
     - ctx.services.http(url, { method?, headers?, body?, query? }) — a fetch-like transport. Returns a PLAIN object { status, ok, headers, body } (body is parsed JSON when JSON). Use this for ALL network/API calls — NOT the global fetch. (It returns a serializable object so the call can be recorded/replayed by run_step's cassette, and it keeps secrets out of your code path.)
-    - ctx.services.secrets.get("ENV_NAME") — read an API key / token. Use this for ALL credentials — NOT process.env. (Secrets read this way are automatically scrubbed from recorded cassettes.)
+    - ctx.services.secrets.get("ENV_NAME") — read an API key / token. Use this for ALL credentials — NOT process.env. (Secrets read this way are automatically scrubbed from recorded cassettes.) Call list_secrets to see which credential NAMES already exist; reference an existing name, and if the one you need is missing, tell the user to add it in the Secrets dialog (you can never see the value).
   So a typical REST adapter is: const key = await ctx.services.secrets.get("STRIPE_KEY"); const res = await ctx.services.http("https://api.stripe.com/v1/charges", { query: { customer: cfg.customer }, headers: { authorization: \`Bearer \${key}\` } }); return { charges: res.body.data };
   The built-in "http" step is the canonical example — call get_step("http") to read its source and mirror how it uses ctx.services.http.
 - Prefer raw REST via ctx.services.http — you rarely need a vendor SDK (it's just a wrapper over REST, and an SDK does its own networking so it can't be recorded/replayed). Only import a package other than "vein" if the deployment has pre-installed it (a vendor SDK with gnarly auth); otherwise the step will fail to load. If you're unsure what else is on ctx.services, call get_step on an existing custom step and mirror how it uses ctx.services.
@@ -115,6 +122,7 @@ Tools:
 - list_steps("<path>"): browse step types as a filesystem (steps, steps/core, steps/lib/<ns>, steps/custom).
 - search_steps("keywords"): keyword search across all step types.
 - get_step("<type>"): full schema + (for lib/custom) source code. Always call before using a type.
+- list_secrets(): NAMES of credentials in the deployment's secret store (never values). Call before authoring a step that needs auth — reference an existing name in ctx.services.secrets.get("NAME"), or tell the user to add a missing one.
 - create_step / edit_step: author or revise a custom step (see above).
 - run_step("<type>", config?, input?, params?, cassette?, cassetteName?): run ONE step in isolation and get its output — the inner loop for authoring an adapter, no workflow needed. After create_step, call run_step to test it. Use cassette:"record" for the first live run (captures external calls to a fixture, secrets scrubbed), then cassette:"replay" to iterate offline (deterministic, no rate limits, no side effects) while you edit_step.
 - list_workflows(): list existing workflows (name, active version, versions, description). Check this before creating a new workflow or referencing one in a subflow.
@@ -128,7 +136,7 @@ Workflow:
 2. Call get_step for EVERY step type you will use. Each has a description with the exact YAML config format — you MUST read it before writing. Do not guess config fields.
 3. If a needed step doesn't exist, author it with create_step (or edit_step to revise one), then it's available by its type. For a step that hits an external API, test it in isolation with run_step BEFORE wiring it into a workflow: run_step(type, config, cassette:"record") once to capture a fixture, then run_step(..., cassette:"replay") + edit_step to iterate offline until the output is right.
 4. Call create_workflow with the final YAML (or edit_workflow to publish a new version of an existing workflow — get_workflow to read it first).
-5. Call run_workflow with a sample input to test it. Report the result (success/error, output, or which step failed) to the user.
+5. Call run_workflow with a sample input to test it — pass "input" as a JSON OBJECT (e.g. { "owner": "vercel", "repo": "next.js", "pull_number": 1 }), NOT a JSON string. Report the result (success/error, output, or which step failed) to the user.
 6. To debug a failure or inspect prior behavior, use list_runs + get_run. To build on or reference existing workflows, use list_workflows + get_workflow first.
 
 Be concise. Don't over-explain.`;

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -42,6 +42,22 @@ function slimEvent(e: RunEvent) {
 
 // ── Tools ──────────────────────────────────────────────────────────────────
 
+/** LLMs sometimes pass an object-valued tool arg as a JSON *string* (e.g.
+ *  run_workflow's `input`). The template engine then sees a string, so
+ *  `{{ input.owner }}` resolves to undefined and every field fails validation.
+ *  Defensively parse a JSON string back into the object/array it represents;
+ *  leave anything else untouched. */
+function coerceJsonArg(v: unknown): unknown {
+  if (typeof v !== "string") return v;
+  const t = v.trim();
+  if (!(t.startsWith("{") || t.startsWith("["))) return v;
+  try {
+    return JSON.parse(t);
+  } catch {
+    return v;
+  }
+}
+
 export function buildTools(deps: AiDeps) {
   return {
     list_steps: tool({
@@ -86,6 +102,19 @@ export function buildTools(deps: AiDeps) {
         const source = await readStepSource(type, deps);
 
         return { type, description: def.description, fields, source };
+      },
+    }),
+
+    list_secrets: tool({
+      description:
+        "List the NAMES of credentials available in the deployment's secret store (e.g. GITHUB_TOKEN, GOOGLE_SERVICE_ACCOUNT_JSON). Returns names + metadata ONLY — never the secret values. Use this before authoring a step that needs auth: reference an existing name in ctx.services.secrets.get(\"NAME\"), and if the credential you need isn't listed, tell the user to add it via the Secrets dialog (the value is never visible to you).",
+      inputSchema: z.object({}),
+      execute: async () => {
+        if (!deps.secrets) {
+          return { error: "Secret store is not available in this deployment." };
+        }
+        const secrets = await deps.secrets.list();
+        return { secrets: secrets.map((s) => ({ name: s.name, updatedAt: s.updatedAt })) };
       },
     }),
 
@@ -307,7 +336,7 @@ export function buildTools(deps: AiDeps) {
           .any()
           .optional()
           .describe(
-            "Input object passed to the workflow (the run subject — e.g. PR number, repo). Shape depends on the workflow's input schema; use {} if none.",
+            "Input passed to the workflow as a JSON OBJECT (not a string), referenced in step configs via {{ input.* }} — the run subject, e.g. { owner, repo, pull_number }. Use {} if none.",
           ),
         params: z
           .record(z.any())
@@ -333,11 +362,11 @@ export function buildTools(deps: AiDeps) {
           };
         }
 
-        const result = await runWorkflow(flow, input ?? {}, deps.registry, {
+        const result = await runWorkflow(flow, coerceJsonArg(input) ?? {}, deps.registry, {
           store: deps.store,
           workspace: deps.workspace,
           services: deps.services,
-          params,
+          params: coerceJsonArg(params) as Record<string, unknown> | undefined,
         });
 
         return result;
@@ -376,9 +405,9 @@ export function buildTools(deps: AiDeps) {
         const registry = deps.registry;
         if (!registry[type]) return { error: `Step type "${type}" not found` };
         return runSingleStep(type, registry, deps.services, {
-          config,
-          input,
-          params,
+          config: coerceJsonArg(config) as Record<string, unknown> | undefined,
+          input: coerceJsonArg(input),
+          params: coerceJsonArg(params) as Record<string, unknown> | undefined,
           workspace: deps.workspace,
           ...(cassette
             ? { cassette: { mode: cassette, path: cassettePath(deps.workspace.path, cassetteName ?? type) } }

--- a/vein/src/capabilities.ts
+++ b/vein/src/capabilities.ts
@@ -20,20 +20,46 @@
 // ── secrets ────────────────────────────────────────────────────────────────
 
 /** Credential access. The single boundary through which adapters read secrets
- *  (API keys, tokens). Backed by `process.env` by default; swap the `source`
- *  for a real secret store later without touching any adapter. */
+ *  (API keys, tokens). Backed by `process.env` by default; back it with a
+ *  persisted {@link SecretReadable} (e.g. a `SecretStore`) for UI-managed
+ *  secrets — without touching any adapter. */
 export interface SecretsCapability {
   get(name: string): Promise<string | undefined>;
 }
 
-/** Build a secrets capability over a flat key→value source (defaults to
- *  `process.env`). */
+/** The narrow read surface a secrets capability needs from a backing store —
+ *  satisfied by `SecretStore` (secret-store.ts) without importing it here. */
+export interface SecretReadable {
+  get(name: string): Promise<string | undefined>;
+}
+
+/**
+ * Build a secrets capability. Pass either:
+ *   - a flat key→value source (defaults to `process.env`), or
+ *   - a `SecretReadable` store (e.g. a `SecretStore`), optionally with an
+ *     `envFallback` so unset secrets still resolve from `process.env`.
+ *
+ * The store path is async-aware: a managed secret wins, then the env fallback.
+ */
 export function secretsCapability(
-  source: Record<string, string | undefined> = process.env,
+  source: Record<string, string | undefined> | SecretReadable = process.env,
+  opts: { envFallback?: Record<string, string | undefined> } = {},
 ): SecretsCapability {
+  if (typeof (source as SecretReadable).get === "function") {
+    const store = source as SecretReadable;
+    const fallback = opts.envFallback;
+    return {
+      async get(name: string) {
+        const v = await store.get(name);
+        if (v !== undefined) return v;
+        return fallback?.[name];
+      },
+    };
+  }
+  const flat = source as Record<string, string | undefined>;
   return {
     async get(name: string) {
-      return source[name];
+      return flat[name];
     },
   };
 }
@@ -167,13 +193,22 @@ export interface VeinCapabilities {
   secrets: SecretsCapability;
 }
 
-/** The default standard services bag: env-backed secrets + global-fetch http.
- *  Injected by the standard server; override per environment as needed. */
+/** The default standard services bag: global-fetch http + secrets. Secrets are
+ *  env-backed by default; pass `secretStore` for a persisted (UI-managed) store
+ *  with `process.env` as fallback. Injected by the standard server; override
+ *  per environment as needed. */
 export function standardServices(
-  opts: { fetchImpl?: FetchLike; secretsSource?: Record<string, string | undefined> } = {},
+  opts: {
+    fetchImpl?: FetchLike;
+    secretsSource?: Record<string, string | undefined>;
+    secretStore?: SecretReadable;
+  } = {},
 ): VeinCapabilities {
+  const secrets = opts.secretStore
+    ? secretsCapability(opts.secretStore, { envFallback: process.env })
+    : secretsCapability(opts.secretsSource);
   return {
     http: httpCapability(opts.fetchImpl),
-    secrets: secretsCapability(opts.secretsSource),
+    secrets,
   };
 }

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -24,6 +24,12 @@ import type { StepSources } from "./steps/registry.js";
 import { runWorkflow } from "./runner.js";
 import { requireApiKey, warnIfUnconfigured } from "./auth.js";
 import { standardServices } from "./capabilities.js";
+import type { SecretStore } from "./secret-store.js";
+import {
+  FileSecretStore,
+  MemorySecretStore,
+  isValidSecretName,
+} from "./secret-store.js";
 import { runSingleStep, cassettePath } from "./run-step.js";
 import type { CassetteMode } from "./cassette.js";
 
@@ -71,6 +77,14 @@ export interface VeinOptions<TServices = unknown> {
    *  `store` is a `MemoryRunStore`). */
   chatStore?: ChatStore;
 
+  /** Deployment-scoped secret store backing `ctx.services.secrets` and the
+   *  `/secrets` admin endpoints. Defaults to an encrypted `FileSecretStore`
+   *  rooted at the workspace path (or `MemorySecretStore` when `store` is a
+   *  `MemoryRunStore`). The default `secrets` capability reads this store with
+   *  `process.env` as fallback. Pass your own `services.secrets` to bypass
+   *  entirely (then the `/secrets` endpoints return 501). */
+  secretStore?: SecretStore;
+
   /** Max agent steps (tool-call iterations) per chat turn. Raise for longer
    *  autonomous "let it rip" loops. Defaults to `VEIN_CHAT_MAX_STEPS` or 30. */
   chatMaxSteps?: number;
@@ -99,6 +113,9 @@ export interface Vein<TServices = unknown> {
   app: Hono;
   workspace: WorkspaceManager;
   store: RunStore;
+  /** Deployment-scoped secret store backing `ctx.services.secrets` + the
+   *  `/secrets` endpoints. */
+  secretStore: SecretStore;
   services: TServices;
 
   /** Current registry. Reads through the closure so callers always see
@@ -252,12 +269,27 @@ export async function createVein<TServices = unknown>(
   // restart / crash / cancellation) and is reported as "stale" rather than a
   // perpetual "running".
   const activeRuns = new Set<string>();
+  // Deployment-scoped secret store backing the `secrets` capability + the
+  // `/secrets` admin endpoints. Mirrors the run/chat store defaults: encrypted
+  // file store for the standard server, in-memory when runs are in-memory.
+  const secretStore: SecretStore =
+    opts.secretStore ??
+    (store instanceof FileRunStore
+      ? new FileSecretStore(workspace.path)
+      : new MemorySecretStore());
+  // Did the consumer inject their own `secrets` capability? If so we leave it
+  // alone and the `/secrets` endpoints (which manage *our* store) report 501.
+  const secretsInjected =
+    opts.services != null &&
+    typeof (opts.services as Record<string, unknown>)["secrets"] === "object";
   // Auto-provide the standard capabilities (http + secrets) every adapter step
   // builds on, with the consumer's bag spread on top so they can override or
-  // extend any capability. This is what lets an LLM-authored adapter rely on
-  // `ctx.services.http` / `ctx.services.secrets` existing out of the box.
+  // extend any capability. The default `secrets` capability reads the secret
+  // store (UI-managed) with `process.env` as fallback. This is what lets an
+  // LLM-authored adapter rely on `ctx.services.http` / `ctx.services.secrets`
+  // existing out of the box.
   const services = {
-    ...(standardServices() as unknown as Record<string, unknown>),
+    ...(standardServices({ secretStore }) as unknown as Record<string, unknown>),
     ...((opts.services ?? {}) as Record<string, unknown>),
   } as TServices;
   const serveUi = opts.serveUi ?? true;
@@ -587,6 +619,50 @@ export async function createVein<TServices = unknown>(
     }
   });
 
+  // ── Secrets ──────────────────────────────────────────────────────────────
+  // Deployment-scoped credential store behind `ctx.services.secrets`. Values
+  // are write-only over the API: GET returns NAMES + metadata only, never the
+  // value. All routes are gated by `VEIN_API_KEY` (permissive in dev mode).
+  // 501 when the consumer injected their own `secrets` capability (we don't
+  // own that store).
+
+  app.get("/secrets", requireApiKey, async (c) => {
+    if (secretsInjected) {
+      return c.json({ error: "secrets are managed by an injected capability" }, 501);
+    }
+    return c.json({ secrets: await secretStore.list() });
+  });
+
+  app.put("/secrets/:name", requireApiKey, async (c) => {
+    if (secretsInjected) {
+      return c.json({ error: "secrets are managed by an injected capability" }, 501);
+    }
+    const name = c.req.param("name");
+    if (!name || !isValidSecretName(name)) {
+      return c.json(
+        { error: `invalid secret name "${name}" — use letters, digits, underscore (not starting with a digit)` },
+        400,
+      );
+    }
+    const body = await c.req.json<{ value?: unknown }>().catch(() => ({ value: undefined }));
+    if (typeof body.value !== "string" || body.value.length === 0) {
+      return c.json({ error: "value (non-empty string) is required" }, 400);
+    }
+    await secretStore.set(name, body.value);
+    return c.json({ ok: true, name });
+  });
+
+  app.delete("/secrets/:name", requireApiKey, async (c) => {
+    if (secretsInjected) {
+      return c.json({ error: "secrets are managed by an injected capability" }, 501);
+    }
+    const name = c.req.param("name");
+    if (!name) return c.json({ error: "secret name is required" }, 400);
+    const existed = await secretStore.delete(name);
+    if (!existed) return c.json({ error: `secret "${name}" not found` }, 404);
+    return c.json({ ok: true, name });
+  });
+
   // ── Steps ────────────────────────────────────────────────────────────────
 
   app.get("/steps", async (c) => {
@@ -853,6 +929,7 @@ export async function createVein<TServices = unknown>(
             registry,
             store,
             services,
+            secrets: secretsInjected ? undefined : secretStore,
             publishingEnabled: !registryWasInjected,
             getRegistry: async () => {
               if (registryWasInjected) return registry;
@@ -1085,6 +1162,7 @@ export async function createVein<TServices = unknown>(
     app,
     workspace,
     store,
+    secretStore,
     services,
     getRegistry: () => registry,
     rebuildRegistry,

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -109,8 +109,19 @@ export {
   type HttpRequestOptions,
   type HttpResponse,
   type SecretsCapability,
+  type SecretReadable,
   type FetchLike,
 } from "./capabilities.js";
+
+// Secret store — deployment-scoped, encrypted credential persistence behind
+// the `secrets` capability + the `/secrets` admin endpoints.
+export {
+  type SecretStore,
+  type SecretInfo,
+  FileSecretStore,
+  MemorySecretStore,
+  isValidSecretName,
+} from "./secret-store.js";
 
 // Record/replay for the services bag (the adapter "safe inner loop").
 export {

--- a/vein/src/secret-store.test.ts
+++ b/vein/src/secret-store.test.ts
@@ -1,0 +1,231 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, rm, readFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+
+import {
+  FileSecretStore,
+  MemorySecretStore,
+  isValidSecretName,
+} from "./secret-store.js";
+import { secretsCapability } from "./capabilities.js";
+import { createVein } from "./createVein.js";
+import { WorkspaceManager } from "./workspace.js";
+import { MemoryRunStore } from "./store.js";
+
+// ── name validation ─────────────────────────────────────────────────────────
+
+describe("isValidSecretName", () => {
+  it("accepts env-var-style names", () => {
+    assert.ok(isValidSecretName("GITHUB_TOKEN"));
+    assert.ok(isValidSecretName("_x"));
+    assert.ok(isValidSecretName("a1_b2"));
+  });
+  it("rejects invalid names", () => {
+    assert.ok(!isValidSecretName("1leading"));
+    assert.ok(!isValidSecretName("has-dash"));
+    assert.ok(!isValidSecretName("has space"));
+    assert.ok(!isValidSecretName("dot.name"));
+    assert.ok(!isValidSecretName(""));
+  });
+});
+
+// ── MemorySecretStore ───────────────────────────────────────────────────────
+
+describe("MemorySecretStore", () => {
+  it("set / get / delete / list round-trips", async () => {
+    const s = new MemorySecretStore();
+    assert.equal(await s.get("A"), undefined);
+
+    await s.set("A", "secret-a");
+    await s.set("B", "secret-b");
+    assert.equal(await s.get("A"), "secret-a");
+
+    const list = await s.list();
+    assert.deepEqual(
+      list.map((x) => x.name),
+      ["A", "B"],
+    );
+    // list never leaks values
+    assert.ok(!JSON.stringify(list).includes("secret-a"));
+
+    assert.equal(await s.delete("A"), true);
+    assert.equal(await s.delete("A"), false);
+    assert.equal(await s.get("A"), undefined);
+  });
+
+  it("preserves createdAt across overwrite, bumps updatedAt", async () => {
+    const s = new MemorySecretStore();
+    await s.set("K", "v1");
+    const [first] = await s.list();
+    await new Promise((r) => setTimeout(r, 5));
+    await s.set("K", "v2");
+    const [second] = await s.list();
+    assert.equal(await s.get("K"), "v2");
+    assert.equal(first.createdAt, second.createdAt);
+    assert.notEqual(first.updatedAt, second.updatedAt);
+  });
+
+  it("rejects invalid names on set", async () => {
+    const s = new MemorySecretStore();
+    await assert.rejects(() => s.set("bad-name", "x"), /invalid secret name/);
+  });
+});
+
+// ── FileSecretStore ─────────────────────────────────────────────────────────
+
+describe("FileSecretStore", () => {
+  let tempDir: string;
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `vein-secrets-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("persists encrypted; plaintext never hits disk; round-trips across instances", async () => {
+    const a = new FileSecretStore(tempDir);
+    await a.set("API_KEY", "super-secret-value");
+
+    // A fresh instance reads the same persisted value (decrypts correctly).
+    const b = new FileSecretStore(tempDir);
+    assert.equal(await b.get("API_KEY"), "super-secret-value");
+
+    // The on-disk file must NOT contain the plaintext.
+    const raw = await readFile(join(tempDir, "secrets.json"), "utf-8");
+    assert.ok(!raw.includes("super-secret-value"), "value must be encrypted at rest");
+    assert.ok(raw.includes("API_KEY"), "name is stored in clear (it's not the secret)");
+  });
+
+  it("list returns names + metadata only, no values", async () => {
+    const s = new FileSecretStore(tempDir);
+    await s.set("TOK", "abc123");
+    const list = await s.list();
+    assert.equal(list.length, 1);
+    assert.equal(list[0].name, "TOK");
+    assert.ok(!JSON.stringify(list).includes("abc123"));
+  });
+});
+
+// ── secretsCapability over a store ──────────────────────────────────────────
+
+describe("secretsCapability (store-backed)", () => {
+  it("reads store first, falls back to env", async () => {
+    const store = new MemorySecretStore();
+    await store.set("FROM_STORE", "store-val");
+    const cap = secretsCapability(store, {
+      envFallback: { FROM_ENV: "env-val", FROM_STORE: "should-not-win" },
+    });
+    assert.equal(await cap.get("FROM_STORE"), "store-val");
+    assert.equal(await cap.get("FROM_ENV"), "env-val");
+    assert.equal(await cap.get("MISSING"), undefined);
+  });
+
+  it("still supports a flat source (back-compat)", async () => {
+    const cap = secretsCapability({ X: "1" });
+    assert.equal(await cap.get("X"), "1");
+    assert.equal(await cap.get("Y"), undefined);
+  });
+});
+
+// ── /secrets endpoints ──────────────────────────────────────────────────────
+
+describe("/secrets endpoints", () => {
+  let tempDir: string;
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `vein-secrets-api-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  async function makeVein() {
+    return createVein({
+      workspace: new WorkspaceManager(tempDir),
+      store: new MemoryRunStore(),
+      secretStore: new MemorySecretStore(),
+      serveUi: false,
+      enableChat: false,
+    });
+  }
+
+  it("PUT then GET returns names only (never the value)", async () => {
+    const vein = await makeVein();
+
+    const put = await vein.app.request("/secrets/GITHUB_TOKEN", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: "ghp_topsecret" }),
+    });
+    assert.equal(put.status, 200);
+
+    const get = await vein.app.request("/secrets");
+    assert.equal(get.status, 200);
+    const body = (await get.json()) as { secrets: { name: string }[] };
+    assert.deepEqual(
+      body.secrets.map((s) => s.name),
+      ["GITHUB_TOKEN"],
+    );
+    assert.ok(!JSON.stringify(body).includes("ghp_topsecret"));
+  });
+
+  it("the stored value is readable by the secrets capability", async () => {
+    const vein = await makeVein();
+    await vein.app.request("/secrets/MY_KEY", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: "v-123" }),
+    });
+    const svc = vein.services as { secrets: { get(n: string): Promise<string | undefined> } };
+    assert.equal(await svc.secrets.get("MY_KEY"), "v-123");
+  });
+
+  it("rejects an invalid name (400) and a missing value (400)", async () => {
+    const vein = await makeVein();
+
+    const badName = await vein.app.request("/secrets/bad-name", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: "x" }),
+    });
+    assert.equal(badName.status, 400);
+
+    const noValue = await vein.app.request("/secrets/GOOD", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({}),
+    });
+    assert.equal(noValue.status, 400);
+  });
+
+  it("DELETE removes a secret; deleting a missing one is 404", async () => {
+    const vein = await makeVein();
+    await vein.app.request("/secrets/TMP", {
+      method: "PUT",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ value: "x" }),
+    });
+
+    const del = await vein.app.request("/secrets/TMP", { method: "DELETE" });
+    assert.equal(del.status, 200);
+
+    const again = await vein.app.request("/secrets/TMP", { method: "DELETE" });
+    assert.equal(again.status, 404);
+  });
+
+  it("returns 501 when the consumer injected their own secrets capability", async () => {
+    const vein = await createVein({
+      workspace: new WorkspaceManager(tempDir),
+      store: new MemoryRunStore(),
+      services: { secrets: { async get() { return "injected"; } } },
+      serveUi: false,
+      enableChat: false,
+    });
+    const get = await vein.app.request("/secrets");
+    assert.equal(get.status, 501);
+  });
+});

--- a/vein/src/secret-store.ts
+++ b/vein/src/secret-store.ts
@@ -1,0 +1,227 @@
+/**
+ * Deployment-scoped secret store — the persistence behind the `secrets`
+ * capability (see `capabilities.ts`). Steps still read credentials through
+ * the read-only `ctx.services.secrets.get(name)` boundary (which keeps
+ * cassette scrubbing working); this module is the *admin* side that lets a
+ * UI / API create, list, and delete the values that boundary serves.
+ *
+ * Scope is deployment-global (one store per workspace), matching the
+ * `VEIN_API_KEY` single-trust-domain model — NOT per-user. The mutating
+ * endpoints are gated by `VEIN_API_KEY` (see `createVein.ts`).
+ *
+ * **At-rest encryption.** Values are encrypted with AES-256-GCM using a key
+ * derived (scrypt) from `VEIN_SECRET_KEY`. A random per-file salt is stored
+ * in the header. Without `VEIN_SECRET_KEY` set, a fixed dev passphrase is
+ * used and a one-time warning is logged — the on-disk file is then only
+ * obfuscated, not meaningfully protected. Set `VEIN_SECRET_KEY` in any real
+ * deployment.
+ */
+
+import {
+  createCipheriv,
+  createDecipheriv,
+  randomBytes,
+  scryptSync,
+} from "node:crypto";
+import { mkdir, readFile, writeFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+
+/** Metadata about a stored secret. Deliberately never includes the value —
+ *  `list()` and the `GET /secrets` endpoint return only this shape. */
+export interface SecretInfo {
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+/**
+ * Admin interface for managing secrets. The step-facing read path
+ * (`SecretsCapability.get`) is intentionally separate and narrower; build it
+ * over a store with `secretsCapability(store)` in `capabilities.ts`.
+ */
+export interface SecretStore {
+  /** Read a secret value (decrypted), or undefined if not set. */
+  get(name: string): Promise<string | undefined>;
+  /** Create or overwrite a secret. */
+  set(name: string, value: string): Promise<void>;
+  /** Delete a secret. Returns true if it existed. */
+  delete(name: string): Promise<boolean>;
+  /** List secret NAMES + metadata — never values. */
+  list(): Promise<SecretInfo[]>;
+}
+
+// ── name validation ──────────────────────────────────────────────────────
+
+/** Secret names are env-var-style identifiers: letters, digits, underscore,
+ *  not starting with a digit. Keeps them safe as keys + matches the
+ *  `secrets.get("NAME")` convention. */
+const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function isValidSecretName(name: string): boolean {
+  return NAME_RE.test(name);
+}
+
+export function assertValidSecretName(name: string): void {
+  if (!isValidSecretName(name)) {
+    throw new Error(
+      `invalid secret name "${name}" — use letters, digits, underscore (not starting with a digit)`,
+    );
+  }
+}
+
+// ── encryption helpers ───────────────────────────────────────────────────
+
+const ENV_KEY = "VEIN_SECRET_KEY";
+const DEV_PASSPHRASE = "vein-insecure-dev-key";
+let warnedNoKey = false;
+
+function passphrase(): string {
+  const v = process.env[ENV_KEY];
+  if (v && v.length > 0) return v;
+  if (!warnedNoKey) {
+    warnedNoKey = true;
+    console.warn(
+      `[vein] ${ENV_KEY} is not set — secrets are stored with a default key (obfuscated, NOT securely encrypted). Set ${ENV_KEY} in production.`,
+    );
+  }
+  return DEV_PASSPHRASE;
+}
+
+interface EncryptedValue {
+  iv: string;
+  tag: string;
+  ct: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface SecretsFile {
+  version: 1;
+  salt: string;
+  secrets: Record<string, EncryptedValue>;
+}
+
+function deriveKey(salt: Buffer): Buffer {
+  return scryptSync(passphrase(), salt, 32);
+}
+
+function encrypt(value: string, salt: Buffer): { iv: string; tag: string; ct: string } {
+  const key = deriveKey(salt);
+  const iv = randomBytes(12);
+  const cipher = createCipheriv("aes-256-gcm", key, iv);
+  const ct = Buffer.concat([cipher.update(value, "utf-8"), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return { iv: iv.toString("base64"), tag: tag.toString("base64"), ct: ct.toString("base64") };
+}
+
+function decrypt(enc: EncryptedValue, salt: Buffer): string {
+  const key = deriveKey(salt);
+  const decipher = createDecipheriv("aes-256-gcm", key, Buffer.from(enc.iv, "base64"));
+  decipher.setAuthTag(Buffer.from(enc.tag, "base64"));
+  const pt = Buffer.concat([
+    decipher.update(Buffer.from(enc.ct, "base64")),
+    decipher.final(),
+  ]);
+  return pt.toString("utf-8");
+}
+
+// ── filesystem implementation ────────────────────────────────────────────
+
+/** Filesystem-backed, encrypted secret store. Persists a single
+ *  `<workspace>/secrets.json` with a random per-file salt + AES-256-GCM
+ *  values. The default for the standard server. */
+export class FileSecretStore implements SecretStore {
+  private file: string;
+  private cache: SecretsFile | null = null;
+
+  constructor(workspaceRoot: string) {
+    this.file = join(workspaceRoot, "secrets.json");
+  }
+
+  private async load(): Promise<SecretsFile> {
+    if (this.cache) return this.cache;
+    try {
+      const raw = await readFile(this.file, "utf-8");
+      this.cache = JSON.parse(raw) as SecretsFile;
+    } catch {
+      this.cache = { version: 1, salt: randomBytes(16).toString("base64"), secrets: {} };
+    }
+    return this.cache;
+  }
+
+  private async save(data: SecretsFile): Promise<void> {
+    this.cache = data;
+    await mkdir(dirname(this.file), { recursive: true });
+    await writeFile(this.file, JSON.stringify(data, null, 2), "utf-8");
+  }
+
+  async get(name: string): Promise<string | undefined> {
+    const data = await this.load();
+    const enc = data.secrets[name];
+    if (!enc) return undefined;
+    return decrypt(enc, Buffer.from(data.salt, "base64"));
+  }
+
+  async set(name: string, value: string): Promise<void> {
+    assertValidSecretName(name);
+    const data = await this.load();
+    const salt = Buffer.from(data.salt, "base64");
+    const now = new Date().toISOString();
+    const existing = data.secrets[name];
+    data.secrets[name] = {
+      ...encrypt(value, salt),
+      createdAt: existing?.createdAt ?? now,
+      updatedAt: now,
+    };
+    await this.save(data);
+  }
+
+  async delete(name: string): Promise<boolean> {
+    const data = await this.load();
+    if (!(name in data.secrets)) return false;
+    delete data.secrets[name];
+    await this.save(data);
+    return true;
+  }
+
+  async list(): Promise<SecretInfo[]> {
+    const data = await this.load();
+    return Object.entries(data.secrets)
+      .map(([name, v]) => ({ name, createdAt: v.createdAt, updatedAt: v.updatedAt }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+}
+
+// ── in-memory implementation (tests / ephemeral) ──────────────────────────
+
+/** In-memory secret store. No encryption (nothing hits disk). For tests and
+ *  ephemeral / library usage. */
+export class MemorySecretStore implements SecretStore {
+  private map = new Map<string, { value: string; createdAt: string; updatedAt: string }>();
+
+  async get(name: string): Promise<string | undefined> {
+    return this.map.get(name)?.value;
+  }
+
+  async set(name: string, value: string): Promise<void> {
+    assertValidSecretName(name);
+    const now = new Date().toISOString();
+    const existing = this.map.get(name);
+    this.map.set(name, { value, createdAt: existing?.createdAt ?? now, updatedAt: now });
+  }
+
+  async delete(name: string): Promise<boolean> {
+    return this.map.delete(name);
+  }
+
+  async list(): Promise<SecretInfo[]> {
+    return [...this.map.entries()]
+      .map(([name, v]) => ({ name, createdAt: v.createdAt, updatedAt: v.updatedAt }))
+      .sort((a, b) => a.name.localeCompare(b.name));
+  }
+}
+
+/** Test-only: reset the one-time no-key warning so tests stay deterministic. */
+export function _resetSecretWarning(): void {
+  warnedNoKey = false;
+}

--- a/vein/src/steps/lib/gdrive/export-file.ts
+++ b/vein/src/steps/lib/gdrive/export-file.ts
@@ -1,0 +1,134 @@
+import { z } from "zod";
+import { defineStep, type StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+
+const EXAMPLE = `- id: doc
+  type: gdrive/export-file
+  config:
+    fileId: "1AbCdEfGhIjKlMnOpQrStUvWxYz"
+    accessToken: "{{ input.googleAccessToken }}"`;
+
+// Default export format per Google-native ("application/vnd.google-apps.*")
+// type. Anything not listed here falls back to text/plain; non-Google files
+// are downloaded as-is via alt=media. Override with `exportMimeType`.
+const EXPORT_MIME: Record<string, string> = {
+  "application/vnd.google-apps.document": "text/markdown",
+  "application/vnd.google-apps.spreadsheet": "text/csv",
+  "application/vnd.google-apps.presentation": "text/plain",
+  "application/vnd.google-apps.script": "application/vnd.google-apps.script+json",
+};
+
+const GOOGLE_NATIVE_PREFIX = "application/vnd.google-apps";
+const DEFAULT_NATIVE_EXPORT = "text/plain";
+const DRIVE_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly";
+
+export default defineStep({
+  type: "gdrive/export-file",
+  description: `Fetch a Google Drive file and return its text content for LLM consumption. Google-native files (Docs → markdown, Sheets → CSV, Slides → text) are exported; other files are downloaded as-is. Auth: pass an OAuth \`accessToken\`, else falls back to Application Default Credentials (e.g. a service account via GOOGLE_APPLICATION_CREDENTIALS). Output: { content, truncated, file: { id, name, mimeType, modifiedTime, size, webViewLink } }.\n\n${EXAMPLE}`,
+  input: z.object({
+    fileId: z.string().min(1),
+    accessToken: z.string().optional(),
+    /** Override the export MIME type for Google-native files. Ignored for
+     *  non-Google files (which are always downloaded as-is). */
+    exportMimeType: z.string().optional(),
+    /** Truncate content to this many characters (LLM token hygiene). */
+    maxChars: z.number().int().positive().default(50000),
+  }),
+  output: z.object({
+    content: z.string(),
+    truncated: z.boolean(),
+    file: z.object({
+      id: z.string(),
+      name: z.string(),
+      mimeType: z.string(),
+      modifiedTime: z.string().nullable(),
+      size: z.number().nullable(),
+      webViewLink: z.string().nullable(),
+    }),
+  }),
+  async run(cfg, ctx: StepContext<VeinCapabilities>) {
+    // Lazy-load the SDK inside run() so the heavy dep is only pulled into
+    // memory when this step actually executes — not at registry-build time.
+    // See AGENTS.md "Lib step dependency convention".
+    const { drive, auth } = await import("@googleapis/drive");
+
+    // Credentials flow through the secrets capability (UI-managed store → env
+    // fallback) so they're cassette-scrubbed; explicit config always wins.
+    // See AGENTS.md "Lib step credentials".
+    const secrets = ctx?.services?.secrets;
+    const token =
+      cfg.accessToken ?? (await secrets?.get("GOOGLE_ACCESS_TOKEN"));
+    const saJson = await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON");
+
+    let authClient;
+    if (token) {
+      const oauth = new auth.OAuth2();
+      oauth.setCredentials({ access_token: token });
+      authClient = oauth;
+    } else if (saJson) {
+      // A pasted service-account JSON key (no expiry — the recommended setup).
+      authClient = new auth.GoogleAuth({
+        credentials: JSON.parse(saJson),
+        scopes: [DRIVE_READONLY_SCOPE],
+      });
+    } else {
+      // Application Default Credentials (e.g. GOOGLE_APPLICATION_CREDENTIALS).
+      authClient = new auth.GoogleAuth({ scopes: [DRIVE_READONLY_SCOPE] });
+    }
+
+    const client = drive({ version: "v3", auth: authClient });
+
+    const { data: meta } = await client.files.get({
+      fileId: cfg.fileId,
+      fields: "id,name,mimeType,modifiedTime,size,webViewLink",
+      supportsAllDrives: true,
+    });
+
+    const mimeType = meta.mimeType ?? "application/octet-stream";
+    const isNative = mimeType.startsWith(GOOGLE_NATIVE_PREFIX);
+
+    let raw: unknown;
+    if (isNative) {
+      const exportMime =
+        cfg.exportMimeType ?? EXPORT_MIME[mimeType] ?? DEFAULT_NATIVE_EXPORT;
+      ({ data: raw } = await client.files.export({
+        fileId: cfg.fileId,
+        mimeType: exportMime,
+      }));
+    } else {
+      ({ data: raw } = await client.files.get({
+        fileId: cfg.fileId,
+        alt: "media",
+        supportsAllDrives: true,
+      }));
+    }
+
+    const full = coerceText(raw);
+    const truncated = full.length > cfg.maxChars;
+    const content = truncated
+      ? `${full.slice(0, cfg.maxChars)}\n\n... [truncated ${full.length - cfg.maxChars} characters]`
+      : full;
+
+    return {
+      content,
+      truncated,
+      file: {
+        id: meta.id ?? cfg.fileId,
+        name: meta.name ?? "unknown",
+        mimeType,
+        modifiedTime: meta.modifiedTime ?? null,
+        size: meta.size != null ? Number(meta.size) : null,
+        webViewLink: meta.webViewLink ?? null,
+      },
+    };
+  },
+});
+
+/** Coerce a Drive export/download body into a string. Text exports come back
+ *  as a string already; structured bodies are JSON-stringified as a fallback. */
+function coerceText(data: unknown): string {
+  if (typeof data === "string") return data;
+  if (data == null) return "";
+  if (data instanceof Uint8Array) return Buffer.from(data).toString("utf-8");
+  return JSON.stringify(data);
+}

--- a/vein/src/steps/lib/github/fetch-pr.ts
+++ b/vein/src/steps/lib/github/fetch-pr.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
-import { Octokit } from "@octokit/rest";
-import { defineStep } from "../../../core.js";
+import { defineStep, type StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
 
 const EXAMPLE = `- id: pr
   type: github/fetch-pr
@@ -46,8 +46,16 @@ export default defineStep({
       changedFiles: z.number(),
     }),
   }),
-  async run(cfg) {
-    const auth = cfg.token ?? process.env["GITHUB_TOKEN"];
+  async run(cfg, ctx: StepContext<VeinCapabilities>) {
+    // Lazy-load the SDK inside run() so the heavy dep is only pulled into
+    // memory when this step actually executes — not at registry-build time.
+    // See AGENTS.md "Lib step dependency convention".
+    const { Octokit } = await import("@octokit/rest");
+    // Credentials flow through the secrets capability (UI-managed store → env
+    // fallback) so they're cassette-scrubbed; explicit config always wins.
+    // See AGENTS.md "Lib step credentials".
+    const auth =
+      cfg.token ?? (await ctx?.services?.secrets?.get("GITHUB_TOKEN"));
     const octokit = new Octokit(auth ? { auth } : {});
 
     const prInfo = {

--- a/vein/src/steps/registry.test.ts
+++ b/vein/src/steps/registry.test.ts
@@ -43,10 +43,11 @@ describe("buildRegistry", () => {
   it("tags lib steps (shipped under src/steps/lib) with source: lib", async () => {
     const { registry, sources } = await buildRegistry(tempDir);
 
-    // github/fetch-pr is currently the only shipped lib step. If lib steps
-    // change, this test should adapt — but at minimum we expect anything
-    // not in CORE_STEP_TYPES to be either "lib" or "custom", and there
-    // should be at least one "lib" entry to validate the tagging works.
+    // Shipped lib steps live under src/steps/lib (e.g. github/fetch-pr,
+    // gdrive/export-file). If lib steps change, this test should adapt —
+    // but at minimum we expect anything not in CORE_STEP_TYPES to be either
+    // "lib" or "custom", and there should be at least one "lib" entry to
+    // validate the tagging works.
     const libEntries = Object.entries(sources).filter(([, s]) => s === "lib");
     assert.ok(
       libEntries.length > 0,

--- a/vein/src/steps/registry.ts
+++ b/vein/src/steps/registry.ts
@@ -178,8 +178,10 @@ async function loadStepFile(filePath: string): Promise<AnyStepDef | null> {
  * Resolution order: core/ → lib/ → custom/. Higher tiers cannot shadow
  * lower ones — a name collision is skipped with a warning.
  *
- * Lib and custom steps are loaded with dynamic `import()` so their
- * dependencies are only resolved when actually used.
+ * Lib and custom step *files* are loaded with dynamic `import()` at
+ * build time (cheap: just schema + metadata). Their heavy SDK deps must
+ * be `await import()`-ed inside `run()` so they only load when a step
+ * actually executes — see AGENTS.md "Lib step dependency convention".
  *
  * Returns both the registry and a parallel `sources` map so callers can
  * report which tier each step came from without guessing from the name.
@@ -250,8 +252,10 @@ export function coreRegistry(): StepRegistry {
  *   - **core/** — 8 built-in steps (http, log, if, loop, foreach,
  *     subflow, llm, wait)
  *   - **lib/** — engine-shipped domain integrations (e.g.
- *     `github/fetch-pr`). These are dynamically imported, so their
- *     deps are only resolved at registry-build time.
+ *     `github/fetch-pr`). Their step *files* are imported here (cheap:
+ *     just schema + metadata); their heavy SDK deps are `await import()`-ed
+ *     inside `run()`, so they only load when a step actually executes.
+ *     See AGENTS.md "Lib step dependency convention".
  *   - whatever you pass in `steps`
  *
  * Workspace **custom/** steps live on disk and are loaded via

--- a/vein/src/workspace.test.ts
+++ b/vein/src/workspace.test.ts
@@ -69,6 +69,42 @@ describe("WorkspaceManager", () => {
       assert.equal(content, SAMPLE_YAML);
     });
 
+    it("rejects an unquoted template value with a clear error", async () => {
+      const badYaml = `name: bad
+steps:
+  - id: fetch
+    type: github/fetch-pr
+    config:
+      pull_number: {{ input.pull_number }}
+`;
+      await assert.rejects(
+        () => ws.publishWorkflow("bad", "v1", badYaml),
+        /unquoted template|wrap/i,
+      );
+    });
+
+    it("accepts a quoted template value (and {{ }} inside block scalars)", async () => {
+      const goodYaml = `name: good
+steps:
+  - id: fetch
+    type: github/fetch-pr
+    config:
+      pull_number: "{{ input.pull_number }}"
+  - id: result
+    type: log
+    config:
+      message: |
+        PR #{{ fetch.pr.number }}: {{ fetch.pr.title }}
+`;
+      // Must NOT throw — the block-scalar {{ }} is content, not a YAML value.
+      await ws.publishWorkflow("good", "v1", goodYaml);
+      const content = await readFile(
+        join(tempDir, "workflows", "good", "v1.yaml"),
+        "utf-8",
+      );
+      assert.ok(content.includes('"{{ input.pull_number }}"'));
+    });
+
     it("adds a second version and sets it active", async () => {
       await ws.publishWorkflow("deploy", "v1", { steps: SAMPLE_STEPS }, "first");
       await ws.publishWorkflow("deploy", "v2", { steps: SAMPLE_STEPS }, "second");

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -12,6 +12,42 @@ import { evaluateExpr } from "./expr.js";
 const PARAM_SELF_REF = /\{\{\s*(params(?:\.[\w$]+|\[[^\]]+\])+)\s*\}\}/g;
 
 /**
+ * Validate a workflow's YAML before it's published. Catches the single most
+ * common authoring footgun: an **unquoted** template value, e.g.
+ *
+ *   pull_number: {{ input.pull_number }}     # WRONG
+ *
+ * A leading `{{` is parsed by YAML as a flow-mapping, so the value silently
+ * becomes an object (which stringifies to `[object Object]`) instead of the
+ * template string. Downstream this surfaces as a baffling "expected number,
+ * received object". We detect it on the PARSED structure (so we don't false-
+ * positive on `{{ }}` inside block-scalar message bodies) and throw a clear,
+ * actionable error pointing at the fix: quote the template.
+ */
+function assertValidWorkflowYaml(yamlStr: string): void {
+  let parsed: unknown;
+  try {
+    parsed = yaml.load(yamlStr);
+  } catch (err) {
+    throw new Error(
+      `Invalid workflow YAML: ${err instanceof Error ? err.message : String(err)}. ` +
+        `A common cause is an unquoted template — always wrap templates in quotes, ` +
+        `e.g. pull_number: "{{ input.pull_number }}".`,
+    );
+  }
+  // An unquoted `{{ ... }}` value parses to an object used as a map key, which
+  // serializes as the literal "[object Object]". No legitimate config contains
+  // that string, so it's a reliable corruption signature.
+  if (JSON.stringify(parsed ?? null).includes("[object Object]")) {
+    throw new Error(
+      `Workflow YAML has an unquoted template value: a "{{ ... }}" was parsed as a ` +
+        `YAML object instead of a string. Wrap every template in quotes, ` +
+        `e.g. pull_number: "{{ input.pull_number }}".`,
+    );
+  }
+}
+
+/**
  * Resolve `{{ params.* }}` references that appear INSIDE other param values, so a
  * workflow can factor a shared value into one param and reuse it (e.g. a base
  * `podDomain` referenced by a big prompt param). Walks the params deeply; for
@@ -243,6 +279,8 @@ export class WorkspaceManager {
             },
             { lineWidth: 120, noRefs: true },
           );
+
+    assertValidWorkflowYaml(yamlStr);
 
     await writeFile(join(dir, `${version}.yaml`), yamlStr, "utf-8");
 

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -471,3 +471,27 @@ function dispatchChatEvent(e: ChatEvent, cb: ChatCallbacks): void {
       break;
   }
 }
+
+// ── Secrets ────────────────────────────────────────────────────────────────
+// Deployment-scoped credentials. Values are write-only over the API — the
+// list endpoint returns NAMES + metadata only, never the secret value.
+
+export interface SecretInfo {
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export const listSecrets = () =>
+  fetchJSON<{ secrets: SecretInfo[] }>("/secrets").then((r) => r.secrets);
+
+export const setSecret = (name: string, value: string) =>
+  fetchJSON<{ ok: true; name: string }>(`/secrets/${encodeURIComponent(name)}`, {
+    method: "PUT",
+    body: JSON.stringify({ value }),
+  });
+
+export const deleteSecret = (name: string) =>
+  fetchJSON<{ ok: true; name: string }>(`/secrets/${encodeURIComponent(name)}`, {
+    method: "DELETE",
+  });

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -11,6 +11,7 @@ import "./styles/components.css";
 import { deepEqual, normalizeSteps, statusTone } from "./helpers";
 import { ChatFlyout } from "./components/ChatFlyout";
 import { CreateDialog } from "./components/CreateDialog";
+import { SecretsDialog } from "./components/SecretsDialog";
 import { AddStepDialog, StepTypeEntry } from "./components/AddStepDialog";
 import { StepEditFlyout } from "./components/StepEditFlyout";
 import { EventsPanel } from "./components/EventsPanel";
@@ -68,6 +69,7 @@ export function App() {
   // name, and that workflow's steps. Empty = viewing the root.
   const [runDrill, setRunDrill] = useState<DrillFrame[]>([]);
   const [showCreate, setShowCreate] = useState(false);
+  const [showSecrets, setShowSecrets] = useState(false);
   const [showAddStep, setShowAddStep] = useState(false);
   const [stepTypes, setStepTypes] = useState<StepTypeEntry[]>([]);
   const [publishedSteps, setPublishedSteps] = useState<StepData[] | null>(null);
@@ -613,6 +615,7 @@ export function App() {
               )}
             </div>
           )}
+          <button class="btn" onClick={() => setShowSecrets(true)}>Secrets</button>
           <button class="btn" onClick={() => setShowChat(!showChat)}>AI</button>
         </div>
       </div>
@@ -681,6 +684,7 @@ export function App() {
 
       {/* Create dialog */}
       {showCreate && <CreateDialog onClose={() => setShowCreate(false)} onCreate={handleCreate} />}
+      {showSecrets && <SecretsDialog onClose={() => setShowSecrets(false)} />}
 
       {/* Add step dialog */}
       {showAddStep && <AddStepDialog stepTypes={stepTypes} onSelect={handleAddStepSelect} onClose={() => setShowAddStep(false)} />}

--- a/vein/web/src/components/SecretsDialog.tsx
+++ b/vein/web/src/components/SecretsDialog.tsx
@@ -1,0 +1,152 @@
+// ── Secrets Dialog ──────────────────────────────────────────────────────────
+// Manage deployment-scoped credentials (API keys, tokens, service-account
+// JSON). Values are write-only: the list shows NAMES + metadata only — the
+// server never returns a stored value. Steps read these via
+// `ctx.services.secrets.get("NAME")`.
+
+import { useEffect, useState } from "preact/hooks";
+import * as api from "../api";
+
+const NAME_RE = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function SecretsDialog(props: { onClose: () => void }) {
+  const [secrets, setSecrets] = useState<api.SecretInfo[]>([]);
+  const [name, setName] = useState("");
+  const [value, setValue] = useState("");
+  const [error, setError] = useState("");
+  const [busy, setBusy] = useState(false);
+
+  const refresh = async () => {
+    try {
+      setSecrets(await api.listSecrets());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  useEffect(() => {
+    refresh();
+  }, []);
+
+  const handleSave = async () => {
+    if (!NAME_RE.test(name)) {
+      setError("Name: letters, digits, underscore (not starting with a digit)");
+      return;
+    }
+    if (!value) {
+      setError("Value is required");
+      return;
+    }
+    setBusy(true);
+    setError("");
+    try {
+      await api.setSecret(name, value);
+      setName("");
+      setValue("");
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleDelete = async (n: string) => {
+    setBusy(true);
+    setError("");
+    try {
+      await api.deleteSecret(n);
+      await refresh();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const existingNames = new Set(secrets.map((s) => s.name));
+
+  return (
+    <div
+      class="dialog-backdrop"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) props.onClose();
+      }}
+    >
+      <div class="dialog">
+        <div class="dialog-title">Secrets</div>
+        <div class="dialog-hint" style="margin-bottom:12px;">
+          Deployment-wide credentials read by steps via{" "}
+          <code>ctx.services.secrets.get("NAME")</code>. Values are write-only —
+          they're never shown again after saving.
+        </div>
+
+        <div class="secret-list">
+          {secrets.length === 0 && (
+            <div class="secret-empty">No secrets yet.</div>
+          )}
+          {secrets.map((s) => (
+            <div class="secret-row" key={s.name}>
+              <span class="secret-name">{s.name}</span>
+              <span class="secret-meta">
+                updated {new Date(s.updatedAt).toLocaleDateString()}
+              </span>
+              <button
+                class="btn secret-del"
+                disabled={busy}
+                onClick={() => handleDelete(s.name)}
+                title="Delete"
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+
+        <div class="dialog-field">
+          <label>Name</label>
+          <input
+            type="text"
+            value={name}
+            placeholder="GITHUB_TOKEN"
+            onInput={(e) => {
+              setName((e.target as HTMLInputElement).value);
+              setError("");
+            }}
+          />
+        </div>
+        <div class="dialog-field">
+          <label>Value</label>
+          <textarea
+            value={value}
+            rows={3}
+            placeholder="paste secret value (or service-account JSON)"
+            onInput={(e) => {
+              setValue((e.target as HTMLTextAreaElement).value);
+              setError("");
+            }}
+          />
+          {name && existingNames.has(name) && (
+            <div class="dialog-hint">
+              "{name}" exists — saving overwrites it.
+            </div>
+          )}
+        </div>
+
+        {error && (
+          <div style="color:var(--danger);font-size:12px;margin-bottom:8px;">
+            {error}
+          </div>
+        )}
+        <div class="dialog-actions">
+          <button class="btn" onClick={props.onClose}>
+            Close
+          </button>
+          <button class="btn btn-primary" disabled={busy} onClick={handleSave}>
+            Save secret
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -364,6 +364,49 @@ body.is-resizing-events * {
   margin-top: var(--sp-1);
 }
 
+/* ─── secrets dialog ──────────────────────────────────────────── */
+
+.secret-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  max-height: 220px;
+  overflow-y: auto;
+  margin-bottom: var(--sp-3);
+}
+.secret-empty {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: var(--sp-2) 0;
+}
+.secret-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-1) var(--sp-2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm, 4px);
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.03));
+}
+.secret-name {
+  font-family: var(--mono, monospace);
+  font-size: 12px;
+  font-weight: 600;
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.secret-meta {
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+.secret-del {
+  padding: 0 6px;
+  line-height: 1.6;
+}
+
 /* ─── flyout (step editor) ────────────────────────────────────── */
 
 .flyout {

--- a/vein/web/vite.config.ts
+++ b/vein/web/vite.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
       "/workflows": { target: "http://localhost:3000", configure: sseConfigure },
       "/chat": { target: "http://localhost:3000", configure: sseConfigure },
       "/steps": "http://localhost:3000",
+      "/secrets": "http://localhost:3000",
       "/health": "http://localhost:3000",
     },
   },


### PR DESCRIPTION
## Summary

Adds a deployment-scoped **secrets** system to vein, a **Google Drive** lib step, a documented **lazy-dependency convention** for lib steps, and several **AI-builder robustness fixes** uncovered while debugging a real workflow-authoring session.

## Secrets

- `src/secret-store.ts` — `SecretStore` interface + `FileSecretStore` (encrypted at rest, AES-256-GCM, key from `VEIN_SECRET_KEY`) + `MemorySecretStore`. Parallel to `RunStore`/`ChatStore`.
- The default `secrets` capability now reads the store first, then falls back to `process.env`. Injectable via `createVein({ secretStore })`; exposed on the `Vein` instance.
- Endpoints gated by `VEIN_API_KEY` (permissive in dev): `GET /secrets` returns **names + metadata only — never values**; `PUT /secrets/:name`, `DELETE /secrets/:name`. Returns `501` when the consumer injects their own `services.secrets`.
- UI: topbar **Secrets** dialog — list (names + updated date), add (name + multi-line value, e.g. a service-account JSON), delete. Values are write-only.
- **Scope is deployment-global** (matches the `VEIN_API_KEY` trust model). **No OAuth** — paste a key / service-account JSON; if interactive OAuth is ever needed, the host app owns the dance and deposits tokens into this store.

## Google Drive + lib-step dependency convention

- `gdrive/export-file` (uses `@googleapis/drive`): exports a Doc/Drive file as text/markdown for LLM consumption. Auth via `GOOGLE_ACCESS_TOKEN` or pasted `GOOGLE_SERVICE_ACCOUNT_JSON`.
- **Convention:** lib steps keep schema/metadata at the top level but `await import()` heavy SDKs **inside `run()`**, so registry build stays cheap and unused SDKs never load (the n8n-style monolith-lazy model). `github/fetch-pr` converted to match.
- `github/fetch-pr` + `gdrive/export-file` read credentials through `ctx.services.secrets` (explicit `cfg` field wins), which also gives them cassette-scrubbing.

## AI builder robustness (from a real debugging session)

A workflow took 5 versions to author because of two authoring footguns (the engine was never at fault):
- The agent passed `run_workflow` `input` as a **JSON string** → `{{ input.* }}` resolved to `undefined`. Fixed with `coerceJsonArg` (parses string args for `run_workflow`/`run_step`).
- It then wrote `pull_number: {{ input.pull_number }}` **unquoted** → YAML parses it as an object → "expected number, received object". Fixed with a publish-time lint (`assertValidWorkflowYaml`) that detects the corruption signature and throws an actionable error, plus a quote-your-templates rule in the system prompt.
- New read-only `list_secrets` tool so the agent references existing credential **names** when authoring steps (never values).

## Docs

`AGENTS.md` updated throughout: Secrets section, lib-step dependency + credentials conventions, the YAML-quoting + JSON-string-arg footguns, `list_secrets`, env table (`VEIN_SECRET_KEY`), layout.

## Testing

- `npm test` → **391/391 pass** (+19 new across secret store, endpoints, `list_secrets`, stringified-input coercion, YAML lint).
- Engine `tsc --noEmit` clean; web `tsc --noEmit` + `vite build` clean.