### PR TITLE
vein: agent tools + visible agent-loop iterations

### DIFF
--- a/mcp/src/lab/gitsee/steps/boot-and-exercise.ts
+++ b/mcp/src/lab/gitsee/steps/boot-and-exercise.ts
@@ -678,7 +678,7 @@ export default defineStep({
     keepUp: z.boolean().default(false).describe("skip teardown (leave compose + apps running for debugging)"),
   }),
   output: z.any(),
-  async run(cfg) {
+  async run(cfg, ctx) {
     const wp = cfg.workspacePath;
     const logBuf: string[] = [];
     const log = (s: string) => {
@@ -940,6 +940,52 @@ export default defineStep({
         execute: async ({ report }: { report: string }) => report,
       }),
     };
+
+    // Emit a nested run EVENT per tool call so each iteration is visible in the
+    // UI's events panel + run drill-down — otherwise the whole loop is one opaque
+    // `agent`-style node. The path nests under this step's path
+    // (`<stepPath>/NNN-<tool>`), mirroring the core agent's buildRegistryTools
+    // convention, so the events re-key cleanly. ctx is absent when run outside the
+    // runner (smokes) → no-op. final_answer is skipped (terminal, noisy).
+    if (ctx?.emit && ctx.path) {
+      const basePath = ctx.path;
+      const emitEvent = ctx.emit as unknown as (e: Record<string, unknown>) => Promise<void>;
+      let toolCalls = 0;
+      const summarize = (v: unknown): string => {
+        const s = typeof v === "string" ? v : JSON.stringify(v ?? "");
+        return s.length > 1500 ? s.slice(0, 1500) + "\n[… truncated for event log …]" : s;
+      };
+      for (const [name, t] of Object.entries(tools)) {
+        if (name === "final_answer") continue;
+        const orig = (t as { execute?: unknown }).execute;
+        if (typeof orig !== "function") continue; // provider-executed tools (none here) have no execute
+        (t as { execute: unknown }).execute = async (input: unknown, opts: unknown) => {
+          const n = ++toolCalls;
+          const path = `${basePath}/${String(n).padStart(3, "0")}-${name}`;
+          const startedAt = Date.now();
+          await emitEvent({ type: "step.start", path, stepType: `tool:${name}`, input });
+          try {
+            const out = await (orig as (i: unknown, o: unknown) => Promise<unknown>)(input, opts);
+            await emitEvent({
+              type: "step.end",
+              path,
+              stepType: `tool:${name}`,
+              output: summarize(out),
+              durationMs: Date.now() - startedAt,
+            });
+            return out;
+          } catch (e) {
+            await emitEvent({
+              type: "step.error",
+              path,
+              stepType: `tool:${name}`,
+              error: { message: (e as Error).message },
+            });
+            throw e;
+          }
+        };
+      }
+    }
 
     const system = `You are an autonomous setup-and-QA engineer. A web app's source is cloned under the working directory, and an initial pm2.config.js + docker-compose.yml have been staged there. Your mission: get the app's FRONTEND genuinely FUNCTIONAL — not just rendering, but with working navigation and core user flows — by ITERATING until it works.
 

--- a/vein/plans/agentic-loop-as-workflow.md
+++ b/vein/plans/agentic-loop-as-workflow.md
@@ -19,9 +19,29 @@ For eval we want to tune **#5 alone** while holding 1–4 fixed — and we want 
 
 The plan: make **tools** and the **loop** first-class vein constructs so the
 monolith dissolves into small, versioned, individually-evaluable pieces, and the
-run becomes visible on the canvas.
+run becomes visible on the canvas. Every design question below has a **firm
+decision** — there are no open wrinkles. Two small, generic vein-core changes are
+required (see "Core changes" at the end); everything else is additive.
 
-**Status: nothing below is built.** This is the design + sequencing doc.
+## Implementation status
+
+- **DONE — vein-core foundation** (420 tests green, tsc clean): `StepContext.registry`
+  (populated in `dispatchStep`), the generic `services.onRunEnd(runId)` `finally`
+  hook in `runWorkflow`, and the `agent` step's `agentTools` (registry step-types
+  as LLM tools via the exported, unit-tested `buildRegistryTools`, with nested
+  `step.start`/`step.end` emit). `agent.run` now consumes `ctx`.
+- **DONE — visualization MVP (layer 1)**: `boot-and-exercise.ts` now wraps every
+  tool's `execute` to emit a nested run event (`<stepPath>/NNN-<tool>`), so each
+  iteration's tool calls show in the UI events panel / drill-down. Uses only
+  pre-existing `ctx.emit`/`ctx.path` → runs against the current copied vein dep,
+  **no `refresh-vein` required**. This satisfies the headline ask ("see each
+  iteration in the UI") without touching the loop's behavior.
+- **TODO — layer 2**: §2 services (browser/stack/vision as per-run factories +
+  `LabServices.onRunEnd`), §1b tool-steps, §3 the C2 loop workflow. Build after
+  the layer-1 MVP is confirmed in the UI (it validates the event-path approach
+  end-to-end before the bigger decomposition rests on it).
+
+The rest of this doc is the design + sequencing for layer 2.
 
 ---
 
@@ -39,105 +59,109 @@ from `events.jsonl`**, where each event carries a hierarchical `path`:
 **No path events → nothing to render.** The agent run is invisible because the
 entire `ToolLoopAgent` loop runs *inside one step's `run()`*: the only events
 emitted are the single `step.start`/`step.end` for that node. Tool calls are
-anonymous closures that are only `console.log`ged (`agent.ts:571-578`,
+anonymous closures only `console.log`ged (`agent.ts:571-578`,
 `boot-and-exercise.ts:977-984`), never `ctx.emit`ed.
 
-There are **two routes to visibility**, which compose:
+**DECISION — two complementary routes, both adopted:**
 
 - **C2 (loop as real steps):** express boot → drive → observe → assess as real
-  `loop`/`subflow`/`foreach` steps. The runner *already* emits all the nested
-  events and the existing drill-down renders them — **zero new emit code, zero
-  UI change.** Cost: the outer loop is deterministic (less agent autonomy).
-- **A2 (tools as steps + per-tool emit):** keep an agentic node but have it
-  `emit` a `step.start`/`step.end` per tool call at
-  `${ctx.path}/iter${n}/${toolType}`. `ctx.emit`/`ctx.path` already reach every
-  leaf step (`runner.ts:478-485`). Cost: a vein-core change (below) + a UI tweak
-  for the dynamic sub-canvas.
+  `loop`/`subflow` steps. The runner *already* emits the nested events and the
+  existing drill-down renders them — **zero new emit code, zero UI change.** This
+  is the committed surface for per-iteration visibility (it directly satisfies
+  "see each iteration in the UI").
+- **A2 (tools as steps + per-tool emit):** the inner diagnose-and-fix agent emits
+  a `step.start`/`step.end` per tool call at `${ctx.path}/i${n}/${toolType}`, so
+  even that node's tool calls appear in the **events panel**. `ctx.emit`/`ctx.path`
+  already reach every leaf step (`runner.ts:478-485`).
 
-Recommended: **C2 for the outer skeleton (free, immediate), A2 for the tool
-calls inside the inner diagnose-and-fix agent** (so even that node isn't black).
+**DECISION — the bespoke "agent node → dynamic sub-canvas" is OUT OF SCOPE.** C2
+delivers loop-level drill-down for free via the existing subflow/foreach
+machinery, and A2's tool calls render in the events panel keyed by nested path.
+That fully satisfies the requirement; building a canvas from dynamic (non-static-
+workflow) events is unnecessary and is explicitly cut, not deferred.
 
 ---
 
 ## 1. Tools as a first-class entity (the unlock)
 
-### 1a. Inject tools into the core `agent` step (minimal)
+### 1a. Inject tools into the core `agent` step (minimal, ships first)
 `agent` accepts an extra `tools` list it merges with its built-ins. boot-and-
 exercise stops forking the loop — it *configures* the core agent. Kills ~600
-lines of duplication immediately. This is the cheap first step and is **fully
-self-contained in `agent.ts`** (no core change).
+lines of duplication. **Fully self-contained in `agent.ts`** (no core change).
 
 ### 1b. Tools ARE steps (the "vein" version)
 A tool call and a step call are the same shape: named unit, Zod input, output.
-Let `agent` take `agentTools: ["browser/click", "gitsee/boot", ...]` — registry
+`agent` takes `agentTools: ["browser/click", "gitsee/boot", ...]` — registry
 step-types whose `input` schema becomes the LLM tool schema and whose `run` is
-the executor. Payoffs:
+the executor. Payoffs: each tool is independently **versioned / inspectable /
+editable / testable** via the existing `/steps` API + UI; tool calls become
+**nested run events**; eval can target a **single tool**.
 
-- each tool is independently **versioned / inspectable / editable / testable**
-  via the existing vein UI + `/steps` API
-- the agent's tool calls become **nested run events** → visible in the run
-  drill-down (the visualization win)
-- eval can target a **single tool** (is `assess-ui` a good judge? is `boot`
-  reliable?)
+**DECISION — give `agent` registry access via `StepContext.registry`, keep the
+loop in `agent.ts`.** Add an optional `registry: StepRegistry` to `StepContext`
+(`core.ts:44-51`), populated by the runner in `dispatchStep` (`runner.ts:478`).
+The `agent` step (now consuming `ctx` — today `run(cfg)` ignores it,
+`agent.ts:413`) looks up each `agentTools` type, builds the LLM tool from
+`def.input` + `def.description`, and on a tool call executes
+`def.run(input, childCtx)` where `childCtx = { ...ctx, path:
+\`${ctx.path}/i${n}/${type}\` }`, emitting `step.start`/`step.end` around it.
 
-**WRINKLE (must own): a leaf step's `ctx` has no registry.** `StepContext`
-(`core.ts:44-51`) is `{ runId, path, scope, input, emit, services }` — no way to
-look up another step def by type. `subflow`/`foreach`/`loop` only reach other
-steps because the runner handles them specially (`SELF_RESOLVING_STEPS`,
-`runner.ts:301`). Two ways to give `agent` registry access:
+*Rejected:* promoting `agent` to a runner-handled container step (à la
+`subflow`). It would fracture the AI-SDK `ToolLoopAgent` loop into `runner.ts`.
+Keeping the loop in the step file with read-only `registry` access is simpler and
+keeps the runner generic. *Rejected:* a `ctx.runStep` closure over the internal
+`executeStep` — tools don't need retry/onError, so the extra contract isn't worth
+it. (Re-derive `executeStep` reuse later only if a tool ever needs retry.)
 
-- **(b, preferred) promote `agent` to a runner-aware container step**: add it to
-  `SELF_RESOLVING_STEPS`, handle it in `dispatchStep`, and pass it the registry +
-  a child-exec helper (the same machinery `executeSubflow` uses). Mirrors the
-  existing pattern; keeps `StepContext` clean.
-- (a) add `registry` to `StepContext`. Simpler diff, but widens the contract for
-  every step.
-
-Either way **`agent.run` must start consuming `ctx`** (today `async run(cfg)`
-ignores it — `agent.ts:413`).
-
-### 1c. Toolkits (ergonomics, later)
-Mount `browser/*` as a bundle instead of listing 9 names. Only after 1b.
+### 1c. Toolkits (ergonomics)
+Mount `browser/*` as a bundle instead of listing names. **DECISION:** deferred to
+after 1b lands and proves the per-name list is annoying — pure sugar, no new
+capability.
 
 ---
 
 ## 2. Stateful resources become services
 
 `BrowserSession` (`boot-and-exercise.ts:418-595`) and the pm2/staklink/compose
-lifecycle (`736-809`) are infrastructure, not agent logic. Move them into
-`LabServices` so the tool-steps in §1b are thin wrappers (`ctx.services.browser.
-click(ref)`), and so they're swappable for eval (real Playwright ↔ cassette;
-staklink ↔ inline boot; swap the vision model).
+lifecycle (`736-809`) are infrastructure, not agent logic. They move into
+`LabServices` so the §1b tool-steps are thin wrappers, and so they're swappable
+for eval (real Playwright ↔ cassette; staklink ↔ inline boot; swap the vision
+model).
 
-- **`browser` service** — per-page session.
-- **`stack`/`runner` service** — boot + teardown of the app + backing services.
-- **`vision`/`judge` service** — `assessScreenshot` (`615-659`); swappable model;
-  evaluable against a labeled (screenshot+logs → verdict) dataset.
+**DECISION — three services, with per-run sessioning:**
 
-**WRINKLE (must own): services are singletons, this state is per-run.**
-`createLabVein` builds the services bag **once**, shared across all runs
-(`createLabVein.ts:70`). A live browser page / booted stack is per-run mutable
-state — concurrent runs would collide on one shared page. So `browser`/`stack`
-must be **session factories keyed by runId** (`services.browser.session(runId)`),
-not a singleton holding one page. Each session owns its own lifecycle.
+- **`browser`** — `services.browser.session(runId)` returns/creates a per-run
+  page session (the current `BrowserSession`, lifted verbatim).
+- **`stack`** — `services.stack.session(runId, workspacePath)` owns boot
+  (compose up + staklink/pm2 + wait-for-port) and teardown (the snapshot-diff
+  container cleanup).
+- **`vision`** — stateless `assessScreenshot(...)` (`615-659`); a swappable
+  judge, evaluable against a labeled (screenshot+logs → verdict) dataset.
 
-**WRINKLE (must own): teardown guarantee is lost on decomposition.** Today one
-`try/finally` (`boot-and-exercise.ts:1032-1049`) guarantees pm2 + compose +
-snapshot-diff container cleanup even on error — critical, because a leaked
-`supabase start` stack is ~12 containers. vein has **no workflow-level
-"finally"** (only `when`/`onError` per step). Decomposing into steps risks
-leaking docker stacks on kill/error. Options to evaluate:
+**DECISION — sessions are factories keyed by `runId`, NOT singletons.**
+`createLabVein` builds the services bag once, shared across all runs
+(`createLabVein.ts:70`); a live page / booted stack is per-run mutable state, and
+the optimize loop runs many evals concurrently. Each service holds a
+`Map<runId, session>`; tool-steps get `runId` from `ctx.runId`. This makes
+concurrent runs collision-free by construction.
 
-- a dedicated teardown step that runs on both success and error (needs a
-  guaranteed-run / `finally`-style semantic vein doesn't have yet — possible
-  small core add), **or**
-- the `stack` service registers its sessions and `createVein` tears down live
-  sessions on `run.end`/`run.error` (service-owned lifecycle, no workflow
-  change), **or**
-- keep boot+teardown inside ONE step (a `stack`-lifecycle step that brings up,
-  yields, and tears down) and only decompose the drive/observe/fix loop.
+**DECISION — teardown is guaranteed by a generic `services.onRunEnd(runId)`
+lifecycle hook.** The runner calls `await (services as any)?.onRunEnd?.(runId)` in
+a `finally` wrapping `executeFlow` in `runWorkflow` (`runner.ts:110-155`), so it
+fires on **both** success and error, for **every** run path (detached,
+`optimizer.run`, tests) — `runWorkflow` is the single choke point, and subflows
+reuse the parent runId so it fires once per top-level run. `LabServices.onRunEnd`
+disposes that run's browser + stack sessions. This **exactly preserves today's
+`try/finally` guarantee** (`boot-and-exercise.ts:1032-1049`) while staying generic
+(the runner never names "stack"/"browser").
 
-The `cleanup.ts` script (the manual rescue for killed runs) stays regardless.
+*Rejected:* a new vein-level guaranteed-`finally` *step*. It's a bigger, more
+general core change than needed; `onRunEnd` is ~3 lines and sufficient. (A
+finally-step can be proposed independently later if other workflows want it.)
+
+**Hard-kill caveat (unchanged from today):** `onRunEnd` runs in-process, so a
+`SIGKILL` of the host still skips it — identical to today's `finally`.
+`mcp/src/lab/gitsee/cleanup.ts` remains the rescue for that case.
 
 ---
 
@@ -146,75 +170,92 @@ The `cleanup.ts` script (the manual rescue for killed runs) stays regardless.
 Re-express `gitsee-setup-and-run.yaml`'s opaque `run` node as a real loop:
 
 ```
-loop (until $current.working || maxIters):
+loop  until: "{{ $current.working }}"   maxIterations: {{ params.maxIters }}
   body: subflow "gitsee-qa-iteration"
-    boot            (stack service tool-step)
-    drive+snapshot  (browser tool-steps)
-    observe+assess  (browser + vision tool-steps → STRUCTURED outputs)
-    diagnose-and-fix (agent step, narrow tools: fs + bash + read_logs)
+    boot             (stack tool-step)
+    drive+snapshot   (browser tool-steps)
+    observe+assess   (browser + vision tool-steps → STRUCTURED outputs)
+    diagnose-and-fix (agent step; tools: fs + bash + read_logs + re-snapshot)
     -> returns { working, ... }
 ```
 
-Every phase becomes a canvas node, separately inspectable and **evaluable**.
+Every phase is a canvas node, separately inspectable and **evaluable**.
 
-**WRINKLE (must own): `loop` body is a single `Step`** (`loop.ts:23`). The
-multi-step iteration must be wrapped in a `subflow` body; `until` references
-`$current` (the subflow's output, e.g. `$current.working`). This is supported
-today — just a structural requirement, not a code change.
+**DECISION — the iteration is a `subflow` used as the `loop` body.** vein's `loop`
+body is a single `Step` (`loop.ts:23`), so the multi-step iteration is its own
+workflow (`gitsee-qa-iteration`), and `until` reads `$current.working` (the
+subflow's output). This uses only existing vein features — no code change, just
+the committed structure.
 
-**Tension to weigh honestly:** C2 trades agent autonomy for structure. The magic
-today may partly BE the agent fluidly interleaving bash + browser in an order we
-didn't anticipate. Mitigation: keep the inner `diagnose-and-fix` agent's tool
-budget generous (fs + bash + read_logs + re-snapshot) so it still investigates
-freely within each iteration; only the *outer* rhythm is fixed.
+**DECISION — keep the inner agent autonomous within each iteration.** C2 fixes
+only the *outer* rhythm; `diagnose-and-fix` keeps a generous tool budget (fs +
+bash + read_logs + re-snapshot) so it still investigates freely. An **A/B vs the
+free-form monolith is a required validation gate** (see Validation) before
+retiring `boot-and-exercise.ts`.
 
 ---
 
 ## 4. Observations/verdicts as first-class artifacts
 
-`browser_observe`, `assess_ui`, `read_logs` emit *signals*. As tool-steps with
-**structured** outputs they become independently scorable, replayable, and
-cacheable — and you can build an eval dataset for the vision judge itself.
-This is what makes "continuous self-improvement" measurable instead of vibes.
+**DECISION:** `observe`, `assess-ui`, `read_logs` are tool-steps returning
+**structured** outputs (not strings). That makes each signal independently
+scorable, replayable, and cacheable, and lets us build an eval dataset for the
+vision judge itself — turning "self-improvement" into something measured, not
+vibed.
 
 ---
 
 ## 5. Harness vs policy split (the eval payoff)
 
-Draw a hard line so an optimize loop can sweep policy while the harness stays
-constant:
+**DECISION — a hard line, enforced by where things live:**
 
-- **Harness (fixed):** services (browser/stack/vision) + tool-steps + teardown.
-- **Policy (tunable, lives in `params`):** system prompt, which tools are
-  mounted, model, loop strategy, maxIters.
+- **Harness (fixed):** the `browser`/`stack`/`vision` services + the tool-steps +
+  `onRunEnd` teardown.
+- **Policy (tunable, in `params`):** the agent `system` prompt, which
+  `agentTools` are mounted, `model`, and `maxIters`.
 
-This mirrors how `gitsee-optimize` already tunes the explorer `system` prompt —
-impossible for boot-and-exercise today because policy is welded into the TS file.
+A `gitsee-setup-optimize` loop then sweeps policy with the harness held constant
+— mirroring how `gitsee-optimize` already tunes the explorer `system` prompt
+(impossible for boot-and-exercise today because policy is welded into the TS file).
 
 ---
 
-## Suggested sequencing
+## Core changes (the complete list — both small + generic)
 
-1. **§1a** — inject tools into `core/agent` (self-contained; ends the fork;
-   ~600 LOC of duplication deleted). Lowest risk, highest immediate payoff.
-2. **§2 browser + stack services** as per-run factories; decide the teardown
-   strategy (the riskiest open question — pick before decomposing).
-3. **§3 (C2)** — re-express the loop as `loop`+`subflow`; visualization via the
-   runner's existing events, **zero UI change**. This delivers "see each
-   iteration in the UI."
-4. **§1b** — promote `agent` to a registry-aware container step; tools = steps;
-   per-tool emit for the inner agent node.
-5. **§4 / §5** — structured signals + harness/policy split → a
-   `gitsee-setup-optimize` loop.
-6. **Tier-2 UI**: dynamic agent sub-canvas built from events (only if the events
-   panel proves insufficient).
+1. **`StepContext.registry?: StepRegistry`** (`core.ts`), populated by the runner
+   in `dispatchStep` (`runner.ts:478`). Optional, ignored by steps that don't use
+   it (exactly like `services`). Enables §1b.
+2. **`services.onRunEnd?(runId)` hook** invoked in a `finally` around
+   `executeFlow` in `runWorkflow` (`runner.ts:110-155`). Optional + generic.
+   Enables §2 teardown.
 
-## Open questions / risks
+Everything else is additive: new lab services, new tool-steps, two new lab
+workflows (`gitsee-qa-iteration`, the rewritten `gitsee-setup-and-run`), and the
+deletion of `boot-and-exercise.ts` once §3's A/B passes.
 
-- **Teardown semantics** (§2) — the one genuinely unsolved design choice. A
-  vein-level guaranteed-`finally` step would be broadly useful but is a core add.
-- **Does C2 regress quality** vs the free-form loop? Needs an A/B once §3 lands.
-- **A2 sub-canvas** — building a canvas from dynamic events (no static child
-  flow) is new UI territory; defer until Tier-1 (events panel) is proven thin.
-- **Concurrency** — per-run service sessions assume runs may overlap (the
-  optimize loop runs many evals); verify the factory keying before relying on it.
+---
+
+## Sequencing
+
+1. **§1a** — inject tools into `core/agent` (self-contained; ends the fork; ~600
+   LOC deleted). Lowest risk, immediate payoff.
+2. **Core change #1** (`StepContext.registry`) + **§1b** — tools = steps; per-tool
+   emit.
+3. **§2** — `browser`/`stack`/`vision` services as per-run factories +
+   **core change #2** (`onRunEnd`) for guaranteed teardown.
+4. **§3 (C2)** — `gitsee-qa-iteration` + rewritten `gitsee-setup-and-run`;
+   visualization lands here via the runner's existing events (no UI work).
+5. **§4 / §5** — structured signals + harness/policy split → `gitsee-setup-optimize`.
+
+## Validation (the gates, not open risks)
+
+- **C2 quality A/B** (§3): run the decomposed loop vs the current monolith on the
+  `hive` + `heroku-node` workspaces; require parity (working-rate + iterations)
+  before deleting `boot-and-exercise.ts`. If the fixed outer rhythm regresses,
+  widen the inner agent's per-iteration budget rather than reverting.
+- **Concurrency** (§2): a 2-run overlap test asserting browser/stack sessions
+  don't collide and `onRunEnd` disposes the correct run's sessions.
+- **Teardown** (§2): kill-path test — force a mid-run error and assert compose +
+  spawned containers are gone (parity with today's `finally`).
+- **Live agent** (§1b): one real chat/optimize turn confirming the agent drives
+  the registry tool-steps and the events panel shows per-iteration tool calls.

--- a/vein/src/core.ts
+++ b/vein/src/core.ts
@@ -48,6 +48,12 @@ export interface StepContext<TServices = unknown> {
   input: unknown;
   emit: (event: RunEvent) => Promise<void>;
   services: TServices;
+  /** The step registry, populated by the runner. Lets a step that orchestrates
+   *  OTHER steps (e.g. the `agent` step exposing registry step-types as LLM
+   *  tools) look up their defs by type — without promoting itself to a
+   *  runner-handled container step. Optional: absent when a step is invoked
+   *  outside the runner (e.g. unit tests). Read-only by convention. */
+  registry?: StepRegistry;
 }
 
 /** Error handling options for a step. */

--- a/vein/src/runner.ts
+++ b/vein/src/runner.ts
@@ -152,6 +152,22 @@ export async function runWorkflow<TServices = unknown>(
       error,
     });
     return { runId, status: "error", error };
+  } finally {
+    // Generic per-run teardown hook. A consumer's services bag may implement
+    // `onRunEnd(runId)` to dispose any per-run resources it allocated during the
+    // run (e.g. the lab's headless browser + booted docker stack, keyed by
+    // runId). Runs in a `finally` so it fires on BOTH success and error, for
+    // EVERY run path (detached launch, in-process `optimizer.run`, tests) —
+    // `runWorkflow` is the single choke point, and nested subflows reuse the
+    // parent runId so it fires once per top-level run. The runner stays generic:
+    // it never names what gets disposed. Guarded so a teardown failure can't mask
+    // the run's real result. (Hard kills (SIGKILL) still skip this — identical to
+    // any in-process `finally`; that case is handled out-of-band.)
+    try {
+      await (services as { onRunEnd?: (id: string) => unknown })?.onRunEnd?.(runId);
+    } catch (teardownErr) {
+      console.error(`[runner] onRunEnd hook failed for run ${runId}:`, teardownErr);
+    }
   }
 }
 
@@ -482,6 +498,7 @@ async function dispatchStep(
         input: scope["input"],
         emit,
         services,
+        registry,
       };
 
       return def.run(validConfig, ctx);

--- a/vein/src/services.test.ts
+++ b/vein/src/services.test.ts
@@ -196,6 +196,63 @@ describe("services injection", () => {
     assert.deepEqual(graph.calls, ["Q1", "Q2"]);
   });
 
+  it("calls services.onRunEnd(runId) in a finally — on success AND on error", async () => {
+    const ended: string[] = [];
+    const ok = defineStep({
+      type: "ok",
+      input: z.object({}),
+      output: z.string(),
+      async run() { return "done"; },
+    });
+    const boom = defineStep({
+      type: "kaboom",
+      input: z.object({}),
+      output: z.any(),
+      async run() { throw new Error("nope"); },
+    });
+    const services = { onRunEnd: async (id: string) => { ended.push(id); } };
+
+    const okWf = flow("ok-wf", { input: z.object({}), steps: [step("a", "ok", {})] });
+    const okRes = await runWorkflow(okWf, {}, { ok } as StepRegistry, { services });
+    assert.equal(okRes.status, "success");
+    assert.deepEqual(ended, [okRes.runId], "onRunEnd fired for the successful run");
+
+    const failWf = flow("fail-wf", { input: z.object({}), steps: [step("a", "kaboom", {})] });
+    const failRes = await runWorkflow(failWf, {}, { kaboom: boom } as StepRegistry, { services });
+    assert.equal(failRes.status, "error");
+    assert.deepEqual(ended, [okRes.runId, failRes.runId], "onRunEnd ALSO fired for the errored run");
+  });
+
+  it("a teardown failure in onRunEnd does not mask the run result", async () => {
+    const ok = defineStep({
+      type: "ok2",
+      input: z.object({}),
+      output: z.string(),
+      async run() { return "done"; },
+    });
+    const services = { onRunEnd: async () => { throw new Error("teardown blew up"); } };
+    const wf = flow("ok2-wf", { input: z.object({}), steps: [step("a", "ok2", {})] });
+    const res = await runWorkflow(wf, {}, { ok2: ok } as StepRegistry, { services });
+    assert.equal(res.status, "success");
+    assert.equal(res.output, "done");
+  });
+
+  it("exposes the step registry on ctx.registry", async () => {
+    const introspect = defineStep({
+      type: "introspect",
+      input: z.object({}),
+      output: z.any(),
+      async run(_cfg, ctx) {
+        return Object.keys(ctx.registry ?? {}).sort();
+      },
+    });
+    const reg = { introspect } as StepRegistry;
+    const wf = flow("introspect-wf", { input: z.object({}), steps: [step("i", "introspect", {})] });
+    const res = await runWorkflow(wf, {}, reg);
+    assert.equal(res.status, "success");
+    assert.deepEqual(res.output, ["introspect"]);
+  });
+
   it("propagates the same services into onError fallback steps", async () => {
     const seen: string[] = [];
     const failing = defineStep({

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -3,8 +3,10 @@ import assert from "node:assert/strict";
 import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { z } from "zod";
 import { coreRegistry } from "../registry.js";
-import agent, { repoTree, textEdit } from "./agent.js";
+import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
+import agent, { repoTree, textEdit, buildRegistryTools } from "./agent.js";
 
 // These tests are OFFLINE: they exercise registration, the input schema, and the
 // config-validation guards in run() that fire BEFORE any model call. The actual
@@ -46,6 +48,72 @@ describe("core agent step", () => {
       provider: "not-a-provider",
     });
     await assert.rejects(() => (agent.run as any)(cfg, {}), /Unknown LLM provider/);
+  });
+});
+
+describe("agentTools (buildRegistryTools — tools are steps)", () => {
+  // A fake `tool()` factory: identity, so we can inspect the produced tool def
+  // (description/inputSchema/execute) without importing the AI SDK.
+  const fakeTool = (def: any) => def;
+
+  const echoStep = defineStep({
+    type: "demo/echo",
+    description: "Echo the message back.",
+    input: z.object({ msg: z.string() }),
+    output: z.string(),
+    async run(cfg) {
+      return `got:${cfg.msg}`;
+    },
+  });
+  const registry = { "demo/echo": echoStep } as StepRegistry;
+
+  it("builds a tool per registry step, sanitizing the slash in the tool name", () => {
+    const tools = buildRegistryTools(["demo/echo"], registry, undefined, fakeTool);
+    assert.ok(tools["demo_echo"], "slash sanitized to underscore");
+    assert.equal((tools["demo_echo"] as any).description, "Echo the message back.");
+    assert.equal((tools["demo_echo"] as any).inputSchema, echoStep.input);
+  });
+
+  it("skips unknown step types (no throw)", () => {
+    const tools = buildRegistryTools(["nope/missing", "demo/echo"], registry, undefined, fakeTool);
+    assert.deepEqual(Object.keys(tools), ["demo_echo"]);
+  });
+
+  it("returns {} with no names or no registry", () => {
+    assert.deepEqual(buildRegistryTools([], registry, undefined, fakeTool), {});
+    assert.deepEqual(buildRegistryTools(["demo/echo"], undefined, undefined, fakeTool), {});
+  });
+
+  it("executes the step and emits nested step.start/step.end events", async () => {
+    const events: any[] = [];
+    const ctx = {
+      runId: "r1",
+      path: "wf/diagnose",
+      scope: {},
+      input: undefined,
+      emit: async (e: any) => { events.push(e); },
+      services: undefined,
+      registry,
+    } as unknown as StepContext;
+
+    const tools = buildRegistryTools(["demo/echo"], registry, ctx, fakeTool);
+    const out = await (tools["demo_echo"] as any).execute({ msg: "hi" });
+
+    assert.equal(out, "got:hi");
+    assert.equal(events.length, 2);
+    assert.equal(events[0].type, "step.start");
+    assert.equal(events[0].path, "wf/diagnose/001-demo_echo");
+    assert.equal(events[0].stepType, "demo/echo");
+    assert.deepEqual(events[0].input, { msg: "hi" });
+    assert.equal(events[1].type, "step.end");
+    assert.equal(events[1].path, "wf/diagnose/001-demo_echo");
+    assert.equal(events[1].output, "got:hi");
+  });
+
+  it("returns an Error string (not throw) on invalid tool input", async () => {
+    const tools = buildRegistryTools(["demo/echo"], registry, undefined, fakeTool);
+    const out = await (tools["demo_echo"] as any).execute({ wrong: 1 });
+    assert.match(String(out), /Error: invalid input for "demo\/echo"/);
   });
 });
 

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep } from "../../core.js";
+import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
 import { usageFromResult, computeCost, addUsage } from "../../pricing.js";
 import { spawn } from "node:child_process";
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
@@ -379,10 +379,86 @@ export function textEdit(input: TextEditInput, cwd: string): string {
   }
 }
 
+// ── registry-backed tools (agentTools) ────────────────────────────────────────
+
+/** Tool-call name from a registry step type: tool names can't contain slashes
+ *  (`browser/click` → `browser_click`), so we sanitize for the LLM and map back. */
+function toolNameFor(stepType: string): string {
+  return stepType.replace(/[^a-zA-Z0-9_]/g, "_");
+}
+
+/**
+ * Turn a list of registry step-types into AI-SDK tools the agent can call —
+ * the "tools ARE steps" model. Each step's `input` Zod schema becomes the tool's
+ * input schema and its `run` is the executor, invoked with a CHILD context whose
+ * `path` is nested under the agent's (`<agentPath>/NNN-<tool>`). We emit a
+ * `step.start`/`step.end` (or `step.error`) around every call so each tool
+ * invocation shows up as a nested run event — that's what makes the otherwise
+ * opaque agent loop visible in the events panel / run drill-down.
+ *
+ * Pure + offline-testable: the `tool` factory and (optional) `ctx`/`registry`
+ * are injected, so it can be unit-tested with a fake registry + a capturing
+ * `emit` and no model/network. Unknown step-types are skipped (the agent simply
+ * doesn't get that tool). Returns a record keyed by the sanitized tool name.
+ */
+export function buildRegistryTools(
+  names: string[] | undefined,
+  registry: StepRegistry | undefined,
+  ctx: StepContext | undefined,
+  // The AI SDK `tool()` factory. Typed loosely (like the built-in tools, which
+  // cast `inputSchema` to any) — the SDK's Tool generics over-constrain here.
+  toolFactory: (def: any) => unknown,
+): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  if (!names?.length || !registry) return out;
+  let calls = 0;
+  for (const stepType of names) {
+    const def = registry[stepType];
+    if (!def) {
+      console.warn(`[agent] agentTools: unknown step type "${stepType}" — skipping`);
+      continue;
+    }
+    out[toolNameFor(stepType)] = toolFactory({
+      description: def.description ?? `Run the "${stepType}" step.`,
+      inputSchema: def.input,
+      execute: async (input: unknown) => {
+        const n = ++calls;
+        const path = ctx?.path ? `${ctx.path}/${String(n).padStart(3, "0")}-${toolNameFor(stepType)}` : undefined;
+        const startTime = Date.now();
+        // Validate against the step's own input schema (so the tool sees what a
+        // real step run would). Cast emit to bypass the full-RunEvent type — the
+        // runner's emit fills ts/runId.
+        const emit = ctx?.emit as undefined | ((e: Record<string, unknown>) => Promise<void>);
+        let parsed: unknown;
+        try {
+          parsed = def.input.parse(input ?? {});
+        } catch (e) {
+          return `Error: invalid input for "${stepType}": ${(e as Error).message}`;
+        }
+        if (emit && path) await emit({ type: "step.start", path, stepType, input: parsed });
+        try {
+          const childCtx: StepContext = ctx
+            ? { ...ctx, path: path ?? ctx.path }
+            : ({ runId: "", path: path ?? "", scope: {}, input: undefined, emit: (async () => {}) as any, services: undefined });
+          const output = await def.run(parsed, childCtx);
+          if (emit && path)
+            await emit({ type: "step.end", path, stepType, output, durationMs: Date.now() - startTime });
+          return output;
+        } catch (e) {
+          if (emit && path)
+            await emit({ type: "step.error", path, stepType, error: { message: (e as Error).message } });
+          throw e;
+        }
+      },
+    });
+  }
+  return out;
+}
+
 export default defineStep({
   type: "agent",
   description:
-    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of tool names; empty = all), model?, provider? (anthropic|openai), maxSteps (default 40), returnMessages? (default false — the full session is huge + persisted per step). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, usage, cost } (+ messages when returnMessages).",
+    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of built-in tool names; empty = all), agentTools? (registry step TYPES exposed as extra tools — the 'tools are steps' model; each tool call emits a nested run event), model?, provider? (anthropic|openai), maxSteps (default 40), returnMessages? (default false — the full session is huge + persisted per step). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, usage, cost } (+ messages when returnMessages).",
   input: z.object({
     cwd: z.string().describe("working directory the tools operate in"),
     system: z.string().describe("system prompt / agent persona"),
@@ -399,6 +475,12 @@ export default defineStep({
       .array(z.string())
       .default([])
       .describe("subset of built-in tool names to enable; empty = all. (final_answer is always available in finalAnswer mode.)"),
+    agentTools: z
+      .array(z.string())
+      .default([])
+      .describe(
+        "registry step TYPES to expose as additional LLM tools (the 'tools are steps' model, e.g. ['gitsee/read-logs']). Each step's input schema becomes the tool schema and its run() is the executor, called with a nested ctx so every tool call emits a step.start/step.end run event (visible in the events panel). Merged ON TOP of the built-ins (not subject to toolFilter). Unknown types are skipped. Requires the runner-populated ctx.registry.",
+      ),
     model: z.string().optional(),
     provider: z.string().optional(),
     maxSteps: z.number().int().positive().default(40),
@@ -410,7 +492,7 @@ export default defineStep({
       ),
   }),
   output: z.any(),
-  async run(cfg) {
+  async run(cfg, ctx) {
     const { ToolLoopAgent, Output, tool, stepCountIs, hasToolCall, jsonSchema, generateText } = await import("ai");
 
     const provider = cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? "anthropic";
@@ -543,6 +625,11 @@ export default defineStep({
     for (const [name, t] of Object.entries(allTools)) {
       if (!filter.length || filter.includes(name)) tools[name] = t;
     }
+
+    // Registry-backed tools (the "tools are steps" model). Merged ON TOP of the
+    // (filtered) built-ins — explicitly requested, so not subject to toolFilter.
+    // Needs the runner-populated ctx.registry; absent (in-code/test) → no-op.
+    Object.assign(tools, buildRegistryTools(cfg.agentTools, ctx?.registry, ctx, tool));
 
     // Output mode: schema (structured) vs finalAnswer (terminal tool) vs text.
     const useSchema = cfg.schema != null;


### PR DESCRIPTION
## What

Foundation for decomposing the gitsee `boot-and-exercise` monolith into composable, observable pieces, plus an immediate visualization win. Full design + sequencing: `vein/plans/agentic-loop-as-workflow.md`.

### vein-core (additive, all fields optional — no behavior change for existing steps)
- **`StepContext.registry`** — populated by the runner in `dispatchStep`, so a step can look up other step defs by type without being promoted to a runner-handled container step.
- **`services.onRunEnd(runId)`** — generic per-run teardown hook in a `finally` around `executeFlow` in `runWorkflow`. Fires on **success and error**, for every run path; a teardown throw can't mask the run result. Lets a consumer's services bag dispose per-run resources (headless browser / booted docker stack) keyed by `runId`.
- **`agent` step `agentTools`** — exposes registry step-types as LLM tools (the "tools are steps" model) via the exported, unit-tested `buildRegistryTools`. Each tool call runs the step with a nested-path child ctx and emits `step.start`/`step.end`, so tool calls become nested run events. `agent.run` now consumes `ctx`.

### mcp gitsee (visualization MVP — the headline ask)
- `boot-and-exercise` wraps every tool's `execute` to emit a nested run event (`<stepPath>/NNN-<tool>`), so each QA iteration's tool calls are visible in the UI events panel / run drill-down. Uses only pre-existing `ctx.emit`/`ctx.path` → **runs against the current copied vein dep, no `refresh-vein` needed**, loop behavior unchanged.

## Why

The agent loop was one opaque node — you couldn't see each iteration in the UI. Nested-path run events are exactly how vein renders structure, so emitting one per tool call makes the loop observable. The vein-core additions unblock the larger layer-2 decomposition (services as per-run factories + tool-steps + a visible `loop`/`subflow` workflow) tracked in the plan doc.

## Test plan
- `vein`: `npm test` → 420 green; `npx tsc --noEmit` clean.
- `mcp`: `npx tsc --noEmit` clean.
- Manual (follow-up): run `gitsee-setup-and-run` and confirm per-iteration tool calls render in the run view.

## Not in this PR (layer 2, see plan doc)
browser/stack/vision services as per-run factories + `LabServices.onRunEnd`; the tool-steps; the C2 `gitsee-qa-iteration` + rewritten `gitsee-setup-and-run` loop; the C2-vs-monolith A/B gate.