### PR TITLE
vein: slack steps, gdrive/list-files, actionable lib-step errors

### DIFF
--- a/vein/package.json
+++ b/vein/package.json
@@ -22,7 +22,7 @@
     "build:web": "npm --prefix web run build",
     "dev": "npm run build:web && tsx --env-file=.env src/server.ts",
     "start": "node build/server.js",
-    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts"
+    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts src/slack.test.ts src/gdrive.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.81",

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -117,6 +117,7 @@ Authoring custom steps (create_step / edit_step):
   The built-in "http" step is the canonical example — call get_step("http") to read its source and mirror how it uses ctx.services.http.
 - Prefer raw REST via ctx.services.http — you rarely need a vendor SDK (it's just a wrapper over REST, and an SDK does its own networking so it can't be recorded/replayed). Only import a package other than "vein" if the deployment has pre-installed it (a vendor SDK with gnarly auth); otherwise the step will fail to load. If you're unsure what else is on ctx.services, call get_step on an existing custom step and mirror how it uses ctx.services.
 - Keep the step's algorithm inline (that's the editable part). To change a prompt or heuristic in an existing step, call get_step to read it, then edit_step with the full updated source.
+- Fail with ACTIONABLE errors. API calls return opaque statuses (a GitHub/Drive 404 means "wrong id, private, OR it's actually a different resource type" — not just "not found"). Catch the common failures and throw an Error whose message names the resource and the likely fix (bad/expired token, missing scope, wrong id, resource is private). Let unexpected errors propagate as-is. The lib steps github/fetch-pr and gdrive/export-file are the reference examples — call get_step to mirror their handling.
 
 Tools:
 - list_steps("<path>"): browse step types as a filesystem (steps, steps/core, steps/lib/<ns>, steps/custom).

--- a/vein/src/gdrive.test.ts
+++ b/vein/src/gdrive.test.ts
@@ -1,0 +1,85 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { buildQuery } from "./steps/lib/gdrive/list-files.js";
+import { statusOf, describeDriveError } from "./steps/lib/gdrive/_shared.js";
+
+// gdrive/* steps use the @googleapis/drive SDK directly (not an injectable
+// http capability), so we unit-test the pure pieces: the `q` builder and the
+// error mapper. (A full run() test would need to mock the SDK import.)
+
+describe("gdrive/list-files buildQuery", () => {
+  it("excludes trashed by default", () => {
+    assert.equal(buildQuery({ includeTrashed: false }), "trashed = false");
+  });
+
+  it("includes trashed → empty filter (list everything)", () => {
+    assert.equal(buildQuery({ includeTrashed: true }), "");
+  });
+
+  it("AND-combines folder, modifiedAfter, and mimeType", () => {
+    const q = buildQuery({
+      folderId: "FOLDER1",
+      modifiedAfter: "2024-01-01T00:00:00Z",
+      mimeType: "application/vnd.google-apps.document",
+      includeTrashed: false,
+    });
+    assert.equal(
+      q,
+      "'FOLDER1' in parents and modifiedTime > '2024-01-01T00:00:00Z' and mimeType = 'application/vnd.google-apps.document' and trashed = false",
+    );
+  });
+
+  it("builds the incremental-sync clause from a cursor", () => {
+    assert.equal(
+      buildQuery({
+        folderId: "F",
+        modifiedAfter: "2024-06-01T12:00:00Z",
+        includeTrashed: false,
+      }),
+      "'F' in parents and modifiedTime > '2024-06-01T12:00:00Z' and trashed = false",
+    );
+  });
+});
+
+describe("gdrive statusOf", () => {
+  it("reads status from .status, .response.status, or numeric .code", () => {
+    assert.equal(statusOf({ status: 404 }), 404);
+    assert.equal(statusOf({ response: { status: 403 } }), 403);
+    assert.equal(statusOf({ code: 401 }), 401);
+    assert.equal(statusOf({ code: "500" }), 500);
+    assert.equal(statusOf({ code: "ENOTFOUND" }), undefined);
+    assert.equal(statusOf(new Error("boom")), undefined);
+  });
+});
+
+describe("gdrive describeDriveError", () => {
+  it("404 → actionable not-found/access message", () => {
+    const e = describeDriveError({ status: 404 }, 'file "X"', true);
+    assert.match(e.message, /not found.*access/s);
+    assert.match(e.message, /file "X"/);
+  });
+
+  it("403 → scope / permission hint", () => {
+    const e = describeDriveError({ status: 403 }, "file listing", true);
+    assert.match(e.message, /access denied \(403\).*drive\.readonly/s);
+  });
+
+  it("401 → expired/invalid token hint", () => {
+    const e = describeDriveError({ status: 401 }, "file listing", true);
+    assert.match(e.message, /auth failed \(401\).*GOOGLE_ACCESS_TOKEN/s);
+  });
+
+  it("no creds + ADC failure → 'no credentials' guidance", () => {
+    const e = describeDriveError(
+      new Error("Could not load the default credentials"),
+      "file listing",
+      false,
+    );
+    assert.match(e.message, /No Google credentials available/);
+  });
+
+  it("passes unknown errors through unchanged", () => {
+    const orig = new Error("network blip");
+    assert.equal(describeDriveError(orig, "file listing", true), orig);
+  });
+});

--- a/vein/src/slack.test.ts
+++ b/vein/src/slack.test.ts
@@ -1,0 +1,231 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import type { HttpResponse } from "./capabilities.js";
+import postMessage from "./steps/lib/slack/post-message.js";
+import readChannel from "./steps/lib/slack/read-channel.js";
+
+// ── Fake ctx ────────────────────────────────────────────────────────────────
+//
+// Slack steps go through ctx.services.http (raw REST). We stub it with a
+// per-method response map keyed by the Slack API method (last URL segment),
+// and record the calls so we can assert what was sent.
+
+interface Call {
+  method: string;
+  reqMethod: string;
+  body?: unknown;
+  query?: Record<string, unknown>;
+  auth?: string;
+}
+
+function makeCtx(
+  responses: Record<string, unknown>,
+  opts: { secrets?: Record<string, string>; status?: number } = {},
+) {
+  const calls: Call[] = [];
+  const http = async (
+    url: string,
+    o: {
+      method?: string;
+      headers?: Record<string, string>;
+      body?: unknown;
+      query?: Record<string, string | number | boolean>;
+    } = {},
+  ): Promise<HttpResponse> => {
+    const apiMethod = url.split("/").pop()!;
+    calls.push({
+      method: apiMethod,
+      reqMethod: o.method ?? "GET",
+      body: o.body,
+      query: o.query,
+      auth: o.headers?.authorization,
+    });
+    const body = responses[apiMethod] ?? { ok: false, error: "unknown_method" };
+    return { status: opts.status ?? 200, ok: true, headers: {}, body };
+  };
+  const ctx = {
+    runId: "t",
+    path: "t",
+    scope: {},
+    input: {},
+    emit: async () => {},
+    services: {
+      http,
+      secrets: { get: async (n: string) => opts.secrets?.[n] },
+    },
+  } as never;
+  return { ctx, calls };
+}
+
+// ── post-message ─────────────────────────────────────────────────────────────
+
+describe("slack/post-message", () => {
+  it("posts text and returns ts + channel", async () => {
+    const { ctx, calls } = makeCtx({
+      "chat.postMessage": { ok: true, ts: "1700000000.000100", channel: "C1" },
+    });
+    const out = await postMessage.run(
+      { channel: "C1", text: "hello", token: "xoxb-test" },
+      ctx,
+    );
+    assert.deepEqual(out, { ts: "1700000000.000100", channel: "C1" });
+    assert.equal(calls[0]!.method, "chat.postMessage");
+    assert.equal(calls[0]!.reqMethod, "POST");
+    assert.equal(calls[0]!.auth, "Bearer xoxb-test");
+    assert.deepEqual(calls[0]!.body, { channel: "C1", text: "hello" });
+  });
+
+  it("threads via thread_ts and supports blocks-only", async () => {
+    const { ctx, calls } = makeCtx({
+      "chat.postMessage": { ok: true, ts: "2.0", channel: "C1" },
+    });
+    await postMessage.run(
+      {
+        channel: "C1",
+        blocks: [{ type: "section" }],
+        thread_ts: "1.0",
+        token: "x",
+      },
+      ctx,
+    );
+    assert.deepEqual(calls[0]!.body, {
+      channel: "C1",
+      blocks: [{ type: "section" }],
+      thread_ts: "1.0",
+    });
+  });
+
+  it("requires text or blocks", async () => {
+    const { ctx } = makeCtx({});
+    await assert.rejects(
+      () => postMessage.run({ channel: "C1", token: "x" }, ctx),
+      /needs `text` or `blocks`/,
+    );
+  });
+
+  it("maps ok:false to an actionable error", async () => {
+    const { ctx } = makeCtx({
+      "chat.postMessage": { ok: false, error: "not_in_channel" },
+    });
+    await assert.rejects(
+      () => postMessage.run({ channel: "C1", text: "hi", token: "x" }, ctx),
+      /isn't a member.*error: not_in_channel/s,
+    );
+  });
+
+  it("reads the token from the SLACK_BOT_TOKEN secret", async () => {
+    const { ctx, calls } = makeCtx(
+      { "chat.postMessage": { ok: true, ts: "1.0", channel: "C1" } },
+      { secrets: { SLACK_BOT_TOKEN: "xoxb-secret" } },
+    );
+    await postMessage.run({ channel: "C1", text: "hi" }, ctx);
+    assert.equal(calls[0]!.auth, "Bearer xoxb-secret");
+  });
+
+  it("errors clearly when no token is available", async () => {
+    const { ctx } = makeCtx({});
+    await assert.rejects(
+      () => postMessage.run({ channel: "C1", text: "hi" }, ctx),
+      /No Slack token/,
+    );
+  });
+});
+
+// ── read-channel ─────────────────────────────────────────────────────────────
+
+describe("slack/read-channel", () => {
+  it("returns messages chronologically with resolved names + markdown", async () => {
+    const { ctx, calls } = makeCtx({
+      "conversations.history": {
+        ok: true,
+        has_more: false,
+        // Slack returns newest-first:
+        messages: [
+          { ts: "1700000002.0", user: "U2", text: "second" },
+          { ts: "1700000001.0", user: "U1", text: "first" },
+        ],
+      },
+      "users.info": { ok: true, user: { profile: { display_name: "alice" } } },
+    });
+    const out = await readChannel.run(
+      { channel: "C1", limit: 50, resolveUsers: true, token: "x" },
+      ctx,
+    );
+
+    // chronological (oldest first)
+    assert.deepEqual(
+      out.messages.map((m) => m.text),
+      ["first", "second"],
+    );
+    assert.equal(out.hasMore, false);
+    assert.equal(out.messages[0]!.user, "alice");
+    assert.match(out.markdown, /# Slack channel C1 \(2 messages\)/);
+    assert.match(out.markdown, /\*\*@alice\*\*/);
+
+    // history is a GET with channel+limit in the query
+    const hist = calls.find((c) => c.method === "conversations.history")!;
+    assert.equal(hist.reqMethod, "GET");
+    assert.deepEqual(hist.query, { channel: "C1", limit: 50 });
+  });
+
+  it("falls back to the user id when name resolution fails", async () => {
+    const { ctx } = makeCtx({
+      "conversations.history": {
+        ok: true,
+        messages: [{ ts: "1.0", user: "U9", text: "hi" }],
+      },
+      "users.info": { ok: false, error: "missing_scope" },
+    });
+    const out = await readChannel.run(
+      { channel: "C1", limit: 50, resolveUsers: true, token: "x" },
+      ctx,
+    );
+    assert.equal(out.messages[0]!.user, "U9");
+  });
+
+  it("skips user resolution when resolveUsers is false", async () => {
+    const { ctx, calls } = makeCtx({
+      "conversations.history": {
+        ok: true,
+        messages: [{ ts: "1.0", user: "U9", text: "hi" }],
+      },
+    });
+    const out = await readChannel.run(
+      { channel: "C1", limit: 50, resolveUsers: false, token: "x" },
+      ctx,
+    );
+    assert.equal(out.messages[0]!.user, "U9");
+    assert.equal(
+      calls.some((c) => c.method === "users.info"),
+      false,
+    );
+  });
+
+  it("labels bot messages without a user id", async () => {
+    const { ctx } = makeCtx({
+      "conversations.history": {
+        ok: true,
+        messages: [{ ts: "1.0", username: "deploybot", text: "shipped" }],
+      },
+    });
+    const out = await readChannel.run(
+      { channel: "C1", limit: 50, resolveUsers: false, token: "x" },
+      ctx,
+    );
+    assert.equal(out.messages[0]!.user, "deploybot");
+  });
+
+  it("maps channel_not_found to an actionable error", async () => {
+    const { ctx } = makeCtx({
+      "conversations.history": { ok: false, error: "channel_not_found" },
+    });
+    await assert.rejects(
+      () =>
+        readChannel.run(
+          { channel: "bad", limit: 50, resolveUsers: false, token: "x" },
+          ctx,
+        ),
+      /channel not found.*error: channel_not_found/s,
+    );
+  });
+});

--- a/vein/src/steps/lib/gdrive/_shared.ts
+++ b/vein/src/steps/lib/gdrive/_shared.ts
@@ -1,0 +1,107 @@
+// Shared helpers for the gdrive/* lib steps. Leading-underscore file → imported
+// by siblings, skipped by registry discovery (see AGENTS.md).
+//
+// The @googleapis/drive SDK is heavy, so it's `await import()`-ed INSIDE the
+// async helpers (never at module top level) — `import type` is erased at
+// compile time, so it carries no runtime cost. See AGENTS.md "Lib step
+// dependency convention".
+import type { drive_v3 } from "@googleapis/drive";
+import type { StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+
+export const DRIVE_READONLY_SCOPE =
+  "https://www.googleapis.com/auth/drive.readonly";
+
+/** Build an authenticated Drive v3 client. Credentials flow through the secrets
+ *  capability (UI store → env fallback), explicit `accessToken` config wins.
+ *  Returns `haveAuth` so error messages can distinguish "no creds at all" from
+ *  "creds present but rejected". See AGENTS.md "Lib step credentials". */
+export async function buildDriveClient(
+  accessToken: string | undefined,
+  ctx: StepContext<VeinCapabilities>,
+): Promise<{ client: drive_v3.Drive; haveAuth: boolean }> {
+  const { drive, auth } = await import("@googleapis/drive");
+
+  const secrets = ctx?.services?.secrets;
+  const token = accessToken ?? (await secrets?.get("GOOGLE_ACCESS_TOKEN"));
+  const saJson = await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON");
+
+  let authClient;
+  if (token) {
+    const oauth = new auth.OAuth2();
+    oauth.setCredentials({ access_token: token });
+    authClient = oauth;
+  } else if (saJson) {
+    // A pasted service-account JSON key (no expiry — the recommended setup).
+    let credentials: Record<string, unknown>;
+    try {
+      credentials = JSON.parse(saJson);
+    } catch {
+      throw new Error(
+        "GOOGLE_SERVICE_ACCOUNT_JSON is not valid JSON. Paste the full service-account key file (the JSON object with client_email/private_key) into the secret.",
+      );
+    }
+    authClient = new auth.GoogleAuth({
+      credentials,
+      scopes: [DRIVE_READONLY_SCOPE],
+    });
+  } else {
+    // Application Default Credentials (e.g. GOOGLE_APPLICATION_CREDENTIALS).
+    authClient = new auth.GoogleAuth({ scopes: [DRIVE_READONLY_SCOPE] });
+  }
+
+  return {
+    client: drive({ version: "v3", auth: authClient }),
+    haveAuth: Boolean(token || saJson),
+  };
+}
+
+/** Extract the HTTP status from a googleapis/gaxios error (it lives on
+ *  `.status`, `.code`, or `.response.status` depending on the path). */
+export function statusOf(err: unknown): number | undefined {
+  const e = err as {
+    status?: number;
+    code?: number | string;
+    response?: { status?: number };
+  };
+  const raw = e?.status ?? e?.response?.status ?? e?.code;
+  const n = typeof raw === "string" ? Number(raw) : raw;
+  return typeof n === "number" && !Number.isNaN(n) ? n : undefined;
+}
+
+/** Turn an opaque Drive API error into an actionable one. Google returns 404
+ *  both for missing resources and for ones the caller can't see; 401/403 mean
+ *  the token is bad or lacks the drive.readonly scope. `resource` is a short
+ *  label for the thing being accessed, e.g. `file "abc"` or `file listing`. */
+export function describeDriveError(
+  err: unknown,
+  resource: string,
+  haveAuth: boolean,
+): Error {
+  const status = statusOf(err);
+  const msg = (err as { message?: string })?.message ?? "";
+
+  // No credentials resolved at all → Application Default Credentials threw.
+  if (!haveAuth && /could not load the default credentials/i.test(msg)) {
+    return new Error(
+      "No Google credentials available. Pass an OAuth `accessToken`, or add a GOOGLE_ACCESS_TOKEN / GOOGLE_SERVICE_ACCOUNT_JSON secret (or set GOOGLE_APPLICATION_CREDENTIALS).",
+    );
+  }
+
+  switch (status) {
+    case 404:
+      return new Error(
+        `Google Drive ${resource} not found. The ID may be wrong, or the authenticated account/service account may not have access (share it with them).`,
+      );
+    case 401:
+      return new Error(
+        `Google Drive auth failed (401) for ${resource}. The access token is missing, expired, or invalid — refresh it or re-add the GOOGLE_ACCESS_TOKEN secret.`,
+      );
+    case 403:
+      return new Error(
+        `Google Drive access denied (403) for ${resource}. The credentials lack permission or the drive.readonly scope, or the Drive API is not enabled for the project.`,
+      );
+    default:
+      return err instanceof Error ? err : new Error(String(err));
+  }
+}

--- a/vein/src/steps/lib/gdrive/export-file.ts
+++ b/vein/src/steps/lib/gdrive/export-file.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 import { defineStep, type StepContext } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
+import { buildDriveClient, statusOf, describeDriveError } from "./_shared.js";
 
 const EXAMPLE = `- id: doc
   type: gdrive/export-file
@@ -20,7 +21,6 @@ const EXPORT_MIME: Record<string, string> = {
 
 const GOOGLE_NATIVE_PREFIX = "application/vnd.google-apps";
 const DEFAULT_NATIVE_EXPORT = "text/plain";
-const DRIVE_READONLY_SCOPE = "https://www.googleapis.com/auth/drive.readonly";
 
 export default defineStep({
   type: "gdrive/export-file",
@@ -47,42 +47,18 @@ export default defineStep({
     }),
   }),
   async run(cfg, ctx: StepContext<VeinCapabilities>) {
-    // Lazy-load the SDK inside run() so the heavy dep is only pulled into
-    // memory when this step actually executes — not at registry-build time.
-    // See AGENTS.md "Lib step dependency convention".
-    const { drive, auth } = await import("@googleapis/drive");
+    const { client, haveAuth } = await buildDriveClient(cfg.accessToken, ctx);
+    const resource = `file "${cfg.fileId}"`;
 
-    // Credentials flow through the secrets capability (UI-managed store → env
-    // fallback) so they're cassette-scrubbed; explicit config always wins.
-    // See AGENTS.md "Lib step credentials".
-    const secrets = ctx?.services?.secrets;
-    const token =
-      cfg.accessToken ?? (await secrets?.get("GOOGLE_ACCESS_TOKEN"));
-    const saJson = await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON");
-
-    let authClient;
-    if (token) {
-      const oauth = new auth.OAuth2();
-      oauth.setCredentials({ access_token: token });
-      authClient = oauth;
-    } else if (saJson) {
-      // A pasted service-account JSON key (no expiry — the recommended setup).
-      authClient = new auth.GoogleAuth({
-        credentials: JSON.parse(saJson),
-        scopes: [DRIVE_READONLY_SCOPE],
+    const { data: meta } = await client.files
+      .get({
+        fileId: cfg.fileId,
+        fields: "id,name,mimeType,modifiedTime,size,webViewLink",
+        supportsAllDrives: true,
+      })
+      .catch((err: unknown) => {
+        throw describeDriveError(err, resource, haveAuth);
       });
-    } else {
-      // Application Default Credentials (e.g. GOOGLE_APPLICATION_CREDENTIALS).
-      authClient = new auth.GoogleAuth({ scopes: [DRIVE_READONLY_SCOPE] });
-    }
-
-    const client = drive({ version: "v3", auth: authClient });
-
-    const { data: meta } = await client.files.get({
-      fileId: cfg.fileId,
-      fields: "id,name,mimeType,modifiedTime,size,webViewLink",
-      supportsAllDrives: true,
-    });
 
     const mimeType = meta.mimeType ?? "application/octet-stream";
     const isNative = mimeType.startsWith(GOOGLE_NATIVE_PREFIX);
@@ -91,16 +67,22 @@ export default defineStep({
     if (isNative) {
       const exportMime =
         cfg.exportMimeType ?? EXPORT_MIME[mimeType] ?? DEFAULT_NATIVE_EXPORT;
-      ({ data: raw } = await client.files.export({
-        fileId: cfg.fileId,
-        mimeType: exportMime,
-      }));
+      ({ data: raw } = await client.files
+        .export({ fileId: cfg.fileId, mimeType: exportMime })
+        .catch((err: unknown) => {
+          if (statusOf(err) === 400) {
+            throw new Error(
+              `Google Drive cannot export "${meta.name ?? cfg.fileId}" (${mimeType}) as "${exportMime}". Set a supported \`exportMimeType\` for this file type.`,
+            );
+          }
+          throw describeDriveError(err, resource, haveAuth);
+        }));
     } else {
-      ({ data: raw } = await client.files.get({
-        fileId: cfg.fileId,
-        alt: "media",
-        supportsAllDrives: true,
-      }));
+      ({ data: raw } = await client.files
+        .get({ fileId: cfg.fileId, alt: "media", supportsAllDrives: true })
+        .catch((err: unknown) => {
+          throw describeDriveError(err, resource, haveAuth);
+        }));
     }
 
     const full = coerceText(raw);

--- a/vein/src/steps/lib/gdrive/list-files.ts
+++ b/vein/src/steps/lib/gdrive/list-files.ts
@@ -1,0 +1,110 @@
+import { z } from "zod";
+import { defineStep, type StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+import { buildDriveClient, describeDriveError } from "./_shared.js";
+
+const EXAMPLE = `- id: list
+  type: gdrive/list-files
+  config:
+    folderId: "1AbCdEfGhIjKlMnOpQrStUvWxYz"
+    modifiedAfter: "{{ input.since }}"   # RFC 3339, e.g. 2024-01-01T00:00:00Z`;
+
+export default defineStep({
+  type: "gdrive/list-files",
+  description: `List files in Google Drive (optionally in a folder, modified after a timestamp, or of a MIME type) for incremental indexing. Pair with foreach → gdrive/export-file to process each. Auth: same as gdrive/export-file (OAuth \`accessToken\`, or GOOGLE_ACCESS_TOKEN / GOOGLE_SERVICE_ACCOUNT_JSON secret, or ADC). Output: { files: [{ id, name, mimeType, modifiedTime, size, webViewLink }], nextPageToken, newestModifiedTime }. Use newestModifiedTime as the cursor for the next run's \`modifiedAfter\`.\n\n${EXAMPLE}`,
+  input: z.object({
+    /** Only files whose parent is this folder ID. */
+    folderId: z.string().optional(),
+    /** RFC 3339 timestamp — only files modified strictly after it (the
+     *  incremental-sync cursor). */
+    modifiedAfter: z.string().optional(),
+    /** Exact MIME type filter (e.g. "application/vnd.google-apps.document"). */
+    mimeType: z.string().optional(),
+    /** Raw Drive `q` query — when set, it REPLACES the folder/modifiedAfter/
+     *  mimeType filters above (full control; see Drive "search for files"). */
+    query: z.string().optional(),
+    /** Include trashed files (default false). Ignored when `query` is set. */
+    includeTrashed: z.boolean().default(false),
+    /** Page size (Drive caps at 1000). */
+    pageSize: z.number().int().positive().max(1000).default(100),
+    /** Cursor from a previous call's `nextPageToken` to fetch the next page. */
+    pageToken: z.string().optional(),
+    /** Drive orderBy (e.g. "modifiedTime", "modifiedTime desc", "name"). */
+    orderBy: z.string().default("modifiedTime"),
+    accessToken: z.string().optional(),
+  }),
+  output: z.object({
+    files: z.array(
+      z.object({
+        id: z.string(),
+        name: z.string(),
+        mimeType: z.string(),
+        modifiedTime: z.string().nullable(),
+        size: z.number().nullable(),
+        webViewLink: z.string().nullable(),
+      }),
+    ),
+    nextPageToken: z.string().nullable(),
+    /** Max modifiedTime across the returned files — the cursor to feed the next
+     *  run's `modifiedAfter`. Null when no files matched. */
+    newestModifiedTime: z.string().nullable(),
+  }),
+  async run(cfg, ctx: StepContext<VeinCapabilities>) {
+    const { client, haveAuth } = await buildDriveClient(cfg.accessToken, ctx);
+    const q = cfg.query ?? buildQuery(cfg);
+
+    const { data } = await client.files
+      .list({
+        ...(q ? { q } : {}),
+        pageSize: cfg.pageSize,
+        ...(cfg.pageToken ? { pageToken: cfg.pageToken } : {}),
+        orderBy: cfg.orderBy,
+        fields:
+          "nextPageToken, files(id,name,mimeType,modifiedTime,size,webViewLink)",
+        // Surface files from shared drives too, not just My Drive.
+        includeItemsFromAllDrives: true,
+        supportsAllDrives: true,
+        spaces: "drive",
+      })
+      .catch((err: unknown) => {
+        throw describeDriveError(err, "file listing", haveAuth);
+      });
+
+    const files = (data.files ?? []).map((f) => ({
+      id: f.id ?? "",
+      name: f.name ?? "unknown",
+      mimeType: f.mimeType ?? "application/octet-stream",
+      modifiedTime: f.modifiedTime ?? null,
+      size: f.size != null ? Number(f.size) : null,
+      webViewLink: f.webViewLink ?? null,
+    }));
+
+    const newestModifiedTime = files.reduce<string | null>((max, f) => {
+      if (!f.modifiedTime) return max;
+      return max === null || f.modifiedTime > max ? f.modifiedTime : max;
+    }, null);
+
+    return {
+      files,
+      nextPageToken: data.nextPageToken ?? null,
+      newestModifiedTime,
+    };
+  },
+});
+
+/** Compose a Drive `q` from the convenience filters. Clauses are AND-ed; an
+ *  empty result means "no filter" (list everything the creds can see).
+ *  Exported for unit testing. */
+export function buildQuery(cfg: {
+  folderId?: string;
+  modifiedAfter?: string;
+  mimeType?: string;
+  includeTrashed: boolean;
+}): string {
+  const clauses: string[] = [];
+  if (cfg.folderId) clauses.push(`'${cfg.folderId}' in parents`);
+  if (cfg.modifiedAfter) clauses.push(`modifiedTime > '${cfg.modifiedAfter}'`);
+  if (cfg.mimeType) clauses.push(`mimeType = '${cfg.mimeType}'`);
+  if (!cfg.includeTrashed) clauses.push("trashed = false");
+  return clauses.join(" and ");
+}

--- a/vein/src/steps/lib/github/fetch-pr.ts
+++ b/vein/src/steps/lib/github/fetch-pr.ts
@@ -83,7 +83,19 @@ export default defineStep({
       }),
       octokit.pulls.listReviews({ ...prInfo, per_page: 100 }),
       octokit.pulls.listCommits({ ...prInfo, per_page: 100 }),
-    ]);
+    ]).catch((err: unknown) => {
+      // GitHub returns 404 both when a PR genuinely doesn't exist AND when
+      // the number is an *issue* (issues + PRs share one number sequence) or
+      // the repo is private and the token can't see it. Rethrow with an
+      // actionable message instead of the bare "Not Found".
+      if ((err as { status?: number })?.status === 404) {
+        const ref = `${cfg.owner}/${cfg.repo}#${cfg.pull_number}`;
+        throw new Error(
+          `Pull request ${ref} not found. It may be an issue rather than a pull request (issues and PRs share one number sequence), the number may not exist, or the repo may be private and the token lacks access.`,
+        );
+      }
+      throw err;
+    });
 
     const markdown = formatPRContent(
       prData as Record<string, unknown>,

--- a/vein/src/steps/lib/slack/_shared.ts
+++ b/vein/src/steps/lib/slack/_shared.ts
@@ -1,0 +1,81 @@
+// Shared helpers for the slack/* lib steps. Leading-underscore file → imported
+// by siblings, skipped by registry discovery (see AGENTS.md). Slack adapters go
+// through ctx.services.http (raw REST — no SDK needed, fully recordable) rather
+// than @slack/web-api, per the "prefer raw REST" authoring convention.
+import type { StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+
+const SLACK_API = "https://slack.com/api";
+
+/** Resolve a Slack bot token: explicit config wins, else the SLACK_BOT_TOKEN
+ *  secret (UI-managed store → env). Throws an actionable error if neither. */
+export async function slackToken(
+  explicit: string | undefined,
+  ctx: StepContext<VeinCapabilities>,
+): Promise<string> {
+  const token =
+    explicit ?? (await ctx?.services?.secrets?.get("SLACK_BOT_TOKEN"));
+  if (!token) {
+    throw new Error(
+      "No Slack token. Pass `token` in config or add a SLACK_BOT_TOKEN secret (a bot token, starts with xoxb-).",
+    );
+  }
+  return token;
+}
+
+/** Call a Slack Web API method and return its (ok:true) payload.
+ *
+ *  Slack is unusual: it returns HTTP 200 even on logical failures, signalling
+ *  the real outcome in the JSON body (`{ ok: false, error: "channel_not_found" }`).
+ *  So we check `body.ok`, NOT the HTTP status, and map the common `error`
+ *  codes to actionable messages. */
+export async function slackCall(
+  ctx: StepContext<VeinCapabilities>,
+  method: string,
+  token: string,
+  opts: {
+    body?: unknown;
+    query?: Record<string, string | number | boolean>;
+  } = {},
+): Promise<Record<string, unknown>> {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("slack steps require ctx.services.http");
+
+  const res = await http(`${SLACK_API}/${method}`, {
+    method: opts.body !== undefined ? "POST" : "GET",
+    headers: { authorization: `Bearer ${token}` },
+    body: opts.body,
+    query: opts.query,
+  });
+
+  const data = (res.body ?? {}) as Record<string, unknown>;
+  // A non-2xx with no JSON body (proxy error, 5xx) won't have `ok` at all.
+  if (data.ok !== true) {
+    const code =
+      typeof data.error === "string" ? data.error : `http_${res.status}`;
+    throw describeSlackError(code, method);
+  }
+  return data;
+}
+
+/** Map a Slack `error` code to an actionable Error. Unknown codes pass through
+ *  verbatim so nothing is swallowed. */
+export function describeSlackError(error: string, method: string): Error {
+  const hints: Record<string, string> = {
+    channel_not_found:
+      "channel not found — use the channel ID (e.g. C0123ABCD) and make sure the bot has been added to it",
+    not_in_channel:
+      "the bot isn't a member of that channel — /invite it, or post to a channel it has joined",
+    is_archived: "the channel is archived",
+    missing_scope: `the bot token is missing a required OAuth scope for ${method} (e.g. chat:write to post, channels:history to read, users:read to resolve names)`,
+    invalid_auth:
+      "invalid Slack token — check SLACK_BOT_TOKEN (a bot token starts with xoxb-)",
+    not_authed: "no Slack token was sent — set SLACK_BOT_TOKEN",
+    token_revoked: "the Slack token has been revoked — generate a new bot token",
+    account_inactive: "the Slack token's bot/user has been deactivated",
+    msg_too_long: "the message text is too long for Slack",
+    rate_limited: "rate limited by Slack — retry after a short delay",
+  };
+  const hint = hints[error] ?? error;
+  return new Error(`Slack ${method} failed: ${hint} (error: ${error})`);
+}

--- a/vein/src/steps/lib/slack/post-message.ts
+++ b/vein/src/steps/lib/slack/post-message.ts
@@ -1,0 +1,51 @@
+import { z } from "zod";
+import { defineStep, type StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+import { slackToken, slackCall } from "./_shared.js";
+
+const EXAMPLE = `- id: notify
+  type: slack/post-message
+  config:
+    channel: "C0123ABCD"
+    text: "Build {{ build.status }} for {{ input.repo }}"
+    token: "{{ input.slackToken }}"`;
+
+export default defineStep({
+  type: "slack/post-message",
+  description: `Post a message to a Slack channel (or thread). Auth: a bot token (xoxb-…) via \`token\` config or the SLACK_BOT_TOKEN secret; the bot needs the chat:write scope and must be a member of the channel. Output: { ts, channel } — pass \`ts\` back as a later step's \`thread_ts\` to reply in-thread.\n\n${EXAMPLE}`,
+  input: z.object({
+    /** Channel ID (e.g. C0123ABCD) — recommended — or a #channel name. */
+    channel: z.string().min(1),
+    /** Message text (markdown-ish "mrkdwn"). Required unless `blocks` is set. */
+    text: z.string().optional(),
+    /** Slack Block Kit blocks, for rich messages. Overrides `text` layout. */
+    blocks: z.array(z.record(z.unknown())).optional(),
+    /** Reply in a thread by passing the parent message's `ts`. */
+    thread_ts: z.string().optional(),
+    token: z.string().optional(),
+  }),
+  output: z.object({
+    ts: z.string(),
+    channel: z.string(),
+  }),
+  async run(cfg, ctx: StepContext<VeinCapabilities>) {
+    if (!cfg.text && !cfg.blocks) {
+      throw new Error("slack/post-message needs `text` or `blocks`.");
+    }
+    const token = await slackToken(cfg.token, ctx);
+
+    const data = await slackCall(ctx, "chat.postMessage", token, {
+      body: {
+        channel: cfg.channel,
+        ...(cfg.text ? { text: cfg.text } : {}),
+        ...(cfg.blocks ? { blocks: cfg.blocks } : {}),
+        ...(cfg.thread_ts ? { thread_ts: cfg.thread_ts } : {}),
+      },
+    });
+
+    return {
+      ts: (data.ts as string) ?? "",
+      channel: (data.channel as string) ?? cfg.channel,
+    };
+  },
+});

--- a/vein/src/steps/lib/slack/read-channel.ts
+++ b/vein/src/steps/lib/slack/read-channel.ts
@@ -1,0 +1,153 @@
+import { z } from "zod";
+import { defineStep, type StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+import { slackToken, slackCall } from "./_shared.js";
+
+const EXAMPLE = `- id: history
+  type: slack/read-channel
+  config:
+    channel: "C0123ABCD"
+    limit: 50
+    token: "{{ input.slackToken }}"`;
+
+export interface SlackMessage {
+  ts: string;
+  user: string;
+  text: string;
+  threadTs: string | null;
+}
+
+export default defineStep({
+  type: "slack/read-channel",
+  description: `Read recent messages from a Slack channel and format them as markdown for LLM consumption. Returns messages oldest→newest with author names resolved. Auth: a bot token (xoxb-…) via \`token\` or the SLACK_BOT_TOKEN secret; the bot needs channels:history (and users:read to resolve names) and must be a member of the channel. Output: { markdown, messages: [{ ts, user, text, threadTs }], channel, hasMore }.\n\n${EXAMPLE}`,
+  input: z.object({
+    /** Channel ID (e.g. C0123ABCD). */
+    channel: z.string().min(1),
+    /** Max messages to fetch (Slack caps a page at 1000). */
+    limit: z.number().int().positive().max(1000).default(50),
+    /** Only messages after this Unix ts (Slack `oldest` cursor). */
+    oldest: z.string().optional(),
+    /** Only messages before this Unix ts (Slack `latest` cursor). */
+    latest: z.string().optional(),
+    /** Resolve user IDs → display names via users.info (one call per unique
+     *  participant, fail-soft to the ID). Set false to skip (no users:read). */
+    resolveUsers: z.boolean().default(true),
+    token: z.string().optional(),
+  }),
+  output: z.object({
+    markdown: z.string(),
+    channel: z.string(),
+    hasMore: z.boolean(),
+    messages: z.array(
+      z.object({
+        ts: z.string(),
+        user: z.string(),
+        text: z.string(),
+        threadTs: z.string().nullable(),
+      }),
+    ),
+  }),
+  async run(cfg, ctx: StepContext<VeinCapabilities>) {
+    const token = await slackToken(cfg.token, ctx);
+
+    const data = await slackCall(ctx, "conversations.history", token, {
+      query: {
+        channel: cfg.channel,
+        limit: cfg.limit,
+        ...(cfg.oldest ? { oldest: cfg.oldest } : {}),
+        ...(cfg.latest ? { latest: cfg.latest } : {}),
+      },
+    });
+
+    const raw = (data.messages as Record<string, unknown>[]) ?? [];
+    const userMap = cfg.resolveUsers
+      ? await resolveUserNames(ctx, token, raw)
+      : {};
+
+    const messages: SlackMessage[] = raw.map((m) => ({
+      ts: (m.ts as string) ?? "",
+      user: authorOf(m, userMap),
+      text: (m.text as string) ?? "",
+      threadTs: (m.thread_ts as string) ?? null,
+    }));
+    // Slack returns newest-first; flip to chronological for natural reading.
+    messages.reverse();
+
+    return {
+      markdown: formatChannel(cfg.channel, messages),
+      channel: cfg.channel,
+      hasMore: data.has_more === true,
+      messages,
+    };
+  },
+});
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/** Best-effort author label: resolved display name, else bot username, else
+ *  the raw id. */
+function authorOf(
+  m: Record<string, unknown>,
+  userMap: Record<string, string>,
+): string {
+  const userId = m.user as string | undefined;
+  if (userId) return userMap[userId] ?? userId;
+  return (m.username as string) ?? (m.bot_id as string) ?? "unknown";
+}
+
+/** Resolve unique user IDs → display names. One users.info per id (in
+ *  parallel); a failure (e.g. missing users:read scope) falls back to the id
+ *  so reading never breaks on name resolution. */
+async function resolveUserNames(
+  ctx: StepContext<VeinCapabilities>,
+  token: string,
+  messages: Record<string, unknown>[],
+): Promise<Record<string, string>> {
+  const ids = [
+    ...new Set(messages.map((m) => m.user as string).filter(Boolean)),
+  ];
+  const entries = await Promise.all(
+    ids.map(async (id) => {
+      try {
+        const info = await slackCall(ctx, "users.info", token, {
+          query: { user: id },
+        });
+        const user = info.user as
+          | {
+              profile?: { display_name?: string; real_name?: string };
+              real_name?: string;
+              name?: string;
+            }
+          | undefined;
+        const name =
+          user?.profile?.display_name ||
+          user?.profile?.real_name ||
+          user?.real_name ||
+          user?.name ||
+          id;
+        return [id, name] as const;
+      } catch {
+        return [id, id] as const;
+      }
+    }),
+  );
+  return Object.fromEntries(entries);
+}
+
+function formatChannel(channel: string, messages: SlackMessage[]): string {
+  const lines = [`# Slack channel ${channel} (${messages.length} messages)`];
+  for (const m of messages) {
+    const when = formatTs(m.ts);
+    const threadNote = m.threadTs ? " (in thread)" : "";
+    lines.push(`\n**@${m.user}** — ${when}${threadNote}`);
+    lines.push(`> ${m.text.replace(/\n/g, "\n> ")}`);
+  }
+  return lines.join("\n");
+}
+
+/** Slack ts is "<seconds>.<microseconds>" — render as a readable date. */
+function formatTs(ts: string): string {
+  const seconds = Number(ts.split(".")[0]);
+  if (!Number.isFinite(seconds)) return ts;
+  return new Date(seconds * 1000).toISOString();
+}

--- a/vein/web/src/flow-to-canvas.ts
+++ b/vein/web/src/flow-to-canvas.ts
@@ -59,6 +59,10 @@ const STEP_COLORS: Record<string, { fill: string; stroke: string }> = {
   llm:      { fill: "rgba(76, 29, 149, 0.4)", stroke: "#c084fc" },
   agent:    { fill: "rgba(124, 45, 18, 0.4)", stroke: "#fb923c" },
   wait:     { fill: "rgba(71, 85, 105, 0.4)", stroke: "#94a3b8" },
+  "slack/post-message": { fill: "rgba(74, 21, 75, 0.4)",  stroke: "#e879f9" },
+  "slack/read-channel": { fill: "rgba(74, 21, 75, 0.4)",  stroke: "#e879f9" },
+  "gdrive/export-file": { fill: "rgba(20, 83, 45, 0.4)",  stroke: "#4ade80" },
+  "gdrive/list-files":  { fill: "rgba(20, 83, 45, 0.4)",  stroke: "#4ade80" },
   default:  { fill: "rgba(38, 38, 38, 0.6)",  stroke: "#737373" },
 };
 


### PR DESCRIPTION
## What

Adds three new vein lib steps and hardens error messaging across the GitHub/Drive adapters.

### New steps
- **`slack/post-message`** — post text/blocks to a channel or thread.
- **`slack/read-channel`** — read channel history, resolve author names, format as LLM markdown.
- **`gdrive/list-files`** — list Drive files with `folderId` / `modifiedAfter` / `mimeType` filters (or a raw `q` override). Returns `newestModifiedTime` as an incremental-sync cursor.

The Slack steps go through `ctx.services.http` (raw REST, no SDK — recordable/replayable), with a shared `slack/_shared.ts` handling auth and Slack's quirk of returning HTTP `200` on logical failures (`{ ok: false, error: ... }`).

### Error handling
- **`github/fetch-pr`**: a `404` now explains the likely cause (the number is an *issue* not a PR / private repo / nonexistent) instead of the bare `HttpError: Not Found`. This was the original bug — `#400` was an issue, not a PR.
- **`gdrive`**: extracted `buildDriveClient` + `statusOf` + `describeDriveError` into `gdrive/_shared.ts` (shared by `export-file` + `list-files`); clearer `401`/`403`/`404`, malformed-service-account-JSON, and no-credentials messages.
- **`ai/prompts.ts`**: one bullet reminding the workflow builder to throw actionable errors when authoring steps, pointing at the two lib steps as references.

### Use case this unblocks
`gdrive/list-files` → `foreach` → `subflow(gdrive/export-file → agents → sink)` for indexing every new uploaded doc/transcript/grant. The external cron threads `newestModifiedTime` back as the next run's `modifiedAfter` (no new state primitive needed). The trigger (cron → `POST /run`) and sink (`graph/upsert` → neo4j) remain deployment-specific.

## Misc
- Node colors for the slack/gdrive steps.
- Registered `slack.test.ts` + `gdrive.test.ts` in the `test` script — they weren't globbed (the script lists files explicitly). Note: `pricing.test.ts` is *also* still unlisted (pre-existing, left alone).

## Testing
- `npm test` → **412 pass** (was 391; +21 from the two newly-registered test files).
- `cd web && npx tsc --noEmit && npx vite build` → clean.
- Registry discovery confirmed: all four `gdrive/*` + `slack/*` steps load as `lib`.
- Slack steps are fully unit-tested via a fake `ctx.services.http`; gdrive steps unit-test the pure pieces (`buildQuery`, error mapper) since they use the SDK directly.