### PR TITLE
feat: transparent replay mode for repo agent via `messages` param

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -285,6 +285,11 @@ export interface GetContextOptions {
   commitList?: string[];
   // Skip prepending repo info to the first prompt (handler-level; recorded in config)
   ignoreRepoInfo?: boolean;
+  // Replay mode: `prompt` is a full ModelMessage[] (including the system turn)
+  // that is run verbatim. No system prompt is generated, no enrichment blocks
+  // are appended, no session history is loaded, no attachments are resolved,
+  // and nothing is persisted. Used by evals to faithfully replay a transcript.
+  transparent?: boolean;
 }
 
 interface PreparedAgent {
@@ -339,6 +344,10 @@ async function prepareAgent(
     onStepEvent,
   } = opts;
   const startTime = Date.now();
+  // Transparent replay: run `prompt` (a ModelMessage[]) verbatim with no
+  // code-generated system prompt, enrichment, session history, attachments,
+  // or persistence. The system turn must live inside the messages array.
+  const transparent = opts.transparent === true;
   const { model, apiKey, provider, contextLimit, modelId } = getModelDetails(modelName, apiKeyIn, baseUrl, opts.headers);
   console.log("===> model", modelId, "provider", provider, "contextLimit", contextLimit);
 
@@ -371,7 +380,7 @@ async function prepareAgent(
   let instructions = systemOverride || DEFAULT_SYSTEM(toolsConfig);
 
   // If an org_agent tool is available from MCP, inject a strong hint to use it for unclear/high-level questions.
-  if (orgAgentToolNames.length > 0) {
+  if (!transparent && orgAgentToolNames.length > 0) {
     const toolList = orgAgentToolNames.map(n => `\`${n}\``).join(", ");
     const single = orgAgentToolNames.length === 1;
     const primary = orgAgentToolNames[0];
@@ -399,7 +408,7 @@ After getting high-level context back, use graph/bash tools on the actual codeba
   // console.log("INSTRUCTIONS", instructions);
 
   // Append sub-agent instructions if any sub-agents are registered
-  if (subAgents && subAgents.length > 0) {
+  if (!transparent && subAgents && subAgents.length > 0) {
     const validSubAgents = subAgents.filter(sa => sa.name && sa.url && sa.apiToken);
     if (validSubAgents.length > 0) {
       const agentList = validSubAgents
@@ -423,7 +432,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     .filter(([, enabled]) => enabled)
     .map(([name]) => name);
 
-  if (activeSkills.length > 0) {
+  if (!transparent && activeSkills.length > 0) {
     const inlineSkills = activeSkills.filter(name => !name.includes("/") && SKILLS[name]);
     const pathSkills = activeSkills.filter(name => name.includes("/") || !SKILLS[name]);
 
@@ -455,11 +464,13 @@ Apply the guidance from each skill throughout your response.`;
 
   // Resolve image attachments for THIS turn (body field preferred, else the
   // <attachments> tag on the last user message) and strip the tag from text.
-  const { urls: attachmentUrls, cleanedPrompt } = resolveCurrentTurnAttachments(
-    finalPrompt,
-    opts.attachments,
-  );
-  finalPrompt = cleanedPrompt;
+  // Skipped in transparent mode — the prompt is replayed verbatim.
+  let attachmentUrls: string[] = [];
+  if (!transparent) {
+    const resolved = resolveCurrentTurnAttachments(finalPrompt, opts.attachments);
+    attachmentUrls = resolved.urls;
+    finalPrompt = resolved.cleanedPrompt;
+  }
 
   if (typeof opts.maxTurns === "number" && opts.maxTurns > 0) {
     stopConditions.push(stepCountIs(opts.maxTurns));
@@ -478,7 +489,7 @@ Apply the guidance from each skill throughout your response.`;
   let previousMessages: ModelMessage[] = [];
   let hasSystemTurn = false;
 
-  if (inputSessionId) {
+  if (!transparent && inputSessionId) {
     if (sessionExists(inputSessionId)) {
       sessionId = inputSessionId;
       hasSystemTurn = loadSession(sessionId)[0]?.role === "system";
@@ -546,7 +557,9 @@ Apply the guidance from each skill throughout your response.`;
 
   const agent = new ToolLoopAgent({
     model,
-    instructions,
+    // Transparent replay: no code-generated system prompt — the system turn
+    // (if any) must be present inside the replayed messages array.
+    instructions: transparent ? undefined : instructions,
     tools,
     stopWhen,
     stopSequences: ["[END_OF_ANSWER]"],

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -3,6 +3,7 @@ import { get_context, stream_context } from "./agent.js";
 import { ToolsConfig, SkillsConfig, GgnnConfig, getDefaultToolDescriptions, normalizeToolsConfig } from "./tools.js";
 import { type SubAgent, normalizeSubAgent } from "./subagent.js";
 import { Request, Response } from "express";
+import { ModelMessage } from "ai";
 import { randomUUID } from "crypto";
 import { gitleaksDetect, gitleaksProtect } from "./gitleaks.js";
 import * as asyncReqs from "../graph/reqs.js";
@@ -125,6 +126,12 @@ function parseAgentBody(req: Request) {
   const pat = req.body.pat as string | undefined;
   const commitList = parseCommitList(req.body.commit as string | undefined);
   const prompt = req.body.prompt as any;
+  // Transparent replay: a full ai-sdk transcript (including the system turn) to
+  // run verbatim. When present, the agent skips all prompt/instruction
+  // enrichment, session history, attachments, and persistence.
+  const messages = Array.isArray(req.body.messages)
+    ? (req.body.messages as ModelMessage[])
+    : undefined;
   const toolsConfig = normalizeToolsConfig(req.body.toolsConfig);
   const schema = req.body.jsonSchema as { [key: string]: any } | undefined;
   const modelName = req.body.model as ModelName | undefined;
@@ -156,7 +163,7 @@ function parseAgentBody(req: Request) {
     .filter((url: string) => url.length > 0);
 
   return {
-    repoUrl, username, pat, commitList, prompt, toolsConfig, schema,
+    repoUrl, username, pat, commitList, prompt, messages, toolsConfig, schema,
     modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, mcpServers,
     systemOverride, skills, subAgents, ggnn, stream, repoList, maxTurns, headers,
     ignoreRepoInfo, attachments, _metadata,
@@ -217,18 +224,25 @@ export async function repo_agent(req: Request, res: Response) {
 
   const body = parseAgentBody(req);
 
-  if (!body.prompt) {
+  // Transparent replay: `messages` is a full transcript run verbatim. It takes
+  // the place of `prompt` and disables all enrichment/history/persistence.
+  const transparent = Boolean(body.messages && body.messages.length > 0);
+
+  if (!body.prompt && !transparent) {
     res.status(400).json({ error: "Missing prompt" });
     return;
   }
 
   const graphRepos = await getGraphRepoList();
   const effectiveRepos = body.repoList.length > 0 ? body.repoList : graphRepos;
-  // Only prepend repo info on the first message of a session (or when there's no session)
+  // Only prepend repo info on the first message of a session (or when there's no session).
+  // In transparent mode the replayed messages are sent verbatim — no repo info.
   const isExistingSession = body.sessionId && sessionExists(body.sessionId);
-  const promptWithRepoInfo = (isExistingSession || body.ignoreRepoInfo)
-    ? body.prompt
-    : prependRepoInfo(body.prompt, body.repoList, graphRepos);
+  const promptInput: string | ModelMessage[] = transparent
+    ? body.messages!
+    : (isExistingSession || body.ignoreRepoInfo)
+      ? body.prompt
+      : prependRepoInfo(body.prompt, body.repoList, graphRepos);
   // ── Streaming path: direct SSE response ──────────────────────────────
   if (body.stream) {
     // Register abort controller keyed by sessionId so a separate request can cancel it
@@ -242,9 +256,10 @@ export async function repo_agent(req: Request, res: Response) {
       console.log(`===> POST /repo/agent (stream) ${repoDir}`);
 
       const { streamResult, finalizeSession } = await stream_context(
-        promptWithRepoInfo,
+        promptInput,
         repoDir,
         {
+          transparent,
           pat: body.pat,
           toolsConfig: body.toolsConfig,
           schema: body.schema,
@@ -364,7 +379,8 @@ export async function repo_agent(req: Request, res: Response) {
     repoDirPromise
       .then((repoDir) => {
         console.log(`===> POST /repo/agent ${repoDir}`);
-        return get_context(promptWithRepoInfo, repoDir, {
+        return get_context(promptInput, repoDir, {
+          transparent,
           pat: body.pat,
           toolsConfig: body.toolsConfig,
           schema: body.schema,


### PR DESCRIPTION
## What

Adds a **transparent replay mode** to the repo agent for evals. When the `/repo/agent` request body includes a `messages` array (ai-sdk `ModelMessage[]` format), the agent runs that transcript **verbatim**:

- **No code-generated system prompt** — `DEFAULT_SYSTEM` is not called; the system turn must live inside the `messages` array.
- **No enrichment** — org-agent, sub-agent, and skills instruction blocks are skipped.
- **No session history** — prior messages are not loaded.
- **No attachments resolution** — the prompt is sent as-is.
- **No persistence** — `sessionId` stays undefined, nothing is written.

This lets evals "replay" conversations at specific points (including transcripts from older versions of the codebase that constructed prompts differently) without the current construction layer mutating them.

Tools still load and execute, and the repo is still cloned (driven by `repo_url` / `commit`), so tool calls in the loop run normally.

## How

- `GetContextOptions.transparent?: boolean` gates `prepareAgent`: instructions become `undefined`, enrichment blocks are skipped, session/attachments are bypassed, and the prompt is passed through untouched. The existing `buildCallParams` already sends a `ModelMessage[]` as `{ messages }`.
- Handler adds a single `messages` body field; its presence implies `transparent`. Validation accepts `prompt` **or** `messages`, and `prependRepoInfo` is skipped in replay.

## Backwards compatibility

When `messages` is omitted, `transparent` is `false` and every changed branch collapses to its original expression — behavior is identical to before.

## Usage

```json
{
  "repo_url": "https://github.com/stakwork/hive",
  "commit": "<sha-to-replay-against>",
  "messages": [
    { "role": "system", "content": "...the old version's system prompt..." },
    { "role": "user", "content": "..." },
    { "role": "assistant", "content": "..." }
  ]
}
```

## Verification

- `npx tsc --noEmit` passes.