### PR TITLE
Refactor publish-mcp workflow to use parallel native builds and registry caching

### DIFF
--- a/.github/workflows/publish-mcp.yml
+++ b/.github/workflows/publish-mcp.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 jobs:
-  build-and-push:
+  build-amd64:
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -40,13 +40,82 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push Docker image
+      - name: Build and push Docker image (amd64)
         uses: docker/build-push-action@v5
         with:
           context: ./mcp
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           push: true
-          # no-cache: true
-          tags: |
-            ghcr.io/stakwork/stakgraph-mcp:${{ github.ref_name }}
-            ghcr.io/stakwork/stakgraph-mcp:latest
+          tags: ghcr.io/stakwork/stakgraph-mcp:${{ github.ref_name }}-amd64
+          cache-from: type=registry,ref=ghcr.io/stakwork/stakgraph-mcp:buildcache-amd64
+          cache-to: type=registry,ref=ghcr.io/stakwork/stakgraph-mcp:buildcache-amd64,mode=max
+          provenance: false
+          sbom: false
+
+  build-arm64:
+    runs-on: ubuntu-arm64
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Stage vein into the mcp build context
+        run: |
+          rm -rf mcp/.vein
+          rsync -a \
+            --exclude node_modules \
+            --exclude web/node_modules \
+            --exclude build \
+            --exclude web/dist \
+            --exclude .git \
+            --exclude .env \
+            --exclude workspace \
+            vein/ mcp/.vein/
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image (arm64)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./mcp
+          platforms: linux/arm64
+          push: true
+          tags: ghcr.io/stakwork/stakgraph-mcp:${{ github.ref_name }}-arm64
+          cache-from: type=registry,ref=ghcr.io/stakwork/stakgraph-mcp:buildcache-arm64
+          cache-to: type=registry,ref=ghcr.io/stakwork/stakgraph-mcp:buildcache-arm64,mode=max
+          provenance: false
+          sbom: false
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: [build-amd64, build-arm64]
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Create and push multi-arch manifest
+        run: |
+          docker buildx imagetools create \
+            -t ghcr.io/stakwork/stakgraph-mcp:${{ github.ref_name }} \
+            -t ghcr.io/stakwork/stakgraph-mcp:latest \
+            ghcr.io/stakwork/stakgraph-mcp:${{ github.ref_name }}-amd64 \
+            ghcr.io/stakwork/stakgraph-mcp:${{ github.ref_name }}-arm64


### PR DESCRIPTION
Generated with Hive: Refactor publish-mcp workflow to use parallel native builds and registry caching