### PR TITLE
Fix logs_agent tool session source label

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -934,7 +934,10 @@ curl -X POST \
   -H "Content-Type: application/json" \
   -d '{
     "repo_url": "https://github.com/stakwork/hive",
-    "prompt": "tell me a joke"
+    "prompt": "as logs_agent to tell me a joke",
+    "toolsConfig": {
+      "logs_agent": true
+    }
   }' \
   "http://localhost:3355/repo/agent"
 */

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -850,7 +850,7 @@ export async function get_tools(
               apiKey,
               logsDir,
               sessionId,
-              source: "repo_agent",
+              source: "logs_agent",
             });
             return result.final || "No result returned from logs agent.";
           } catch (e) {


### PR DESCRIPTION
## Problem

The `logs_agent` tool in `mcp/src/repo/tools.ts` spawns a new nested session (with a random UUID) but passed `source: "repo_agent"`. This caused those sessions to display as **"repo agent"** in the session UI, even though they are logs agent invocations.

Real logs agent invocations via the API use `source: "logs_agent"` (see `mcp/src/log/index.ts:189`).

## Fix

Pass `source: "logs_agent"` from the `logs_agent` tool so nested sessions are correctly labeled, matching real logs agent API invocations.

Also updated the example curl in `agent.ts` to demonstrate enabling the `logs_agent` tool.