### PR TITLE
feat: accept optional _metadata param on repo agent

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -44,6 +44,7 @@ import {
   appendSearchProvenance,
   sessionExists,
   saveSessionConfig,
+  saveSessionMetadata,
   SessionConfig,
   StepMeta,
 } from "./session.js";
@@ -278,6 +279,8 @@ export interface GetContextOptions {
   attachments?: string[];
   // Custom HTTP headers attached to every LLM endpoint request (provider-level)
   headers?: Record<string, string>;
+  // Arbitrary caller-provided JSON persisted to the session and returned by GET /session
+  _metadata?: unknown;
 }
 
 interface PreparedAgent {
@@ -496,6 +499,13 @@ Apply the guidance from each skill throughout your response.`;
       });
       hasSystemTurn = true;
     }
+  }
+
+  // Persist arbitrary caller-provided metadata if supplied. Unlike the init
+  // config (written once at session creation), this is saved/updated whenever
+  // `_metadata` is provided so callers can attach or refresh it on any turn.
+  if (sessionId && opts._metadata !== undefined) {
+    saveSessionMetadata(sessionId, opts._metadata);
   }
 
   // Rehydrate cached image attachments from prior turns (placeholder -> bytes)

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -10,7 +10,7 @@ import { startTracking, endTracking } from "../busy.js";
 import { services_agent } from "./services.js";
 import { mocks_agent } from "./mocks.js";
 import { ModelName } from "../aieo/src/index.js";
-import { SessionConfig, loadSession, loadSessionConfig, sessionExists } from "./session.js";
+import { SessionConfig, loadSession, loadSessionConfig, loadSessionMetadata, sessionExists } from "./session.js";
 import { McpServer } from "./mcpServers.js";
 import { existsSync } from "fs";
 import path from "path";
@@ -148,6 +148,7 @@ function parseAgentBody(req: Request) {
         (a): a is string => typeof a === "string" && a.trim().length > 0,
       )
     : undefined;
+  const _metadata = req.body._metadata as unknown;
 
   const repoList = (repoUrl || "")
     .split(",")
@@ -158,7 +159,7 @@ function parseAgentBody(req: Request) {
     repoUrl, username, pat, commitList, prompt, toolsConfig, schema,
     modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, mcpServers,
     systemOverride, skills, subAgents, ggnn, stream, repoList, maxTurns, headers,
-    ignoreRepoInfo, attachments,
+    ignoreRepoInfo, attachments, _metadata,
   };
 }
 
@@ -264,6 +265,7 @@ export async function repo_agent(req: Request, res: Response) {
           maxTurns: body.maxTurns,
           headers: body.headers,
           attachments: body.attachments,
+          _metadata: body._metadata,
         },
       );
 
@@ -381,6 +383,7 @@ export async function repo_agent(req: Request, res: Response) {
           maxTurns: body.maxTurns,
           headers: body.headers,
           attachments: body.attachments,
+          _metadata: body._metadata,
           onStepEvent: (content) => {
             const events = filterStepContent(content);
             for (const ev of events) bus.emit(ev);
@@ -501,7 +504,8 @@ export async function get_agent_session(req: Request, res: Response) {
   try {
     const messages = loadSession(sessionId);
     const config = loadSessionConfig(sessionId);
-    res.json({ sessionId, messages, config });
+    const _metadata = loadSessionMetadata(sessionId);
+    res.json({ sessionId, messages, config, _metadata });
   } catch (e) {
     console.error("Error in get_agent_session", e);
     res.status(500).json({ error: "Internal server error" });

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -215,6 +215,10 @@ export function deleteSession(sessionId: string): void {
   if (existsSync(configPath)) {
     unlinkSync(configPath);
   }
+  const metadataPath = getMetadataFile(sessionId);
+  if (existsSync(metadataPath)) {
+    unlinkSync(metadataPath);
+  }
   deleteAttachments(sessionId);
 }
 
@@ -247,6 +251,40 @@ export function loadSessionConfig(sessionId: string): SessionInitConfig | null {
   if (!existsSync(filePath)) return null;
   try {
     return JSON.parse(readFileSync(filePath, "utf-8")) as SessionInitConfig;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Get the file path for a session's arbitrary metadata sidecar.
+ */
+function getMetadataFile(sessionId: string): string {
+  const sessionDir = path.isAbsolute(SESSIONS_DIR)
+    ? SESSIONS_DIR
+    : path.join(process.cwd(), SESSIONS_DIR);
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true });
+  }
+  return path.join(sessionDir, `${sessionId}.metadata.json`);
+}
+
+/**
+ * Persist arbitrary caller-provided metadata for a session to a sidecar file.
+ */
+export function saveSessionMetadata(sessionId: string, metadata: unknown): void {
+  writeFileSync(getMetadataFile(sessionId), JSON.stringify(metadata, null, 2));
+}
+
+/**
+ * Load arbitrary session metadata from the sidecar file.
+ * Returns null if no sidecar exists or if parsing fails.
+ */
+export function loadSessionMetadata(sessionId: string): unknown | null {
+  const filePath = getMetadataFile(sessionId);
+  if (!existsSync(filePath)) return null;
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8"));
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary
Adds an optional `_metadata` param (arbitrary JSON) to the `POST /repo/agent` endpoint that is persisted to the session and returned by `GET /repo/agent/session`.

The session response is now `{ sessionId, messages, config, _metadata }`.

## Changes
- **session.ts**: added `saveSessionMetadata` / `loadSessionMetadata` (sidecar `<id>.metadata.json`) and cleanup in `deleteSession`.
- **agent.ts**: added optional `_metadata?: unknown` to `GetContextOptions`; persisted in `prepareAgent` when provided (on any turn, not just session creation).
- **index.ts**: parses `_metadata` from the request body, threads it into both `get_context` and `stream_context`, and returns it from `GET /repo/agent/session`.

## Notes
- Fully optional and backwards compatible: omitting `_metadata` writes no sidecar; `GET /session` returns `_metadata: null` when none was set.
- Unlike the init `config` (written once at session creation), `_metadata` is saved/updated whenever provided so callers can attach or refresh it on any turn.

## Test plan
- `npx tsc --noEmit` passes.