### PR TITLE
fix: expose ref_id on PR records

### DIFF
--- a/mcp/src/gitree/routes.ts
+++ b/mcp/src/gitree/routes.ts
@@ -450,6 +450,7 @@ export async function gitree_get_pr(req: Request, res: Response) {
 
     res.json({
       pr: {
+        ref_id: pr.ref_id,
         number: pr.number,
         repo: pr.repo,
         title: pr.title,

--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -1584,6 +1584,7 @@ export class GraphStorage extends Storage {
     const props = node.properties;
     
     return {
+      ref_id: props.ref_id || undefined,
       number: props.number.toNumber ? props.number.toNumber() : props.number,
       repo: props.repo || undefined,
       title: props.title,

--- a/mcp/src/gitree/types.ts
+++ b/mcp/src/gitree/types.ts
@@ -36,6 +36,7 @@ export interface Concept {
 }
 
 export interface PRRecord {
+  ref_id?: string;
   number: number;
   repo?: string; // Repository identifier "owner/repo" - optional for backwards compat
   title: string;


### PR DESCRIPTION
## Summary
Adds the missing `ref_id` field to PR records so it can be returned by the `GET /gitree/prs/:number` endpoint.

## Changes
- `types.ts`: added `ref_id?: string` to the `PRRecord` interface (fixes `Property 'ref_id' does not exist on type 'PRRecord'` TS2339).
- `store/graphStorage.ts`: populate `ref_id` from the Neo4j node in `nodeToPR`, so the value isn't always `undefined`.
- `routes.ts`: include `ref_id` in the PR response payload.

## Testing
- `npx tsc --noEmit` passes clean.