### PR TITLE
vein+gitsee: agent tool-call visibility + per-run QA services

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -55,7 +55,10 @@ A port of `mcp/src/gitsee`'s "services" mode (the agent that emits a
 `pm2.config.js` + `docker-compose.yml` to set up a project). No import from
 existing code (`src/gitsee`), so that dir can eventually be deleted. The agent
 loop itself is **not** gitsee code anymore — it's the **vein-core `agent`
-step** (see `vein/AGENTS.md`); gitsee only supplies the clone + the prompts.
+step** (see `vein/AGENTS.md`); gitsee supplies the clone + the prompts, and (for
+the product loop) a `gitsee` **`services` bag** (`gitsee/services/`: per-run
+browser + stack managers + a vision judge) that its thin tool-steps reach via
+`ctx.services.gitsee.*` — see "The product loop" below.
 
 **WORKSPACE-oriented** (not single-repo): a workspace is a set of repos cloned
 as **siblings** under `/workspaces/<repo>` — typically one runnable **frontend**
@@ -139,47 +142,73 @@ booted stack is left up. Clean it with `npx tsx src/lab/gitsee/cleanup.ts`
 projects; leaves Neo4j etc. alone). `keepUp:true` intentionally skips teardown for
 debugging.
 
-**The product loop (`gitsee/boot-and-exercise`) — NOT an eval signal.** Where
+**The product loop (`gitsee-setup-and-run`) — NOT an eval signal.** Where
 `verify-setup` is a READ-ONLY boot GATE (boot once → one screenshot → one vision
-verdict → score), `boot-and-exercise.ts` (`gitsee/boot-and-exercise`) is the
-autonomous "set up a repo until it actually runs" loop. It stages the produced
-setup, then runs a **tool-using agent** that BOOTS the app, DRIVES the live
-frontend in a real headless browser, OBSERVES failures like a QA engineer, FIXES
-the cause, REBOOTS, and repeats until the app is functional. Tools: `boot`
-(re-stage + compose up + staklink/pm2 + wait for port; call after every edit),
-`browser_open` / `browser_snapshot` (visible interactive elements with `@eN`
-refs) / `browser_click` / `browser_fill` / `browser_press`, **`browser_observe`**
-(drains console errors + failed requests + **4xx/5xx API responses** since the
-last call — the key "renders but is broken" signal a screenshot can't show),
-`assess_ui` (the "eyes": fresh screenshot + errors + server logs → an anthropic
-vision verdict), `read_logs`, `bash`, `str_replace_based_edit_tool` (edit
-pm2.config.js env / docker-compose.yml / repo source, sandboxed to the
-workspace), and `final_answer` (a `## SUMMARY` / `## WORKING` / `## MISSING`
-markdown report). The agent works in LOCAL path terms; the final `setup` output
-is rewritten back to pod-portable `/workspaces/<repo>`. A working-dir **preamble**
-(the real local workspace path + sibling repos) is prepended to the prompt so the
-agent doesn't burn steps guessing pod paths. **Pod URLs (`$POD_ID`/`$POD_URL`)**
-are kept in the deliverable (the pod contract) but **localized only in the
-staged-for-boot copy** (`podSubstituteLocal`: `https://$POD_ID-<port>.<domain>` →
-`http://localhost:<port>`, `$POD_URL` → `http://localhost:<frontendPort>`) — on
-the real sandbox the platform expands them + proxies `<podid>-<port>.<domain>` to
-`localhost:<port>`; locally there's no proxy, so we emulate it (NOT a staklink
-concern). The agent is told these are auto-substituted and to KEEP them rather
-than rewrite to localhost. (verify-setup could adopt the same helper.) Because it is allowed to
-**WRITE/FIX**, it must **NOT** be wired into the scored `gitsee-optimize` loop —
-fixing in place would erase the gradient that teaches the explorer. Its home is
-the standalone **`gitsee-setup-and-run`** workflow (`clone → produce
-(gitsee-explore-services) → boot-and-exercise`); the deliverable is a known-good
-`setup` + the `diff` + the `report`, not a grade. Like the explore path it also
-captures the agent's repo edits as a replayable per-repo `git diff` (inlined here
-rather than reusing `gitsee/capture-edits` — a workflow's output is its last
-step's, and capture-edits would drop the richer setup/report/booted/working
-fields). Same boot/teardown machinery + caveats as verify-setup (snapshot-diff
-container teardown; `keepUp:true` to inspect; needs `docker` + `git` + `npx
-playwright install chromium`). Output `{ booted, working, port, setup, report,
-diff, changedRepos, changed, screenshotPath, iterations, logsTail, usage, cost }`.
-Dev smoke (not seeded): `src/lab/gitsee/smoke-boot.ts` (`clone → core agent →
-boot-and-exercise`, real calls; `KEEP_UP=1` leaves the stack up).
+verdict → score), `gitsee-setup-and-run` is the autonomous "set up a repo until it
+actually runs" loop: an agent that BOOTS the app, DRIVES the live frontend in a
+real headless browser, OBSERVES failures like a QA engineer, FIXES the cause,
+REBOOTS, and repeats until functional. Because it WRITES/FIXES, it must **NOT** be
+wired into the scored `gitsee-optimize` loop (fixing in place erases the gradient
+that teaches the explorer); the deliverable is a known-good `setup` + `diff` +
+`report`, not a grade.
+
+**Architecture: this is now DECOMPOSED onto the vein-core `agent` step** (it used
+to be one ~1050-line `gitsee/boot-and-exercise` step that forked the whole agent
+loop). See `vein/plans/agentic-loop-as-workflow.md` for the full design. The
+pieces:
+
+- **The QA harness = a gitsee `services` bag** (`gitsee/services/`, in-code,
+  merged into `LabServices` by `createLabVein`; NOT seeded): `BrowserManager` +
+  `StackManager` (per-run sessions keyed by `runId`) + a stateless `vision` judge.
+  `_infra.ts` holds the shell/pm2/compose/pod-url/port/log helpers; the
+  per-run state (browser page, booted stack, last vision verdict) lives on the
+  session. **Teardown is automatic**: `LabServices.onRunEnd(runId)` (the generic
+  vein hook the runner calls in a `finally`, success OR error) disposes the run's
+  browser + booted stack — no teardown code in any step. (`cleanup.ts` is still
+  the rescue for a hard `SIGKILL`, which skips the in-process `finally`.)
+- **The capabilities = thin seeded tool-steps** (`gitsee/steps/`) reaching the
+  harness via `ctx.services.gitsee.*`, keyed by `ctx.runId`: `gitsee/stage-setup`
+  (stage the produced files + create the per-run stack session), `gitsee/boot`
+  (re-stage + compose up + staklink/pm2 + wait for port), `gitsee/browser-open` /
+  `-snapshot` / `-click` / `-fill` / `-press`, **`gitsee/browser-observe`** (drains
+  console errors + failed requests + **4xx/5xx API responses** — the "renders but
+  is broken" signal a screenshot can't show), `gitsee/assess-ui` (the "eyes":
+  screenshot + errors + logs → vision verdict, recorded on the stack session),
+  `gitsee/read-logs`, and `gitsee/finalize-setup` (the deliverable: pod-portable
+  `setup` + per-repo `git diff` + the booted/working verdict). Each works BOTH as
+  a workflow step AND as an `agentTools` tool.
+- **The loop = the core `agent` step** with those steps as `agentTools` (+
+  built-in `bash`/`str_replace_based_edit_tool` for edits). `gitsee-setup-and-run`
+  is `clone → produce (gitsee-explore-services) → stage → qa(agent) → finalize`.
+  Every tool call emits a nested run event (the agent step's `wrapToolsWithEmit`),
+  so **each iteration is visible in the UI events panel / run drill-down**. The QA
+  `system` prompt + `agentTools` list + `model` + `maxSteps` live in the
+  workflow's `params` (the harness/policy split — a future `gitsee-setup-optimize`
+  can sweep the prompt with the harness fixed).
+
+  *Why agent-orchestrated, not a deterministic `loop` step:* vein's `loop` THROWS
+  on `maxIterations`-without-convergence (`runner.ts`), which would error the run
+  and yield NO deliverable when an app can't be fixed; and QA control flow is
+  inherently dynamic. The agent's own tool loop still gives per-iteration
+  visibility, preserves autonomy, and always finalizes.
+
+**Pod URLs (`$POD_ID`/`$POD_URL`)** are kept in the deliverable (the pod contract)
+but **localized only in the staged-for-boot copy** (`podSubstituteLocal` in
+`services/_infra.ts`: `https://$POD_ID-<port>.<domain>` → `http://localhost:<port>`,
+`$POD_URL` → `http://localhost:<frontendPort>`) — on the real sandbox the platform
+expands them + proxies `<podid>-<port>.<domain>` to `localhost:<port>`; locally
+there's no proxy, so we emulate it. The QA system prompt tells the agent these are
+auto-substituted and to KEEP them.
+
+Output `{ booted, working, reason, port, setup, report, diff, changedRepos,
+changed, screenshotPath }`. Needs `docker` + `git` + `npx playwright install
+chromium`.
+
+**`gitsee/boot-and-exercise` (the old monolith) is still seeded but UNUSED by the
+workflow** — kept as the A/B reference to validate the decomposed loop reaches
+parity before deletion (plan Step E). Its dev smoke `src/lab/gitsee/smoke-boot.ts`
+still drives that step directly; `src/lab/gitsee/services/smoke-services.ts` is a
+no-docker lifecycle smoke for the new harness (per-run keying + `onRunEnd`).
 
 **Eval/optimize stack** (mirrors `concepts-*`; reuses the generic `eval/*`
 steps EXCEPT scoring, which is gitsee-specific — see below). The gold is the

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -12,6 +12,7 @@ import {
 import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
 import { seedEvalSteps } from "./eval/seed.js";
 import { seedGitseeWorkflows, seedGitseeSteps } from "./gitsee/seed.js";
+import { buildGitseeServices, type GitseeServices } from "./gitsee/services/index.js";
 
 /**
  * Lets a step run other workflows (and read their params) from inside a run —
@@ -37,6 +38,12 @@ export interface OptimizerCapability {
 export interface LabServices extends ConceptServices {
   /** Run-sub-workflows capability for the optimize loop. Injected post-build. */
   optimizer?: OptimizerCapability;
+  /** Gitsee QA harness: per-run browser + stack session managers + vision judge,
+   *  reached by the gitsee tool-steps via `ctx.services.gitsee.*`. */
+  gitsee?: GitseeServices;
+  /** Generic per-run teardown hook called by the vein runner in a `finally`
+   *  (success AND error). Disposes a run's gitsee browser + booted stack. */
+  onRunEnd?(runId: string): Promise<void>;
 }
 
 export interface CreateLabVeinOptions extends BuildServicesOptions {
@@ -65,10 +72,24 @@ export interface CreateLabVeinOptions extends BuildServicesOptions {
 export async function createLabVein(
   opts: CreateLabVeinOptions = {},
 ): Promise<Vein<LabServices>> {
-  // Merged services bag. Today just concepts; spread additional
-  // experiments' bags here as they're added.
+  // Merged services bag. Today concepts + the gitsee QA harness; spread
+  // additional experiments' bags here as they're added.
   const services: LabServices =
     opts.services ?? (await buildConceptServices(opts));
+
+  // Gitsee harness: per-run browser + stack managers + vision judge, plus the
+  // generic per-run teardown hook. Wired even when `opts.services` was supplied
+  // (so a custom bag still gets the gitsee harness + teardown) — only added when
+  // absent, to respect a caller that intentionally provided its own gitsee bag.
+  if (!services.gitsee) {
+    const { gitsee, disposeRun } = buildGitseeServices();
+    services.gitsee = gitsee;
+    const priorOnRunEnd = services.onRunEnd?.bind(services);
+    services.onRunEnd = async (runId: string) => {
+      if (priorOnRunEnd) await priorOnRunEnd(runId);
+      await disposeRun(runId);
+    };
+  }
 
   const workspacePath =
     opts.workspacePath ??

--- a/mcp/src/lab/gitsee/seed.ts
+++ b/mcp/src/lab/gitsee/seed.ts
@@ -9,9 +9,12 @@ import type { WorkspaceManager } from "vein";
  * — see concepts/seed.ts for the reconciliation contract (unchanged → no-op,
  * edited → new active version, prior versions archived).
  *
- * Unlike concepts (whose steps reach runtime objects via `ctx.services`), these
- * steps are FULLY self-contained: they import only `vein`, the third-party AI
- * SDK, and Node builtins. So there's no services bag to merge here.
+ * Steps are self-contained source (they import only `vein`, the third-party AI
+ * SDK, Node builtins, and TYPE-ONLY imports that erase at runtime). The explore +
+ * eval steps need no services. The QA tool-steps (gitsee/boot, browser-*, etc.)
+ * DO reach a runtime `gitsee` services bag via `ctx.services.gitsee.*` — that bag
+ * (`gitsee/services/`) is built + merged into `LabServices` in `createLabVein`,
+ * not seeded here.
  */
 
 const SEED_WORKFLOWS = [

--- a/mcp/src/lab/gitsee/seed.ts
+++ b/mcp/src/lab/gitsee/seed.ts
@@ -40,6 +40,21 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   // Product loop (NOT eval): boots the produced setup, DRIVES the live app in a
   // browser, observes failures, fixes the config/repo, reboots — until it runs.
   { file: "boot-and-exercise.ts", type: "gitsee/boot-and-exercise" },
+  // QA tool-steps (the decomposed boot-and-exercise): thin, self-contained steps
+  // that reach the per-run browser/stack/vision HARNESS via ctx.services.gitsee.*
+  // (see ../services). Usable BOTH as workflow steps (the C2 gitsee-qa-iteration
+  // loop) AND as agent tools (agentTools on the core `agent` step).
+  { file: "stage-setup.ts", type: "gitsee/stage-setup" },
+  { file: "boot.ts", type: "gitsee/boot" },
+  { file: "browser-open.ts", type: "gitsee/browser-open" },
+  { file: "browser-snapshot.ts", type: "gitsee/browser-snapshot" },
+  { file: "browser-click.ts", type: "gitsee/browser-click" },
+  { file: "browser-fill.ts", type: "gitsee/browser-fill" },
+  { file: "browser-press.ts", type: "gitsee/browser-press" },
+  { file: "browser-observe.ts", type: "gitsee/browser-observe" },
+  { file: "assess-ui.ts", type: "gitsee/assess-ui" },
+  { file: "read-logs.ts", type: "gitsee/read-logs" },
+  { file: "finalize-setup.ts", type: "gitsee/finalize-setup" },
   // Captures the agent's repo edits as a replayable git diff (part of the
   // deliverable): the last step of gitsee-explore-services, passes the agent
   // output through and adds `diff`.

--- a/mcp/src/lab/gitsee/services/_infra.ts
+++ b/mcp/src/lab/gitsee/services/_infra.ts
@@ -1,0 +1,212 @@
+/**
+ * Shared, pure-ish infra helpers for the gitsee lab services (browser / stack /
+ * vision). Lifted near-verbatim from the old `boot-and-exercise.ts` so the
+ * services own the machinery and the (future) tool-steps stay thin. In-code only
+ * (NOT a seeded step) — free to import node builtins + each other.
+ */
+import { spawn } from "node:child_process";
+import { readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { createConnection } from "node:net";
+import vm from "node:vm";
+import yaml from "js-yaml";
+
+// ── shell ──────────────────────────────────────────────────────────────────
+
+export interface ShResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/** Run a shell command, capture output, never reject. Mirrors staklink's runner
+ *  env (CI=1, non-interactive) for parity. */
+export function sh(
+  command: string,
+  cwd: string,
+  env: Record<string, string>,
+  timeoutMs: number,
+): Promise<ShResult> {
+  return new Promise((resolve) => {
+    const child = spawn("sh", ["-c", command], {
+      cwd,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, CI: "1", DEBIAN_FRONTEND: "noninteractive", ...env },
+    });
+    let stdout = "";
+    let stderr = "";
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, timeoutMs);
+    child.stdout?.on("data", (d) => (stdout += d.toString()));
+    child.stderr?.on("data", (d) => (stderr += d.toString()));
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      resolve({ code, stdout, stderr, timedOut });
+    });
+    child.on("error", (err) => {
+      clearTimeout(timer);
+      resolve({ code: -1, stdout, stderr: stderr + String(err), timedOut });
+    });
+  });
+}
+
+/** All docker container IDs (running + stopped), for the snapshot-diff teardown. */
+export async function dockerContainerIds(): Promise<Set<string>> {
+  const r = await sh("docker ps -aq", process.cwd(), {}, 15000);
+  return new Set(r.stdout.split("\n").map((s) => s.trim()).filter(Boolean));
+}
+
+/** Poll a TCP port until something is listening (the app booted) or timeout. */
+export function waitForPort(port: number, host: string, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs;
+  return new Promise((resolve) => {
+    const attempt = () => {
+      const socket = createConnection({ port, host });
+      socket.setTimeout(2000);
+      socket.once("connect", () => {
+        socket.destroy();
+        resolve(true);
+      });
+      const retry = () => {
+        socket.destroy();
+        if (Date.now() >= deadline) resolve(false);
+        else setTimeout(attempt, 1500);
+      };
+      socket.once("error", retry);
+      socket.once("timeout", retry);
+    };
+    attempt();
+  });
+}
+
+// ── booted-service logs ──────────────────────────────────────────────────────
+
+export async function captureAppLogs(wp: string, appName: string): Promise<string> {
+  const chunks: string[] = [];
+  const inlineLog = join(wp, ".verify", "app.log");
+  if (existsSync(inlineLog)) {
+    try {
+      chunks.push(readFileSync(inlineLog, "utf-8"));
+    } catch {
+      /* ignore */
+    }
+  }
+  const r = await sh(`npx -y pm2 logs ${appName} --nostream --lines 200`, wp, {}, 30000);
+  if (r.stdout.trim()) chunks.push(r.stdout);
+  const pm2dir = join(homedir(), ".pm2", "logs");
+  for (const f of [`${appName}-out.log`, `${appName}-error.log`]) {
+    const p = join(pm2dir, f);
+    if (existsSync(p)) {
+      try {
+        chunks.push(`--- ${f} ---\n${readFileSync(p, "utf-8")}`);
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+  const out = chunks.join("\n");
+  return out.length > 20000 ? out.slice(-20000) : out; // keep the tail
+}
+
+const LOG_ERROR_RE =
+  /(^|\b)(Error:|UnhandledPromiseRejection|unhandledRejection|uncaughtException|EADDRINUSE|ECONNREFUSED|Cannot find module|MODULE_NOT_FOUND|PrismaClientInitializationError|FATAL|panic:|Traceback \(most recent|errored|exited with code [1-9])/i;
+
+export function scanLogErrors(logs: string): string[] {
+  return logs
+    .split("\n")
+    .filter((l) => LOG_ERROR_RE.test(l))
+    .slice(0, 20);
+}
+
+// ── produced-file parsing ─────────────────────────────────────────────────────
+
+export interface TwoFiles {
+  pm2?: string;
+  compose?: string;
+}
+
+export function splitFiles(doc: string): TwoFiles {
+  const out: TwoFiles = {};
+  const re = /FILENAME:\s*([^\n]+?)\s*\n+```[a-zA-Z0-9]*\n([\s\S]*?)\n```/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(doc)) !== null) {
+    const name = m[1].trim().toLowerCase();
+    const body = m[2];
+    if (name.includes("pm2")) out.pm2 ??= body;
+    else if (name.includes("compose")) out.compose ??= body;
+  }
+  return out;
+}
+
+export function hasComposeServices(text: string | undefined): boolean {
+  if (!text) return false;
+  try {
+    const doc = yaml.load(text) as { services?: Record<string, unknown> } | undefined;
+    return !!doc?.services && Object.keys(doc.services).length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/** A callable, infinitely-chainable no-op for sandboxed require() chains. */
+function callableStub(): unknown {
+  const fn = function () {
+    return stub;
+  };
+  const stub: unknown = new Proxy(fn, { get: () => stub, apply: () => stub });
+  return stub;
+}
+
+export interface Pm2App {
+  name?: string;
+  script?: string;
+  args?: string;
+  cwd?: string;
+  env?: Record<string, unknown>;
+}
+
+export function parsePm2(code: string | undefined): Pm2App[] | null {
+  if (!code) return null;
+  const sandbox: Record<string, unknown> = {
+    module: { exports: {} },
+    require: () => callableStub(),
+    console: { log() {}, error() {}, warn() {}, info() {} },
+    process: { env: {} },
+  };
+  sandbox.exports = (sandbox.module as { exports: unknown }).exports;
+  try {
+    vm.createContext(sandbox);
+    vm.runInContext(code, sandbox, { timeout: 1000 });
+    const exported = (sandbox.module as { exports: unknown }).exports as { apps?: unknown };
+    return Array.isArray(exported?.apps) ? (exported.apps as Pm2App[]) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * LOCAL emulation of the pod's `$POD_ID` / `$POD_URL` substitution. On the real
+ * sandbox the platform expands these AND proxies `https://<podid>-<port>.<domain>`
+ * → `localhost:<port>`; locally there's no proxy, so we rewrite the pod-URL
+ * PATTERNS to their localhost equivalents in the staged-for-boot copy ONLY.
+ */
+export function podSubstituteLocal(pm2Code: string, frontendPort: number): string {
+  return pm2Code
+    .replace(/https?:\/\/\$\{?POD_ID\}?-(\d+)\.[A-Za-z0-9.\-]+/g, "http://localhost:$1")
+    .replace(/https?:\/\/\$\{?POD_ID\}?\.[A-Za-z0-9.\-]+/g, `http://localhost:${frontendPort}`)
+    .replace(/\$\{?POD_URL\}?/g, `http://localhost:${frontendPort}`)
+    .replace(/\$\{?POD_ID\}?/g, "local");
+}
+
+/** The frontend app (named "frontend", else the first app) + its port. */
+export function frontendApp(apps: Pm2App[]): { app: Pm2App; port: number } | null {
+  if (!apps.length) return null;
+  const app = apps.find((a) => a.name === "frontend") ?? apps[0];
+  const port = parseInt(String(app.env?.PORT ?? "3000"), 10) || 3000;
+  return { app, port };
+}

--- a/mcp/src/lab/gitsee/services/browser.ts
+++ b/mcp/src/lab/gitsee/services/browser.ts
@@ -1,0 +1,239 @@
+/**
+ * Browser service: a headless-chromium page session that accumulates
+ * console/network errors and exposes a snapshot→interact→re-snapshot toolset
+ * (the agent-browser pattern). Lifted from `boot-and-exercise.ts`.
+ *
+ * Sessions are PER-RUN, keyed by runId (a live page is mutable state; the
+ * optimize loop runs many evals concurrently, so a singleton page would
+ * collide). The manager hands out / reuses one `BrowserSession` per runId and
+ * disposes it on `onRunEnd(runId)`.
+ */
+import { mkdirSync, existsSync } from "node:fs";
+import { join } from "node:path";
+
+export interface Observations {
+  console: string[];
+  pageErrors: string[];
+  failedRequests: string[];
+  httpErrors: string[];
+}
+
+export class BrowserSession {
+  private chromium: any;
+  private browser: any;
+  private page: any;
+  private refs = new Map<string, any>();
+  obs: Observations = { console: [], pageErrors: [], failedRequests: [], httpErrors: [] };
+  available = true;
+  note = "";
+
+  constructor(private baseUrl: string, private screenshotDir: string, private timeoutMs: number) {}
+
+  private push(arr: string[], v: string) {
+    arr.push(v);
+    if (arr.length > 200) arr.shift();
+  }
+
+  async ensure(): Promise<boolean> {
+    if (this.page) return true;
+    try {
+      ({ chromium: this.chromium } = await import("@playwright/test"));
+    } catch (e) {
+      this.available = false;
+      this.note = `playwright not available: ${(e as Error).message}`;
+      return false;
+    }
+    try {
+      this.browser = await this.chromium.launch();
+    } catch (e) {
+      this.available = false;
+      this.note = `could not launch chromium (browsers installed?): ${(e as Error).message}`;
+      return false;
+    }
+    this.page = await this.browser.newPage();
+    this.page.on("console", (m: any) => {
+      if (m.type() === "error") this.push(this.obs.console, m.text());
+    });
+    this.page.on("pageerror", (e: any) => this.push(this.obs.pageErrors, String(e)));
+    this.page.on("requestfailed", (r: any) =>
+      this.push(this.obs.failedRequests, `${r.method()} ${r.url()} — ${r.failure()?.errorText ?? "failed"}`),
+    );
+    this.page.on("response", (r: any) => {
+      const s = r.status();
+      if (s >= 400) this.push(this.obs.httpErrors, `${s} ${r.request().method()} ${r.url()}`);
+    });
+    return true;
+  }
+
+  async open(path: string): Promise<string> {
+    if (!(await this.ensure())) return `browser unavailable: ${this.note}`;
+    const url = path.startsWith("http") ? path : `${this.baseUrl}${path.startsWith("/") ? "" : "/"}${path}`;
+    this.refs.clear();
+    try {
+      const resp = await this.page
+        .goto(url, { waitUntil: "networkidle", timeout: this.timeoutMs })
+        .catch(async () => this.page.goto(url, { waitUntil: "domcontentloaded", timeout: this.timeoutMs }));
+      const status = resp?.status?.();
+      const title = await this.page.title().catch(() => "");
+      return `opened ${url} (HTTP ${status ?? "?"}, title: ${JSON.stringify(title)})`;
+    } catch (e) {
+      return `navigation failed: ${(e as Error).message}`;
+    }
+  }
+
+  async snapshot(): Promise<string> {
+    if (!this.page) return "no page open — call browser_open first";
+    this.refs.clear();
+    const sel =
+      "a, button, input, select, textarea, [role=button], [role=link], [role=tab], [onclick], [type=submit], [type=button]";
+    let handles: any[] = [];
+    try {
+      handles = await this.page.$$(sel);
+    } catch (e) {
+      return `snapshot failed: ${(e as Error).message}`;
+    }
+    const lines: string[] = [];
+    let i = 1;
+    for (const h of handles) {
+      let visible = false;
+      try {
+        visible = await h.isVisible();
+      } catch {
+        /* detached */
+      }
+      if (!visible) continue;
+      let info: any = {};
+      try {
+        info = await h.evaluate((el: any) => ({
+          tag: el.tagName.toLowerCase(),
+          type: el.getAttribute("type") || "",
+          role: el.getAttribute("role") || "",
+          name: (
+            el.getAttribute("aria-label") ||
+            el.getAttribute("placeholder") ||
+            (el.innerText || el.value || "").trim() ||
+            el.getAttribute("name") ||
+            ""
+          ).slice(0, 80),
+        }));
+      } catch {
+        continue;
+      }
+      const ref = `e${i++}`;
+      this.refs.set(ref, h);
+      const desc = info.type
+        ? `${info.tag}[type=${info.type}]`
+        : info.role
+          ? `${info.tag}[role=${info.role}]`
+          : info.tag;
+      lines.push(`@${ref} ${desc} ${JSON.stringify(info.name)}`);
+      if (i > 120) break;
+    }
+    const cur = await this.page.url().catch(() => "");
+    return `URL: ${cur}\n` + (lines.join("\n") || "(no visible interactive elements)");
+  }
+
+  async click(ref: string): Promise<string> {
+    const h = this.refs.get(ref);
+    if (!h) return `unknown ref ${ref} — re-run browser_snapshot (refs reset on navigation)`;
+    try {
+      await h.click({ timeout: 8000 });
+      await this.page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+      return `clicked ${ref}`;
+    } catch (e) {
+      return `click failed: ${(e as Error).message}`;
+    }
+  }
+
+  async fill(ref: string, text: string): Promise<string> {
+    const h = this.refs.get(ref);
+    if (!h) return `unknown ref ${ref} — re-run browser_snapshot`;
+    try {
+      await h.fill(text, { timeout: 8000 });
+      return `filled ${ref}`;
+    } catch (e) {
+      return `fill failed: ${(e as Error).message}`;
+    }
+  }
+
+  async press(key: string): Promise<string> {
+    if (!this.page) return "no page open";
+    try {
+      await this.page.keyboard.press(key);
+      await this.page.waitForLoadState("networkidle", { timeout: 5000 }).catch(() => {});
+      return `pressed ${key}`;
+    } catch (e) {
+      return `press failed: ${(e as Error).message}`;
+    }
+  }
+
+  async screenshot(name = "exercise.png"): Promise<string | undefined> {
+    if (!this.page) return undefined;
+    mkdirSync(this.screenshotDir, { recursive: true });
+    const p = join(this.screenshotDir, name);
+    await this.page.screenshot({ path: p, fullPage: true }).catch(() => {});
+    return existsSync(p) ? p : undefined;
+  }
+
+  /** Drain + clear the accumulated observations (errors since the last drain). */
+  drain(): Observations {
+    const snap = this.obs;
+    this.obs = { console: [], pageErrors: [], failedRequests: [], httpErrors: [] };
+    return snap;
+  }
+
+  setBaseUrl(url: string) {
+    this.baseUrl = url;
+  }
+
+  async close() {
+    await this.browser?.close().catch(() => {});
+    this.browser = undefined;
+    this.page = undefined;
+    this.refs.clear();
+  }
+}
+
+export function summarizeObs(o: Observations): string {
+  const parts: string[] = [];
+  const block = (label: string, arr: string[]) =>
+    arr.length ? `${label} (${arr.length}):\n` + arr.slice(0, 15).map((s) => `  - ${s.slice(0, 200)}`).join("\n") : "";
+  for (const [label, arr] of [
+    ["console errors", o.console],
+    ["page errors", o.pageErrors],
+    ["failed requests", o.failedRequests],
+    ["HTTP 4xx/5xx responses", o.httpErrors],
+  ] as const) {
+    const b = block(label, arr);
+    if (b) parts.push(b);
+  }
+  return parts.length ? parts.join("\n") : "no console/network errors observed";
+}
+
+/** Per-run browser sessions, keyed by runId. */
+export class BrowserManager {
+  private sessions = new Map<string, BrowserSession>();
+
+  /** Get (or create) the session for a run. `baseUrl`/`screenshotDir` are only
+   *  used on first creation; later calls just return the existing session. */
+  session(runId: string, baseUrl: string, screenshotDir: string, timeoutMs = 30000): BrowserSession {
+    let s = this.sessions.get(runId);
+    if (!s) {
+      s = new BrowserSession(baseUrl, screenshotDir, timeoutMs);
+      this.sessions.set(runId, s);
+    }
+    return s;
+  }
+
+  has(runId: string): boolean {
+    return this.sessions.has(runId);
+  }
+
+  /** Dispose a run's session (called from onRunEnd). Idempotent. */
+  async dispose(runId: string): Promise<void> {
+    const s = this.sessions.get(runId);
+    if (!s) return;
+    this.sessions.delete(runId);
+    await s.close().catch(() => {});
+  }
+}

--- a/mcp/src/lab/gitsee/services/browser.ts
+++ b/mcp/src/lab/gitsee/services/browser.ts
@@ -182,6 +182,12 @@ export class BrowserSession {
     return snap;
   }
 
+  /** Drain + format the observations as a readable summary (so a seeded
+   *  tool-step doesn't need to import `summarizeObs`). */
+  drainSummary(): string {
+    return summarizeObs(this.drain());
+  }
+
   setBaseUrl(url: string) {
     this.baseUrl = url;
   }
@@ -227,6 +233,11 @@ export class BrowserManager {
 
   has(runId: string): boolean {
     return this.sessions.has(runId);
+  }
+
+  /** The existing session for a run, or undefined (no auto-create). */
+  get(runId: string): BrowserSession | undefined {
+    return this.sessions.get(runId);
   }
 
   /** Dispose a run's session (called from onRunEnd). Idempotent. */

--- a/mcp/src/lab/gitsee/services/index.ts
+++ b/mcp/src/lab/gitsee/services/index.ts
@@ -1,0 +1,48 @@
+/**
+ * Gitsee lab services bag — the HARNESS that the (future) QA tool-steps reach via
+ * `ctx.services.gitsee.*`. Holds per-run BROWSER + STACK session managers and a
+ * stateless VISION judge. The matching `onRunEnd(runId)` disposes a run's live
+ * browser + booted stack — wired into vein's generic `services.onRunEnd` so
+ * teardown is guaranteed on success AND error (the optimize-loop teardown fix).
+ *
+ * In-code only (constructed in `createLabVein`), NOT a seeded step — so the
+ * tool-steps stay self-contained and swappable (real Playwright ↔ cassette;
+ * staklink ↔ inline boot; swap the vision model) without touching the steps.
+ */
+import { BrowserManager } from "./browser.js";
+import { StackManager } from "./stack.js";
+import { buildVisionService, type VisionService } from "./vision.js";
+
+export { BrowserManager, BrowserSession, summarizeObs } from "./browser.js";
+export type { Observations } from "./browser.js";
+export { StackManager, StackSession } from "./stack.js";
+export type { StackOptions, BootResult } from "./stack.js";
+export { buildVisionService } from "./vision.js";
+export type { VisionService, VisionVerdict } from "./vision.js";
+
+export interface GitseeServices {
+  browser: BrowserManager;
+  stack: StackManager;
+  vision: VisionService;
+}
+
+/** Build the gitsee harness services + a disposer for a run's per-run sessions.
+ *  The disposer is invoked by the lab's `onRunEnd(runId)`; stack teardown honors
+ *  the session's own `keepUp` (set when the stack session was created). */
+export function buildGitseeServices(): {
+  gitsee: GitseeServices;
+  disposeRun: (runId: string) => Promise<void>;
+} {
+  const browser = new BrowserManager();
+  const stack = new StackManager();
+  const vision = buildVisionService();
+
+  return {
+    gitsee: { browser, stack, vision },
+    async disposeRun(runId) {
+      // Close the browser first (cheap), then tear the stack down.
+      await browser.dispose(runId).catch(() => {});
+      await stack.dispose(runId).catch(() => {});
+    },
+  };
+}

--- a/mcp/src/lab/gitsee/services/smoke-services.ts
+++ b/mcp/src/lab/gitsee/services/smoke-services.ts
@@ -1,0 +1,45 @@
+/**
+ * Dev smoke for the gitsee harness services' LIFECYCLE (no docker / playwright /
+ * LLM): per-run session keying + onRunEnd disposal idempotency. Run:
+ *   npx tsx src/lab/gitsee/services/smoke-services.ts
+ */
+import assert from "node:assert/strict";
+import { buildGitseeServices } from "./index.js";
+
+async function main() {
+  const { gitsee, disposeRun } = buildGitseeServices();
+
+  // Two concurrent runs get DISTINCT sessions (no singleton collision). keepUp
+  // so teardown is a no-op (no docker calls in this smoke).
+  const sA = gitsee.stack.session("runA", "/tmp/wsA", { keepUp: true });
+  const sB = gitsee.stack.session("runB", "/tmp/wsB", { keepUp: true });
+  assert.notEqual(sA, sB, "distinct stack sessions per runId");
+  assert.equal(gitsee.stack.session("runA", "/tmp/wsA", { keepUp: true }), sA, "same session reused for a runId");
+  assert.equal(sA.workspacePath, "/tmp/wsA");
+  assert.equal(sB.workspacePath, "/tmp/wsB");
+
+  const bA = gitsee.browser.session("runA", "http://localhost:3000", "/tmp/wsA/.shots");
+  assert.equal(gitsee.browser.session("runA", "x", "y"), bA, "same browser session reused for a runId");
+
+  assert.ok(gitsee.stack.has("runA") && gitsee.browser.has("runA"));
+
+  // Disposing runA frees ONLY runA's sessions; runB untouched.
+  await disposeRun("runA");
+  assert.equal(gitsee.stack.has("runA"), false, "runA stack disposed");
+  assert.equal(gitsee.browser.has("runA"), false, "runA browser disposed");
+  assert.equal(gitsee.stack.has("runB"), true, "runB stack untouched");
+
+  // Idempotent: disposing again (or an unknown run) is a no-op, not a throw.
+  await disposeRun("runA");
+  await disposeRun("never-existed");
+
+  await disposeRun("runB");
+  assert.equal(gitsee.stack.has("runB"), false);
+
+  console.log("[smoke-services] OK — per-run keying + onRunEnd disposal verified");
+}
+
+main().catch((e) => {
+  console.error("[smoke-services] FAILED:", e);
+  process.exit(1);
+});

--- a/mcp/src/lab/gitsee/services/stack.ts
+++ b/mcp/src/lab/gitsee/services/stack.ts
@@ -65,6 +65,12 @@ export class StackSession {
   /** The original produced two-file string (local form), for finalSetup. */
   private initialSetup = "";
   lastBooted: boolean | null = null;
+  /** The most recent vision verdict (recorded by gitsee/assess-ui), read by
+   *  gitsee/finalize-setup so the deliverable carries it no matter how the
+   *  agent loop ends. */
+  lastWorking: boolean | null = null;
+  lastReason = "";
+  lastScreenshot: string | undefined;
 
   constructor(workspacePath: string, opts: StackOptions = {}) {
     this.workspacePath = workspacePath;
@@ -188,6 +194,13 @@ export class StackSession {
 
   async readLogs(): Promise<string> {
     return captureAppLogs(this.workspacePath, this.appName);
+  }
+
+  /** Record the latest vision verdict (called by gitsee/assess-ui). */
+  recordVerdict(working: boolean | null, reason: string, screenshotPath?: string) {
+    this.lastWorking = working;
+    this.lastReason = reason;
+    if (screenshotPath) this.lastScreenshot = screenshotPath;
   }
 
   /** Per-repo `git diff` (intent-to-add so NEW files show as additions) — the

--- a/mcp/src/lab/gitsee/services/stack.ts
+++ b/mcp/src/lab/gitsee/services/stack.ts
@@ -1,0 +1,269 @@
+/**
+ * Stack service: owns the pod-faithful BOOT lifecycle of a produced setup —
+ * stage the `pm2.config.js` + `docker-compose.yml`, bring up backing services
+ * (docker compose), start the apps (staklink or an inline pm2-free fallback),
+ * wait for the frontend port, read logs, and TEAR DOWN everything on disposal
+ * (pm2 + compose + a snapshot-diff of app-spawned containers like a `supabase
+ * start` stack). Lifted from `boot-and-exercise.ts`.
+ *
+ * Sessions are PER-RUN, keyed by runId, and disposed by `onRunEnd(runId)` — so
+ * an errored eval in the optimize loop frees its stack without waiting for the
+ * whole process to exit. (A hard SIGKILL still needs `cleanup.ts`.)
+ */
+import {
+  writeFileSync,
+  readFileSync,
+  mkdirSync,
+  existsSync,
+  rmSync,
+  openSync,
+} from "node:fs";
+import { join } from "node:path";
+import { spawn } from "node:child_process";
+import {
+  sh,
+  splitFiles,
+  parsePm2,
+  frontendApp,
+  hasComposeServices,
+  podSubstituteLocal,
+  waitForPort,
+  dockerContainerIds,
+  captureAppLogs,
+  scanLogErrors,
+} from "./_infra.js";
+
+export interface StackOptions {
+  useStaklink?: boolean;
+  bootCommand?: string;
+  bootTimeoutMs?: number;
+  /** Skip teardown on disposal (leave compose + apps up for debugging). */
+  keepUp?: boolean;
+}
+
+export interface BootResult {
+  booted: boolean;
+  port: number;
+  logsTail: string;
+  errors: string[];
+  report: string;
+}
+
+export class StackSession {
+  readonly workspacePath: string;
+  readonly useStaklink: boolean;
+  readonly bootCommand: string;
+  readonly bootTimeoutMs: number;
+  readonly keepUp: boolean;
+
+  port = 3000;
+  appName = "frontend";
+  private composeBroughtUp = false;
+  private preBootContainers = new Set<string>();
+  private logBuf: string[] = [];
+  /** The original produced two-file string (local form), for finalSetup. */
+  private initialSetup = "";
+  lastBooted: boolean | null = null;
+
+  constructor(workspacePath: string, opts: StackOptions = {}) {
+    this.workspacePath = workspacePath;
+    this.useStaklink = opts.useStaklink ?? true;
+    this.bootCommand = opts.bootCommand ?? "npx -y staklink@latest start";
+    this.bootTimeoutMs = opts.bootTimeoutMs ?? 420000;
+    this.keepUp = opts.keepUp ?? false;
+  }
+
+  private log(s: string) {
+    console.log(`[gitsee/stack] ${s}`);
+    this.logBuf.push(s);
+  }
+
+  private toLocal = (s: string) => s.replace(/\/workspaces\//g, `${this.workspacePath}/`);
+  private toPod = (s: string) => s.split(`${this.workspacePath}/`).join("/workspaces/");
+
+  /**
+   * Stage the produced setup into the workspace (local-path form) and snapshot
+   * the running containers so teardown can remove everything this run spins up.
+   * Returns the parsed frontend port + app name, or an error string.
+   */
+  async stage(setup: string): Promise<{ ok: true; port: number; appName: string } | { ok: false; error: string }> {
+    this.initialSetup = setup;
+    const files = splitFiles(setup);
+    if (!files.pm2) return { ok: false, error: "no pm2.config.js in the provided setup" };
+    const apps = parsePm2(files.pm2);
+    if (!apps) return { ok: false, error: "provided pm2.config.js did not parse" };
+    const fe = frontendApp(apps);
+    if (!fe) return { ok: false, error: "no app found in pm2.config.js" };
+
+    this.port = fe.port;
+    this.appName = fe.app.name ?? "frontend";
+    const wp = this.workspacePath;
+    writeFileSync(join(wp, "pm2.config.js"), this.toLocal(files.pm2));
+    if (files.compose) writeFileSync(join(wp, "docker-compose.yml"), this.toLocal(files.compose));
+    this.log(`staged pm2.config.js (frontend port ${this.port})${files.compose ? " + docker-compose.yml" : ""}`);
+
+    this.preBootContainers = await dockerContainerIds();
+    return { ok: true, port: this.port, appName: this.appName };
+  }
+
+  /** (Re)boot: re-read the (possibly edited) config, bring up compose, start the
+   *  apps, wait for the frontend port. Safe to call repeatedly. */
+  async boot(): Promise<BootResult> {
+    const wp = this.workspacePath;
+    await sh("npx -y pm2 delete all", wp, {}, 60000).catch(() => {});
+
+    const pm2Code = existsSync(join(wp, "pm2.config.js")) ? readFileSync(join(wp, "pm2.config.js"), "utf-8") : "";
+    const curApps = parsePm2(pm2Code);
+    if (!curApps) return this.bootReport(false, "pm2.config.js did not parse — fix it before booting", "");
+    const curFe = frontendApp(curApps);
+    if (!curFe) return this.bootReport(false, "no app in pm2.config.js", "");
+    this.port = curFe.port;
+
+    // Localize pod-URL placeholders in the staged-for-boot copy ONLY.
+    const pm2Staged = podSubstituteLocal(pm2Code, this.port);
+    mkdirSync(join(wp, ".pod-config", ".user-dockerfile"), { recursive: true });
+    writeFileSync(join(wp, ".pod-config", ".user-dockerfile", "pm2.config.js"), pm2Staged);
+
+    const composeText = existsSync(join(wp, "docker-compose.yml"))
+      ? readFileSync(join(wp, "docker-compose.yml"), "utf-8")
+      : undefined;
+
+    if (hasComposeServices(composeText)) {
+      const up = await sh("docker compose up -d --wait", wp, {}, 300000);
+      if (up.code !== 0) {
+        const up2 = await sh("docker compose up -d", wp, {}, 300000);
+        if (up2.code !== 0)
+          return this.bootReport(false, `docker compose up failed: ${(up.stderr || up2.stderr).slice(0, 600)}`, "");
+      }
+      this.composeBroughtUp = true;
+    }
+
+    if (this.useStaklink) {
+      const boot = await sh(this.bootCommand, wp, {}, 180000);
+      if (boot.code !== 0) this.log(`staklink start returned ${boot.code}: ${boot.stderr.slice(0, 400)}`);
+    } else {
+      const app = frontendApp(parsePm2(pm2Staged) ?? curApps)?.app ?? curFe.app;
+      const appCwd = (app.cwd ?? "").replace(/\/workspaces\//g, `${wp}/`) || wp;
+      const appEnv: Record<string, string> = {};
+      for (const [k, v] of Object.entries(app.env ?? {})) appEnv[k] = String(v);
+      for (const [key, command] of [
+        ["REBUILD_COMMAND", appEnv.REBUILD_COMMAND],
+        ["INSTALL_COMMAND", appEnv.INSTALL_COMMAND],
+        ["PRE_START_COMMAND", appEnv.PRE_START_COMMAND ?? appEnv.PRE_RUN_COMMAND],
+      ] as const) {
+        if (!command) continue;
+        const r = await sh(command, appCwd, appEnv, 600000);
+        if (r.code !== 0) this.log(`${key} exited ${r.code}: ${r.stderr.slice(0, 300)}`);
+      }
+      const script = [app.script, app.args].filter(Boolean).join(" ");
+      mkdirSync(join(wp, ".verify"), { recursive: true });
+      const logFd = openSync(join(wp, ".verify", "app.log"), "w");
+      spawn("sh", ["-c", script], {
+        cwd: appCwd,
+        detached: true,
+        stdio: ["ignore", logFd, logFd],
+        env: { ...process.env, CI: "1", ...appEnv },
+      }).unref();
+    }
+
+    const booted = await waitForPort(this.port, "127.0.0.1", this.bootTimeoutMs);
+    this.lastBooted = booted;
+    const logs = await captureAppLogs(wp, this.appName);
+    const errs = scanLogErrors(logs);
+    const header = booted
+      ? `BOOTED: frontend port ${this.port} is listening.`
+      : `NOT BOOTED: port ${this.port} never bound in ${this.bootTimeoutMs}ms.`;
+    return this.bootReport(booted, header, logs, errs);
+  }
+
+  private bootReport(booted: boolean, header: string, logs: string, errs: string[] = []): BootResult {
+    const report = [
+      header,
+      errs.length ? `Log errors (heuristic):\n${errs.slice(0, 10).join("\n")}` : "No obvious fatal log lines.",
+      `Server log tail:\n${logs.slice(-3000)}`,
+    ].join("\n\n");
+    return { booted, port: this.port, logsTail: logs.slice(-3000), errors: errs, report };
+  }
+
+  async readLogs(): Promise<string> {
+    return captureAppLogs(this.workspacePath, this.appName);
+  }
+
+  /** Re-read the final (edited) files and re-emit in pod-portable form. The
+   *  deliverable keeps the `$POD_*` placeholders + pod-absolute `cwd`. */
+  finalSetup(): string {
+    const wp = this.workspacePath;
+    const files = splitFiles(this.initialSetup);
+    const finalPm2 = existsSync(join(wp, "pm2.config.js"))
+      ? readFileSync(join(wp, "pm2.config.js"), "utf-8")
+      : this.toLocal(files.pm2 ?? "");
+    const finalCompose = existsSync(join(wp, "docker-compose.yml"))
+      ? readFileSync(join(wp, "docker-compose.yml"), "utf-8")
+      : files.compose;
+    return (
+      `FILENAME: pm2.config.js\n\n\`\`\`js\n${this.toPod(finalPm2)}\n\`\`\`` +
+      (finalCompose ? `\n\nFILENAME: docker-compose.yml\n\n\`\`\`yaml\n${this.toPod(finalCompose)}\n\`\`\`` : "")
+    );
+  }
+
+  /** Tear down everything this run brought up: pm2, staklink, compose, and — via
+   *  the pre-boot container snapshot — any app-spawned stack. Honors `keepUp`
+   *  (set at construction). Idempotent. */
+  async teardown(): Promise<void> {
+    if (this.keepUp) {
+      this.log("keepUp:true — leaving services + apps running");
+      return;
+    }
+    const wp = this.workspacePath;
+    this.log("teardown: pm2 delete all + staklink stop + compose down + remove spawned containers");
+    await sh("npx -y pm2 delete all", wp, {}, 60000).catch(() => {});
+    if (this.useStaklink)
+      await sh(`${this.bootCommand.split(" ").slice(0, -1).join(" ")} stop`, wp, {}, 30000).catch(() => {});
+    if (this.composeBroughtUp) await sh("docker compose down -v", wp, {}, 120000).catch(() => {});
+    try {
+      const now = await dockerContainerIds();
+      const spawned = [...now].filter((id) => !this.preBootContainers.has(id));
+      if (spawned.length) {
+        this.log(`removing ${spawned.length} app-spawned container(s)`);
+        await sh(`docker rm -fv ${spawned.join(" ")}`, wp, {}, 120000).catch(() => {});
+        await sh("docker network prune -f", wp, {}, 30000).catch(() => {});
+      }
+    } catch {
+      /* ignore */
+    }
+    // Remove only the staging dir; KEEP the edited config + repo edits (the
+    // deliverable).
+    try {
+      rmSync(join(wp, ".pod-config"), { recursive: true, force: true });
+    } catch {
+      /* ignore */
+    }
+  }
+}
+
+/** Per-run stack sessions, keyed by runId. */
+export class StackManager {
+  private sessions = new Map<string, StackSession>();
+
+  session(runId: string, workspacePath: string, opts?: StackOptions): StackSession {
+    let s = this.sessions.get(runId);
+    if (!s) {
+      s = new StackSession(workspacePath, opts);
+      this.sessions.set(runId, s);
+    }
+    return s;
+  }
+
+  has(runId: string): boolean {
+    return this.sessions.has(runId);
+  }
+
+  /** Dispose a run's stack (called from onRunEnd). Tears down (honoring the
+   *  session's `keepUp`) + drops it. Idempotent. */
+  async dispose(runId: string): Promise<void> {
+    const s = this.sessions.get(runId);
+    if (!s) return;
+    this.sessions.delete(runId);
+    await s.teardown().catch((e) => console.error(`[gitsee/stack] teardown failed for ${runId}:`, e));
+  }
+}

--- a/mcp/src/lab/gitsee/services/stack.ts
+++ b/mcp/src/lab/gitsee/services/stack.ts
@@ -20,6 +20,7 @@ import {
 } from "node:fs";
 import { join } from "node:path";
 import { spawn } from "node:child_process";
+import { readdirSync } from "node:fs";
 import {
   sh,
   splitFiles,
@@ -189,6 +190,33 @@ export class StackSession {
     return captureAppLogs(this.workspacePath, this.appName);
   }
 
+  /** Per-repo `git diff` (intent-to-add so NEW files show as additions) — the
+   *  replayable record of the agent's source edits. Teardown only touches
+   *  pm2/docker/.pod-config (no repo tree), so edits are intact at finalize. */
+  async captureRepoDiff(maxBytes = 60000): Promise<{ diff: string; changedRepos: string[] }> {
+    const wp = this.workspacePath;
+    const repos = existsSync(wp)
+      ? readdirSync(wp, { withFileTypes: true })
+          .filter((e) => e.isDirectory() && existsSync(join(wp, e.name, ".git")))
+          .map((e) => e.name)
+          .sort()
+      : [];
+    const parts: string[] = [];
+    const changedRepos: string[] = [];
+    for (const repo of repos) {
+      const dir = join(wp, repo);
+      await sh("git add -A -N", dir, {}, 30000).catch(() => {});
+      const d = await sh("git diff", dir, {}, 30000);
+      if (d.stdout.trim()) {
+        changedRepos.push(repo);
+        parts.push(`=== ${repo} ===\n${d.stdout}`);
+      }
+    }
+    let diff = parts.join("\n\n");
+    if (diff.length > maxBytes) diff = diff.slice(0, maxBytes) + "\n\n[... diff truncated ...]";
+    return { diff, changedRepos };
+  }
+
   /** Re-read the final (edited) files and re-emit in pod-portable form. The
    *  deliverable keeps the `$POD_*` placeholders + pod-absolute `cwd`. */
   finalSetup(): string {
@@ -256,6 +284,11 @@ export class StackManager {
 
   has(runId: string): boolean {
     return this.sessions.has(runId);
+  }
+
+  /** The existing stack session for a run, or undefined (no auto-create). */
+  get(runId: string): StackSession | undefined {
+    return this.sessions.get(runId);
   }
 
   /** Dispose a run's stack (called from onRunEnd). Tears down (honoring the

--- a/mcp/src/lab/gitsee/services/vision.ts
+++ b/mcp/src/lab/gitsee/services/vision.ts
@@ -1,0 +1,72 @@
+/**
+ * Vision service: the agent's "eyes" — judge a full-page screenshot (plus the
+ * browser console/network errors and the server log tail) with a vision model.
+ * Lifted from `boot-and-exercise.ts`. Stateless, so it's a plain object (no
+ * per-run session).
+ */
+import { readFileSync } from "node:fs";
+import { z } from "zod";
+import { usageFromResult, computeCost } from "vein";
+import type { Observations } from "./browser.js";
+import { summarizeObs } from "./browser.js";
+
+export interface VisionVerdict {
+  working: boolean;
+  reason: string;
+  usage: ReturnType<typeof usageFromResult>;
+  cost: number;
+}
+
+export interface VisionService {
+  assess(
+    pngPath: string,
+    url: string,
+    obs: Observations,
+    logs: string,
+    model?: string,
+  ): Promise<VisionVerdict>;
+}
+
+export function buildVisionService(): VisionService {
+  return {
+    async assess(pngPath, url, obs, logs, model) {
+      const { generateObject } = await import("ai");
+      const { anthropic } = await import("@ai-sdk/anthropic");
+      const m = anthropic(model ?? process.env["VEIN_LLM_MODEL"] ?? "claude-sonnet-4-6");
+      const schema = z.object({
+        working: z
+          .boolean()
+          .describe(
+            "true ONLY if the intended app UI rendered (a real, populated, styled page — a login/landing page counts) AND there is no blank/white page, error overlay, stack trace, or 404/500, AND no fatal console/network/server error is breaking the page.",
+          ),
+        reason: z.string().describe("one or two short sentences: what the screenshot shows + whether the errors look fatal."),
+      });
+      const image = readFileSync(pngPath);
+      const { object, usage: rawUsage } = await generateObject({
+        model: m as any,
+        schema: schema as any,
+        messages: [
+          {
+            role: "user",
+            content: [
+              {
+                type: "text",
+                text: `A web app is booted locally at ${url}. Below is a full-page screenshot, the browser console/network errors, and the server log tail. Did the app's intended UI render and is it functional (not a blank/error/404/500 page, no fatal errors)?
+
+BROWSER OBSERVATIONS:
+${summarizeObs(obs)}
+
+SERVER LOGS (tail):
+${logs ? logs.slice(-6000) : "(none)"}`,
+              },
+              { type: "image", image },
+            ],
+          },
+        ],
+      });
+      const usage = usageFromResult(rawUsage);
+      const o = object as { working: boolean; reason: string };
+      return { working: o.working, reason: o.reason, usage, cost: computeCost("anthropic", usage) };
+    },
+  };
+}

--- a/mcp/src/lab/gitsee/steps/assess-ui.ts
+++ b/mcp/src/lab/gitsee/steps/assess-ui.ts
@@ -1,0 +1,38 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/**
+ * Take a fresh full-page screenshot and have a vision model judge whether the
+ * intended UI rendered and looks functional (vs blank/error/404/500),
+ * considering the recent browser + server errors. The structured "did it work"
+ * signal. Per-run browser + stack keyed by `ctx.runId`. Workflow step OR agent
+ * tool.
+ *
+ * Output: { working, reason, screenshotPath, cost, usage }.
+ */
+export default defineStep({
+  type: "gitsee/assess-ui",
+  description:
+    "Take a fresh full-page screenshot and have a vision model judge whether the intended UI rendered and looks functional (vs blank/error/404/500), considering recent browser + server errors. Use to confirm progress after fixes. Config: checkPath? (default /), model?. Output: { working, reason, screenshotPath, cost, usage }.",
+  input: z.object({
+    checkPath: z.string().default("/"),
+    model: z.string().optional(),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const browser = gitsee.browser.get(ctx.runId);
+    const stack = gitsee.stack.get(ctx.runId);
+    if (!browser) return { working: null, reason: "no page open — call gitsee/browser-open first" };
+    const shot = await browser.screenshot();
+    if (!shot) return { working: null, reason: `no screenshot (browser unavailable: ${browser.note})` };
+    const logs = stack ? await stack.readLogs() : "";
+    const port = stack?.port ?? 3000;
+    try {
+      const v = await gitsee.vision.assess(shot, `http://localhost:${port}${cfg.checkPath}`, browser.obs, logs, cfg.model);
+      return { working: v.working, reason: v.reason, screenshotPath: shot, cost: v.cost, usage: v.usage };
+    } catch (e) {
+      return { working: null, reason: `vision assessment failed: ${(e as Error).message}`, screenshotPath: shot };
+    }
+  },
+});

--- a/mcp/src/lab/gitsee/steps/assess-ui.ts
+++ b/mcp/src/lab/gitsee/steps/assess-ui.ts
@@ -30,9 +30,12 @@ export default defineStep({
     const port = stack?.port ?? 3000;
     try {
       const v = await gitsee.vision.assess(shot, `http://localhost:${port}${cfg.checkPath}`, browser.obs, logs, cfg.model);
+      stack?.recordVerdict(v.working, v.reason, shot); // so finalize has the last verdict
       return { working: v.working, reason: v.reason, screenshotPath: shot, cost: v.cost, usage: v.usage };
     } catch (e) {
-      return { working: null, reason: `vision assessment failed: ${(e as Error).message}`, screenshotPath: shot };
+      const reason = `vision assessment failed: ${(e as Error).message}`;
+      stack?.recordVerdict(null, reason, shot);
+      return { working: null, reason, screenshotPath: shot };
     }
   },
 });

--- a/mcp/src/lab/gitsee/steps/boot.ts
+++ b/mcp/src/lab/gitsee/steps/boot.ts
@@ -1,0 +1,29 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/**
+ * (Re)boot the staged app: re-read the (possibly edited) pm2.config.js +
+ * docker-compose.yml, bring up backing services, start the apps (staklink or
+ * inline), and wait for the frontend port. Call after every config/repo edit.
+ * Usable both as a workflow step AND as an agent tool (it derives the per-run
+ * stack from `ctx.runId`, so it needs no config). Requires gitsee/stage-setup to
+ * have run first.
+ *
+ * Output: { booted, port, logsTail, errors, report }.
+ */
+export default defineStep({
+  type: "gitsee/boot",
+  description:
+    "Boot (or reboot) the staged app: re-stage current config, bring up compose services, start the frontend, wait for its port. Call after every config/repo edit. Returns whether the port bound + the server log tail + heuristic error lines. Requires gitsee/stage-setup first. No config. Output: { booted, port, logsTail, errors, report }.",
+  input: z.object({}),
+  output: z.any(),
+  async run(_cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const stack = gitsee.stack.get(ctx.runId);
+    if (!stack) return { booted: false, report: "no staged stack — run gitsee/stage-setup first" };
+    const res = await stack.boot();
+    // Point the (lazily-created) browser session at the booted port.
+    gitsee.browser.get(ctx.runId)?.setBaseUrl(`http://localhost:${res.port}`);
+    return res;
+  },
+});

--- a/mcp/src/lab/gitsee/steps/browser-click.ts
+++ b/mcp/src/lab/gitsee/steps/browser-click.ts
@@ -1,0 +1,17 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/** Click an element by its `@eN` ref from the latest snapshot. Per-run browser
+ *  session keyed by `ctx.runId`. Usable as a workflow step OR an agent tool. */
+export default defineStep({
+  type: "gitsee/browser-click",
+  description: "Click an element by its @eN ref from the latest gitsee/browser-snapshot.",
+  input: z.object({ ref: z.string().describe("an @eN ref, e.g. e3") }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const browser = gitsee.browser.get(ctx.runId);
+    if (!browser) return "no page open — call gitsee/browser-open first";
+    return browser.click(cfg.ref.replace(/^@/, ""));
+  },
+});

--- a/mcp/src/lab/gitsee/steps/browser-fill.ts
+++ b/mcp/src/lab/gitsee/steps/browser-fill.ts
@@ -1,0 +1,17 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/** Type text into an input/textarea by its `@eN` ref (clears first). Per-run
+ *  browser session keyed by `ctx.runId`. Usable as a workflow step OR agent tool. */
+export default defineStep({
+  type: "gitsee/browser-fill",
+  description: "Type text into an input/textarea by its @eN ref (clears first). Use to fill login forms etc.",
+  input: z.object({ ref: z.string(), text: z.string() }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const browser = gitsee.browser.get(ctx.runId);
+    if (!browser) return "no page open — call gitsee/browser-open first";
+    return browser.fill(cfg.ref.replace(/^@/, ""), cfg.text);
+  },
+});

--- a/mcp/src/lab/gitsee/steps/browser-observe.ts
+++ b/mcp/src/lab/gitsee/steps/browser-observe.ts
@@ -1,0 +1,22 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/**
+ * Drain the browser console errors, failed requests, and 4xx/5xx API responses
+ * accumulated since the last call — THE key "renders but is broken" signal a
+ * screenshot can't show. Per-run session keyed by `ctx.runId`. Workflow step OR
+ * agent tool.
+ */
+export default defineStep({
+  type: "gitsee/browser-observe",
+  description:
+    "Drain the browser console errors, failed requests, and 4xx/5xx API responses accumulated since the last call. THE key signal for 'renders but is broken' — a page can look fine while every API call 500s.",
+  input: z.object({}),
+  output: z.any(),
+  async run(_cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const browser = gitsee.browser.get(ctx.runId);
+    if (!browser) return "no page open — call gitsee/browser-open first";
+    return browser.drainSummary();
+  },
+});

--- a/mcp/src/lab/gitsee/steps/browser-open.ts
+++ b/mcp/src/lab/gitsee/steps/browser-open.ts
@@ -1,0 +1,25 @@
+import { z, defineStep } from "vein";
+import { join } from "node:path";
+import type { GitseeServices } from "../services/index.js";
+
+/**
+ * Open a path of the booted app in a real headless browser (the per-run session,
+ * keyed by `ctx.runId`; created here on first use, pointed at the booted port).
+ * Usable as a workflow step OR an agent tool. Output: a status/title string.
+ */
+export default defineStep({
+  type: "gitsee/browser-open",
+  description:
+    "Open a path of the booted app in a real headless browser (default the app root). Returns the HTTP status + page title. Call after gitsee/boot, and after actions that should navigate. Requires a staged+booted stack.",
+  input: z.object({ path: z.string().default("/").describe("path like /, /login, /dashboard") }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const stack = gitsee.stack.get(ctx.runId);
+    if (!stack) return "no staged stack — run gitsee/stage-setup + gitsee/boot first";
+    const base = `http://localhost:${stack.port}`;
+    const browser = gitsee.browser.session(ctx.runId, base, join(stack.workspacePath, ".exercise"));
+    browser.setBaseUrl(base);
+    return browser.open(cfg.path ?? "/");
+  },
+});

--- a/mcp/src/lab/gitsee/steps/browser-press.ts
+++ b/mcp/src/lab/gitsee/steps/browser-press.ts
@@ -1,0 +1,17 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/** Press a keyboard key on the page (e.g. Enter to submit a focused form).
+ *  Per-run browser session keyed by `ctx.runId`. Workflow step OR agent tool. */
+export default defineStep({
+  type: "gitsee/browser-press",
+  description: "Press a keyboard key on the page (e.g. Enter to submit a focused form).",
+  input: z.object({ key: z.string().describe("a key name like Enter, Tab, Escape") }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const browser = gitsee.browser.get(ctx.runId);
+    if (!browser) return "no page open — call gitsee/browser-open first";
+    return browser.press(cfg.key);
+  },
+});

--- a/mcp/src/lab/gitsee/steps/browser-snapshot.ts
+++ b/mcp/src/lab/gitsee/steps/browser-snapshot.ts
@@ -1,0 +1,21 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/**
+ * List the currently-visible interactive elements (links, buttons, inputs…) with
+ * `@eN` refs to click/fill. Refs reset on every navigation. Per-run browser
+ * session keyed by `ctx.runId`. Usable as a workflow step OR an agent tool.
+ */
+export default defineStep({
+  type: "gitsee/browser-snapshot",
+  description:
+    "List the currently visible interactive elements (links, buttons, inputs…) with @eN refs to click/fill. Refs reset on every navigation — re-snapshot after anything that changes the page. Requires gitsee/browser-open first.",
+  input: z.object({}),
+  output: z.any(),
+  async run(_cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const browser = gitsee.browser.get(ctx.runId);
+    if (!browser) return "no page open — call gitsee/browser-open first";
+    return browser.snapshot();
+  },
+});

--- a/mcp/src/lab/gitsee/steps/finalize-setup.ts
+++ b/mcp/src/lab/gitsee/steps/finalize-setup.ts
@@ -1,0 +1,43 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/**
+ * Produce the boot-and-exercise deliverable from the per-run stack session
+ * (keyed by `ctx.runId`): the final pod-portable `setup` (re-read edited config,
+ * `$POD_*` placeholders kept), the replayable per-repo `git diff` of the agent's
+ * source edits, and the boot/working verdict. The LAST step of the QA loop.
+ *
+ * The teardown of the booted stack is handled by the lab's `onRunEnd` — this
+ * step is read-only against the (still-live) workspace, so the diff is intact.
+ *
+ * Output: { booted, working, port, setup, report, diff, changedRepos, changed }.
+ */
+export default defineStep({
+  type: "gitsee/finalize-setup",
+  description:
+    "Produce the deliverable from the per-run stack: final pod-portable setup (pm2.config.js + docker-compose.yml), the replayable per-repo git diff, and the boot/working verdict. Config: report? (the agent's markdown report), working? (last assess verdict). Output: { booted, working, port, setup, report, diff, changedRepos, changed }.",
+  input: z.object({
+    report: z.string().default(""),
+    working: z.boolean().nullable().default(null),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const stack = gitsee.stack.get(ctx.runId);
+    if (!stack) {
+      return { booted: null, working: cfg.working, port: null, setup: "", report: cfg.report, diff: "", changedRepos: [], changed: false };
+    }
+    const setup = stack.finalSetup();
+    const { diff, changedRepos } = await stack.captureRepoDiff();
+    return {
+      booted: stack.lastBooted,
+      working: cfg.working,
+      port: stack.port,
+      setup,
+      report: cfg.report,
+      diff,
+      changedRepos,
+      changed: changedRepos.length > 0,
+    };
+  },
+});

--- a/mcp/src/lab/gitsee/steps/finalize-setup.ts
+++ b/mcp/src/lab/gitsee/steps/finalize-setup.ts
@@ -15,29 +15,30 @@ import type { GitseeServices } from "../services/index.js";
 export default defineStep({
   type: "gitsee/finalize-setup",
   description:
-    "Produce the deliverable from the per-run stack: final pod-portable setup (pm2.config.js + docker-compose.yml), the replayable per-repo git diff, and the boot/working verdict. Config: report? (the agent's markdown report), working? (last assess verdict). Output: { booted, working, port, setup, report, diff, changedRepos, changed }.",
+    "Produce the deliverable from the per-run stack: final pod-portable setup (pm2.config.js + docker-compose.yml), the replayable per-repo git diff, and the boot/working verdict (read from the last gitsee/assess-ui). Config: report? (the agent's markdown report). Output: { booted, working, reason, port, setup, report, diff, changedRepos, changed, screenshotPath }.",
   input: z.object({
     report: z.string().default(""),
-    working: z.boolean().nullable().default(null),
   }),
   output: z.any(),
   async run(cfg, ctx) {
     const { gitsee } = ctx.services as { gitsee: GitseeServices };
     const stack = gitsee.stack.get(ctx.runId);
     if (!stack) {
-      return { booted: null, working: cfg.working, port: null, setup: "", report: cfg.report, diff: "", changedRepos: [], changed: false };
+      return { booted: null, working: null, reason: "", port: null, setup: "", report: cfg.report, diff: "", changedRepos: [], changed: false };
     }
     const setup = stack.finalSetup();
     const { diff, changedRepos } = await stack.captureRepoDiff();
     return {
       booted: stack.lastBooted,
-      working: cfg.working,
+      working: stack.lastWorking,
+      reason: stack.lastReason,
       port: stack.port,
       setup,
       report: cfg.report,
       diff,
       changedRepos,
       changed: changedRepos.length > 0,
+      screenshotPath: stack.lastScreenshot,
     };
   },
 });

--- a/mcp/src/lab/gitsee/steps/read-logs.ts
+++ b/mcp/src/lab/gitsee/steps/read-logs.ts
@@ -1,0 +1,20 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/** Read the booted frontend's recent server logs (stdout+stderr). Use to find
+ *  the cause of a 500 or a crash loop. Per-run stack keyed by `ctx.runId`.
+ *  Workflow step OR agent tool. */
+export default defineStep({
+  type: "gitsee/read-logs",
+  description:
+    "Read the booted frontend's recent server logs (stdout+stderr). Use to find the cause of a 500 or a crash loop. Requires a staged+booted stack.",
+  input: z.object({}),
+  output: z.any(),
+  async run(_cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const stack = gitsee.stack.get(ctx.runId);
+    if (!stack) return "no staged stack — run gitsee/stage-setup + gitsee/boot first";
+    const logs = await stack.readLogs();
+    return logs.slice(-8000) || "(no logs captured)";
+  },
+});

--- a/mcp/src/lab/gitsee/steps/stage-setup.ts
+++ b/mcp/src/lab/gitsee/steps/stage-setup.ts
@@ -1,0 +1,39 @@
+import { z, defineStep } from "vein";
+import type { GitseeServices } from "../services/index.js";
+
+/**
+ * Stage a produced `pm2.config.js` + `docker-compose.yml` (FILENAME two-file
+ * string) into the cloned workspace, creating the PER-RUN stack session that the
+ * boot / browser / read-logs / finalize steps share (keyed by `ctx.runId`). The
+ * session also snapshots running containers so teardown removes everything this
+ * run spins up — disposed automatically by the lab's `onRunEnd`.
+ *
+ * Thin: all machinery lives in `ctx.services.gitsee.stack`. Output:
+ * { staged, port, appName }.
+ */
+export default defineStep({
+  type: "gitsee/stage-setup",
+  description:
+    "Stage the produced pm2.config.js + docker-compose.yml into the cloned workspace and create the per-run stack session (shared by gitsee/boot, browser, read-logs, finalize). Config: workspacePath, setup (the two-file string), useStaklink? (default true), bootCommand?, bootTimeoutMs? (default 420000), keepUp? (default false). Output: { staged, port, appName, error? }.",
+  input: z.object({
+    workspacePath: z.string(),
+    setup: z.string(),
+    useStaklink: z.boolean().default(true),
+    bootCommand: z.string().default("npx -y staklink@latest start"),
+    bootTimeoutMs: z.number().int().positive().default(420000),
+    keepUp: z.boolean().default(false),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { gitsee } = ctx.services as { gitsee: GitseeServices };
+    const stack = gitsee.stack.session(ctx.runId, cfg.workspacePath, {
+      useStaklink: cfg.useStaklink,
+      bootCommand: cfg.bootCommand,
+      bootTimeoutMs: cfg.bootTimeoutMs,
+      keepUp: cfg.keepUp,
+    });
+    const res = await stack.stage(cfg.setup);
+    if (!res.ok) return { staged: false, error: res.error };
+    return { staged: true, port: res.port, appName: res.appName };
+  },
+});

--- a/mcp/src/lab/gitsee/workflows/gitsee-setup-and-run.yaml
+++ b/mcp/src/lab/gitsee/workflows/gitsee-setup-and-run.yaml
@@ -1,20 +1,26 @@
 name: gitsee-setup-and-run
-# PRODUCT loop (not an eval): clone a workspace, PRODUCE an initial
-# pm2.config.js + docker-compose.yml with the core `agent`, then hand it to
-# `gitsee/boot-and-exercise` which BOOTS the app, DRIVES it in a real headless
-# browser, OBSERVES failures (console + network 4xx/5xx + server logs), FIXES the
-# config/repo, REBOOTS, and repeats until the frontend is genuinely functional.
+# PRODUCT loop (not an eval): clone → PRODUCE an initial setup → STAGE it → an
+# autonomous QA AGENT that boots the app, drives it in a real headless browser,
+# observes failures (console + network 4xx/5xx + server logs), fixes the
+# config/repo, reboots, and repeats until the frontend is genuinely functional.
 #
-# Unlike gitsee-eval there is NO scoring/gold here — the deliverable is a
-# known-good `setup` + a human-readable `report` of what was changed and what (if
-# anything) is still missing. The boot-and-exercise step is allowed to WRITE, so
-# this must NOT be wired into the scored optimize loop.
+# This is the DECOMPOSED boot-and-exercise. The agent loop is the vein-core
+# `agent` step; the QA capabilities (boot / browser / observe / assess / logs)
+# are gitsee TOOL-STEPS exposed as `agentTools`, each reaching the per-run
+# browser + stack + vision HARNESS via `ctx.services.gitsee.*` (keyed by runId).
+# Two wins over the old monolith step:
+#   - EVERY tool call emits a nested run event → each iteration is visible in the
+#     UI events panel / run drill-down (the agent step's wrapToolsWithEmit).
+#   - the booted stack is torn down automatically by the lab's `onRunEnd`
+#     (success OR error) — no teardown code in the step.
+#
+# Unlike gitsee-eval there is NO scoring/gold — the deliverable is a known-good
+# `setup` + a human-readable `report` + the replayable repo `diff`. The agent
+# WRITES/FIXES, so this must NOT be wired into the scored optimize loop.
 #
 # Input:  { workspace, repos: [{ owner, repo, rev? }], token? }
-# Output: { booted, working, port, setup, report, diff, changedRepos, changed,
-#           screenshotPath, iterations, usage, cost }   (from boot-and-exercise).
-#           `setup` + `diff` are the deliverable: the known-good config pair plus
-#           the replayable per-repo source edits (re-applied on a fresh pod clone).
+# Output: { booted, working, reason, port, setup, report, diff, changedRepos,
+#           changed, screenshotPath }   (from gitsee/finalize-setup).
 #
 # Needs ANTHROPIC_API_KEY + git + docker on PATH and `npx playwright install
 # chromium`; (for useStaklink) network for `npx staklink`.
@@ -26,7 +32,7 @@ steps:
       repos: "{{ input.repos }}"
       token: "{{ input.token }}"
 
-  # Produce the initial setup files (reuses the explorer prompts in params).
+  # Produce the initial setup files (reuses the explorer prompts in its params).
   - id: produce
     type: subflow
     depends: clone
@@ -37,26 +43,105 @@ steps:
         repos: "{{ input.repos }}"
         token: "{{ input.token }}"
 
-  # Boot it for real and iterate until it works.
-  - id: run
-    type: gitsee/boot-and-exercise
+  # Stage the produced pm2.config.js + docker-compose.yml into the clone AND
+  # create the per-run stack session shared by the agent's boot/browser/read-logs
+  # tools + finalize (keyed by ctx.runId). Snapshots running containers so
+  # teardown removes everything this run spins up.
+  - id: stage
+    type: gitsee/stage-setup
     depends: produce
     config:
       workspacePath: "{{ clone.workspacePath }}"
       setup: "{{ produce.result }}"
-      checkPath: "{{ params.checkPath }}"
-      maxSteps: "{{ params.maxSteps }}"
-      bootTimeoutMs: "{{ params.bootTimeoutMs }}"
       useStaklink: "{{ params.useStaklink }}"
-      model: "{{ params.model }}"
+      bootCommand: "{{ params.bootCommand }}"
+      bootTimeoutMs: "{{ params.bootTimeoutMs }}"
       keepUp: "{{ params.keepUp }}"
 
+  # The autonomous QA agent. The gitsee tool-steps are its agentTools (every call
+  # → a nested run event); the built-in bash + str_replace_based_edit_tool let it
+  # edit the config/repo. cwd is the cloned workspace (the agent prepends a
+  # working-dir listing automatically).
+  - id: qa
+    type: agent
+    depends: stage
+    config:
+      cwd: "{{ clone.workspacePath }}"
+      system: "{{ params.system }}"
+      prompt: |-
+        {{ params.prompt }}
+
+        The initial setup you're improving has been staged into the workspace
+        (pm2.config.js + docker-compose.yml). Begin by calling gitsee_boot, then
+        drive the app and iterate until the frontend is functional. For reference,
+        the produced setup is:
+
+        {{ produce.result }}
+      finalAnswer: "{{ params.finalAnswer }}"
+      model: "{{ params.model }}"
+      maxSteps: "{{ params.maxSteps }}"
+      agentTools:
+        - gitsee/boot
+        - gitsee/browser-open
+        - gitsee/browser-snapshot
+        - gitsee/browser-click
+        - gitsee/browser-fill
+        - gitsee/browser-press
+        - gitsee/browser-observe
+        - gitsee/assess-ui
+        - gitsee/read-logs
+
+  # Deliverable: pod-portable setup + per-repo diff + the booted/working verdict
+  # (read from the last gitsee/assess-ui via the stack session).
+  - id: finalize
+    type: gitsee/finalize-setup
+    depends: qa
+    config:
+      report: "{{ qa.result }}"
+
 params:
-  checkPath: "/"
-  maxSteps: 240
-  bootTimeoutMs: 420000
-  useStaklink: true
   model: claude-sonnet-4-6
-  # Leave the booted stack up after the run (for manual inspection). Default
-  # false so the step tears everything down (pm2 + compose + spawned containers).
+  # A complex multi-service app + reboots burns a lot of tool calls.
+  maxSteps: 240
+  useStaklink: true
+  bootCommand: npx -y staklink@latest start
+  bootTimeoutMs: 420000
+  # Leave the booted stack up after the run (manual inspection). Default false →
+  # onRunEnd tears everything down (pm2 + compose + spawned containers).
   keepUp: false
+
+  prompt: |-
+    Get this workspace's FRONTEND genuinely functional — not just rendering, but
+    with working navigation and core user flows — by ITERATING until it works:
+    boot it, drive it in the browser, observe the failures, diagnose the root
+    cause, fix the config or the repo, reboot, and repeat.
+
+  system: |-
+    You are an autonomous setup-and-QA engineer. A web app's source is cloned under the working directory, and an initial pm2.config.js + docker-compose.yml have been staged there. Your mission: get the app's FRONTEND genuinely FUNCTIONAL — not just rendering, but with working navigation and core user flows — by ITERATING until it works.
+
+    The loop:
+    1. gitsee_boot — (re)boot the app. It tells you whether the frontend port bound + the server log tail.
+    2. gitsee_browser_open then gitsee_browser_snapshot — load the app and see what's on the page. Click/fill (gitsee_browser_click / gitsee_browser_fill / gitsee_browser_press) to exercise REAL flows: follow nav links, try to sign in, submit the primary form, open the main views.
+    3. gitsee_browser_observe (console + failed requests + 4xx/5xx API responses) and gitsee_read_logs (server side). gitsee_assess_ui for a vision verdict on the current screen. A page that LOOKS fine but whose API calls all 500 is BROKEN — always check gitsee_browser_observe.
+    4. Diagnose each failure → root cause: a missing/incorrect env var, an unmigrated or empty database (needs a PRE_START_COMMAND migrate/seed), a missing backing service, a cloud dependency that should be MOCKED (USE_MOCKS / placeholder creds), a wrong host binding (must be 0.0.0.0) or start command.
+    5. Fix with str_replace_based_edit_tool: edit the pm2.config.js env block, the docker-compose.yml, or the repo source. Prefer the repo's own mock/offline mode. Put FILE changes in the repo; put RUNTIME steps (migrate/seed/reset) in PRE_START_COMMAND.
+    6. gitsee_boot again and re-verify.
+
+    Keep going until: the port binds, the intended UI renders, primary navigation works, and there are no fatal console/network/server errors — confirmed via gitsee_assess_ui + gitsee_browser_observe.
+
+    Rules:
+    - Make MINIMAL, surgical edits. Don't refactor.
+    - ENV VARS GO IN pm2.config.js. Whenever you set or fix an environment variable, put it in the relevant app's `env` block in pm2.config.js — even if you also write it into a repo .env file to make the running app pick it up. Repo .env files are usually GITIGNORED, so they are NOT captured in the deliverable diff and would be LOST on a fresh clone; the pm2.config.js env block is the source of truth that ships.
+    - POD URLS ARE AUTOMATIC — KEEP THEM. Env values may use the pod placeholders `$POD_URL` (this app's own public base URL) and `https://$POD_ID-<port>.<domain>` (a sibling service on another port). These are AUTOMATICALLY substituted to the correct `http://localhost:<port>` for you when the app is booted locally — so the live app you're testing already has working URLs. KEEP the `$POD_URL` / `$POD_ID-<port>` placeholders as-is in pm2.config.js; do NOT rewrite them to localhost yourself (that would break the deliverable on the real pod). This matters MOST for BROWSER-FACING vars (`NEXT_PUBLIC_*`, Vite `VITE_*`, OAuth callback/redirect URLs): they MUST keep the `https://$POD_ID-<port>.<domain>` form, never hardcoded localhost. Only purely INTERNAL server-to-server values (a backend's own DB connection string) stay literal localhost.
+    - PREFER THE PROJECT'S OWN LOCAL-DEV TOOLING over hand-rolling infrastructure. If the project ships a first-party way to bring up its backing stack — `supabase start` (the Supabase CLI spins up its OWN Postgres + Auth + Storage + REST and applies the repo's migrations), a devcontainer script, a Makefile/compose target — USE IT via PRE_START_COMMAND; do NOT hand-wire the individual services yourself in docker-compose.yml. If you've INHERITED such a hand-rolled setup and it's fighting you, REPLACE it with the first-party command (drop the self-hosted services from docker-compose.yml and put `supabase start` in PRE_START_COMMAND).
+    - Keep the frontend pm2 service named "frontend"; the dev server MUST bind 0.0.0.0.
+    - Only a primary datastore gets a docker-compose service; mock everything else (no containers for caches/queues/cloud APIs). A CLI-managed stack like `supabase start` is NOT a compose service — it goes in PRE_START_COMMAND.
+    - DRIVE THE UI — don't drown in the shell. The browser tools are how you VERIFY success and they're your success criterion; bash/curl is only for QUICK diagnosis of a specific error. After a couple of diagnostic shell calls, GO BACK to the browser. If you've run several bash commands in a row without touching the browser, stop and call gitsee_assess_ui to re-orient.
+    - Reboots are expensive (install/build/migrate) — batch related edits before calling gitsee_boot.
+    - Don't loop forever: if you've truly exhausted what you can fix, call final_answer and honestly report what's still missing.
+
+  finalAnswer: |-
+    Call when the app is functional, or when you've hit a wall you genuinely cannot fix. Provide a markdown report with:
+    ## SUMMARY (what you changed + the final state)
+    ## WORKING (features you verified in the browser)
+    ## MISSING (anything still broken/absent to make it great — each with the evidence and the fix it needs)

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -220,6 +220,19 @@ const token = cfg.token ?? (await ctx?.services?.secrets?.get("GITHUB_TOKEN"));
   real vs fake LLM) without touching workflows or the registry. Threaded
   through `createVein({ services })` / `vein.run(wf, input, { services })`
   / `runWorkflow(flow, input, registry, { services })`.
+  - **`services.onRunEnd(runId)`** — an OPTIONAL generic per-run teardown
+    hook the runner calls in a `finally` around `executeFlow` in
+    `runWorkflow` (so it fires on success AND error, for every run path,
+    once per top-level run; a throw in it can't mask the run result). Lets a
+    services bag dispose per-run resources keyed by `runId` (e.g. mcp `/lab`'s
+    gitsee browser + booted docker stack). A hard `SIGKILL` still skips it
+    (in-process `finally`), so that case stays out-of-band.
+
+- **`ctx.registry`** — the step registry, populated by the runner in
+  `dispatchStep`. Lets a step that orchestrates OTHER steps look them up by
+  type without being promoted to a runner-handled container step — the seam
+  the `agent` step uses for `agentTools` ("tools are steps"). Optional (absent
+  outside the runner, e.g. unit tests); read-only by convention.
 
 - **`createRegistry(steps)`** builds a registry from in-code step defs
   layered on core + lib (no filesystem custom/ discovery) — the
@@ -501,6 +514,25 @@ const token = cfg.token ?? (await ctx?.services?.secrets?.get("GITHUB_TOKEN"));
   `events.jsonl`/`run.json` and buries `result`. Anything domain-
   specific lives in the CALLER's prompts, not the step (e.g. mcp's
   `/lab` `gitsee-explore-services` wires `clone → agent`).
+  - **`agentTools` — "tools are steps"** (`buildRegistryTools`). Beyond the
+    built-ins, a caller can expose any REGISTRY step-types as extra LLM tools
+    via `agentTools: ["gitsee/boot", "gitsee/read-logs", …]`: each step's
+    `input` schema becomes the tool schema and its `run` is the executor,
+    invoked with the agent's `ctx` (so tool-steps reach `ctx.services`).
+    Resolved through the runner-populated **`ctx.registry`** (see Key
+    concepts) — keeps the AI-SDK loop in the step rather than promoting `agent`
+    to a container step. Merged ON TOP of the built-ins (not subject to
+    `toolFilter`); unknown types are skipped. This is what lets mcp's `/lab`
+    `gitsee-setup-and-run` drive a QA harness (boot/browser/observe/assess) as
+    the core `agent` instead of a forked loop.
+  - **Every tool call emits a nested run event** (`wrapToolsWithEmit`, applied
+    to built-ins AND `agentTools` with one shared counter): a
+    `step.start`/`step.end` (or `step.error`) at `<agentPath>/NNN-<tool>` with
+    `stepType: "tool:<name>"`, I/O truncated for the log. So the otherwise
+    opaque agent loop is **visible in the events panel / run drill-down** —
+    each iteration's tool calls show in order. No-op without a runner `ctx`
+    (in-code/test); skips `final_answer` + provider-executed tools (no
+    `execute`). `agent.run` now consumes `ctx` (registry + emit).
 
 ## Conventions
 

--- a/vein/plans/agentic-loop-as-workflow.md
+++ b/vein/plans/agentic-loop-as-workflow.md
@@ -56,9 +56,29 @@ required (see "Core changes" at the end); everything else is additive.
   `gitsee/finalize-setup`. Each works BOTH as a workflow step (Step D's loop) AND
   as an `agentTools` tool (the diagnose-fix agent). Registered in `seed.ts`; mcp
   tsc clean; all 11 load + schema-parse cleanly.
-- **TODO — Step D**: the C2 `gitsee-qa-iteration` subflow + rewritten
-  `gitsee-setup-and-run` loop wiring these steps; then the A/B gate vs the
-  monolith and deleting `boot-and-exercise.ts`.
+- **DONE — Step D (the QA loop as a workflow)**: `gitsee-setup-and-run.yaml`
+  rewritten to `clone → produce → stage → qa(agent) → finalize`. The `qa` node is
+  the core `agent` step with the 9 gitsee tool-steps as `agentTools` (+ built-in
+  bash/str_replace for edits); the QA system prompt + tool list + model + maxSteps
+  live in `params` (the harness/policy split, §5). Teardown is automatic via
+  `onRunEnd`. Seeds + lints cleanly. **The monolith `boot-and-exercise.ts` is now
+  unused by the workflow but still seeded — the A/B reference for Step E.**
+  - **DESIGN CHANGE from §3 (agent-orchestrated, NOT a deterministic `loop`).**
+    vein's `loop` step THROWS when it exhausts `maxIterations` without `until`
+    becoming true (`runner.ts:580`) — so an app that can't be fixed would error
+    the run and yield NO deliverable (the monolith always returns report+diff even
+    when not working). Plus the QA control flow is inherently dynamic (the model
+    interleaves bash/browser in an order we can't predict). So the loop is the
+    `agent`'s own tool loop, with the tool-steps as `agentTools` — which (a) still
+    makes every iteration visible (Step A's per-tool-call events), (b) preserves
+    agent autonomy, (c) always produces a deliverable via `finalize`, and (d)
+    directly answers the original "why isn't it using the core `agent` step?".
+    The deterministic `loop`+subflow remains a future option if we ever want a
+    fixed rhythm, but it needs a non-throwing `loop` (or a guaranteed-`finally`
+    finalize) first.
+- **TODO — Step E**: the A/B gate (new agent workflow vs the seeded monolith
+  step) on `hive`/`heroku-node`; then delete `boot-and-exercise.ts`. Step F:
+  `gitsee-setup-optimize` (sweep the QA `system` prompt with the harness fixed).
 
 The rest of this doc is the design + sequencing for layer 2.
 

--- a/vein/plans/agentic-loop-as-workflow.md
+++ b/vein/plans/agentic-loop-as-workflow.md
@@ -49,9 +49,16 @@ required (see "Core changes" at the end); everything else is additive.
   lifecycle smoke (`services/smoke-services.ts`) verifies per-run keying +
   idempotent disposal. (Not yet consumed — the tool-steps in Step C will reach it
   via `ctx.services.gitsee.*`; the monolith baseline is untouched.)
-- **TODO — Steps C/D**: §1b tool-steps (reach `ctx.services.gitsee.*`), §3 the C2
-  `gitsee-qa-iteration` + rewritten `gitsee-setup-and-run` loop, then the A/B gate
-  and deleting the monolith.
+- **DONE — Step C (tool-steps)**: 11 thin, self-contained seeded steps reaching
+  the harness via `ctx.services.gitsee.*` (keyed by `ctx.runId`): `gitsee/stage-setup`,
+  `gitsee/boot`, `gitsee/browser-{open,snapshot,click,fill,press}`,
+  `gitsee/browser-observe`, `gitsee/assess-ui`, `gitsee/read-logs`,
+  `gitsee/finalize-setup`. Each works BOTH as a workflow step (Step D's loop) AND
+  as an `agentTools` tool (the diagnose-fix agent). Registered in `seed.ts`; mcp
+  tsc clean; all 11 load + schema-parse cleanly.
+- **TODO — Step D**: the C2 `gitsee-qa-iteration` subflow + rewritten
+  `gitsee-setup-and-run` loop wiring these steps; then the A/B gate vs the
+  monolith and deleting `boot-and-exercise.ts`.
 
 The rest of this doc is the design + sequencing for layer 2.
 

--- a/vein/plans/agentic-loop-as-workflow.md
+++ b/vein/plans/agentic-loop-as-workflow.md
@@ -36,10 +36,22 @@ required (see "Core changes" at the end); everything else is additive.
   pre-existing `ctx.emit`/`ctx.path` → runs against the current copied vein dep,
   **no `refresh-vein` required**. This satisfies the headline ask ("see each
   iteration in the UI") without touching the loop's behavior.
-- **TODO — layer 2**: §2 services (browser/stack/vision as per-run factories +
-  `LabServices.onRunEnd`), §1b tool-steps, §3 the C2 loop workflow. Build after
-  the layer-1 MVP is confirmed in the UI (it validates the event-path approach
-  end-to-end before the bigger decomposition rests on it).
+- **DONE — Step A (core agent tool visibility)**: the core `agent` step now emits
+  a nested run event for EVERY tool call (built-ins + `agentTools`) via the
+  unified `wrapToolsWithEmit` (single shared counter, skips `final_answer` +
+  provider-executed tools). So `produce/explore` and any agent step is observable,
+  not just `boot-and-exercise`. 424 vein tests green; tsc clean.
+- **DONE — Step B (services as per-run factories + teardown)**: `mcp/src/lab/
+  gitsee/services/` — `BrowserManager`/`StackManager` (per-run sessions keyed by
+  runId) + a stateless vision judge, lifted from the monolith. `LabServices.gitsee`
+  + a generic `LabServices.onRunEnd(runId)` (wired into vein's runner `finally`)
+  dispose a run's browser + booted stack on success AND error. mcp tsc clean;
+  lifecycle smoke (`services/smoke-services.ts`) verifies per-run keying +
+  idempotent disposal. (Not yet consumed — the tool-steps in Step C will reach it
+  via `ctx.services.gitsee.*`; the monolith baseline is untouched.)
+- **TODO — Steps C/D**: §1b tool-steps (reach `ctx.services.gitsee.*`), §3 the C2
+  `gitsee-qa-iteration` + rewritten `gitsee-setup-and-run` loop, then the A/B gate
+  and deleting the monolith.
 
 The rest of this doc is the design + sequencing for layer 2.
 

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -82,6 +82,12 @@ Loops:
 - Inside the body's config and the "until" expression, {{ $current }} is the previous iteration's output (undefined on the first iteration).
 - Call get_step("loop") for the exact config shape.
 
+Agent (tool-using sub-agent):
+- The "agent" step runs an autonomous LLM tool-loop over a working dir (cwd) — use it for open-ended tasks (explore/diagnose/edit a codebase, drive + fix an app) that a fixed DAG can't express. It returns a free-form report (set "finalAnswer"), a STRUCTURED object (set "schema"), or text.
+- "TOOLS ARE STEPS": expose any registry step-types as the agent's tools via agentTools: ["my/tool-a", "my/tool-b"] — each step's input schema becomes the tool, its run() the executor (reaching ctx.services like any step). Build a stateful tool by pairing a tool-step with a per-run service in ctx.services. Every tool call shows as a nested run event, so the loop is visible/inspectable.
+- Prefer this agentic pattern over the "loop" step when control flow is dynamic (the model decides the next action) or when a hard stop must still produce a deliverable (loop throws if it never converges; an agent always returns its report).
+- Call get_step("agent") for the exact config (cwd, system, prompt, finalAnswer/schema, agentTools, toolFilter, model, maxSteps).
+
 Error handling:
 - Any step can have options.onError: <Step> as a fallback that runs if the step fails (after retries, if any).
 - Inside the onError step's config, {{ $error }} is available — it has { message, stack }.

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import { coreRegistry } from "../registry.js";
 import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
-import agent, { repoTree, textEdit, buildRegistryTools } from "./agent.js";
+import agent, { repoTree, textEdit, buildRegistryTools, wrapToolsWithEmit } from "./agent.js";
 
 // These tests are OFFLINE: they exercise registration, the input schema, and the
 // config-validation guards in run() that fire BEFORE any model call. The actual
@@ -84,36 +84,80 @@ describe("agentTools (buildRegistryTools — tools are steps)", () => {
     assert.deepEqual(buildRegistryTools(["demo/echo"], undefined, undefined, fakeTool), {});
   });
 
-  it("executes the step and emits nested step.start/step.end events", async () => {
-    const events: any[] = [];
+  it("executes the step and returns its output (no emit here)", async () => {
     const ctx = {
-      runId: "r1",
-      path: "wf/diagnose",
-      scope: {},
-      input: undefined,
-      emit: async (e: any) => { events.push(e); },
-      services: undefined,
-      registry,
+      runId: "r1", path: "wf/diagnose", scope: {}, input: undefined,
+      emit: async () => {}, services: undefined, registry,
     } as unknown as StepContext;
-
     const tools = buildRegistryTools(["demo/echo"], registry, ctx, fakeTool);
     const out = await (tools["demo_echo"] as any).execute({ msg: "hi" });
-
     assert.equal(out, "got:hi");
-    assert.equal(events.length, 2);
-    assert.equal(events[0].type, "step.start");
-    assert.equal(events[0].path, "wf/diagnose/001-demo_echo");
-    assert.equal(events[0].stepType, "demo/echo");
-    assert.deepEqual(events[0].input, { msg: "hi" });
-    assert.equal(events[1].type, "step.end");
-    assert.equal(events[1].path, "wf/diagnose/001-demo_echo");
-    assert.equal(events[1].output, "got:hi");
   });
 
   it("returns an Error string (not throw) on invalid tool input", async () => {
     const tools = buildRegistryTools(["demo/echo"], registry, undefined, fakeTool);
     const out = await (tools["demo_echo"] as any).execute({ wrong: 1 });
     assert.match(String(out), /Error: invalid input for "demo\/echo"/);
+  });
+});
+
+describe("wrapToolsWithEmit (per-call nested run events)", () => {
+  function makeCtx(events: any[]): StepContext {
+    return {
+      runId: "r1", path: "wf/agent", scope: {}, input: undefined,
+      emit: async (e: any) => { events.push(e); }, services: undefined,
+    } as unknown as StepContext;
+  }
+
+  it("emits step.start/step.end around every tool, with a shared ordered counter", async () => {
+    const events: any[] = [];
+    const tools: Record<string, any> = {
+      bash: { execute: async (i: any) => `ran:${i.command}` },
+      assess: { execute: async () => ({ working: true }) },
+    };
+    wrapToolsWithEmit(tools, makeCtx(events));
+
+    const a = await tools.bash.execute({ command: "ls" });
+    const b = await tools.assess.execute({});
+    assert.equal(a, "ran:ls");
+    assert.deepEqual(b, { working: true }); // model still gets the REAL output
+
+    assert.deepEqual(events.map((e) => [e.type, e.path, e.stepType]), [
+      ["step.start", "wf/agent/001-bash", "tool:bash"],
+      ["step.end", "wf/agent/001-bash", "tool:bash"],
+      ["step.start", "wf/agent/002-assess", "tool:assess"],
+      ["step.end", "wf/agent/002-assess", "tool:assess"],
+    ]);
+    assert.deepEqual(events[0].input, { command: "ls" });
+    assert.equal(events[1].output, "ran:ls"); // event output is the summarized string
+  });
+
+  it("skips final_answer and provider-executed tools (no execute)", async () => {
+    const events: any[] = [];
+    const tools: Record<string, any> = {
+      final_answer: { execute: async (i: any) => i.answer },
+      web_search: { type: "provider-defined" }, // no execute
+    };
+    wrapToolsWithEmit(tools, makeCtx(events));
+    await tools.final_answer.execute({ answer: "done" });
+    assert.equal(events.length, 0);
+  });
+
+  it("emits step.error and rethrows when a tool throws", async () => {
+    const events: any[] = [];
+    const tools: Record<string, any> = { boom: { execute: async () => { throw new Error("nope"); } } };
+    wrapToolsWithEmit(tools, makeCtx(events));
+    await assert.rejects(() => tools.boom.execute({}), /nope/);
+    assert.equal(events[0].type, "step.start");
+    assert.equal(events[1].type, "step.error");
+    assert.equal(events[1].error.message, "nope");
+  });
+
+  it("is a no-op without a runner ctx (in-code/test)", async () => {
+    const tools: Record<string, any> = { bash: { execute: async () => "ok" } };
+    const orig = tools.bash.execute;
+    wrapToolsWithEmit(tools, undefined);
+    assert.equal(tools.bash.execute, orig, "execute is left untouched");
   });
 });
 

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -379,7 +379,7 @@ export function textEdit(input: TextEditInput, cwd: string): string {
   }
 }
 
-// ── registry-backed tools (agentTools) ────────────────────────────────────────
+// ── tool plumbing (agentTools + per-call run-event emit) ───────────────────────
 
 /** Tool-call name from a registry step type: tool names can't contain slashes
  *  (`browser/click` → `browser_click`), so we sanitize for the LLM and map back. */
@@ -387,19 +387,23 @@ function toolNameFor(stepType: string): string {
   return stepType.replace(/[^a-zA-Z0-9_]/g, "_");
 }
 
+/** Truncate a tool's I/O for the run-event log (the full thing lives in the
+ *  model transcript; the event log only needs a readable preview). */
+function summarizeForEvent(v: unknown): string {
+  const s = typeof v === "string" ? v : JSON.stringify(v ?? "");
+  return s.length > 1500 ? s.slice(0, 1500) + "\n[… truncated for event log …]" : s;
+}
+
 /**
- * Turn a list of registry step-types into AI-SDK tools the agent can call —
- * the "tools ARE steps" model. Each step's `input` Zod schema becomes the tool's
- * input schema and its `run` is the executor, invoked with a CHILD context whose
- * `path` is nested under the agent's (`<agentPath>/NNN-<tool>`). We emit a
- * `step.start`/`step.end` (or `step.error`) around every call so each tool
- * invocation shows up as a nested run event — that's what makes the otherwise
- * opaque agent loop visible in the events panel / run drill-down.
+ * Turn a list of registry step-types into AI-SDK tools the agent can call — the
+ * "tools ARE steps" model. Each step's `input` Zod schema becomes the tool's
+ * input schema and its `run` is the executor (validated against that schema).
  *
- * Pure + offline-testable: the `tool` factory and (optional) `ctx`/`registry`
- * are injected, so it can be unit-tested with a fake registry + a capturing
- * `emit` and no model/network. Unknown step-types are skipped (the agent simply
- * doesn't get that tool). Returns a record keyed by the sanitized tool name.
+ * Does NOT emit run events itself — `wrapToolsWithEmit` does that uniformly for
+ * built-ins AND registry tools, so there's a single shared call counter and one
+ * code path. Pure + offline-testable (inject the `tool` factory + a fake
+ * registry; no model/network). Unknown step-types are skipped. Returns a record
+ * keyed by the sanitized tool name.
  */
 export function buildRegistryTools(
   names: string[] | undefined,
@@ -411,7 +415,6 @@ export function buildRegistryTools(
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   if (!names?.length || !registry) return out;
-  let calls = 0;
   for (const stepType of names) {
     const def = registry[stepType];
     if (!def) {
@@ -422,37 +425,66 @@ export function buildRegistryTools(
       description: def.description ?? `Run the "${stepType}" step.`,
       inputSchema: def.input,
       execute: async (input: unknown) => {
-        const n = ++calls;
-        const path = ctx?.path ? `${ctx.path}/${String(n).padStart(3, "0")}-${toolNameFor(stepType)}` : undefined;
-        const startTime = Date.now();
-        // Validate against the step's own input schema (so the tool sees what a
-        // real step run would). Cast emit to bypass the full-RunEvent type — the
-        // runner's emit fills ts/runId.
-        const emit = ctx?.emit as undefined | ((e: Record<string, unknown>) => Promise<void>);
         let parsed: unknown;
         try {
           parsed = def.input.parse(input ?? {});
         } catch (e) {
           return `Error: invalid input for "${stepType}": ${(e as Error).message}`;
         }
-        if (emit && path) await emit({ type: "step.start", path, stepType, input: parsed });
-        try {
-          const childCtx: StepContext = ctx
-            ? { ...ctx, path: path ?? ctx.path }
-            : ({ runId: "", path: path ?? "", scope: {}, input: undefined, emit: (async () => {}) as any, services: undefined });
-          const output = await def.run(parsed, childCtx);
-          if (emit && path)
-            await emit({ type: "step.end", path, stepType, output, durationMs: Date.now() - startTime });
-          return output;
-        } catch (e) {
-          if (emit && path)
-            await emit({ type: "step.error", path, stepType, error: { message: (e as Error).message } });
-          throw e;
-        }
+        // Run the step with the agent's ctx (leaf tool-steps reach
+        // ctx.services etc.). The nesting/emit is added by wrapToolsWithEmit.
+        const childCtx: StepContext = ctx ??
+          ({ runId: "", path: "", scope: {}, input: undefined, emit: (async () => {}) as any, services: undefined });
+        return def.run(parsed, childCtx);
       },
     });
   }
   return out;
+}
+
+/**
+ * Wrap EVERY tool's `execute` (built-ins + agentTools) so each call emits a
+ * nested `step.start`/`step.end` (or `step.error`) run event at
+ * `<agentPath>/NNN-<tool>` with `stepType: "tool:<name>"`. A single shared
+ * counter (`NNN`) gives the calls a globally-ordered, sortable path — that's
+ * what makes the otherwise-opaque agent loop visible in the events panel / run
+ * drill-down. Mutates `tools` in place.
+ *
+ * No-op when there's no runner ctx (in-code/test) or no path. Skips
+ * `final_answer` (terminal, noisy) and any tool with no function `execute`
+ * (provider-executed tools like anthropic `web_search`). Output is truncated in
+ * the event only (the model still sees the full result).
+ */
+export function wrapToolsWithEmit(tools: Record<string, any>, ctx: StepContext | undefined): void {
+  if (!ctx?.emit || !ctx.path) return;
+  const basePath = ctx.path;
+  const emit = ctx.emit as unknown as (e: Record<string, unknown>) => Promise<void>;
+  let calls = 0;
+  for (const [name, t] of Object.entries(tools)) {
+    if (name === "final_answer") continue;
+    const orig = t?.execute;
+    if (typeof orig !== "function") continue;
+    t.execute = async (input: unknown, opts: unknown) => {
+      const n = ++calls;
+      const path = `${basePath}/${String(n).padStart(3, "0")}-${name}`;
+      const startedAt = Date.now();
+      await emit({ type: "step.start", path, stepType: `tool:${name}`, input });
+      try {
+        const out = await (orig as (i: unknown, o: unknown) => Promise<unknown>)(input, opts);
+        await emit({
+          type: "step.end",
+          path,
+          stepType: `tool:${name}`,
+          output: summarizeForEvent(out),
+          durationMs: Date.now() - startedAt,
+        });
+        return out;
+      } catch (e) {
+        await emit({ type: "step.error", path, stepType: `tool:${name}`, error: { message: (e as Error).message } });
+        throw e;
+      }
+    };
+  }
 }
 
 export default defineStep({
@@ -643,6 +675,12 @@ export default defineStep({
         execute: async ({ answer }: { answer: string }) => answer,
       });
     }
+
+    // Emit a nested run event per tool call (built-ins + agentTools) so every
+    // iteration is visible in the UI events panel / run drill-down. No-op when
+    // run outside the runner (no ctx). Must come AFTER final_answer is added so
+    // it's uniformly considered (and skipped).
+    wrapToolsWithEmit(tools, ctx);
 
     const stopWhen = !useSchema && cfg.finalAnswer
       ? [hasToolCall("final_answer"), stepCountIs(cfg.maxSteps)]

--- a/vein/web/src/components/EventsPanel.tsx
+++ b/vein/web/src/components/EventsPanel.tsx
@@ -38,6 +38,9 @@ export function EventsPanel(props: {
 }) {
   const [expanded, setExpanded] = useState<number | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
+  // Whether the user is pinned to the bottom (updated on every scroll). New
+  // events only auto-scroll when this is true — scroll up and we leave you be.
+  const stickToBottom = useRef(true);
 
   // Auto-expand run.end when it arrives
   useEffect(() => {
@@ -45,14 +48,19 @@ export function EventsPanel(props: {
     if (idx >= 0) setExpanded(idx);
   }, [props.events]);
 
-  // Auto-scroll to the bottom whenever events change
+  // Auto-scroll to the bottom on new events, but only if already at the bottom.
   useEffect(() => {
     const el = scrollRef.current;
-    if (el) el.scrollTop = el.scrollHeight;
+    if (el && stickToBottom.current) el.scrollTop = el.scrollHeight;
   }, [props.events.length, expanded]);
 
+  const onScroll = () => {
+    const el = scrollRef.current;
+    if (el) stickToBottom.current = el.scrollHeight - el.scrollTop - el.clientHeight < 40;
+  };
+
   return (
-    <div class="shell-events" ref={scrollRef}>
+    <div class="shell-events" ref={scrollRef} onScroll={onScroll}>
       <div class="events-header">Events ({props.events.length})</div>
       {props.events.map((evt, i) => {
         const hasData = evt.input != null || evt.output != null || evt.error != null;

--- a/vein/web/src/components/RunInputPopover.tsx
+++ b/vein/web/src/components/RunInputPopover.tsx
@@ -159,46 +159,48 @@ export function RunInputPopover(props: {
   return (
     <div class="run-popover" ref={ref}>
       <div class="run-popover-title">Run input</div>
-      {props.bindings.map((b) => (
-        <ConfigField
-          key={b.inputKey}
-          field={b.field}
-          value={values[b.inputKey]}
-          onChange={(v) => setValues((prev) => ({ ...prev, [b.inputKey]: v }))}
-        />
-      ))}
-      {paramKeys.length > 0 && (
-        <div class="run-popover-params">
-          <div class="run-popover-subtitle">Params</div>
-          {paramKeys.map((k) => {
-            const isMultiline =
-              typeof paramDefaults[k] === "string" &&
-              ((paramValues[k] ?? "").length > 40 || (paramValues[k] ?? "").includes("\n"));
-            return (
-              <label class="run-popover-param" key={k}>
-                <span class="run-popover-param-name">{k}</span>
-                {isMultiline ? (
-                  <textarea
-                    rows={4}
-                    value={paramValues[k]}
-                    onInput={(e) =>
-                      setParamValues((prev) => ({ ...prev, [k]: (e.target as HTMLTextAreaElement).value }))
-                    }
-                  />
-                ) : (
-                  <input
-                    type="text"
-                    value={paramValues[k]}
-                    onInput={(e) =>
-                      setParamValues((prev) => ({ ...prev, [k]: (e.target as HTMLInputElement).value }))
-                    }
-                  />
-                )}
-              </label>
-            );
-          })}
-        </div>
-      )}
+      <div class="run-popover-body">
+        {props.bindings.map((b) => (
+          <ConfigField
+            key={b.inputKey}
+            field={b.field}
+            value={values[b.inputKey]}
+            onChange={(v) => setValues((prev) => ({ ...prev, [b.inputKey]: v }))}
+          />
+        ))}
+        {paramKeys.length > 0 && (
+          <div class="run-popover-params">
+            <div class="run-popover-subtitle">Params</div>
+            {paramKeys.map((k) => {
+              const isMultiline =
+                typeof paramDefaults[k] === "string" &&
+                ((paramValues[k] ?? "").length > 40 || (paramValues[k] ?? "").includes("\n"));
+              return (
+                <label class="run-popover-param" key={k}>
+                  <span class="run-popover-param-name">{k}</span>
+                  {isMultiline ? (
+                    <textarea
+                      rows={4}
+                      value={paramValues[k]}
+                      onInput={(e) =>
+                        setParamValues((prev) => ({ ...prev, [k]: (e.target as HTMLTextAreaElement).value }))
+                      }
+                    />
+                  ) : (
+                    <input
+                      type="text"
+                      value={paramValues[k]}
+                      onInput={(e) =>
+                        setParamValues((prev) => ({ ...prev, [k]: (e.target as HTMLInputElement).value }))
+                      }
+                    />
+                  )}
+                </label>
+              );
+            })}
+          </div>
+        )}
+      </div>
       <div class="run-popover-actions">
         <button class="btn" onClick={props.onClose}>Cancel</button>
         <button class="btn btn-primary" onClick={handleSubmit}>Run</button>

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -1232,6 +1232,9 @@ body.is-resizing-flyout * {
   border-radius: var(--r-lg);
   padding: var(--sp-4);
   width: min(320px, 90vw);
+  /* Cap the height so a workflow with many params never pushes the Run button
+     below the viewport — the field area scrolls instead (see .run-popover-body). */
+  max-height: min(70vh, 640px);
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
   display: flex;
   flex-direction: column;
@@ -1244,12 +1247,23 @@ body.is-resizing-flyout * {
   letter-spacing: 0.06em;
   color: var(--text-muted);
   margin-bottom: var(--sp-2);
+  flex-shrink: 0;
+}
+/* The scrollable middle: inputs + params. Title and actions stay pinned above
+   and below it. `min-height: 0` lets this flex child actually shrink + scroll. */
+.run-popover-body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+  overflow-y: auto;
+  min-height: 0;
 }
 .run-popover-actions {
   display: flex;
   justify-content: flex-end;
   gap: var(--sp-2);
   margin-top: var(--sp-3);
+  flex-shrink: 0;
 }
 .run-popover-params {
   display: flex;


### PR DESCRIPTION
Layer-2 groundwork for decomposing the gitsee `boot-and-exercise` monolith. Plan: `vein/plans/agentic-loop-as-workflow.md`.

## Step A — core `agent` step emits a nested run event per tool call
- Unified `wrapToolsWithEmit` wraps **built-ins AND `agentTools`** with one shared counter → globally-ordered `<agentPath>/NNN-<tool>` paths, `stepType: tool:<name>`. Skips `final_answer` + provider-executed tools (`web_search`).
- `buildRegistryTools` no longer emits (emit is now a single code path — no double-emit).
- **Effect:** every agent step is observable in the events panel now — including `gitsee-explore-services`' `produce/explore` node, which was previously opaque — not just `boot-and-exercise`.
- +4 unit tests (ordered emit, skip rules, error+rethrow, no-op without ctx). **424 vein tests green**, tsc clean.

## Step B — gitsee QA harness services (per-run factories + guaranteed teardown)
- New `mcp/src/lab/gitsee/services/`: `_infra` (shell/pm2/compose/pod-url/port/log helpers lifted from the monolith), `BrowserManager`/`BrowserSession`, `StackManager`/`StackSession` (stage / boot-reboot / logs / `finalSetup` / teardown), stateless vision judge. **Sessions are per-run, keyed by runId** (concurrent optimize evals can't collide on one page/stack).
- `createLabVein` wires `LabServices.gitsee` + a generic `LabServices.onRunEnd(runId)` — invoked by the vein runner's `finally` (merged in #1387) — that disposes a run's browser + booted stack on **success AND error**. This is the optimize-loop teardown fix.
- `services/smoke-services.ts` verifies per-run keying + idempotent disposal (no docker/Playwright needed).
- **Not yet consumed:** Step C's tool-steps will reach it via `ctx.services.gitsee.*`; the monolith baseline is intentionally untouched (it's the A/B reference).

## Also
- Fix the Run-input popover: a workflow with many params could push the **Run** button below the viewport. Now the popover is height-capped, the fields scroll, and the title + Run/Cancel stay pinned.

## Test plan
- `vein`: `npm test` (424 green), `npx tsc --noEmit`, `cd web && npx tsc --noEmit && npm run build`.
- `mcp`: `npx tsc --noEmit`; `npx tsx src/lab/gitsee/services/smoke-services.ts`.
- Step B's runtime effect (and the new agent emit reaching `/lab`) needs a `yarn refresh-vein`.

## Next (not in this PR)
Step C tool-steps (consume the services) → Step D the C2 `gitsee-qa-iteration` + rewritten `gitsee-setup-and-run` loop → A/B gate → delete the monolith.