### PR TITLE
feat: add gh CLI with per-request scoped auth for repo agent

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -16,6 +16,12 @@ WORKDIR /usr/src/app
 RUN apt update && apt install -y sed git vim tree ripgrep wget curl jq python3 && \
     ln -s /usr/bin/python3 /usr/bin/python
 
+# Install GitHub CLI (gh) from the official apt repo (supports x64 and arm64)
+RUN wget -qO- https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" > /etc/apt/sources.list.d/github-cli.list && \
+    apt update && apt install -y gh
+
 # install Gitleaks (supports x64 and arm64)
 RUN ARCH=$(dpkg --print-architecture) && \
     if [ "$ARCH" = "amd64" ]; then \

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -124,6 +124,7 @@ ${learn_concepts ? "Use list_concepts and learn_concept tools first, to learn ab
 - Limit results: \`rg -n -m3 "pattern" path/to/dir\`
 - Find files by name: \`find path/to/dir -name "*.py" -type f\`
 - Directory overview: \`tree -L 2 path/to/dir\`
+- GitHub CLI: \`gh\` is installed and authenticated as the requesting user (when a token is provided). Use it for GitHub data not in the graph — e.g. \`gh pr view <n>\`, \`gh pr diff <n>\`, \`gh issue view <n>\`, \`gh api <endpoint>\`.
 
 ## Rules
 The prompt prepended to your instructions tells you which repos are graph-backed and which are bash-only. Apply these rules per repo accordingly.

--- a/mcp/src/repo/bash.ts
+++ b/mcp/src/repo/bash.ts
@@ -83,13 +83,15 @@ function execRipgrepCommandDirect(
 function execShellCommand(
   command: string,
   cwd: string,
-  timeoutMs: number = 10000
+  timeoutMs: number = 10000,
+  env?: NodeJS.ProcessEnv
 ): Promise<string> {
   return new Promise((resolve, reject) => {
     const process = spawn(command, {
       cwd,
       shell: true,
       stdio: ["ignore", "pipe", "pipe"],
+      env: env ? { ...globalThis.process.env, ...env } : globalThis.process.env,
     });
 
     let stdout = "";
@@ -339,7 +341,8 @@ export async function fulltextSearch(
 export async function executeBashCommand(
   command: string,
   repoPath: string,
-  timeoutMs?: number
+  timeoutMs?: number,
+  env?: NodeJS.ProcessEnv
 ): Promise<string> {
   if (!repoPath) {
     return "No repository path provided";
@@ -350,7 +353,7 @@ export async function executeBashCommand(
   }
 
   try {
-    const result = await execShellCommand(command, repoPath, timeoutMs);
+    const result = await execShellCommand(command, repoPath, timeoutMs, env);
     return result;
   } catch (error: any) {
     return `Error executing command: ${error.message}`;

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -381,6 +381,12 @@ export async function get_tools(
     // Provider tools need to be added differently
   }
 
+  // Per-request GitHub auth for the `gh` CLI (and any tool reading GH_TOKEN).
+  // Scoped to this request's PAT so `gh` acts as the requesting user.
+  const ghEnv: NodeJS.ProcessEnv | undefined = pat
+    ? { GH_TOKEN: pat, GITHUB_TOKEN: pat }
+    : undefined;
+
   // Always register bash tool — Anthropic uses native provider tool, others use executeBashCommand
   if (bash_tool) {
     // Anthropic: use native provider tool (existing behaviour)
@@ -391,7 +397,7 @@ export async function get_tools(
       }),
       execute: async ({ command }: { command: string }) => {
         try {
-          return await executeBashCommand(command, repoPath);
+          return await executeBashCommand(command, repoPath, undefined, ghEnv);
         } catch (e) {
           return `Command execution failed: ${e}`;
         }
@@ -406,7 +412,7 @@ export async function get_tools(
       }),
       execute: async ({ command }: { command: string }) => {
         try {
-          return await executeBashCommand(command, repoPath);
+          return await executeBashCommand(command, repoPath, undefined, ghEnv);
         } catch (e) {
           return `Command execution failed: ${e}`;
         }


### PR DESCRIPTION
## Summary

Adds the GitHub CLI (`gh`) to the mcp Docker image and makes it usable by the repo agent's `bash` tool, authenticated as the **requesting user** via the per-request PAT.

## Changes

- **`mcp/Dockerfile`** — install `gh` from GitHub's official apt repo (supports both amd64 and arm64, matching the multi-arch build).
- **`mcp/src/repo/bash.ts`** — `execShellCommand` and `executeBashCommand` accept an optional `env`, merged over the inherited process env for the spawned child (`{ ...globalThis.process.env, ...env }`).
- **`mcp/src/repo/tools.ts`** — build a request-scoped env from the incoming PAT and pass it into both bash tool branches as `GH_TOKEN` / `GITHUB_TOKEN`, so `gh` acts as the requesting user.

## Scoping

- The PAT comes from `req.body.pat` per request → flows into `get_tools(...)` → captured in the bash tool's `execute` closure. Each agent run gets its own token.
- No PAT provided → no token injected, child just inherits the normal process env (unchanged behavior).
- Both `GH_TOKEN` and `GITHUB_TOKEN` are set (`gh` prefers `GH_TOKEN`; some tooling reads `GITHUB_TOKEN`).
- Only affects the `bash` tool path; other shell helpers are unchanged.

The agent can now run authenticated `gh` commands (e.g. `gh pr create`, `gh issue list`, `gh api ...`).

## Verification

- `npx tsc --noEmit` passes.