### PR TITLE
fix: graph correctness, query, and security fixes from deep review

### DIFF
--- a/ast/src/lang/asg.rs
+++ b/ast/src/lang/asg.rs
@@ -293,6 +293,7 @@ impl FromStr for NodeType {
             "UnitTest" => Ok(NodeType::UnitTest),
             "IntegrationTest" => Ok(NodeType::IntegrationTest),
             "E2etest" => Ok(NodeType::E2eTest),
+            "Mock" => Ok(NodeType::Mock),
             _ => Err(Error::validation(format!("Invalid NodeType string: {}", s))),
         }
     }

--- a/ast/src/lang/call_finder.rs
+++ b/ast/src/lang/call_finder.rs
@@ -176,8 +176,11 @@ pub fn parse_imports_for_file<G: Graph>(
             }
 
             let exts = lang.kind.exts();
-            if let Some(ext) = exts.iter().find(|&&e| resolved_path.ends_with(e)) {
-                resolved_path = resolved_path.trim_end_matches(ext).to_string();
+            if let Some(ext) = exts
+                .iter()
+                .find(|&&e| resolved_path.ends_with(&format!(".{}", e)))
+            {
+                resolved_path.truncate(resolved_path.len() - ext.len() - 1);
             }
 
             results.push((resolved_path, import_names));

--- a/ast/src/lang/graphs/btreemap_graph.rs
+++ b/ast/src/lang/graphs/btreemap_graph.rs
@@ -108,8 +108,8 @@ impl Graph for BTreeMapGraph {
         self.nodes
             .range(prefix.clone()..)
             .take_while(|(k, _)| k.starts_with(&prefix))
+            .find(|(_, node)| node.node_data.name == name && node.node_data.file == file)
             .map(|(_, node)| node.node_data.clone())
-            .next()
     }
 
     fn add_node_with_parent(
@@ -267,8 +267,8 @@ impl Graph for BTreeMapGraph {
             {
                 if let Some(file_node_data) = self
                     .find_nodes_by_name(NodeType::File, &file_name)
-                    .first()
-                    .cloned()
+                    .into_iter()
+                    .find(|node| node.file == func_clone.file)
                 {
                     let contains_edge = Edge::contains(
                         NodeType::File,
@@ -341,7 +341,11 @@ impl Graph for BTreeMapGraph {
         self.nodes
             .range(prefix.clone()..)
             .take_while(|(k, _)| k.starts_with(&prefix))
-            .find(|(_, node)| node.node_data.meta.get("verb") == Some(&verb.to_string()))
+            .find(|(_, node)| {
+                node.node_data.name == name
+                    && node.node_data.file == file
+                    && node.node_data.meta.get("verb") == Some(&verb.to_string())
+            })
             .map(|(_, node)| node.node_data.clone())
     }
 

--- a/ast/src/lang/graphs/graph_ops.rs
+++ b/ast/src/lang/graphs/graph_ops.rs
@@ -270,6 +270,7 @@ impl GraphOps {
 
         let streaming = streaming.unwrap_or(false);
         let temp_graph = if streaming {
+            self.graph.clear().await?;
             repos.build_graphs_with_batch_upload().await?
         } else {
             repos.build_graphs_local().await?
@@ -277,8 +278,8 @@ impl GraphOps {
 
         temp_graph.analysis();
 
-        self.graph.clear().await?;
         if !streaming {
+            self.graph.clear().await?;
             self.upload_btreemap_to_neo4j(&temp_graph, None).await?;
         }
         self.graph.create_indexes().await?;

--- a/ast/src/lang/graphs/neo4j/queries/nodes.rs
+++ b/ast/src/lang/graphs/neo4j/queries/nodes.rs
@@ -346,16 +346,16 @@ pub fn find_nodes_by_name_contains_query(
 }
 pub fn find_nodes_in_range_query(node_type: &NodeType, file: &str, row: u32) -> (String, BoltMap) {
     let mut params = BoltMap::new();
-    boltmap_insert_str(&mut params, "node_type", &node_type.to_string());
     boltmap_insert_str(&mut params, "file", file);
     boltmap_insert_int(&mut params, "row", row as i64);
 
     let query = format!(
-        "MATCH (n:$node_type)
-         WHERE n.file = $file AND 
-               toInteger(n.start) <= toInteger($row) AND 
+        "MATCH (n:{})
+         WHERE n.file = $file AND
+               toInteger(n.start) <= toInteger($row) AND
                toInteger(n.end) >= toInteger($row)
-         RETURN n"
+         RETURN n",
+        node_type.to_string()
     );
 
     (query, params)
@@ -536,6 +536,10 @@ pub fn restore_muted_status_query(identifiers: &[MutedNodeIdentifier]) -> (Strin
     (query, params)
 }
 
+fn escape_cypher_str(s: &str) -> String {
+    s.replace('\\', "\\\\").replace('\'', "\\'")
+}
+
 pub fn query_nodes_with_count(
     node_types: &[NodeType],
     offset: usize,
@@ -592,7 +596,7 @@ pub fn query_nodes_with_count(
                 let regex_conditions: Vec<String> = filters
                     .unit_regexes
                     .iter()
-                    .map(|r| format!("ut.file =~ '{}'", r))
+                    .map(|r| format!("ut.file =~ '{}'", escape_cypher_str(r)))
                     .collect();
                 clauses.push(format!(
                     "OPTIONAL MATCH (ut:UnitTest)-[:CALLS]->(n) WHERE {}",
@@ -605,7 +609,7 @@ pub fn query_nodes_with_count(
                 let regex_conditions: Vec<String> = filters
                     .integration_regexes
                     .iter()
-                    .map(|r| format!("it.file =~ '{}'", r))
+                    .map(|r| format!("it.file =~ '{}'", escape_cypher_str(r)))
                     .collect();
                 clauses.push(format!(
                     "OPTIONAL MATCH (it:IntegrationTest)-[:CALLS]->(n) WHERE {}",
@@ -618,7 +622,7 @@ pub fn query_nodes_with_count(
                 let regex_conditions: Vec<String> = filters
                     .e2e_regexes
                     .iter()
-                    .map(|r| format!("et.file =~ '{}'", r))
+                    .map(|r| format!("et.file =~ '{}'", escape_cypher_str(r)))
                     .collect();
                 clauses.push(format!(
                     "OPTIONAL MATCH (et:E2etest)-[:CALLS]->(n) WHERE {}",
@@ -660,11 +664,11 @@ pub fn query_nodes_with_count(
             let repos: Vec<&str> = r.split(',').map(|s| s.trim()).collect();
             let conditions: Vec<String> = repos
                 .iter()
-                .map(|repo_path| format!("n.file STARTS WITH '{}'", repo_path))
+                .map(|repo_path| format!("n.file STARTS WITH '{}'", escape_cypher_str(repo_path)))
                 .collect();
             format!("AND ({})", conditions.join(" OR "))
         } else {
-            format!("AND n.file STARTS WITH '{}'", r)
+            format!("AND n.file STARTS WITH '{}'", escape_cypher_str(r))
         }
     } else {
         String::new()
@@ -676,7 +680,7 @@ pub fn query_nodes_with_count(
             .map(|dir| {
                 format!(
                     "(NOT n.file CONTAINS '/{dir}/' AND NOT n.file =~ '.*/{dir}$')",
-                    dir = dir
+                    dir = escape_cypher_str(dir)
                 )
             })
             .collect();
@@ -688,7 +692,7 @@ pub fn query_nodes_with_count(
     let regex_filter = test_filters
         .as_ref()
         .and_then(|f| f.target_regex.as_deref())
-        .map(|pattern| format!("AND n.file =~ '{}'", pattern))
+        .map(|pattern| format!("AND n.file =~ '{}'", escape_cypher_str(pattern)))
         .unwrap_or_default();
 
     let search_filter = search

--- a/ast/src/lang/linker.rs
+++ b/ast/src/lang/linker.rs
@@ -382,8 +382,8 @@ pub fn link_api_nodes<G: Graph>(graph: &mut G) -> Result<()> {
     // Create edges between matching paths and verbs
     let mut i = 0;
     for (req, req_path) in frontend_requests {
-        for (endpoint, _) in &backend_endpoints {
-            if paths_match(&req_path, &endpoint.name) && verbs_match(&req, endpoint) {
+        for (endpoint, normalized) in &backend_endpoints {
+            if paths_match(&req_path, normalized) && verbs_match(&req, endpoint) {
                 let edge = Edge::calls(NodeType::Request, &req, NodeType::Endpoint, endpoint);
                 graph.add_edge(&edge);
                 i += 1;
@@ -556,6 +556,9 @@ mod tests {
         assert!(!paths_match("/api/user/:param", "/api/posts/:id"));
         assert!(!paths_match("/user/:param", "/api/user/:id"));
         assert!(!paths_match("/api/user/:param/extra", "/api/user/:id"));
+        let normalized = normalize_backend_path("/api/users/{id}").unwrap();
+        assert!(paths_match("/api/users/123", &normalized));
+        assert!(!paths_match("/api/users/123", "/api/users/{id}"));
     }
 
     #[test]

--- a/ast/src/lang/mod.rs
+++ b/ast/src/lang/mod.rs
@@ -795,6 +795,7 @@ impl Lang {
                             file,
                             node,
                             &caller_name,
+                            caller_start,
                             graph,
                             lsp_tx,
                         )?;

--- a/ast/src/lang/parse/collect.rs
+++ b/ast/src/lang/parse/collect.rs
@@ -317,6 +317,7 @@ impl Lang {
         file: &str,
         caller_node: TreeNode,
         caller_name: &str,
+        caller_start: usize,
         graph: &G,
         lsp_tx: &Option<CmdSender>,
     ) -> Result<Vec<Edge>> {
@@ -336,7 +337,16 @@ impl Lang {
         let mut res = Vec::new();
         while let Some(m) = matches.next() {
             if let Some(fc) =
-                self.format_integration_test_call(m, code, file, &q, caller_name, graph, lsp_tx)?
+                self.format_integration_test_call(
+                    m,
+                    code,
+                    file,
+                    &q,
+                    caller_name,
+                    caller_start,
+                    graph,
+                    lsp_tx,
+                )?
             {
                 res.push(fc);
             }

--- a/ast/src/lang/parse/format.rs
+++ b/ast/src/lang/parse/format.rs
@@ -1311,6 +1311,7 @@ impl Lang {
         file: &str,
         q: &Query,
         caller_name: &str,
+        caller_start: usize,
         graph: &G,
         lsp_tx: &Option<CmdSender>,
     ) -> Result<Option<Edge>> {
@@ -1386,7 +1387,7 @@ impl Lang {
         let Some(endpoint) = endpoint else {
             return Ok(None);
         };
-        let source = NodeKeys::new(caller_name, file, 0);
+        let source = NodeKeys::new(caller_name, file, caller_start);
         let edge = Edge::new(
             EdgeType::Calls,
             NodeRef::from(source, NodeType::IntegrationTest),

--- a/ast/src/lang/queries/rust.rs
+++ b/ast/src/lang/queries/rust.rs
@@ -207,7 +207,7 @@ impl Stack for Rust {
 
                     if let Some((parent_node, source_type)) = found_node {
                         let operand = Operand {
-                            source: NodeKeys::new(&parent_node.name, file, parent_node.start),
+                            source: NodeKeys::new(&parent_node.name, &parent_node.file, parent_node.start),
                             target: NodeKeys::new(func_name, file, node.start_position().row),
                             source_type,
                         };

--- a/ast/src/utils.rs
+++ b/ast/src/utils.rs
@@ -68,6 +68,17 @@ pub fn logger() {
         .init();
 }
 
+fn truncate_at_char_boundary(s: &str, max: usize) -> &str {
+    if s.len() <= max {
+        return s;
+    }
+    let mut idx = max;
+    while !s.is_char_boundary(idx) {
+        idx -= 1;
+    }
+    &s[..idx]
+}
+
 pub fn create_node_key(node: &Node) -> String {
     let node_type = node.node_type.to_string();
     let node_data = &node.node_data;
@@ -94,7 +105,7 @@ pub fn create_node_key(node: &Node) -> String {
 
     if result.len() > 5000 {
         if sanitized_name.len() > 2000 {
-            let truncated_name = &sanitized_name[..2000];
+            let truncated_name = truncate_at_char_boundary(&sanitized_name, 2000);
             let mut truncated_result = String::new();
             truncated_result.push_str(&sanitize_string(&node_type));
             truncated_result.push('-');
@@ -110,11 +121,13 @@ pub fn create_node_key(node: &Node) -> String {
             }
 
             if truncated_result.len() > 5000 {
-                truncated_result.truncate(5000);
+                let new_len = truncate_at_char_boundary(&truncated_result, 5000).len();
+                truncated_result.truncate(new_len);
             }
             truncated_result
         } else {
-            result.truncate(5000);
+            let new_len = truncate_at_char_boundary(&result, 5000).len();
+            result.truncate(new_len);
             result
         }
     } else {
@@ -179,7 +192,7 @@ pub fn create_node_key_from_ref(node_ref: &NodeRef) -> String {
 
     if result.len() > 5000 {
         if sanitized_name.len() > 2000 {
-            let truncated_name = &sanitized_name[..2000];
+            let truncated_name = truncate_at_char_boundary(&sanitized_name, 2000);
             let mut truncated_result = String::new();
             truncated_result.push_str(&sanitize_string(&node_type));
             truncated_result.push('-');
@@ -195,11 +208,13 @@ pub fn create_node_key_from_ref(node_ref: &NodeRef) -> String {
             }
 
             if truncated_result.len() > 5000 {
-                truncated_result.truncate(5000);
+                let new_len = truncate_at_char_boundary(&truncated_result, 5000).len();
+                truncated_result.truncate(new_len);
             }
             truncated_result
         } else {
-            result.truncate(5000);
+            let new_len = truncate_at_char_boundary(&result, 5000).len();
+            result.truncate(new_len);
             result
         }
     } else {

--- a/lsp/src/git.rs
+++ b/lsp/src/git.rs
@@ -10,7 +10,7 @@ pub async fn validate_git_credentials(
 ) -> Result<()> {
     let repo_url = match (username.as_ref(), pat.as_ref()) {
         (Some(username), Some(pat)) => {
-            let repo_end = &repo.to_string()[8..];
+            let repo_end = repo.strip_prefix("https://").unwrap_or(repo);
             format!("https://{}:{}@{}", username, pat, repo_end)
         }
         _ => repo.to_string(),
@@ -84,7 +84,7 @@ pub async fn git_clone(
 ) -> Result<()> {
     let repo_url = match (username.as_ref(), pat.as_ref()) {
         (Some(username), Some(pat)) => {
-            let repo_end = &repo.to_string()[8..];
+            let repo_end = repo.strip_prefix("https://").unwrap_or(repo);
             format!("https://{}:{}@{}", username, pat, repo_end)
         }
         _ => repo.to_string(),

--- a/mcp/src/graph/cache.ts
+++ b/mcp/src/graph/cache.ts
@@ -30,15 +30,19 @@ export function cacheMiddleware() {
 
     // Override send to cache the response
     res.send = function (data: any) {
-      cache.set(cacheKey, data, ttlSeconds);
-      console.log(`Cached response for ${cacheKey}`);
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        cache.set(cacheKey, data, ttlSeconds);
+        console.log(`Cached response for ${cacheKey}`);
+      }
       return originalSend.call(this, data);
     };
 
     // Override json to cache the response
     res.json = function (data: any) {
-      cache.set(cacheKey, data, ttlSeconds);
-      console.log(`Cached JSON response for ${cacheKey}`);
+      if (res.statusCode >= 200 && res.statusCode < 300) {
+        cache.set(cacheKey, data, ttlSeconds);
+        console.log(`Cached JSON response for ${cacheKey}`);
+      }
       return originalJson.call(this, data);
     };
 

--- a/mcp/src/graph/graph.ts
+++ b/mcp/src/graph/graph.ts
@@ -548,11 +548,17 @@ export async function get_shortest_path(
 ) {
   if (start_ref_id && end_ref_id) {
     const result = await db.get_shortest_path_ref_id(start_ref_id, end_ref_id);
+    if (result.records.length === 0) {
+      return "No path found between the given nodes";
+    }
     const record = result.records[0];
     const path: ShortestPath = record.get("path");
     return pathToSnippets(path);
   } else {
     const result = await db.get_shortest_path(start_node_key, end_node_key);
+    if (result.records.length === 0) {
+      return "No path found between the given nodes";
+    }
     const record = result.records[0];
     const path: ShortestPath = record.get("path");
     return pathToSnippets(path);

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -810,11 +810,20 @@ class Db {
 
       const now = Date.now();
 
-      const result = await session.run(Q.ADD_NODE_QUERY(node_type), {
+      const { ref_id, ...properties } = node_data;
+
+      await session.run(Q.ADD_NODE_QUERY(node_type), {
         node_key,
-        properties: { ...node_data, node_key },
+        properties: { ...properties, node_key },
         now,
       });
+
+      const result = await session.run(
+        `MATCH (n:${node_type} {node_key: $node_key})
+         SET n.ref_id = coalesce(n.ref_id, $ref_id)
+         RETURN n.ref_id as ref_id`,
+        { node_key, ref_id: ref_id || uuidv4() },
+      );
 
       return result.records[0].get("ref_id");
     } finally {
@@ -1531,12 +1540,12 @@ class Db {
       const fileRes = await session.run(
         `
         MATCH (n:Data_Bank)
-        WHERE n.file STARTS WITH $prefix
+        WHERE n.file = $prefix OR n.file STARTS WITH $prefixSlash
         WITH collect(n) as nodes, count(n) as deleted_count
         FOREACH (x IN nodes | DETACH DELETE x)
         RETURN deleted_count
         `,
-        { prefix },
+        { prefix, prefixSlash: `${prefix}/` },
       );
       const file_nodes =
         fileRes.records[0]?.get("deleted_count")?.toNumber?.() ?? 0;
@@ -1748,13 +1757,15 @@ function construct_merge_node_query(node: Node): MergeQuery {
       MERGE (node:${node_type}:${Data_Bank} {node_key: $node_key})
       ON CREATE SET node += $properties
       ON MATCH SET node += $properties
+      SET node.ref_id = coalesce(node.ref_id, $ref_id)
       RETURN node
     `;
   return {
     query,
     parameters: {
       node_key,
-      properties: { ...node_data, node_key, ref_id: uuidv4() },
+      ref_id: uuidv4(),
+      properties: { ...node_data, node_key },
     },
   };
 }
@@ -1762,19 +1773,19 @@ function construct_merge_node_query(node: Node): MergeQuery {
 // Function to construct edge merge query
 function construct_merge_edge_query(edge_data: Edge): MergeQuery {
   const { edge, source, target } = edge_data;
+  const source_key = create_node_key(source);
+  const target_key = create_node_key(target);
   const query = `
-      MATCH (source:${source.node_type} {name: $source_name, file: $source_file})
-      MATCH (target:${target.node_type} {name: $target_name, file: $target_file})
+      MATCH (source:${source.node_type} {node_key: $source_key})
+      MATCH (target:${target.node_type} {node_key: $target_key})
       MERGE (source)-[r:${edge.edge_type}]->(target)
       RETURN r
     `;
   return {
     query,
     parameters: {
-      source_name: source.node_data.name,
-      source_file: source.node_data.file,
-      target_name: target.node_data.name,
-      target_file: target.node_data.file,
+      source_key,
+      target_key,
     },
   };
 }

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -224,8 +224,8 @@ RETURN n.ref_id as ref_id
 `;
 
 export const ADD_EDGE_QUERY = (edgeType: string) => `
-MATCH (source {ref_id: $source_ref_id})
-MATCH (target {ref_id: $target_ref_id})
+MATCH (source:${Data_Bank} {ref_id: $source_ref_id})
+MATCH (target:${Data_Bank} {ref_id: $target_ref_id})
 MERGE (source)-[r:${edgeType}]->(target)
 ON CREATE SET r.ref_id = randomUUID()
 RETURN r
@@ -238,7 +238,7 @@ RETURN h
 
 export const GET_NODE_WITH_RELATED_QUERY = `
 // First, collect all related nodes
-MATCH (h {ref_id: $ref_id})
+MATCH (h:${Data_Bank} {ref_id: $ref_id})
 OPTIONAL MATCH (h)-[e]-(m)
 WITH h, collect(DISTINCT m) AS relatedNodes
 
@@ -390,10 +390,10 @@ LIMIT 5
 `;
 
 export const CREATE_HINT_EDGES_BY_REF_IDS_QUERY = `
-MATCH (h)
+MATCH (h:${Data_Bank})
 WHERE h.ref_id = $hint_ref_id AND (h:Hint OR h:Prompt)
 UNWIND $weighted_ref_ids AS weighted_ref
-MATCH (t {ref_id: weighted_ref.ref_id})
+MATCH (t:${Data_Bank} {ref_id: weighted_ref.ref_id})
 MERGE (h)-[r:USES]->(t)
 ON CREATE SET r.ref_id = randomUUID()
 SET r.relevancy = weighted_ref.relevancy
@@ -446,7 +446,7 @@ LIMIT toInteger($limit)
 `;
 
 export const EDGES_BETWEEN_NODE_KEYS_QUERY = `
-MATCH (a)-[r]->(b)
+MATCH (a:${Data_Bank})-[r]->(b:${Data_Bank})
 WHERE a.node_key IN $keys AND b.node_key IN $keys
 RETURN r, a, b;
 `;
@@ -587,7 +587,7 @@ WITH $node_label AS nodeLabel,
 CALL {
   WITH refId
   WITH refId WHERE refId IS NOT NULL AND refId <> ''
-  MATCH (node {ref_id: refId})
+  MATCH (node:${Data_Bank} {ref_id: refId})
   RETURN node
   UNION
   WITH nodeName, nodeLabel
@@ -625,7 +625,7 @@ WITH $node_label AS nodeLabel,
 CALL {
   WITH refId
   WITH refId WHERE refId IS NOT NULL AND refId <> ''
-  MATCH (node {ref_id: refId})
+  MATCH (node:${Data_Bank} {ref_id: refId})
   RETURN node
   UNION
   // Find by name + label
@@ -816,8 +816,8 @@ RETURN startNode,
 `;
 
 export const SHORTEST_PATH_QUERY = `
-MATCH (start {node_key: $start_node_key}),
-      (end {node_key: $end_node_key})
+MATCH (start:${Data_Bank} {node_key: $start_node_key}),
+      (end:${Data_Bank} {node_key: $end_node_key})
 MATCH path = shortestPath((start)-[*]-(end))
 WHERE ALL(node IN nodes(path) WHERE
     node:Page OR
@@ -835,7 +835,7 @@ RETURN path
 // `;
 
 export const SHORTEST_PATH_QUERY_REF_ID = `
-MATCH (start {ref_id: $start_ref_id}), (end {ref_id: $end_ref_id})
+MATCH (start:${Data_Bank} {ref_id: $start_ref_id}), (end:${Data_Bank} {ref_id: $end_ref_id})
 MATCH path = shortestPath((start)-[*]-(end))
 WHERE ALL(node IN nodes(path) WHERE
     node:Page OR

--- a/mcp/src/graph/uploads.ts
+++ b/mcp/src/graph/uploads.ts
@@ -1,4 +1,5 @@
 import fs from "fs";
+import path from "path";
 import { v4 as uuidv4 } from "uuid";
 import { db } from "./neo4j.js";
 import type { Request, Response } from "express";
@@ -20,6 +21,10 @@ export async function upload_files(req: Request, res: Response) {
     res.status(400).send("No files were uploaded.");
     return;
   }
+  if (!req.files.nodes || !req.files.edges) {
+    res.status(400).send("Both 'nodes' and 'edges' files are required.");
+    return;
+  }
   const requestId = uuidv4();
   const file1 = req.files.nodes;
   const file2 = req.files.edges;
@@ -33,10 +38,10 @@ export async function upload_files(req: Request, res: Response) {
       fs.mkdirSync(UPLOAD_PATH, { recursive: true });
     }
 
-    const node_file = UPLOAD_PATH + nodesFiles[0].name;
+    const node_file = path.join(UPLOAD_PATH, path.basename(nodesFiles[0].name));
     await nodesFiles[0].mv(node_file);
 
-    const edge_file = UPLOAD_PATH + edgesFiles[0].name;
+    const edge_file = path.join(UPLOAD_PATH, path.basename(edgesFiles[0].name));
     await edgesFiles[0].mv(edge_file);
 
     jobStatus.set(requestId, { status: "pending" });

--- a/mcp/src/tools/stakgraph/shortest_path.ts
+++ b/mcp/src/tools/stakgraph/shortest_path.ts
@@ -25,6 +25,18 @@ export const ShortestPathTool: Tool = {
 
 export async function shortestPath(args: z.infer<typeof ShortestPathSchema>) {
   console.log("=> Running shortest_path tool with args:", args);
+  const hasNodeKeys = args.start_node_key && args.end_node_key;
+  const hasRefIds = args.start_ref_id && args.end_ref_id;
+  if (!hasNodeKeys && !hasRefIds) {
+    return {
+      content: [
+        {
+          type: "text",
+          text: "Error: provide both start_node_key and end_node_key, or both start_ref_id and end_ref_id",
+        },
+      ],
+    };
+  }
   const result = await G.get_shortest_path(
     args.start_node_key || "",
     args.end_node_key || "",

--- a/mcp/src/vector/index.ts
+++ b/mcp/src/vector/index.ts
@@ -5,15 +5,15 @@ export const DIMENSIONS = 384;
 export const MODEL = EmbeddingModel.BGESmallENV15;
 
 // Initialize the embedding model once and reuse it
-let flagEmbeddingInstance: Awaited<ReturnType<typeof FlagEmbedding.init>> | null = null;
+let flagEmbeddingPromise: ReturnType<typeof FlagEmbedding.init> | null = null;
 async function getFlagEmbedding() {
-  if (!flagEmbeddingInstance) {
-    flagEmbeddingInstance = await FlagEmbedding.init({
+  if (!flagEmbeddingPromise) {
+    flagEmbeddingPromise = FlagEmbedding.init({
       model: MODEL,
       maxLength: 512,
     });
   }
-  return flagEmbeddingInstance;
+  return flagEmbeddingPromise;
 }
 
 export async function vectorizeQuery(query: string): Promise<number[]> {


### PR DESCRIPTION
## What

18 verified fixes from a multi-agent deep review of the ingest/graph/query pipeline. Every finding was re-verified against the code before fixing; findings that were refuted, debatable, LSP-behavior-only, or required design changes were deliberately left out.

### Rust — graph correctness (`ast/`)

- **`BTreeMapGraph::add_functions`** now selects the File node whose full path equals the function's file instead of `.first()` on a basename lookup — previously any repo with multiple `index.ts`/`mod.rs`/`__init__.py` files attached File→Function CONTAINS edges to the wrong file, and these wrong edges landed in Neo4j via the main build/upload path.
- **`find_node_by_name_in_file` / `find_endpoint`** add exact name+file equality after the sanitized key-prefix scan (sanitization makes `src/Button.ts` a prefix of `src/Button.tsx`), mirroring the ArrayGraph implementation.
- **`update_full(streaming=true)`** cleared the graph *after* the streamed build had already uploaded it, ending with an empty graph. The clear now happens before the streaming build; the non-streaming path is unchanged.
- **`find_nodes_in_range_query`** used `MATCH (n:$node_type)` — Cypher can't parameterize labels, so the query errored on every execution and the error was swallowed, silently dropping range-resolved edges on incremental builds. The label is now interpolated like the sibling queries.
- **`NodeType::from_str`** gains the missing `"Mock"` arm (Display emits it; round-trips dropped Mock nodes).
- **Node key truncation** respects UTF-8 char boundaries instead of byte slicing (panic on long non-ASCII identifiers).

### Rust — linking/parsing (`ast/`)

- **`link_api_nodes`** matched against the raw endpoint name while binding the normalized path it had just computed to `_` — so `{id}`, `<id>`, `[id]` param styles never produced Request→Endpoint edges. It now uses the normalized path; test added.
- **Rust `find_function_parent`** used the method's file with the parent class's start row for the Operand edge source key, producing dangling Class→Function edges whenever `struct` and `impl` live in different files. Now uses the parent node's own coordinates (matching the Go implementation).
- **Import extension stripping** matched dot-less extensions with `ends_with` + `trim_end_matches`, mangling extensionless import paths (`src/posts` → `src/pos`). Now matches `.ext` and strips exactly one suffix.
- **`format_integration_test_call`** hardcoded `start=0` in the edge source key, so the edge never matched the real IntegrationTest node in Neo4j. The caller's start row is now threaded through (matching the parallel path in `mod.rs`).

### Security

- **Cypher injection** (`query_nodes_with_count`): HTTP-supplied repo paths, regexes, and ignore_dirs were interpolated into single-quoted Cypher strings. All 7 sites now escape `\` and `'` (escaping preserves regex intent: `\\` parses back to a literal `\`).
- **Upload path traversal** (`mcp/src/graph/uploads.ts`): client-supplied multipart filenames were concatenated onto `UPLOAD_PATH`, allowing `../../` writes. Now `path.join(UPLOAD_PATH, path.basename(name))`, plus a 400 when `nodes`/`edges` files are missing.
- **`lsp/src/git.rs`** built credential URLs with `&repo[8..]`, panicking on short strings and garbling non-https remotes (this is on the prod clone path). Now `strip_prefix("https://")`.

### TypeScript — mcp graph/query layer

- **`construct_merge_edge_query`** matched edge endpoints by `{name, file}` while node identity is `node_key` (type+name+file+start+verb) — same-named functions, overloads, and GET-vs-POST endpoints got cross-product edges between every source×target combination. Edges now MATCH on `node_key`, computed with the same `create_node_key` used at node upload (also hits the node_key index). Verified the `verb` field lines up between the node JSONL (Rust flattens `meta` to top-level keys) and edge JSONL (`NodeKeys.verb`).
- **`ref_id` stability**: `construct_merge_node_query` baked a fresh `uuidv4()` into the properties applied on `ON MATCH`, so every re-upload rotated every node's public `ref_id`, dangling all previously issued references. Now `SET node.ref_id = coalesce(node.ref_id, $ref_id)`; the gitsee `add_node` path gets the same treatment.
- **`delete_repo`** used `STARTS WITH $prefix` without a slash boundary, so deleting `owner/repo` also DETACH-DELETEd `owner/repo-web`. Now `n.file = $prefix OR n.file STARTS WITH $prefix + "/"`.
- **`:Data_Bank` labels** added to all unlabeled `ref_id`/`node_key` equality matches (ADD_EDGE, hint edges, GET_NODE_WITH_RELATED, both shortest-path queries, EDGES_BETWEEN_NODE_KEYS, FIND_NODE/SUBGRAPH ref_id branches) so the existing label-scoped indexes are used instead of AllNodesScans — the same fix the in-repo comment documents for `BULK_UPDATE_IMPORTANCE_QUERY` after a production incident.
- **`get_shortest_path`** returned an opaque `TypeError: Cannot read properties of undefined` whenever no path existed (common: disconnected nodes, label-restricted paths, bad keys). Now returns "No path found between the given nodes"; the tool wrapper validates that a complete node_key pair or ref_id pair is provided.
- **`cacheMiddleware`** cached every response unconditionally — one transient 500 poisoned the 24h cache and was replayed as HTTP 200. Only 2xx responses are cached now.
- **`getFlagEmbedding`** caches the init promise instead of the resolved instance, fixing the concurrent first-use race (duplicate ONNX model downloads/sessions).

## Reviewer notes

- One behavioral edge from the `:Data_Bank` labeling: `Workflow_documentation` nodes get a `ref_id` without the `:Data_Bank` label, so a generic `/node` lookup by that ref_id would now return empty. Nothing in the codebase does that today.
- The escaping fix for `query_nodes_with_count` is the minimal safe change; full Bolt parameterization of those clauses would be a nicer follow-up.
- Deliberately **not** included: LSP behavior findings (`default_do_lsp` etc. — not on the prod path), the streaming-upload positional watermark redesign (needs key-based flush tracking, a design change), SSRF/token-exchange policy items, and findings whose proposed fixes were themselves questionable (`normalizeGlobToContains`, `unique_functions_filters`).

## Verification

- `cargo check --workspace` clean
- `cargo test -p ast --lib`: 51 passed, 0 failed (includes the language fixture graph tests and a new `paths_match`-with-normalization assertion)
- `npx tsc --noEmit` in `mcp/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)