### PR TITLE
feat(gateway): agent catalog over neo4j HTTP

### DIFF
--- a/gateway/internal/adminapi/catalog.go
+++ b/gateway/internal/adminapi/catalog.go
@@ -1,0 +1,532 @@
+package adminapi
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/stakwork/stakgraph/gateway/internal/graphclient"
+	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
+)
+
+// ─── wire shapes: write (POST /_plugin/agents) ───────────────────────
+
+// catalogPushRequest is the whole-fleet manifest one source pushes.
+// "Whole fleet object" (not one-agent-per-call) because a source
+// typically knows its entire fleet at once and one call per deploy is
+// simpler to operate. A source that only knows one agent sends a
+// one-element Agents slice. See gateway/plans/agent-catalog.md.
+type catalogPushRequest struct {
+	Source string             `json:"source"` // REQUIRED contributing system
+	Agents []catalogPushAgent `json:"agents"`
+}
+
+type catalogPushAgent struct {
+	Name         string              `json:"name"` // REQUIRED; matches x-bf-dim-agent-name
+	DisplayName  string              `json:"display_name"`
+	Description  string              `json:"description"`
+	DefaultModel string              `json:"default_model"` // default LLM for this agent
+	Version      string              `json:"version"`       // source's own stamp (git sha, rev id…)
+	Prompts      []catalogPushPrompt `json:"prompts"`
+	Tools        []catalogPushTool   `json:"tools"`
+	Skills       []catalogPushSkill  `json:"skills"`
+}
+
+type catalogPushPrompt struct {
+	Name   string `json:"name"`
+	Role   string `json:"role"`
+	Body   string `json:"body"`
+	Source string `json:"source"` // optional per-item source override
+}
+
+type catalogPushTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Schema      json.RawMessage `json:"schema"` // JSON parameter schema, stored as a string
+	Source      string          `json:"source"`
+}
+
+type catalogPushSkill struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Source      string `json:"source"`
+}
+
+// catalogWriteResponse reports how many nodes the push wrote.
+type catalogWriteResponse struct {
+	Written struct {
+		Agents  int `json:"agents"`
+		Prompts int `json:"prompts"`
+		Tools   int `json:"tools"`
+		Skills  int `json:"skills"`
+	} `json:"written"`
+}
+
+// ─── wire shapes: read (GET /_plugin/agents/:name/catalog) ───────────
+
+// AgentCatalogResponse is the merged view across all sources for one
+// agent — what the agent is _made of_ (prompts/tools/skills), as
+// opposed to the budget view's what it's _allowed to spend_.
+type AgentCatalogResponse struct {
+	Name         string          `json:"name"`
+	DisplayName  string          `json:"display_name,omitempty"`
+	Description  string          `json:"description,omitempty"`
+	DefaultModel string          `json:"default_model,omitempty"`
+	Sources      []string        `json:"sources"`
+	Prompts      []CatalogPrompt `json:"prompts"`
+	Tools        []CatalogTool   `json:"tools"`
+	Skills       []CatalogSkill  `json:"skills"`
+}
+
+type CatalogPrompt struct {
+	Name      string `json:"name"`
+	Role      string `json:"role"`
+	Body      string `json:"body"`
+	Source    string `json:"source"`
+	Version   string `json:"version,omitempty"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+type CatalogTool struct {
+	Name        string          `json:"name"`
+	Description string          `json:"description"`
+	Schema      json.RawMessage `json:"schema,omitempty"`
+	Source      string          `json:"source"`
+	Version     string          `json:"version,omitempty"`
+	UpdatedAt   string          `json:"updated_at"`
+}
+
+type CatalogSkill struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+	Source      string `json:"source"`
+	Version     string `json:"version,omitempty"`
+	UpdatedAt   string `json:"updated_at"`
+}
+
+// ─── handler ─────────────────────────────────────────────────────────
+
+// catalogHandlers owns the neo4j graph client for the agent catalog.
+// graph is nil when neo4j isn't configured (NEO4J_PASSWORD unset) — in
+// that mode every endpoint returns 503, matching the Redis-style
+// graceful degradation the rest of the plugin uses.
+type catalogHandlers struct {
+	graph *graphclient.Client
+
+	schemaMu    sync.Mutex
+	schemaReady bool // indexes/constraints created? ("on first write")
+}
+
+func newCatalogHandlers(graph *graphclient.Client) *catalogHandlers {
+	return &catalogHandlers{graph: graph}
+}
+
+// maxCatalogBody caps the push payload. A fleet manifest is kilobytes;
+// 4 MiB is generous headroom (large system prompts) while bounding
+// memory.
+const maxCatalogBody = 4 << 20
+
+// push handles POST /_plugin/agents — bearer-only, the server-to-server
+// write front door. Replace-by-source semantics: the push is the
+// complete picture of what THIS source knows about each agent, so the
+// gateway deletes that source's existing children for the agent and
+// re-creates them in one transaction. Other sources' contributions are
+// untouched.
+func (h *catalogHandlers) push(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, http.MethodPost)
+		return
+	}
+	if h.graph == nil {
+		writeError(w, http.StatusServiceUnavailable, "catalog_unavailable",
+			"agent catalog not configured (neo4j unset on this swarm)")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, maxCatalogBody)
+	var req catalogPushRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Source) == "" {
+		writeError(w, http.StatusBadRequest, "missing_source", "source is required")
+		return
+	}
+	for i := range req.Agents {
+		if strings.TrimSpace(req.Agents[i].Name) == "" {
+			writeError(w, http.StatusBadRequest, "missing_agent_name",
+				fmt.Sprintf("agents[%d].name is required", i))
+			return
+		}
+	}
+
+	ctx := r.Context()
+	if err := h.ensureSchema(ctx); err != nil {
+		// Non-fatal for correctness (MERGE on name still works), but
+		// log it — a persistently missing constraint is worth seeing.
+		pluginlog.Warnf("adminapi: catalog ensureSchema: %v", err)
+	}
+
+	stmts, counts := buildCatalogWrite(req)
+	if _, err := h.graph.Run(ctx, stmts...); err != nil {
+		pluginlog.Errf("adminapi: catalog push: %v", err)
+		writeError(w, http.StatusBadGateway, "catalog_write_failed", "neo4j write failed")
+		return
+	}
+
+	var resp catalogWriteResponse
+	resp.Written.Agents = counts.Agents
+	resp.Written.Prompts = counts.Prompts
+	resp.Written.Tools = counts.Tools
+	resp.Written.Skills = counts.Skills
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// read handles GET /_plugin/agents/:name/catalog — cookie-or-bearer,
+// the read-only dashboard view. Returns the merged view across all
+// sources, or 404 when the agent has no catalog node yet.
+func (h *catalogHandlers) read(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	if h.graph == nil {
+		writeError(w, http.StatusServiceUnavailable, "catalog_unavailable",
+			"agent catalog not configured (neo4j unset on this swarm)")
+		return
+	}
+
+	const prefix = "/_plugin/agents/"
+	rest := strings.TrimPrefix(r.URL.Path, prefix)
+	parts := strings.Split(rest, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] != "catalog" {
+		http.NotFound(w, r)
+		return
+	}
+	name := parts[0]
+
+	out, found, err := h.fetchCatalog(r.Context(), name)
+	if err != nil {
+		pluginlog.Errf("adminapi: catalog read agent=%s: %v", name, err)
+		writeError(w, http.StatusBadGateway, "catalog_read_failed", "neo4j read failed")
+		return
+	}
+	if !found {
+		writeError(w, http.StatusNotFound, "not_found", "no catalog for agent")
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// ─── schema (indexes on first write) ─────────────────────────────────
+
+// ensureSchema creates the catalog's constraint + indexes once. Each
+// DDL statement runs as its own transaction (neo4j forbids mixing
+// schema and data writes, and older versions forbid multiple schema
+// updates per tx). On failure schemaReady stays false so the next
+// write retries.
+func (h *catalogHandlers) ensureSchema(ctx context.Context) error {
+	h.schemaMu.Lock()
+	defer h.schemaMu.Unlock()
+	if h.schemaReady {
+		return nil
+	}
+	for _, s := range graphclient.SchemaStatements() {
+		if _, err := h.graph.Run(ctx, s); err != nil {
+			return err
+		}
+	}
+	h.schemaReady = true
+	return nil
+}
+
+// ─── write builder ───────────────────────────────────────────────────
+
+// buildCatalogWrite turns a push request into an ordered batch of
+// statements (one atomic tx) plus the counts for the response.
+//
+// Per agent the statements are:
+//  1. MERGE agent + source + DEFINED_BY; delete this push's sources'
+//     existing children (replace-by-source).
+//  2. UNWIND-create prompts.
+//  3. UNWIND-create tools.
+//  4. UNWIND-create skills.
+//
+// Label and relationship names are interpolated from graphclient
+// constants (never user input), so there's no injection surface; the
+// per-node data all flows through bound $parameters.
+func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct {
+	Agents, Prompts, Tools, Skills int
+}) {
+	now := time.Now().UTC().Format(time.RFC3339)
+	var stmts []graphclient.Statement
+	var counts struct{ Agents, Prompts, Tools, Skills int }
+
+	srcOr := func(override string) string {
+		if strings.TrimSpace(override) != "" {
+			return override
+		}
+		return req.Source
+	}
+
+	for _, ag := range req.Agents {
+		// Collect the distinct set of sources this push touches for
+		// the agent so cleanup removes exactly what we're about to
+		// re-create (plus the push source itself, so an emptied kind
+		// is cleared). Children owned by *other* sources survive.
+		sourceSet := map[string]struct{}{req.Source: {}}
+
+		prompts := make([]map[string]any, 0, len(ag.Prompts))
+		for _, p := range ag.Prompts {
+			src := srcOr(p.Source)
+			sourceSet[src] = struct{}{}
+			prompts = append(prompts, map[string]any{
+				"node_key": nodeKey(ag.Name, src, "prompt", p.Name),
+				"name":     p.Name,
+				"role":     p.Role,
+				"body":     p.Body,
+				"source":   src,
+				"version":  ag.Version,
+			})
+		}
+		tools := make([]map[string]any, 0, len(ag.Tools))
+		for _, t := range ag.Tools {
+			src := srcOr(t.Source)
+			sourceSet[src] = struct{}{}
+			tools = append(tools, map[string]any{
+				"node_key":    nodeKey(ag.Name, src, "tool", t.Name),
+				"name":        t.Name,
+				"description": t.Description,
+				"schema":      rawToString(t.Schema),
+				"source":      src,
+				"version":     ag.Version,
+			})
+		}
+		skills := make([]map[string]any, 0, len(ag.Skills))
+		for _, s := range ag.Skills {
+			src := srcOr(s.Source)
+			sourceSet[src] = struct{}{}
+			skills = append(skills, map[string]any{
+				"node_key":    nodeKey(ag.Name, src, "skill", s.Name),
+				"name":        s.Name,
+				"description": s.Description,
+				"source":      src,
+				"version":     ag.Version,
+			})
+		}
+
+		sources := make([]string, 0, len(sourceSet))
+		for s := range sourceSet {
+			sources = append(sources, s)
+		}
+
+		counts.Agents++
+		counts.Prompts += len(prompts)
+		counts.Tools += len(tools)
+		counts.Skills += len(skills)
+
+		stmts = append(stmts,
+			graphclient.Statement{
+				Statement: fmt.Sprintf(
+					"MERGE (a:%[1]s {name: $name}) "+
+						"SET a.updated_at = $now, "+
+						"a.display_name = CASE WHEN $display_name <> '' THEN $display_name ELSE a.display_name END, "+
+						"a.description = CASE WHEN $description <> '' THEN $description ELSE a.description END, "+
+						"a.default_model = CASE WHEN $default_model <> '' THEN $default_model ELSE a.default_model END "+
+						"MERGE (s:%[2]s {name: $source}) SET s.updated_at = $now "+
+						"MERGE (a)-[:%[3]s]->(s) "+
+						"WITH a "+
+						"OPTIONAL MATCH (a)-[:%[4]s|%[5]s|%[6]s]->(c) WHERE c.source IN $sources "+
+						"DETACH DELETE c",
+					graphclient.LabelAgent, graphclient.LabelSource, graphclient.RelDefinedBy,
+					graphclient.RelHasPrompt, graphclient.RelHasTool, graphclient.RelHasSkill),
+				Parameters: map[string]any{
+					"name":          ag.Name,
+					"display_name":  ag.DisplayName,
+					"description":   ag.Description,
+					"default_model": ag.DefaultModel,
+					"source":        req.Source,
+					"sources":       sources,
+					"now":           now,
+				},
+			},
+			unwindCreate(graphclient.RelHasPrompt, graphclient.LabelPrompt, ag.Name, now, prompts,
+				"node_key: row.node_key, name: row.name, role: row.role, body: row.body, source: row.source, version: row.version"),
+			unwindCreate(graphclient.RelHasTool, graphclient.LabelTool, ag.Name, now, tools,
+				"node_key: row.node_key, name: row.name, description: row.description, schema: row.schema, source: row.source, version: row.version"),
+			unwindCreate(graphclient.RelHasSkill, graphclient.LabelSkill, ag.Name, now, skills,
+				"node_key: row.node_key, name: row.name, description: row.description, source: row.source, version: row.version"),
+		)
+	}
+	return stmts, counts
+}
+
+// unwindCreate builds a single UNWIND-CREATE statement for one child
+// kind. Over an empty `rows` slice it creates nothing (UNWIND of [] is
+// a no-op) — so an agent that dropped all its tools still runs the
+// statement harmlessly after cleanup cleared the old ones.
+func unwindCreate(rel, label, agentName, now string, rows []map[string]any, props string) graphclient.Statement {
+	return graphclient.Statement{
+		Statement: fmt.Sprintf(
+			"MATCH (a:%[1]s {name: $name}) "+
+				"UNWIND $rows AS row "+
+				"CREATE (a)-[:%[2]s]->(:%[3]s {%[4]s, updated_at: $now})",
+			graphclient.LabelAgent, rel, label, props),
+		Parameters: map[string]any{
+			"name": agentName,
+			"rows": rows,
+			"now":  now,
+		},
+	}
+}
+
+// ─── read builder ────────────────────────────────────────────────────
+
+// fetchCatalog runs one tx/commit batch of five statements (existence
+// + scalars, sources, prompts, tools, skills) and assembles the merged
+// view. Separate statements rather than one big OPTIONAL MATCH avoid
+// the cartesian-product blow-up of prompts × tools × skills.
+func (h *catalogHandlers) fetchCatalog(ctx context.Context, name string) (*AgentCatalogResponse, bool, error) {
+	p := map[string]any{"name": name}
+	results, err := h.graph.Run(ctx,
+		graphclient.Statement{
+			Statement:  fmt.Sprintf("MATCH (a:%s {name: $name}) RETURN a.name, a.display_name, a.description, a.default_model", graphclient.LabelAgent),
+			Parameters: p,
+		},
+		graphclient.Statement{
+			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[:%s]->(s:%s) RETURN s.name ORDER BY s.name",
+				graphclient.LabelAgent, graphclient.RelDefinedBy, graphclient.LabelSource),
+			Parameters: p,
+		},
+		graphclient.Statement{
+			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[:%s]->(p:%s) "+
+				"RETURN p.name, p.role, p.body, p.source, p.version, p.updated_at ORDER BY p.source, p.name",
+				graphclient.LabelAgent, graphclient.RelHasPrompt, graphclient.LabelPrompt),
+			Parameters: p,
+		},
+		graphclient.Statement{
+			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[:%s]->(t:%s) "+
+				"RETURN t.name, t.description, t.schema, t.source, t.version, t.updated_at ORDER BY t.source, t.name",
+				graphclient.LabelAgent, graphclient.RelHasTool, graphclient.LabelTool),
+			Parameters: p,
+		},
+		graphclient.Statement{
+			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[:%s]->(k:%s) "+
+				"RETURN k.name, k.description, k.source, k.version, k.updated_at ORDER BY k.source, k.name",
+				graphclient.LabelAgent, graphclient.RelHasSkill, graphclient.LabelSkill),
+			Parameters: p,
+		},
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(results) < 5 || len(results[0].Data) == 0 {
+		return nil, false, nil // agent has no catalog node
+	}
+
+	agentRow := results[0].Data[0].Row
+	out := &AgentCatalogResponse{
+		Name:         rowString(at(agentRow, 0)),
+		DisplayName:  rowString(at(agentRow, 1)),
+		Description:  rowString(at(agentRow, 2)),
+		DefaultModel: rowString(at(agentRow, 3)),
+		Sources:      []string{},
+		Prompts:      []CatalogPrompt{},
+		Tools:        []CatalogTool{},
+		Skills:       []CatalogSkill{},
+	}
+
+	for _, row := range results[1].Data {
+		out.Sources = append(out.Sources, rowString(at(row.Row, 0)))
+	}
+	for _, row := range results[2].Data {
+		out.Prompts = append(out.Prompts, CatalogPrompt{
+			Name:      rowString(at(row.Row, 0)),
+			Role:      rowString(at(row.Row, 1)),
+			Body:      rowString(at(row.Row, 2)),
+			Source:    rowString(at(row.Row, 3)),
+			Version:   rowString(at(row.Row, 4)),
+			UpdatedAt: rowString(at(row.Row, 5)),
+		})
+	}
+	for _, row := range results[3].Data {
+		out.Tools = append(out.Tools, CatalogTool{
+			Name:        rowString(at(row.Row, 0)),
+			Description: rowString(at(row.Row, 1)),
+			Schema:      stringToRaw(rowString(at(row.Row, 2))),
+			Source:      rowString(at(row.Row, 3)),
+			Version:     rowString(at(row.Row, 4)),
+			UpdatedAt:   rowString(at(row.Row, 5)),
+		})
+	}
+	for _, row := range results[4].Data {
+		out.Skills = append(out.Skills, CatalogSkill{
+			Name:        rowString(at(row.Row, 0)),
+			Description: rowString(at(row.Row, 1)),
+			Source:      rowString(at(row.Row, 2)),
+			Version:     rowString(at(row.Row, 3)),
+			UpdatedAt:   rowString(at(row.Row, 4)),
+		})
+	}
+	return out, true, nil
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+// nodeKey is the deterministic identity of a prompt/tool/skill node:
+// a hash of (agent, source, kind, name). Re-pushing the same node
+// yields the same key, so the catalog is idempotent and a child
+// belongs to exactly one (agent, source, kind, name) tuple.
+func nodeKey(agent, source, kind, name string) string {
+	h := sha256.Sum256([]byte(agent + "\x00" + source + "\x00" + kind + "\x00" + name))
+	return hex.EncodeToString(h[:])
+}
+
+// rawToString renders a tool's JSON schema for storage. neo4j has no
+// nested-object property type, so the schema lives as a JSON string
+// and is re-emitted verbatim on read. Empty/null ⇒ "".
+func rawToString(raw json.RawMessage) string {
+	s := strings.TrimSpace(string(raw))
+	if s == "" || s == "null" {
+		return ""
+	}
+	return s
+}
+
+// stringToRaw is rawToString's inverse for the read path: a stored
+// schema string becomes raw JSON in the response (nil ⇒ omitted).
+func stringToRaw(s string) json.RawMessage {
+	if s == "" {
+		return nil
+	}
+	return json.RawMessage(s)
+}
+
+// rowString decodes a single returned cell into a string. neo4j null
+// (unset property) unmarshals into "" without error.
+func rowString(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var s string
+	if err := json.Unmarshal(raw, &s); err != nil {
+		return ""
+	}
+	return s
+}
+
+// at returns the i-th cell of a row, or empty when the RETURN clause
+// produced fewer columns than expected (defensive; shouldn't happen).
+func at(row []json.RawMessage, i int) json.RawMessage {
+	if i < 0 || i >= len(row) {
+		return nil
+	}
+	return row[i]
+}

--- a/gateway/internal/adminapi/catalog_integration_test.go
+++ b/gateway/internal/adminapi/catalog_integration_test.go
@@ -1,0 +1,159 @@
+package adminapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stakwork/stakgraph/gateway/internal/env"
+	"github.com/stakwork/stakgraph/gateway/internal/graphclient"
+)
+
+// Integration test against a live neo4j. Skipped unless RUN_NEO4J_TESTS
+// is set, so the default `go test` run stays hermetic. Run with:
+//
+//	RUN_NEO4J_TESTS=1 NEO4J_HTTP_URL=http://localhost:7474 \
+//	  NEO4J_USER=neo4j NEO4J_PASSWORD=testtest \
+//	  go test ./internal/adminapi/ -run TestCatalogIntegration -v
+func TestCatalogIntegration(t *testing.T) {
+	if os.Getenv("RUN_NEO4J_TESTS") == "" {
+		t.Skip("set RUN_NEO4J_TESTS=1 (and NEO4J_* env) to run the neo4j integration test")
+	}
+	cfg, ok := env.Neo4jHTTPConfigValue()
+	if !ok {
+		t.Fatal("NEO4J_PASSWORD must be set for the integration test")
+	}
+	graph := graphclient.NewFromConfig(cfg)
+	cat := newCatalogHandlers(graph)
+	ctx := context.Background()
+
+	const agent = "test-catalog-agent"
+	cleanup := func() {
+		_, err := graph.Query(ctx,
+			fmt.Sprintf("MATCH (a:%s {name:$n}) OPTIONAL MATCH (a)-->(c) DETACH DELETE a, c", graphclient.LabelAgent),
+			map[string]any{"n": agent})
+		if err != nil {
+			t.Fatalf("cleanup: %v", err)
+		}
+	}
+	cleanup()
+	t.Cleanup(cleanup)
+
+	// ── push from "hive": tools (+ one prompt, one skill) ──
+	hivePush := map[string]any{
+		"source": "hive",
+		"agents": []map[string]any{{
+			"name":          agent,
+			"display_name":  "Test Catalog Agent",
+			"description":   "Used by the integration test.",
+			"default_model": "sonnet",
+			"version":       "git:abc123",
+			"prompts": []map[string]any{
+				{"name": "system", "role": "system", "body": "You are a test."},
+			},
+			"tools": []map[string]any{
+				{"name": "read_file", "description": "Read a file",
+					"schema": map[string]any{"type": "object", "properties": map[string]any{"path": map[string]any{"type": "string"}}}},
+				{"name": "write_file", "description": "Write a file"},
+			},
+			"skills": []map[string]any{
+				{"name": "security-review", "description": "OWASP review"},
+			},
+		}},
+	}
+	wrote := doPush(t, cat, hivePush)
+	if wrote.Written.Agents != 1 || wrote.Written.Prompts != 1 || wrote.Written.Tools != 2 || wrote.Written.Skills != 1 {
+		t.Fatalf("unexpected write counts: %+v", wrote.Written)
+	}
+
+	got := doRead(t, cat, agent, http.StatusOK)
+	if got.DisplayName != "Test Catalog Agent" {
+		t.Errorf("display_name = %q", got.DisplayName)
+	}
+	if got.DefaultModel != "sonnet" {
+		t.Errorf("default_model = %q, want sonnet", got.DefaultModel)
+	}
+	if len(got.Tools) != 2 {
+		t.Fatalf("tools = %d, want 2", len(got.Tools))
+	}
+	// schema round-trips as raw JSON.
+	var schemaTool *CatalogTool
+	for i := range got.Tools {
+		if got.Tools[i].Name == "read_file" {
+			schemaTool = &got.Tools[i]
+		}
+	}
+	if schemaTool == nil || !strings.Contains(string(schemaTool.Schema), `"path"`) {
+		t.Errorf("read_file schema didn't round-trip: %+v", schemaTool)
+	}
+
+	// ── idempotency: re-push the same hive manifest ──
+	doPush(t, cat, hivePush)
+	got = doRead(t, cat, agent, http.StatusOK)
+	if len(got.Tools) != 2 || len(got.Prompts) != 1 || len(got.Skills) != 1 {
+		t.Fatalf("re-push duplicated children: tools=%d prompts=%d skills=%d",
+			len(got.Tools), len(got.Prompts), len(got.Skills))
+	}
+
+	// ── second source (prompt-manager) contributes a prompt ──
+	doPush(t, cat, map[string]any{
+		"source": "prompt-manager",
+		"agents": []map[string]any{{
+			"name":    agent,
+			"version": "rev-42",
+			"prompts": []map[string]any{{"name": "guardrails", "role": "system", "body": "Be careful."}},
+		}},
+	})
+	got = doRead(t, cat, agent, http.StatusOK)
+	if len(got.Sources) != 2 {
+		t.Errorf("sources = %v, want hive + prompt-manager", got.Sources)
+	}
+	if len(got.Prompts) != 2 { // hive's system + prompt-manager's guardrails
+		t.Errorf("prompts = %d, want 2 (hive's preserved across other source's push)", len(got.Prompts))
+	}
+	// hive's tools must survive prompt-manager's push (replace-by-source).
+	if len(got.Tools) != 2 {
+		t.Errorf("tools = %d, want 2 (hive's tools clobbered by other source)", len(got.Tools))
+	}
+
+	// ── 404 for unknown agent ──
+	doRead(t, cat, "no-such-agent-xyz", http.StatusNotFound)
+}
+
+func doPush(t *testing.T, cat *catalogHandlers, body any) catalogWriteResponse {
+	t.Helper()
+	raw, _ := json.Marshal(body)
+	req := httptest.NewRequest(http.MethodPost, "/_plugin/agents", strings.NewReader(string(raw)))
+	rec := httptest.NewRecorder()
+	cat.push(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("push status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var out catalogWriteResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+		t.Fatalf("push decode: %v", err)
+	}
+	return out
+}
+
+func doRead(t *testing.T, cat *catalogHandlers, name string, wantStatus int) AgentCatalogResponse {
+	t.Helper()
+	req := httptest.NewRequest(http.MethodGet, "/_plugin/agents/"+name+"/catalog", nil)
+	rec := httptest.NewRecorder()
+	cat.read(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("read %s status = %d (want %d), body = %s", name, rec.Code, wantStatus, rec.Body.String())
+	}
+	var out AgentCatalogResponse
+	if wantStatus == http.StatusOK {
+		if err := json.Unmarshal(rec.Body.Bytes(), &out); err != nil {
+			t.Fatalf("read decode: %v", err)
+		}
+	}
+	return out
+}

--- a/gateway/internal/adminapi/server.go
+++ b/gateway/internal/adminapi/server.go
@@ -20,10 +20,12 @@ package adminapi
 import (
 	"context"
 	"net/http"
+	"strings"
 	"sync"
 	"time"
 
 	"github.com/stakwork/stakgraph/gateway/internal/env"
+	"github.com/stakwork/stakgraph/gateway/internal/graphclient"
 	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
 	"github.com/stakwork/stakgraph/gateway/internal/sessions"
 	"github.com/stakwork/stakgraph/gateway/internal/trust"
@@ -103,6 +105,14 @@ func start() {
 		pluginlog.Warnf("adminapi: session store disabled (redis not configured); /_plugin/login will 503")
 	}
 
+	// Agent-catalog graph client. nil when neo4j isn't configured
+	// (NEO4J_PASSWORD unset) — the catalog endpoints then return 503,
+	// the same graceful degradation Redis uses for observability mode.
+	graph := graphclient.New()
+	if graph == nil {
+		pluginlog.Warnf("adminapi: agent catalog disabled (neo4j not configured); catalog endpoints will 503")
+	}
+
 	mux := http.NewServeMux()
 	registerRoutes(mux, routeDeps{
 		adminUser:         adminUser,
@@ -111,6 +121,7 @@ func start() {
 		trust:             registry,
 		sessions:          store,
 		logstore:          newLogstoreClient(adminUser, adminPass),
+		graph:             graph,
 	})
 
 	addr := env.PluginAddr()
@@ -138,9 +149,10 @@ type routeDeps struct {
 	adminUser         string
 	adminPass         string
 	provisioningToken string
-	trust             *trust.Registry  // nil ⇒ skip /_plugin/trust/* registration
-	sessions          *sessions.Store  // nil ⇒ /_plugin/login returns 503
-	logstore          *logstoreClient  // nil ⇒ skip phase-7 observability routes
+	trust             *trust.Registry     // nil ⇒ skip /_plugin/trust/* registration
+	sessions          *sessions.Store     // nil ⇒ /_plugin/login returns 503
+	logstore          *logstoreClient     // nil ⇒ skip phase-7 observability routes
+	graph             *graphclient.Client // nil ⇒ agent-catalog endpoints return 503
 }
 
 // methodMuxedAuth picks one of two middleware chains based on the
@@ -260,7 +272,33 @@ func registerRoutes(mux *http.ServeMux, deps routeDeps) {
 	// shape and 404s on anything else (phase-9 `:name/state` and
 	// `:name/kill` live under the same prefix later).
 	bgt := newBudgetHandlers(deps.logstore)
-	mux.HandleFunc("/_plugin/agents/", cookieOrBearer(bgt.budget))
+	cat := newCatalogHandlers(deps.graph)
+
+	// The `/_plugin/agents/` subtree is shared: ServeMux allows only
+	// one handler per pattern, so a small dispatcher fans the trailing
+	// `<name>/<view>` segment out to the budget (phase-8.5) or catalog
+	// (agent-catalog) read. Both are cookie-or-bearer reads. Anything
+	// else under the prefix 404s, preserving the budget handler's
+	// existing contract.
+	agentsSubtree := func(w http.ResponseWriter, r *http.Request) {
+		rest := strings.TrimPrefix(r.URL.Path, "/_plugin/agents/")
+		parts := strings.Split(rest, "/")
+		if len(parts) == 2 && parts[0] != "" && parts[1] == "catalog" {
+			cat.read(w, r)
+			return
+		}
+		// Default: the budget handler owns `<name>/budget` and 404s
+		// the rest.
+		bgt.budget(w, r)
+	}
+	mux.HandleFunc("/_plugin/agents/", cookieOrBearer(agentsSubtree))
+
+	// Catalog write front door: POST /_plugin/agents (exact, no
+	// trailing slash). Bearer-only (server-to-server), same posture as
+	// the trust-registry mutations. Registered even when neo4j is
+	// unconfigured so the handler can answer 503 rather than ServeMux
+	// 301-redirecting to the subtree.
+	mux.HandleFunc("/_plugin/agents", bearer(cat.push))
 
 	// SPA — served WITHOUT middleware auth. The SPA itself probes
 	// /_plugin/me at boot and redirects to /login on 401; gating

--- a/gateway/internal/adminapi/ui/dist/index.html
+++ b/gateway/internal/adminapi/ui/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=1280" />
     <meta name="color-scheme" content="dark" />
     <title>Agent Mothership</title>
-    <script type="module" crossorigin src="/_plugin/ui/assets/index-4TDzzE-r.js"></script>
-    <link rel="stylesheet" crossorigin href="/_plugin/ui/assets/index-BGvSJWak.css">
+    <script type="module" crossorigin src="/_plugin/ui/assets/index-CQFO5_FQ.js"></script>
+    <link rel="stylesheet" crossorigin href="/_plugin/ui/assets/index-BtmCFt7S.css">
   </head>
   <body>
     <div id="root"></div>

--- a/gateway/internal/adminapi/ui/src/api/queries.ts
+++ b/gateway/internal/adminapi/ui/src/api/queries.ts
@@ -8,6 +8,7 @@ import { useQueries, useQuery } from "@tanstack/react-query";
 import { apiFetch, ApiCallError } from "./client";
 import type {
   AgentBudgetResponse,
+  AgentCatalogResponse,
   CallDetailResponse,
   HistogramCostResponse,
   MeResponse,
@@ -176,6 +177,42 @@ export function useAgentBudgets(names: string[]) {
     out[n] = queries[i]?.data;
   });
   return out;
+}
+
+// ─── /agents/:name/catalog ──────────────────────────────────────────
+//
+// What the agent is _made of_ (prompts/tools/skills), pushed into the
+// neo4j catalog by hive / prompt-manager / goose pods. Slow cadence:
+// the catalog changes on deploy, not per second, so a long stale time
+// and no aggressive poll. Two non-error "empty" states are folded into
+// the data:
+//
+//   - 404 (agent has no catalog node yet) ⇒ resolves to `null`; the
+//     page renders empty tabs rather than an error.
+//   - 503 (neo4j not wired on this swarm) ⇒ propagates as an
+//     ApiCallError with code "catalog_unavailable"; the page renders a
+//     "catalog not wired" notice. Distinguished so the copy can differ.
+
+export function useAgentCatalog(name: string | undefined) {
+  return useQuery({
+    queryKey: ["agents", name, "catalog"],
+    queryFn: async (): Promise<AgentCatalogResponse | null> => {
+      try {
+        return await apiFetch<AgentCatalogResponse>(
+          `/agents/${encodeURIComponent(name!)}/catalog`
+        );
+      } catch (e) {
+        if (e instanceof ApiCallError && e.status === 404) {
+          return null; // no catalog for this agent (yet)
+        }
+        throw e; // 503 "catalog_unavailable" and real failures bubble up
+      }
+    },
+    enabled: !!name,
+    staleTime: 5 * 60_000,
+    refetchInterval: 5 * 60_000,
+    retry: false,
+  });
 }
 
 // ─── /users/:id ─────────────────────────────────────────────────────

--- a/gateway/internal/adminapi/ui/src/api/types.ts
+++ b/gateway/internal/adminapi/ui/src/api/types.ts
@@ -313,6 +313,53 @@ export interface AgentBudgetResponse {
   ratio: number | null;
 }
 
+// ─── agent catalog ──────────────────────────────────────────────────
+// Mirrors gateway/internal/adminapi/catalog.go. The catalog answers
+// "what is this agent _made of_?" (prompts/tools/skills), as opposed to
+// the budget view's "what is it _allowed to spend_?". Sourced from the
+// neo4j Hive* catalog subgraph via GET /_plugin/agents/:name/catalog.
+
+export interface CatalogPrompt {
+  name: string;
+  role: string;
+  body: string;
+  source: string;
+  version?: string;
+  updated_at: string;
+}
+
+export interface CatalogTool {
+  name: string;
+  description: string;
+  /** JSON parameter schema, passed through opaque — the UI renders it
+   *  as pretty-printed JSON. Absent when the source didn't supply one. */
+  schema?: unknown;
+  source: string;
+  version?: string;
+  updated_at: string;
+}
+
+export interface CatalogSkill {
+  name: string;
+  description: string;
+  source: string;
+  version?: string;
+  updated_at: string;
+}
+
+// Merged catalog view across all contributing sources for one agent.
+export interface AgentCatalogResponse {
+  name: string;
+  display_name?: string;
+  description?: string;
+  /** Default LLM used for this agent (model shortcut or full id). */
+  default_model?: string;
+  sources: string[];
+  prompts: CatalogPrompt[];
+  tools: CatalogTool[];
+  skills: CatalogSkill[];
+}
+
 // Phase-7 error envelope (returned on 4xx/5xx).
 export interface ApiError {
   error: {

--- a/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
@@ -15,15 +15,27 @@ import { Link } from "wouter-preact";
 import { CostHistogram } from "../components/charts/CostHistogram";
 import { ErrorBoundary } from "../components/ErrorBoundary";
 import { WindowPicker } from "../components/controls/WindowPicker";
-import type { AgentBudgetResponse } from "../api/types";
-import { getErrorMessage } from "../api/client";
-import { useAgentBudget, useHistogramCost } from "../api/queries";
+import type {
+  AgentBudgetResponse,
+  AgentCatalogResponse,
+  CatalogPrompt,
+  CatalogSkill,
+  CatalogTool,
+} from "../api/types";
+import { ApiCallError, getErrorMessage } from "../api/client";
+import {
+  useAgentBudget,
+  useAgentCatalog,
+  useHistogramCost,
+} from "../api/queries";
 import type { HistogramCostResponse, Window } from "../api/types";
 import { windowToSeconds } from "../api/window";
 
 interface Props {
   name: string;
 }
+
+type Tab = "overview" | "prompts" | "tools" | "skills";
 
 const fmtUSD = (v: number) => {
   if (v === 0) return "$0.00";
@@ -85,6 +97,15 @@ export function AgentDetail({ name }: Props) {
 
   const totalCost = filtered?.series[0]?.points.reduce((s, p) => s + p.cost, 0) ?? 0;
 
+  const [tab, setTab] = useState<Tab>("overview");
+  const catalog = useAgentCatalog(name);
+  // 503 ⇒ neo4j not wired on this swarm: the catalog tabs render a
+  // "not configured" notice rather than an error banner.
+  const catalogUnavailable =
+    catalog.error instanceof ApiCallError &&
+    catalog.error.code === "catalog_unavailable";
+  const cat = catalog.data ?? null;
+
   return (
     <>
       <div class="page-header">
@@ -92,11 +113,96 @@ export function AgentDetail({ name }: Props) {
           <div class="crumbs">
             <Link href="/agents">Agents</Link> / {name}
           </div>
-          <h1 class="mono">{name}</h1>
+          <h1 class="mono">
+            {name}
+            {cat?.default_model ? (
+              <span class="pill pill-accent model-chip" title="Default model">
+                {cat.default_model}
+              </span>
+            ) : null}
+          </h1>
         </div>
-        <WindowPicker value={window} onChange={setWindow} />
+        {tab === "overview" ? (
+          <WindowPicker value={window} onChange={setWindow} />
+        ) : null}
       </div>
 
+      <nav class="tabs" role="tablist">
+        <TabButton id="overview" active={tab} onSelect={setTab} label="Overview" />
+        <TabButton
+          id="prompts"
+          active={tab}
+          onSelect={setTab}
+          label="Prompts"
+          count={cat?.prompts.length}
+        />
+        <TabButton
+          id="tools"
+          active={tab}
+          onSelect={setTab}
+          label="Tools"
+          count={cat?.tools.length}
+        />
+        <TabButton
+          id="skills"
+          active={tab}
+          onSelect={setTab}
+          label="Skills"
+          count={cat?.skills.length}
+        />
+      </nav>
+
+      {tab !== "overview" ? (
+        <CatalogPanel
+          tab={tab}
+          catalog={cat}
+          loading={catalog.isLoading}
+          unavailable={catalogUnavailable}
+          error={
+            catalog.isError && !catalogUnavailable
+              ? getErrorMessage(catalog.error)
+              : null
+          }
+        />
+      ) : (
+        <OverviewTab
+          window={window}
+          bucket={bucket}
+          totalCost={totalCost}
+          budget={budget.data}
+          histogram={histogram}
+          filtered={filtered}
+          windowSeconds={windowSeconds}
+          recentRuns={recentRuns}
+        />
+      )}
+    </>
+  );
+}
+
+interface OverviewProps {
+  window: Window;
+  bucket: string;
+  totalCost: number;
+  budget: AgentBudgetResponse | undefined;
+  histogram: ReturnType<typeof useHistogramCost>;
+  filtered: HistogramCostResponse | undefined;
+  windowSeconds: number;
+  recentRuns: { run_id: string; cost: number; calls: number }[];
+}
+
+function OverviewTab({
+  window,
+  bucket,
+  totalCost,
+  budget,
+  histogram,
+  filtered,
+  windowSeconds,
+  recentRuns,
+}: OverviewProps) {
+  return (
+    <>
       <div class="kpi">
         <div class="card kpi-card">
           <div class="kpi-label">Spend ({window})</div>
@@ -104,8 +210,8 @@ export function AgentDetail({ name }: Props) {
         </div>
       </div>
 
-      {budget.data && budget.data.cap_usd != null ? (
-        <BudgetCard data={budget.data} />
+      {budget && budget.cap_usd != null ? (
+        <BudgetCard data={budget} />
       ) : null}
 
       <section class="chart-frame">
@@ -209,5 +315,158 @@ function BudgetCard({ data }: { data: AgentBudgetResponse }) {
         />
       </div>
     </section>
+  );
+}
+
+// ─── catalog tabs ──────────────────────────────────────────────────
+
+function TabButton({
+  id,
+  active,
+  onSelect,
+  label,
+  count,
+}: {
+  id: Tab;
+  active: Tab;
+  onSelect: (t: Tab) => void;
+  label: string;
+  count?: number;
+}) {
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={active === id}
+      class={"tab" + (active === id ? " is-active" : "")}
+      onClick={() => onSelect(id)}
+    >
+      {label}
+      {count != null && count > 0 ? <span class="tab-count">{count}</span> : null}
+    </button>
+  );
+}
+
+interface PanelProps {
+  tab: Exclude<Tab, "overview">;
+  catalog: AgentCatalogResponse | null;
+  loading: boolean;
+  unavailable: boolean;
+  error: string | null;
+}
+
+// CatalogPanel handles the shared empty / loading / error chrome for
+// the three catalog tabs, then delegates to the per-kind renderer.
+function CatalogPanel({ tab, catalog, loading, unavailable, error }: PanelProps) {
+  if (unavailable) {
+    return (
+      <div class="empty">
+        Catalog not wired on this swarm. Set <span class="mono">NEO4J_PASSWORD</span>{" "}
+        on the gateway to enable prompts, tools and skills.
+      </div>
+    );
+  }
+  if (loading) return <div class="loading">Loading…</div>;
+  if (error) return <div class="error-banner">{error}</div>;
+  if (!catalog) {
+    return (
+      <div class="empty">
+        No catalog for this agent yet. Sources (hive, prompt-manager, goose)
+        push manifests as they deploy.
+      </div>
+    );
+  }
+
+  if (tab === "prompts") return <PromptsView prompts={catalog.prompts} />;
+  if (tab === "tools") return <ToolsView tools={catalog.tools} />;
+  return <SkillsView skills={catalog.skills} />;
+}
+
+// SourceChip is the source + version provenance marker shared by all
+// three kinds — which system contributed this node and at what stamp.
+function SourceChip({ source, version }: { source: string; version?: string }) {
+  return (
+    <span class="pill pill-accent" title={version ? `version ${version}` : undefined}>
+      {source}
+      {version ? <span class="text-dim">· {version}</span> : null}
+    </span>
+  );
+}
+
+function PromptsView({ prompts }: { prompts: CatalogPrompt[] }) {
+  if (prompts.length === 0) return <div class="empty">No prompts.</div>;
+  return (
+    <div class="catalog-list">
+      {prompts.map((p) => (
+        <details key={p.source + "/" + p.name} class="card catalog-card">
+          <summary class="catalog-summary">
+            <span class="catalog-summary-main">
+              <span class={"badge role-" + (p.role || "system")}>{p.role || "—"}</span>
+              <span class="mono">{p.name}</span>
+            </span>
+            <SourceChip source={p.source} version={p.version} />
+          </summary>
+          <pre class="catalog-body mono">{p.body}</pre>
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function ToolsView({ tools }: { tools: CatalogTool[] }) {
+  if (tools.length === 0) return <div class="empty">No tools.</div>;
+  return (
+    <div class="catalog-list">
+      {tools.map((t) => (
+        <details key={t.source + "/" + t.name} class="card catalog-card">
+          <summary class="catalog-summary">
+            <span class="catalog-summary-main">
+              <span class="mono">{t.name}</span>
+              <span class="text-dim">{t.description}</span>
+            </span>
+            <SourceChip source={t.source} version={t.version} />
+          </summary>
+          {t.schema != null ? (
+            <pre class="catalog-body mono">
+              {JSON.stringify(t.schema, null, 2)}
+            </pre>
+          ) : (
+            <div class="text-dim" style="padding: 8px 0 0">
+              No parameter schema.
+            </div>
+          )}
+        </details>
+      ))}
+    </div>
+  );
+}
+
+function SkillsView({ skills }: { skills: CatalogSkill[] }) {
+  if (skills.length === 0) return <div class="empty">No skills.</div>;
+  return (
+    <div class="table-wrap">
+      <table class="table">
+        <thead>
+          <tr>
+            <th>Skill</th>
+            <th>Description</th>
+            <th>Source</th>
+          </tr>
+        </thead>
+        <tbody>
+          {skills.map((s) => (
+            <tr key={s.source + "/" + s.name}>
+              <td>
+                <span class="mono">{s.name}</span>
+              </td>
+              <td class="text-dim">{s.description}</td>
+              <td>
+                <SourceChip source={s.source} version={s.version} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
   );
 }

--- a/gateway/internal/adminapi/ui/src/styles/components.css
+++ b/gateway/internal/adminapi/ui/src/styles/components.css
@@ -1005,3 +1005,134 @@ table.table {
   gap: var(--sp-4);
   font-size: 12px;
 }
+
+/* ─── agent catalog: tabs + prompt/tool/skill cards ──────────── */
+
+.tabs {
+  display: flex;
+  gap: var(--sp-1);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--sp-5);
+}
+.tab {
+  appearance: none;
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  margin-bottom: -1px;
+  padding: var(--sp-3) var(--sp-4);
+  color: var(--text-muted);
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.tab:hover {
+  color: var(--text);
+}
+.tab.is-active {
+  color: var(--text);
+  border-bottom-color: var(--accent);
+}
+.tab-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 18px;
+  height: 18px;
+  padding: 0 5px;
+  border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  color: var(--text-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1;
+}
+.tab.is-active .tab-count {
+  background: rgba(110, 168, 255, 0.12);
+  border-color: rgba(110, 168, 255, 0.35);
+  color: var(--accent);
+}
+
+.model-chip {
+  margin-left: var(--sp-3);
+  vertical-align: middle;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.catalog-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+}
+.catalog-card {
+  padding: var(--sp-4);
+}
+.catalog-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sp-3);
+  cursor: pointer;
+  list-style: none;
+}
+.catalog-summary::-webkit-details-marker {
+  display: none;
+}
+.catalog-summary::before {
+  content: "▸";
+  color: var(--text-dim);
+  font-size: 10px;
+  flex-shrink: 0;
+}
+details[open] > .catalog-summary::before {
+  content: "▾";
+}
+.catalog-summary-main {
+  display: flex;
+  align-items: baseline;
+  gap: var(--sp-3);
+  min-width: 0;
+  flex: 1;
+}
+.catalog-summary-main .text-dim {
+  font-size: 12px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.catalog-body {
+  margin: var(--sp-3) 0 0;
+  padding: var(--sp-3);
+  background: var(--bg, #0d1219);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--text);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 460px;
+  overflow: auto;
+}
+
+/* Role badges on prompt cards reuse the badge pill shape. */
+.badge.role-system {
+  background: rgba(110, 168, 255, 0.15);
+  color: var(--accent);
+  border: 1px solid rgba(110, 168, 255, 0.3);
+}
+.badge.role-user {
+  background: rgba(105, 214, 164, 0.15);
+  color: var(--ok);
+  border: 1px solid rgba(105, 214, 164, 0.3);
+}
+.badge.role-assistant {
+  background: rgba(245, 184, 108, 0.15);
+  color: var(--warning);
+  border: 1px solid rgba(245, 184, 108, 0.3);
+}

--- a/gateway/internal/env/env.go
+++ b/gateway/internal/env/env.go
@@ -98,6 +98,28 @@ const (
 	// is served from the same Hive origin and proxies to whichever
 	// per-swarm gateway plugin it needs.
 	HiveOrigin = "HIVE_ORIGIN"
+
+	// Neo4jHTTPURL is the base URL of neo4j's native transactional
+	// Cypher HTTP API used by the agent catalog (graphclient). Note
+	// the 7474 HTTP port, NOT 7687 (bolt) — the gateway speaks the
+	// REST `/db/<db>/tx/commit` endpoint, not bolt, so it needs no
+	// driver. See gateway/plans/agent-catalog.md.
+	Neo4jHTTPURL = "NEO4J_HTTP_URL"
+
+	// Neo4jUser is the Basic-auth user for the neo4j HTTP API.
+	Neo4jUser = "NEO4J_USER"
+
+	// Neo4jPassword is the Basic-auth password for the neo4j HTTP
+	// API. Empty / unset ⇒ the agent-catalog endpoints return 503
+	// and the UI hides the prompts/tools/skills tabs (the same
+	// graceful-degradation posture Redis uses for observability
+	// mode). This is the neo4j password, distinct from mcp's
+	// API_TOKEN and the gateway's BIFROST_PROVISIONING_TOKEN.
+	Neo4jPassword = "NEO4J_PASSWORD"
+
+	// Neo4jDatabase is the database name segment in
+	// `/db/<db>/tx/commit`. Defaults to "neo4j".
+	Neo4jDatabase = "NEO4J_DATABASE"
 )
 
 // Defaults that apply when an env var is unset.
@@ -112,6 +134,14 @@ const (
 	// DefaultHiveOrigin is production Hive. Override via HIVE_ORIGIN
 	// for staging / dev (e.g. `http://localhost:8080`).
 	DefaultHiveOrigin = "https://hive.sphinx.chat"
+
+	// Neo4j HTTP defaults. The base URL points at the swarm's neo4j
+	// over its HTTP port; user/database match mcp/standalone's
+	// conventions. Only NEO4J_PASSWORD has no default — its absence
+	// is the "catalog not configured" signal.
+	DefaultNeo4jHTTPURL  = "http://neo4j.sphinx:7474"
+	DefaultNeo4jUser     = "neo4j"
+	DefaultNeo4jDatabase = "neo4j"
 )
 
 // Get reads `name` and returns its value or "" if unset.
@@ -186,6 +216,34 @@ func IsProduction() bool {
 // CSP `frame-ancestors` directive and (in future) as an allowlist
 // for cookie-authed mutation `Origin` checks.
 func HiveOriginValue() string { return GetOr(HiveOrigin, DefaultHiveOrigin) }
+
+// Neo4jConfig is the resolved connection info for neo4j's HTTP Cypher
+// API, consumed by internal/graphclient.
+type Neo4jConfig struct {
+	BaseURL  string
+	User     string
+	Password string
+	Database string
+}
+
+// Neo4jHTTPConfigValue returns (cfg, ok). `ok` is false when
+// NEO4J_PASSWORD is unset — callers should treat that as "agent
+// catalog not configured" and return 503 from the catalog endpoints,
+// exactly the way RedisURLValue gates observability mode. The base
+// URL, user and database all fall back to swarm-sensible defaults so
+// only the password is mandatory.
+func Neo4jHTTPConfigValue() (Neo4jConfig, bool) {
+	pass := os.Getenv(Neo4jPassword)
+	if pass == "" {
+		return Neo4jConfig{}, false
+	}
+	return Neo4jConfig{
+		BaseURL:  GetOr(Neo4jHTTPURL, DefaultNeo4jHTTPURL),
+		User:     GetOr(Neo4jUser, DefaultNeo4jUser),
+		Password: pass,
+		Database: GetOr(Neo4jDatabase, DefaultNeo4jDatabase),
+	}, true
+}
 
 // TrustSeed returns the env-supplied registry seed and where it came
 // from. Exactly one of the two env vars is honoured per

--- a/gateway/internal/graphclient/client.go
+++ b/gateway/internal/graphclient/client.go
@@ -1,0 +1,163 @@
+// Package graphclient is the gateway's thin HTTP client for neo4j's
+// native transactional Cypher endpoint (`/db/<db>/tx/commit`).
+//
+// Why HTTP and not bolt
+// ---------------------
+// The gateway is a Bifrost .so plugin built from pure stdlib HTTP. We
+// don't want to pull the neo4j Go bolt driver (cgo-free but a large
+// dependency) into the plugin just to write a handful of catalog
+// upserts. neo4j ships a first-class JSON-over-HTTP Cypher API on its
+// 7474 port; Basic auth with the neo4j password (already in the swarm
+// env) is all it needs. This mirrors how internal/adminapi's
+// logstoreClient wraps Bifrost's loopback API — same shape, different
+// upstream.
+//
+// Only the gateway holds the neo4j credential and owns the upsert;
+// catalog sources POST manifests to the gateway, never to neo4j
+// directly (see gateway/plans/agent-catalog.md).
+package graphclient
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stakwork/stakgraph/gateway/internal/env"
+)
+
+// requestTimeout caps a single tx/commit round-trip. Catalog writes
+// are small (a fleet manifest is kilobytes) and reads are single-agent
+// lookups, so a tight-ish timeout keeps an unresponsive neo4j from
+// hanging the dashboard.
+const requestTimeout = 8 * time.Second
+
+// Client talks to one neo4j database over its HTTP Cypher API. nil is
+// a valid "not configured" value — callers (the catalog handlers)
+// nil-check and return 503, the same contract redisclient.Client()
+// uses for observability mode.
+type Client struct {
+	endpoint   string // fully-composed .../db/<db>/tx/commit URL
+	httpClient *http.Client
+	authHeader string // pre-encoded "Basic xxx"
+}
+
+// New builds a Client from env config, or returns nil when neo4j is
+// not configured (NEO4J_PASSWORD unset). Wiring this at server start
+// means the per-request path never re-reads env.
+func New() *Client {
+	cfg, ok := env.Neo4jHTTPConfigValue()
+	if !ok {
+		return nil
+	}
+	return NewFromConfig(cfg)
+}
+
+// NewFromConfig is New with an explicit config — handy for tests that
+// point at a local neo4j without touching the process environment.
+func NewFromConfig(cfg env.Neo4jConfig) *Client {
+	endpoint := strings.TrimRight(cfg.BaseURL, "/") + "/db/" + cfg.Database + "/tx/commit"
+	return &Client{
+		endpoint:   endpoint,
+		httpClient: &http.Client{Timeout: requestTimeout},
+		authHeader: "Basic " + base64.StdEncoding.EncodeToString([]byte(cfg.User+":"+cfg.Password)),
+	}
+}
+
+// Statement is one parameterised Cypher statement in a tx/commit
+// batch. Parameters is sent as-is; neo4j accepts scalars, lists and
+// maps (used for UNWIND-driven batch creates).
+type Statement struct {
+	Statement  string         `json:"statement"`
+	Parameters map[string]any `json:"parameters,omitempty"`
+}
+
+// Result is one statement's result block: ordered columns and rows.
+// Each row's values are kept as raw JSON so callers decode positionally
+// into whatever shape the RETURN clause produced (a node's properties
+// object, a scalar, a list, …).
+type Result struct {
+	Columns []string `json:"columns"`
+	Data    []struct {
+		Row []json.RawMessage `json:"row"`
+	} `json:"data"`
+}
+
+// wire shapes for the tx/commit envelope.
+type txRequest struct {
+	Statements []Statement `json:"statements"`
+}
+
+type txResponse struct {
+	Results []Result `json:"results"`
+	Errors  []neoErr `json:"errors"`
+}
+
+type neoErr struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// Run posts one or more statements as a single atomic transaction
+// (tx/commit commits or rolls back the whole batch). It returns one
+// Result per statement, in order. Any neo4j-reported error fails the
+// whole call — the transaction is already rolled back server-side.
+func (c *Client) Run(ctx context.Context, statements ...Statement) ([]Result, error) {
+	body, err := json.Marshal(txRequest{Statements: statements})
+	if err != nil {
+		return nil, fmt.Errorf("graphclient: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, bytes.NewReader(body))
+	if err != nil {
+		return nil, fmt.Errorf("graphclient: build request: %w", err)
+	}
+	req.Header.Set("Authorization", c.authHeader)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("graphclient: neo4j unreachable: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		// 401 (bad password) and 404 (missing db) land here; read a
+		// bounded slice for a useful log line.
+		snippet, _ := io.ReadAll(io.LimitReader(resp.Body, 2048))
+		return nil, fmt.Errorf("graphclient: neo4j http %d: %s",
+			resp.StatusCode, strings.TrimSpace(string(snippet)))
+	}
+
+	var out txResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("graphclient: decode response: %w", err)
+	}
+	if len(out.Errors) > 0 {
+		// neo4j returns 200 with a populated errors[] for Cypher-level
+		// failures (syntax, constraint violation). Surface the first.
+		return nil, fmt.Errorf("graphclient: cypher error %s: %s",
+			out.Errors[0].Code, out.Errors[0].Message)
+	}
+	return out.Results, nil
+}
+
+// Query is the single-statement convenience over Run, returning that
+// statement's Result (or an empty Result if the statement produced no
+// result block).
+func (c *Client) Query(ctx context.Context, cypher string, params map[string]any) (Result, error) {
+	results, err := c.Run(ctx, Statement{Statement: cypher, Parameters: params})
+	if err != nil {
+		return Result{}, err
+	}
+	if len(results) == 0 {
+		return Result{}, nil
+	}
+	return results[0], nil
+}

--- a/gateway/internal/graphclient/schema.go
+++ b/gateway/internal/graphclient/schema.go
@@ -1,0 +1,44 @@
+package graphclient
+
+// Label and relationship-type names for the agent catalog subgraph.
+//
+// All labels are PascalCase with a `Hive` prefix so they never collide
+// with the generic Agent/Prompt/Tool/Skill nodes other systems may
+// push into the shared graph. Hive catalog nodes deliberately do NOT
+// carry the `Data_Bank` label (that label drives mcp's code full-text
+// + vector indexes; the catalog must not pollute code search).
+//
+// This is the one place label/edge names are defined — every Cypher
+// string in this package interpolates these constants so a rename is a
+// single-edit affair. See gateway/plans/agent-catalog.md "Data model".
+const (
+	LabelAgent  = "HiveAgent"
+	LabelPrompt = "HivePrompt"
+	LabelTool   = "HiveTool"
+	LabelSkill  = "HiveSkill"
+	LabelSource = "HiveSource"
+
+	RelHasPrompt = "HAS_PROMPT"
+	RelHasTool   = "HAS_TOOL"
+	RelHasSkill  = "HAS_SKILL"
+	RelDefinedBy = "DEFINED_BY"
+)
+
+// SchemaStatements are the constraint/index DDL the catalog needs.
+// Every statement is `IF NOT EXISTS`, so running them on every cold
+// start is idempotent and cheap. The write handler runs these once
+// (guarded by a sync.Once) before its first upsert — "indexes on
+// first write" rather than a migration step, because the gateway has
+// no migration runner and neo4j may be unreachable at boot.
+func SchemaStatements() []Statement {
+	return []Statement{
+		{Statement: "CREATE CONSTRAINT hive_agent_name IF NOT EXISTS " +
+			"FOR (a:" + LabelAgent + ") REQUIRE a.name IS UNIQUE"},
+		{Statement: "CREATE INDEX hive_prompt_key IF NOT EXISTS " +
+			"FOR (p:" + LabelPrompt + ") ON (p.node_key)"},
+		{Statement: "CREATE INDEX hive_tool_key IF NOT EXISTS " +
+			"FOR (t:" + LabelTool + ") ON (t.node_key)"},
+		{Statement: "CREATE INDEX hive_skill_key IF NOT EXISTS " +
+			"FOR (s:" + LabelSkill + ") ON (s.node_key)"},
+	}
+}

--- a/gateway/plans/agent-catalog.md
+++ b/gateway/plans/agent-catalog.md
@@ -245,8 +245,9 @@ Returns the merged view across all sources for one agent.
 ```
 
 Go response structs live in `internal/adminapi/` and are mirrored into
-`ui/src/api/types.ts` (eventually tygo-generated), per the UI's
-"add a new page" checklist in `ui/AGENTS.md`.
+`internal/adminapi/ui/src/api/types.ts` (eventually tygo-generated),
+per the UI's "add a new page" checklist in
+`internal/adminapi/ui/AGENTS.md`.
 
 ## UI changes
 
@@ -260,8 +261,8 @@ existing budget card:
   schema.
 - **Skills** — table: name, description, source.
 
-Wiring per `ui/AGENTS.md`: one `useAgentCatalog(name)` hook in
-`api/queries.ts` (slow cadence — catalog changes on deploy, not per
+Wiring per `internal/adminapi/ui/AGENTS.md`: one `useAgentCatalog(name)`
+hook in `api/queries.ts` (slow cadence — catalog changes on deploy, not per
 second), types in `api/types.ts`, no new route (same page). The
 `/agents` list can later show small count badges (📄 prompts, 🔧 tools,
 ✦ skills) sourced from a lightweight `GET /_plugin/agents/catalog/summary`,
@@ -283,6 +284,44 @@ this swarm") instead of erroring.
 None of these require schema changes in the source systems for v1 — hive
 already has the data in `agent_logs.config`; the others enumerate what
 they load at startup.
+
+## Addendum: the catalog as authoritative registry (implemented)
+
+The original framing above treats the catalog as *descriptive*. In
+practice it has become the **registry of record** for which agents
+exist on a swarm and what model each defaults to. Two concrete
+deltas landed:
+
+### `default_model` on the agent node
+
+Each `HiveAgent` now carries a `default_model` scalar — the default
+LLM used for that agent (a model id or shortcut string, e.g.
+`claude-sonnet-4-6`). It flows through `POST /_plugin/agents`
+(`agents[].default_model`), is stored on the node, and is returned by
+`GET /:name/catalog` (`default_model`) and surfaced as a chip on the
+agent page. Like `display_name`/`description`, it is set only when the
+push supplies a non-empty value (a blank push never clobbers it).
+
+### Hive seeds the default agent set
+
+Hive's `BIFROST_AGENT_NAMES` stays the compile-time source of truth for
+*which* agents exist (every LLM call site is typed against it). On the
+first LLM call per swarm, Hive's orchestrator pushes those names — with
+display name, description, and `default_model` — to the swarm's gateway
+via `POST /_plugin/agents` (`source="hive"`). The two join by name; the
+catalog owns the *capabilities* (prompts/tools/skills), authored later.
+
+The push is **content-addressed**: Hive hashes the default-agent
+manifest and stamps it on `Swarm.bifrostAgentsSeedHash`. A cache hit is
+a single DB read with no HTTP; the manifest re-seeds only when the set
+or a default model changes. It rides the same lazy, best-effort,
+per-workspace-locked path as the trust reconciler
+(`ensureBifrostAgentCatalog`, mirroring `ensureBifrostTrust`); a `503`
+(neo4j unset on the swarm) is a benign skip, and any failure is logged
+and swallowed so a stale catalog never blocks an LLM call.
+
+User-authored agents and SPA-side editing remain future work — for now
+Hive is the only writer and the default set is the whole catalog.
 
 ## Reconciliation & staleness
 


### PR DESCRIPTION
## What

Adds a **neo4j-backed catalog of what each agent _is_** — its prompts, tools, skills, and **default model** — surfaced on the gateway admin dashboard alongside the existing cost/budget view. Companion to `gateway/plans/agent-catalog.md`.

The catalog answers *"what is this agent made of?"* (and now *"which model does it default to?"*), as opposed to the budget view's *"what is it allowed to spend?"*. Sources push manifests to the gateway; **only the gateway holds the neo4j credential** and owns the upsert.

## How

- **`internal/graphclient`** (new) — thin HTTP client for neo4j's native transactional Cypher endpoint (`/db/<db>/tx/commit`, Basic auth). No bolt driver, no third-party deps. `Hive*` label/rel constants + indexes-on-first-write in `schema.go`.
- **`internal/env`** — `Neo4jHTTPConfigValue() (cfg, ok)`; password-gated exactly like Redis's observability mode (endpoints return `503` and the UI hides the tabs when neo4j is unconfigured).
- **`POST /_plugin/agents`** (bearer) — whole-fleet, **replace-by-source** upsert with deterministic `node_key` hashing for idempotency. Carries `default_model` on the agent node.
- **`GET /_plugin/agents/:name/catalog`** (cookie-or-bearer) — merged view across all contributing sources. Folded into the existing `/_plugin/agents/` subtree dispatcher next to the budget handler; `POST /_plugin/agents` (exact) registered separately so ServeMux doesn't 301 it.
- **UI** — Prompts (collapsible, role-badged) / Tools (expandable JSON schema) / Skills tabs on `AgentDetail`, a default-model chip by the agent name, and a `useAgentCatalog` hook (404 → empty tabs, 503 → "catalog not wired").

## Data model

```
(:HiveAgent { name, display_name, description, default_model, updated_at })
   -[:HAS_PROMPT]-> (:HivePrompt { node_key, name, role, body, source, version, updated_at })
   -[:HAS_TOOL]->   (:HiveTool   { node_key, ... })
   -[:HAS_SKILL]->  (:HiveSkill  { node_key, ... })
   -[:DEFINED_BY]-> (:HiveSource { name, updated_at })
```

`Hive*`-prefixed labels never collide with the generic `Agent`/`Prompt`/… nodes other systems push, and deliberately omit `Data_Bank` so the catalog never pollutes mcp's code search.

## Testing

- `catalog_integration_test.go` exercises write → read → idempotent re-push → multi-source merge → 404, end-to-end against a **live neo4j** (gated by `RUN_NEO4J_TESTS`, so default `go test` stays hermetic). Verified locally; the `Hive*` constraint + indexes get created on first write.
- Existing adminapi tests pass; `tsc -b --noEmit` + `npm run build` clean.

## Companion PR

Hive seeds the default agent set (names + `default_model`) into this catalog — see the matching stakwork/hive PR.