### PR TITLE
feat(gateway): list catalog agents and union them into /agents

### DIFF
--- a/gateway/internal/adminapi/catalog.go
+++ b/gateway/internal/adminapi/catalog.go
@@ -84,6 +84,29 @@ type AgentCatalogResponse struct {
 	Skills       []CatalogSkill  `json:"skills"`
 }
 
+// CatalogAgentSummary is one row of the catalog list — enough to merge
+// the registry into the spend-derived /agents table without pulling
+// every agent's full prompt/tool/skill bodies. Counts let the list
+// render "📄 2 · 🔧 5 · ✦ 1" badges cheaply.
+type CatalogAgentSummary struct {
+	Name         string   `json:"name"`
+	DisplayName  string   `json:"display_name,omitempty"`
+	Description  string   `json:"description,omitempty"`
+	DefaultModel string   `json:"default_model,omitempty"`
+	Sources      []string `json:"sources"`
+	Prompts      int      `json:"prompts"`
+	Tools        int      `json:"tools"`
+	Skills       int      `json:"skills"`
+	UpdatedAt    string   `json:"updated_at"`
+}
+
+// CatalogListResponse is the whole registry — every HiveAgent node,
+// traffic or not. The UI unions this with spend-by-agent so seeded
+// agents that have never been invoked still appear.
+type CatalogListResponse struct {
+	Agents []CatalogAgentSummary `json:"agents"`
+}
+
 type CatalogPrompt struct {
 	Name      string `json:"name"`
 	Role      string `json:"role"`
@@ -220,6 +243,31 @@ func (h *catalogHandlers) read(w http.ResponseWriter, r *http.Request) {
 	}
 	if !found {
 		writeError(w, http.StatusNotFound, "not_found", "no catalog for agent")
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// list handles GET /_plugin/agents/catalog — cookie-or-bearer. Returns
+// every agent in the registry with child counts, so the /agents list
+// can union the catalog with spend-derived agents (seeded agents that
+// have never produced traffic still show up). Empty registry returns
+// an empty array, not 404 — "no agents seeded yet" is a normal state.
+func (h *catalogHandlers) list(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		methodNotAllowed(w, http.MethodGet)
+		return
+	}
+	if h.graph == nil {
+		writeError(w, http.StatusServiceUnavailable, "catalog_unavailable",
+			"agent catalog not configured (neo4j unset on this swarm)")
+		return
+	}
+
+	out, err := h.fetchCatalogList(r.Context())
+	if err != nil {
+		pluginlog.Errf("adminapi: catalog list: %v", err)
+		writeError(w, http.StatusBadGateway, "catalog_read_failed", "neo4j read failed")
 		return
 	}
 	writeJSON(w, http.StatusOK, out)
@@ -389,6 +437,47 @@ func unwindCreate(rel, label, agentName, now string, rows []map[string]any, prop
 
 // ─── read builder ────────────────────────────────────────────────────
 
+// fetchCatalogList returns every agent with child counts in one query.
+// Counts are done with COUNT{} subqueries per kind so the row count
+// stays one-per-agent (no cartesian fan-out), and source names are
+// collected the same way.
+func (h *catalogHandlers) fetchCatalogList(ctx context.Context) (*CatalogListResponse, error) {
+	cypher := fmt.Sprintf(
+		"MATCH (a:%[1]s) "+
+			"RETURN a.name, a.display_name, a.description, a.default_model, "+
+			"COUNT { (a)-[:%[2]s]->(:%[3]s) } AS prompts, "+
+			"COUNT { (a)-[:%[4]s]->(:%[5]s) } AS tools, "+
+			"COUNT { (a)-[:%[6]s]->(:%[7]s) } AS skills, "+
+			"[ (a)-[:%[8]s]->(s:%[9]s) | s.name ] AS sources, "+
+			"a.updated_at "+
+			"ORDER BY coalesce(a.display_name, a.name)",
+		graphclient.LabelAgent,
+		graphclient.RelHasPrompt, graphclient.LabelPrompt,
+		graphclient.RelHasTool, graphclient.LabelTool,
+		graphclient.RelHasSkill, graphclient.LabelSkill,
+		graphclient.RelDefinedBy, graphclient.LabelSource,
+	)
+	res, err := h.graph.Query(ctx, cypher, nil)
+	if err != nil {
+		return nil, err
+	}
+	out := &CatalogListResponse{Agents: []CatalogAgentSummary{}}
+	for _, row := range res.Data {
+		out.Agents = append(out.Agents, CatalogAgentSummary{
+			Name:         rowString(at(row.Row, 0)),
+			DisplayName:  rowString(at(row.Row, 1)),
+			Description:  rowString(at(row.Row, 2)),
+			DefaultModel: rowString(at(row.Row, 3)),
+			Prompts:      rowInt(at(row.Row, 4)),
+			Tools:        rowInt(at(row.Row, 5)),
+			Skills:       rowInt(at(row.Row, 6)),
+			Sources:      rowStrings(at(row.Row, 7)),
+			UpdatedAt:    rowString(at(row.Row, 8)),
+		})
+	}
+	return out, nil
+}
+
 // fetchCatalog runs one tx/commit batch of five statements (existence
 // + scalars, sources, prompts, tools, skills) and assembles the merged
 // view. Separate statements rather than one big OPTIONAL MATCH avoid
@@ -520,6 +609,33 @@ func rowString(raw json.RawMessage) string {
 		return ""
 	}
 	return s
+}
+
+// rowInt decodes a single returned cell into an int. neo4j integers
+// arrive as JSON numbers; null / garbage ⇒ 0.
+func rowInt(raw json.RawMessage) int {
+	if len(raw) == 0 {
+		return 0
+	}
+	var n int
+	if err := json.Unmarshal(raw, &n); err != nil {
+		return 0
+	}
+	return n
+}
+
+// rowStrings decodes a returned cell that is a JSON array of strings
+// (e.g. a Cypher list comprehension of source names). null / garbage
+// ⇒ empty slice.
+func rowStrings(raw json.RawMessage) []string {
+	if len(raw) == 0 {
+		return []string{}
+	}
+	var ss []string
+	if err := json.Unmarshal(raw, &ss); err != nil {
+		return []string{}
+	}
+	return ss
 }
 
 // at returns the i-th cell of a row, or empty when the RETURN clause

--- a/gateway/internal/adminapi/catalog_integration_test.go
+++ b/gateway/internal/adminapi/catalog_integration_test.go
@@ -123,6 +123,37 @@ func TestCatalogIntegration(t *testing.T) {
 
 	// ── 404 for unknown agent ──
 	doRead(t, cat, "no-such-agent-xyz", http.StatusNotFound)
+
+	// ── list includes our agent with correct counts ──
+	req := httptest.NewRequest(http.MethodGet, "/_plugin/agents/catalog", nil)
+	rec := httptest.NewRecorder()
+	cat.list(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("list status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var list CatalogListResponse
+	if err := json.Unmarshal(rec.Body.Bytes(), &list); err != nil {
+		t.Fatalf("list decode: %v", err)
+	}
+	var row *CatalogAgentSummary
+	for i := range list.Agents {
+		if list.Agents[i].Name == agent {
+			row = &list.Agents[i]
+		}
+	}
+	if row == nil {
+		t.Fatalf("list missing %q (got %d agents)", agent, len(list.Agents))
+	}
+	if row.DefaultModel != "sonnet" {
+		t.Errorf("list default_model = %q", row.DefaultModel)
+	}
+	if row.Prompts != 2 || row.Tools != 2 || row.Skills != 1 {
+		t.Errorf("list counts = p%d t%d s%d, want p2 t2 s1",
+			row.Prompts, row.Tools, row.Skills)
+	}
+	if len(row.Sources) != 2 {
+		t.Errorf("list sources = %v, want hive + prompt-manager", row.Sources)
+	}
 }
 
 func doPush(t *testing.T, cat *catalogHandlers, body any) catalogWriteResponse {

--- a/gateway/internal/adminapi/server.go
+++ b/gateway/internal/adminapi/server.go
@@ -283,6 +283,13 @@ func registerRoutes(mux *http.ServeMux, deps routeDeps) {
 	agentsSubtree := func(w http.ResponseWriter, r *http.Request) {
 		rest := strings.TrimPrefix(r.URL.Path, "/_plugin/agents/")
 		parts := strings.Split(rest, "/")
+		// `/_plugin/agents/catalog` (single segment) is the catalog
+		// list — every registry agent, traffic or not. Distinct from
+		// `<name>/catalog` (two segments) which is one agent's detail.
+		if len(parts) == 1 && parts[0] == "catalog" {
+			cat.list(w, r)
+			return
+		}
 		if len(parts) == 2 && parts[0] != "" && parts[1] == "catalog" {
 			cat.read(w, r)
 			return

--- a/gateway/internal/adminapi/ui/dist/index.html
+++ b/gateway/internal/adminapi/ui/dist/index.html
@@ -5,8 +5,8 @@
     <meta name="viewport" content="width=1280" />
     <meta name="color-scheme" content="dark" />
     <title>Agent Mothership</title>
-    <script type="module" crossorigin src="/_plugin/ui/assets/index-CQFO5_FQ.js"></script>
-    <link rel="stylesheet" crossorigin href="/_plugin/ui/assets/index-BtmCFt7S.css">
+    <script type="module" crossorigin src="/_plugin/ui/assets/index-hPiEX19Z.js"></script>
+    <link rel="stylesheet" crossorigin href="/_plugin/ui/assets/index-o3GB2jE-.css">
   </head>
   <body>
     <div id="root"></div>

--- a/gateway/internal/adminapi/ui/src/api/queries.ts
+++ b/gateway/internal/adminapi/ui/src/api/queries.ts
@@ -9,6 +9,7 @@ import { apiFetch, ApiCallError } from "./client";
 import type {
   AgentBudgetResponse,
   AgentCatalogResponse,
+  CatalogListResponse,
   CallDetailResponse,
   HistogramCostResponse,
   MeResponse,
@@ -177,6 +178,32 @@ export function useAgentBudgets(names: string[]) {
     out[n] = queries[i]?.data;
   });
   return out;
+}
+
+// ─── /agents/catalog (list) ─────────────────────────────────────────
+//
+// The whole registry — every catalog agent, traffic or not. The Agents
+// list page unions this with spend-by-agent so seeded agents that have
+// never been invoked still appear. Slow cadence (changes on deploy).
+// 503 (neo4j not wired) ⇒ null; the page falls back to spend-only.
+
+export function useAgentCatalogList() {
+  return useQuery({
+    queryKey: ["agents", "catalog-list"],
+    queryFn: async (): Promise<CatalogListResponse | null> => {
+      try {
+        return await apiFetch<CatalogListResponse>("/agents/catalog");
+      } catch (e) {
+        if (e instanceof ApiCallError && e.status === 503) {
+          return null; // catalog not configured on this swarm
+        }
+        throw e;
+      }
+    },
+    staleTime: 5 * 60_000,
+    refetchInterval: 5 * 60_000,
+    retry: false,
+  });
 }
 
 // ─── /agents/:name/catalog ──────────────────────────────────────────

--- a/gateway/internal/adminapi/ui/src/api/types.ts
+++ b/gateway/internal/adminapi/ui/src/api/types.ts
@@ -347,6 +347,26 @@ export interface CatalogSkill {
   updated_at: string;
 }
 
+// One row of the catalog list (GET /_plugin/agents/catalog) — identity
+// + child counts, enough to merge the registry into the spend-derived
+// /agents table without pulling every prompt/tool/skill body.
+export interface CatalogAgentSummary {
+  name: string;
+  display_name?: string;
+  description?: string;
+  default_model?: string;
+  sources: string[];
+  prompts: number;
+  tools: number;
+  skills: number;
+  updated_at: string;
+}
+
+// The whole registry — every catalog agent, traffic or not.
+export interface CatalogListResponse {
+  agents: CatalogAgentSummary[];
+}
+
 // Merged catalog view across all contributing sources for one agent.
 export interface AgentCatalogResponse {
   name: string;

--- a/gateway/internal/adminapi/ui/src/pages/Agents.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/Agents.tsx
@@ -1,8 +1,8 @@
-// Agents — full table of observed agents in the window.
-//
-// Phase 8 doesn't render kill switches, budget editors, or current-
-// bucket spend (all phase 9). Just name + spend + tokens + calls,
-// each row linking to AgentDetail.
+// Agents — full table of agents: the union of the neo4j registry
+// (every catalog agent, traffic or not) and spend-derived agents
+// (anything that produced calls in the window). A seeded agent with
+// no traffic still shows; an agent with traffic but no catalog entry
+// still shows (tagged "traffic only"). Each row links to AgentDetail.
 
 import { useMemo, useState } from "preact/hooks";
 import { Link, useLocation } from "wouter-preact";
@@ -10,8 +10,28 @@ import { Link, useLocation } from "wouter-preact";
 import { DataTable } from "../components/tables/DataTable";
 import { WindowPicker } from "../components/controls/WindowPicker";
 import { getErrorMessage } from "../api/client";
-import { useAgentBudgets, useSpendByAgent } from "../api/queries";
-import type { AgentSpend, Window } from "../api/types";
+import {
+  useAgentBudgets,
+  useAgentCatalogList,
+  useSpendByAgent,
+} from "../api/queries";
+import type { Window } from "../api/types";
+
+// A merged agent row: spend metrics (zeroed when registry-only) plus
+// catalog identity/counts (absent when traffic-only).
+interface AgentRow {
+  agent_name: string;
+  total_cost: number;
+  total_tokens: number;
+  request_count: number;
+  has_traffic: boolean;
+  in_catalog: boolean;
+  display_name?: string;
+  default_model?: string;
+  prompts: number;
+  tools: number;
+  skills: number;
+}
 
 const fmtUSD = (v: number) => {
   if (v === 0) return "$0.00";
@@ -31,15 +51,58 @@ export function Agents() {
   const [window, setWindow] = useState<Window>("24h");
   const [, setLocation] = useLocation();
   const q = useSpendByAgent(window);
+  const catalog = useAgentCatalogList();
+
+  // Union the registry with spend, keyed by name. Start from the
+  // catalog (so every seeded agent always renders, even at $0), then
+  // overlay spend; spend-only agents with no catalog entry get
+  // appended and tagged `in_catalog: false`.
+  const rows = useMemo<AgentRow[]>(() => {
+    const byName = new Map<string, AgentRow>();
+    for (const a of catalog.data?.agents ?? []) {
+      byName.set(a.name, {
+        agent_name: a.name,
+        total_cost: 0,
+        total_tokens: 0,
+        request_count: 0,
+        has_traffic: false,
+        in_catalog: true,
+        display_name: a.display_name,
+        default_model: a.default_model,
+        prompts: a.prompts,
+        tools: a.tools,
+        skills: a.skills,
+      });
+    }
+    for (const s of q.data?.results ?? []) {
+      const existing = byName.get(s.agent_name);
+      if (existing) {
+        existing.total_cost = s.total_cost;
+        existing.total_tokens = s.total_tokens;
+        existing.request_count = s.request_count;
+        existing.has_traffic = true;
+      } else {
+        byName.set(s.agent_name, {
+          agent_name: s.agent_name,
+          total_cost: s.total_cost,
+          total_tokens: s.total_tokens,
+          request_count: s.request_count,
+          has_traffic: true,
+          in_catalog: false,
+          prompts: 0,
+          tools: 0,
+          skills: 0,
+        });
+      }
+    }
+    return [...byName.values()];
+  }, [catalog.data, q.data]);
 
   // Fan out per-agent budget queries. The list of names comes from
-  // the by-agent query; useMemo so the fan-out doesn't churn on
-  // every render (which would resubscribe the per-row Tanstack
-  // queries and reset their polling clocks).
-  const agentNames = useMemo(
-    () => (q.data?.results ?? []).map((r) => r.agent_name),
-    [q.data]
-  );
+  // the merged rows; useMemo so the fan-out doesn't churn on every
+  // render (which would resubscribe the per-row Tanstack queries and
+  // reset their polling clocks).
+  const agentNames = useMemo(() => rows.map((r) => r.agent_name), [rows]);
   const budgets = useAgentBudgets(agentNames);
 
   return (
@@ -55,9 +118,9 @@ export function Agents() {
       {q.isError ? (
         <div class="error-banner">{getErrorMessage(q.error)}</div>
       ) : (
-        <DataTable<AgentSpend>
-          rows={q.data?.results ?? []}
-          emptyMessage="No agents have produced calls in this window."
+        <DataTable<AgentRow>
+          rows={rows}
+          emptyMessage="No agents in the registry, and none have produced calls in this window."
           onRowClick={(r) =>
             setLocation(`/agents/${encodeURIComponent(r.agent_name)}`)
           }
@@ -66,17 +129,44 @@ export function Agents() {
               key: "agent",
               header: "Agent",
               cell: (r) => (
-                <Link href={`/agents/${encodeURIComponent(r.agent_name)}`}>
-                  {r.agent_name}
-                </Link>
+                <div class="agent-cell">
+                  <Link href={`/agents/${encodeURIComponent(r.agent_name)}`}>
+                    {r.agent_name}
+                  </Link>
+                  {!r.in_catalog ? (
+                    <span class="pill" title="Has traffic but no catalog entry">
+                      traffic only
+                    </span>
+                  ) : r.prompts + r.tools + r.skills > 0 ? (
+                    <span class="cap-badges mono text-dim">
+                      {r.prompts}p · {r.tools}t · {r.skills}s
+                    </span>
+                  ) : null}
+                </div>
               ),
               sort: (r) => r.agent_name,
+            },
+            {
+              key: "model",
+              header: "Model",
+              cell: (r) =>
+                r.default_model ? (
+                  <span class="mono text-dim">{r.default_model}</span>
+                ) : (
+                  <span class="text-dim">—</span>
+                ),
+              sort: (r) => r.default_model ?? "",
             },
             {
               key: "cost",
               header: "Spend",
               align: "num",
-              cell: (r) => fmtUSD(r.total_cost),
+              cell: (r) =>
+                r.has_traffic ? (
+                  fmtUSD(r.total_cost)
+                ) : (
+                  <span class="text-dim">—</span>
+                ),
               sort: (r) => r.total_cost,
             },
             {
@@ -116,11 +206,17 @@ export function Agents() {
               key: "calls",
               header: "Calls",
               align: "num",
-              cell: (r) => fmtInt(r.request_count),
+              cell: (r) =>
+                r.has_traffic ? (
+                  fmtInt(r.request_count)
+                ) : (
+                  <span class="text-dim">—</span>
+                ),
               sort: (r) => r.request_count,
             },
           ]}
-          defaultSortKey="cost"
+          defaultSortKey="agent"
+          defaultSortOrder="asc"
         />
       )}
     </>

--- a/gateway/internal/adminapi/ui/src/styles/components.css
+++ b/gateway/internal/adminapi/ui/src/styles/components.css
@@ -1064,6 +1064,20 @@ table.table {
   font-size: 12px;
 }
 
+/* Agents list: name cell with capability badges / "traffic only" tag. */
+.agent-cell {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.agent-cell .cap-badges {
+  font-size: 11px;
+}
+.agent-cell .pill {
+  font-size: 10px;
+  padding: 1px 6px;
+}
+
 .catalog-list {
   display: flex;
   flex-direction: column;

--- a/gateway/plans/agent-catalog.md
+++ b/gateway/plans/agent-catalog.md
@@ -264,9 +264,9 @@ existing budget card:
 Wiring per `internal/adminapi/ui/AGENTS.md`: one `useAgentCatalog(name)`
 hook in `api/queries.ts` (slow cadence — catalog changes on deploy, not per
 second), types in `api/types.ts`, no new route (same page). The
-`/agents` list can later show small count badges (📄 prompts, 🔧 tools,
-✦ skills) sourced from a lightweight `GET /_plugin/agents/catalog/summary`,
-but that's optional follow-up.
+`/agents` list unions the registry with spend (see below) and shows
+per-agent capability counts + default-model, sourced from
+`GET /_plugin/agents/catalog` (the list endpoint).
 
 When `Neo4jHTTPConfig()` reports not-configured, the read endpoint
 returns `503` and the tabs render an empty-state ("catalog not wired on
@@ -322,6 +322,22 @@ and swallowed so a stale catalog never blocks an LLM call.
 
 User-authored agents and SPA-side editing remain future work — for now
 Hive is the only writer and the default set is the whole catalog.
+
+### List endpoint + `/agents` union
+
+`GET /_plugin/agents/catalog` (cookie-or-bearer) returns every
+`HiveAgent` with child counts (`CatalogAgentSummary`: name, display,
+description, default_model, sources, prompt/tool/skill counts). One
+Cypher query using `COUNT {}` subqueries per kind — one row per agent,
+no cartesian fan-out.
+
+The dashboard's `/agents` page **unions** this with spend-by-agent,
+keyed by name: registry agents always render (at `$0` / `—` when they
+have no traffic in the window), spend-only agents that lack a catalog
+entry still render tagged "traffic only". Without this union a
+seeded-but-never-invoked agent would be invisible — the list was
+previously derived purely from log traffic. When neo4j is unconfigured
+the list endpoint `503`s and the page falls back to spend-only.
 
 ## Reconciliation & staleness
 


### PR DESCRIPTION
## Why

The `/agents` list was built **purely from spend** (`useSpendByAgent` → Bifrost log traffic). Now that the neo4j catalog is the registry of record, that meant:

- a **seeded-but-never-invoked** agent was **invisible** — reachable only by typing `/agents/:name`;
- agents only showed once they'd produced traffic in the selected window.

This unions the registry into the list so every catalog agent always appears.

## How

**Gateway**
- `GET /_plugin/agents/catalog` (cookie-or-bearer) — returns every `HiveAgent` with child counts (`CatalogAgentSummary`: name, display, description, `default_model`, sources, prompt/tool/skill counts). One Cypher query using `COUNT {}` subqueries per kind → one row per agent, no cartesian fan-out.
- Routing: folded into the existing `/_plugin/agents/` subtree dispatcher — single segment `catalog` = list, `<name>/catalog` = detail, `<name>/budget` = budget.

**UI (`Agents.tsx`)**
- Unions catalog + spend keyed by name: start from the registry (so every agent renders, `—`/`$0` when no traffic), overlay spend; spend-only agents with no catalog entry render tagged **"traffic only"**.
- New **Model** column + per-agent capability badges (`Np · Nt · Ns`).
- Default sort is now alphabetical so zero-spend registry agents don't sink to the bottom.
- `useAgentCatalogList` hook; `503` (neo4j unwired) falls back to spend-only.

## Testing

- `catalog_integration_test.go` extended: asserts the agent appears in the list with correct counts, `default_model`, and merged sources. Verified end-to-end against a live neo4j (5.19, `COUNT {}` supported).
- `go test ./internal/adminapi/...`, plugin build, `tsc -b --noEmit`, and `npm run build` all clean.

## Context

Follow-up to #1420 (merged). Makes Hive's seeded default agents (stakwork/hive#4601, merged) visible in the dashboard immediately, before any calls.