### PR TITLE
fix: stop logs_agent hanging on CloudWatch fetches

### DIFF
--- a/mcp/src/log/agent.ts
+++ b/mcp/src/log/agent.ts
@@ -38,7 +38,7 @@ Tips:
 TIME BUDGET (very important): You have roughly 8 minutes of wall-clock time total. Work efficiently:
 - Plan a focused approach up front; don't fetch more than you need. Prefer narrow filter patterns, specific log streams, and shorter time windows over broad fetches.
 - Avoid rabbit holes and redundant tool calls. Each fetch/search should have a clear purpose.
-- Continuously track roughly how much time you've spent. Once you're about 6-7 minutes in (or you have enough to answer), STOP investigating and write up what you've found.
+- Every tool result ends with a "[time budget: ...]" line showing how much time has elapsed and how much is left. Watch it. Once only a couple of minutes remain (or you have enough to answer), STOP investigating and write up what you've found.
 - It is far better to return a partial-but-useful answer than to run out of time with nothing. If you couldn't fully confirm something, say so and report your best findings, leads, and next steps.
 - You MUST always finish by producing a final answer with the [END_OF_ANSWER] marker — never end without one.
 
@@ -81,6 +81,7 @@ export async function log_agent_context(
     stakworkApiKey: opts.stakworkApiKey,
     stakworkRuns: opts.stakworkRuns,
     abortSignal: opts.abortSignal,
+    startTime,
   });
 
   const hasEndMarker = createHasEndMarkerCondition<typeof tools>();

--- a/mcp/src/log/agent.ts
+++ b/mcp/src/log/agent.ts
@@ -56,6 +56,8 @@ export interface LogAgentOptions {
   source?: string;
   /** Custom HTTP headers attached to every LLM endpoint request (provider-level). */
   headers?: Record<string, string>;
+  /** Abort signal to cancel the in-flight run (and forward into tools). */
+  abortSignal?: AbortSignal;
 }
 
 export async function log_agent_context(
@@ -71,6 +73,7 @@ export async function log_agent_context(
     logsDir: opts.logsDir,
     stakworkApiKey: opts.stakworkApiKey,
     stakworkRuns: opts.stakworkRuns,
+    abortSignal: opts.abortSignal,
   });
 
   const hasEndMarker = createHasEndMarkerCondition<typeof tools>();
@@ -124,14 +127,19 @@ export async function log_agent_context(
 
   const userMessage: ModelMessage = { role: "user", content: prompt };
 
+  const abortSignal = opts.abortSignal;
   let result;
   try {
     if (previousMessages.length > 0) {
       result = await agent.generate({
         messages: [...previousMessages, userMessage],
+        ...(abortSignal ? { abortSignal } : {}),
       });
     } else {
-      result = await agent.generate({ prompt });
+      result = await agent.generate({
+        prompt,
+        ...(abortSignal ? { abortSignal } : {}),
+      });
     }
   } catch (err) {
     if (sessionId) {

--- a/mcp/src/log/agent.ts
+++ b/mcp/src/log/agent.ts
@@ -35,6 +35,13 @@ Tips:
 - Look for patterns: recurring errors, timestamps clustering, correlated events.
 - When debugging an issue, search for both the error itself and surrounding context.
 
+TIME BUDGET (very important): You have roughly 8 minutes of wall-clock time total. Work efficiently:
+- Plan a focused approach up front; don't fetch more than you need. Prefer narrow filter patterns, specific log streams, and shorter time windows over broad fetches.
+- Avoid rabbit holes and redundant tool calls. Each fetch/search should have a clear purpose.
+- Continuously track roughly how much time you've spent. Once you're about 6-7 minutes in (or you have enough to answer), STOP investigating and write up what you've found.
+- It is far better to return a partial-but-useful answer than to run out of time with nothing. If you couldn't fully confirm something, say so and report your best findings, leads, and next steps.
+- You MUST always finish by producing a final answer with the [END_OF_ANSWER] marker — never end without one.
+
 CRITICAL: When you are ready to provide your final answer, output your complete response followed by [END_OF_ANSWER] on a new line.
 
 Example format:

--- a/mcp/src/log/cloudwatch.ts
+++ b/mcp/src/log/cloudwatch.ts
@@ -12,12 +12,24 @@ import * as path from "path";
 function getClient(): CloudWatchLogsClient {
   const opts: ConstructorParameters<typeof CloudWatchLogsClient>[0] = {
     region: process.env.AWS_REGION || "us-east-1",
+    // Bound every request so a stalled socket can't hang the agent forever.
+    maxAttempts: 3,
+    requestHandler: {
+      connectionTimeout: 5_000,
+      requestTimeout: 30_000,
+    },
   };
   if (process.env.AWS_PROFILE) {
     opts.credentials = fromIni({ profile: process.env.AWS_PROFILE });
   }
   return new CloudWatchLogsClient(opts);
 }
+
+// Hard caps so FilterLogEvents can't paginate forever when a filter pattern
+// matches sparsely across a high-volume log group (each page returns 0 events
+// but a nextToken, so an `allEvents.length < limit` check never terminates).
+const MAX_FETCH_PAGES = 200;
+const MAX_FETCH_WALL_MS = 60_000;
 
 /** Sanitize a log group name into a safe filename */
 function safeFilename(logGroup: string): string {
@@ -31,6 +43,7 @@ export interface FetchCloudwatchParams {
   minutes?: number;
   limit?: number;
   logsDir: string;
+  abortSignal?: AbortSignal;
 }
 
 export interface FetchCloudwatchResult {
@@ -38,6 +51,7 @@ export interface FetchCloudwatchResult {
   lineCount: number;
   logGroup: string;
   timeRange: { startTime: string; endTime: string };
+  truncated: boolean;
 }
 
 /**
@@ -47,7 +61,7 @@ export interface FetchCloudwatchResult {
 export async function fetchCloudwatchLogs(
   params: FetchCloudwatchParams
 ): Promise<FetchCloudwatchResult> {
-  const { logGroupName, logStreamNames, filterPattern, minutes = 30, limit = 10000, logsDir } = params;
+  const { logGroupName, logStreamNames, filterPattern, minutes = 30, limit = 10000, logsDir, abortSignal } = params;
   const client = getClient();
 
   const endTime = Date.now();
@@ -55,8 +69,29 @@ export async function fetchCloudwatchLogs(
 
   const allEvents: FilteredLogEvent[] = [];
   let nextToken: string | undefined;
+  let pages = 0;
+  const deadline = Date.now() + MAX_FETCH_WALL_MS;
+  let truncated = false;
 
   do {
+    if (abortSignal?.aborted) {
+      throw new Error("CloudWatch fetch aborted");
+    }
+    if (Date.now() > deadline) {
+      truncated = true;
+      console.warn(
+        `[cloudwatch] fetch for ${logGroupName} hit ${MAX_FETCH_WALL_MS}ms wall-clock cap after ${pages} pages (${allEvents.length} events)`
+      );
+      break;
+    }
+    if (pages >= MAX_FETCH_PAGES) {
+      truncated = true;
+      console.warn(
+        `[cloudwatch] fetch for ${logGroupName} hit ${MAX_FETCH_PAGES}-page cap (${allEvents.length} events)`
+      );
+      break;
+    }
+
     const command = new FilterLogEventsCommand({
       logGroupName,
       logStreamNames: logStreamNames?.length ? logStreamNames : undefined,
@@ -67,11 +102,14 @@ export async function fetchCloudwatchLogs(
       nextToken,
     });
 
-    const response = await client.send(command);
+    const response = await client.send(command, {
+      abortSignal: abortSignal as any,
+    });
     if (response.events) {
       allEvents.push(...response.events);
     }
     nextToken = response.nextToken;
+    pages++;
   } while (nextToken && allEvents.length < limit);
 
   // Write to file
@@ -98,6 +136,7 @@ export async function fetchCloudwatchLogs(
       startTime: new Date(startTime).toISOString(),
       endTime: new Date(endTime).toISOString(),
     },
+    truncated,
   };
 }
 

--- a/mcp/src/log/index.ts
+++ b/mcp/src/log/index.ts
@@ -2,6 +2,10 @@ import { Request, Response } from "express";
 import { log_agent_context } from "./agent.js";
 import * as asyncReqs from "../graph/reqs.js";
 import { startTracking, endTracking } from "../busy.js";
+import {
+  registerAbortController,
+  unregisterAbortController,
+} from "../repo/events.js";
 import { ModelName } from "../aieo/src/index.js";
 import { randomUUID } from "crypto";
 import { SessionConfig } from "../repo/session.js";
@@ -122,10 +126,16 @@ export async function logs_agent(req: Request, res: Response) {
   // otherwise generate a random one (cleaned up after the agent finishes).
   const logsDir = createRunLogsDir(sessionId);
 
-  const opId = startTracking("logs_agent");
+  // Register abort controller keyed by request_id (and mirrored under sessionId)
+  // so the 30-min safety timeout in busy.ts can actually cancel the run.
+  const abortController = registerAbortController(request_id);
+  if (sessionId && sessionId !== request_id) {
+    registerAbortController(sessionId, abortController);
+  }
+  const opId = startTracking("logs_agent", abortController);
 
   try {
-    log_agent_context(finalPrompt, { modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, stakworkApiKey, stakworkRuns, logsDir, printAgentProgress, source: "logs_agent", headers })
+    log_agent_context(finalPrompt, { modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, stakworkApiKey, stakworkRuns, logsDir, printAgentProgress, source: "logs_agent", headers, abortSignal: abortController.signal })
       .then((result) => {
         asyncReqs.finishReq(request_id, {
           success: true,
@@ -138,10 +148,19 @@ export async function logs_agent(req: Request, res: Response) {
         });
       })
       .catch((error) => {
-        console.error("[logs_agent] Background work failed:", error);
-        asyncReqs.failReq(request_id, error.message || error.toString());
+        if (abortController.signal.aborted) {
+          console.log(`[logs_agent] Run aborted: ${request_id}`);
+          asyncReqs.failReq(request_id, "aborted");
+        } else {
+          console.error("[logs_agent] Background work failed:", error);
+          asyncReqs.failReq(request_id, error.message || error.toString());
+        }
       })
       .finally(() => {
+        unregisterAbortController(request_id);
+        if (sessionId && sessionId !== request_id) {
+          unregisterAbortController(sessionId);
+        }
         endTracking(opId);
         // Clean up logs directory for non-session runs
         if (!sessionId) {
@@ -153,6 +172,10 @@ export async function logs_agent(req: Request, res: Response) {
   } catch (error: any) {
     console.error("Error in logs_agent", error);
     asyncReqs.failReq(request_id, error);
+    unregisterAbortController(request_id);
+    if (sessionId && sessionId !== request_id) {
+      unregisterAbortController(sessionId);
+    }
     res.status(500).json({ error: "Internal server error" });
     endTracking(opId);
   }

--- a/mcp/src/log/tools.ts
+++ b/mcp/src/log/tools.ts
@@ -18,6 +18,10 @@ export interface LogToolsOptions {
   stakworkApiKey?: string;
   stakworkRuns?: StakworkRunSummary[];
   abortSignal?: AbortSignal;
+  /** Wall-clock start time (ms) used to report elapsed time back to the agent. */
+  startTime?: number;
+  /** Total time budget (ms) the agent should stay within. Default 8 min. */
+  budgetMs?: number;
 }
 
 export function get_log_tools(
@@ -25,6 +29,16 @@ export function get_log_tools(
 ): Record<string, Tool<any, any>> {
   const { logsDir, abortSignal } = opts;
   const redactOpts = { literals: [opts.stakworkApiKey].filter(Boolean) as string[] };
+  const startTime = opts.startTime ?? Date.now();
+  const budgetMs = opts.budgetMs ?? 8 * 60 * 1000;
+  // Appended to every tool result so the agent can actually see how much of
+  // its time budget it has used (it has no clock of its own between steps).
+  const elapsedNote = (): string => {
+    const elapsedMin = (Date.now() - startTime) / 60_000;
+    const budgetMin = budgetMs / 60_000;
+    const remainingMin = Math.max(0, budgetMin - elapsedMin);
+    return `\n\n[time budget: ${elapsedMin.toFixed(1)} min elapsed of ${budgetMin.toFixed(0)} min; ~${remainingMin.toFixed(1)} min left${remainingMin <= 2 ? " — wrap up and write your final answer now" : ""}]`;
+  };
   const tools: Record<string, Tool<any, any>> = {
     fetch_cloudwatch: tool({
       description:
@@ -306,6 +320,19 @@ export function get_log_tools(
         }
       },
     });
+  }
+
+  // Wrap every tool so its (string) result carries the current time-budget
+  // status. This is the only way the agent gets a sense of elapsed wall-clock
+  // time, since it has no clock between steps.
+  for (const key of Object.keys(tools)) {
+    const t = tools[key];
+    const orig = t.execute;
+    if (!orig) continue;
+    t.execute = (async (args: any, options: any) => {
+      const out = await orig(args, options);
+      return typeof out === "string" ? out + elapsedNote() : out;
+    }) as typeof t.execute;
   }
 
   return tools;

--- a/mcp/src/log/tools.ts
+++ b/mcp/src/log/tools.ts
@@ -17,12 +17,13 @@ export interface LogToolsOptions {
   logsDir: string;
   stakworkApiKey?: string;
   stakworkRuns?: StakworkRunSummary[];
+  abortSignal?: AbortSignal;
 }
 
 export function get_log_tools(
   opts: LogToolsOptions
 ): Record<string, Tool<any, any>> {
-  const { logsDir } = opts;
+  const { logsDir, abortSignal } = opts;
   const redactOpts = { literals: [opts.stakworkApiKey].filter(Boolean) as string[] };
   const tools: Record<string, Tool<any, any>> = {
     fetch_cloudwatch: tool({
@@ -76,8 +77,12 @@ export function get_log_tools(
             minutes,
             limit,
             logsDir,
+            abortSignal,
           });
-          return `Fetched ${result.lineCount} log lines from ${result.logGroup} (${result.timeRange.startTime} to ${result.timeRange.endTime}). Saved to file: ${result.file}. Use bash to search through it (e.g. rg, grep, head, tail, awk).`;
+          const truncNote = result.truncated
+            ? " NOTE: the fetch was capped before scanning the full time range (results may be incomplete) — narrow the filter_pattern, log_stream_names, or minutes to get complete results."
+            : "";
+          return `Fetched ${result.lineCount} log lines from ${result.logGroup} (${result.timeRange.startTime} to ${result.timeRange.endTime}). Saved to file: ${result.file}. Use bash to search through it (e.g. rg, grep, head, tail, awk).${truncNote}`;
         } catch (e: any) {
           return `Failed to fetch CloudWatch logs: ${e.message}`;
         }


### PR DESCRIPTION
## Problem

On a prod server heavily using CloudWatch, `logs_agent` would time out after 30 minutes (`[busy] TIMEOUT ... forcing cleanup`) and **never come back** — it "just stops calling tools" with nothing in the server logs.

### Root cause

1. **`logs_agent` had no abort wiring.** Unlike `repo_agent`/`graph_agent`, it called `startTracking("logs_agent")` with no `AbortController`, and `log_agent_context` never forwarded an `abortSignal` into `agent.generate()`. So when the 30-min `busy.ts` timeout fired, the "Safety-aborting" branch was skipped (it only runs when an `externalAbortController` exists) — the timeout just deleted the map entry while the underlying `generate()` promise kept running forever.

2. **The actual hang: the CloudWatch pagination loop.** `fetchCloudwatchLogs` looped `while (nextToken && allEvents.length < limit)`. `FilterLogEvents` returns a `nextToken` to keep scanning even when a page has **zero matching events**, so a sparse/no-match `filter_pattern` over a high-volume log group scans the entire group indefinitely. The `await` sat inside the tool's `execute`, blocking the agent loop — hence "stops calling tools" with no progress logs.

3. The `CloudWatchLogsClient` had no socket/request timeout and no `maxAttempts` cap, so a stalled request could also hang silently.

## Changes

- **`cloudwatch.ts`**: bound the pagination loop with a page cap (200), wall-clock cap (60s), and abort-signal checks; surface a `truncated` flag. Add `maxAttempts: 3` + connection/request timeouts to the client.
- **`tools.ts`**: thread `abortSignal` into the CloudWatch fetch and `client.send`; tell the model when results were truncated so it can narrow the query.
- **`agent.ts`**: accept `abortSignal` and forward it into `agent.generate()` and the tools.
- **`index.ts`**: register an `AbortController` (keyed by `request_id` + `sessionId`), pass it to `startTracking`, and forward the signal — so the 30-min safety timeout can actually cancel the run.

## Net effect

- A sparse/no-match filter returns in ≤60s instead of hanging.
- Even if something else hangs, the 30-min timeout can now genuinely abort the run instead of leaving a zombie promise.

## Testing

- `npx tsc --noEmit` passes.