### PR TITLE
fix(gateway): bump Bifrost to transports/v1.6.1 for Anthropic web_search

### DIFF
--- a/gateway/Dockerfile
+++ b/gateway/Dockerfile
@@ -23,7 +23,7 @@
 # core version comes along via go.work / replace directives in the tree.
 ARG GO_VERSION=1.26.4
 ARG NODE_VERSION=25
-ARG BIFROST_VERSION=transports/v1.5.11
+ARG BIFROST_VERSION=transports/v1.6.1
 
 # ---------------------------------------------------------------------------
 # Stage 0: clone bifrost source once and share via subsequent stages.


### PR DESCRIPTION
## Problem

`web_search` works locally (direct to `api.anthropic.com`) but returns immediately in prod, where LLM calls route through our Bifrost gateway. The stream ends right after the tool call with `finishReason: "tool-calls"` and the search never executes:

```
tool-input-available (web_search) → finish-step → finish (tool-calls) → [DONE]
```

## Root cause

`web_search` is Anthropic's **server-side** provider tool (`web_search_20250305`) — Anthropic executes it and continues the turn. Hive's `@ai-sdk/anthropic` requests go through Bifrost's **conversion pipeline** (the raw-passthrough path only engages for `claude-code` User-Agents, which we don't send).

At the pinned `transports/v1.5.11`, the Responses-pipeline streaming reconstruction of `server_tool_use` + `web_search_tool_result` blocks was incomplete. The streamed-back SSE looked like a terminal **client** `tool_use`, so the SDK reported `finishReason: "tool-calls"` and stopped.

`transports/v1.6.1` substantially rewrote that stream state machine (new `WebSearchQuery` / `WebSearchCaller` state, input-JSON buffering, correct `server_tool_use` pairing).

## Change

Bump `BIFROST_VERSION` `transports/v1.5.11` → `transports/v1.6.1` in `gateway/Dockerfile`.

## Compatibility (verified statically against both tags)

- **Build**: same `GO_VERSION=1.26.4`; UI `outDir` still `out`; `build-enterprise` script present (now also runs `typecheck`).
- **Plugin**: all `core/schemas` symbols the plugin imports still exist; `HTTPTransportPreHook/PostHook/StreamChunkHook` signatures and `HTTPRequest`/`HTTPResponse`/`BifrostStreamChunk` structs unchanged (plugin.go diff is comments only).

## Testing notes

- [ ] CI builds the image (first build of the `.so` plugin against bumped `core` — `go mod tidy` adapts, watch this step).
- [ ] Confirm the deployed container reports v1.6.1 (`/app/BIFROST_COMMIT`, `main.Version`) — the running image may even predate v1.5.11.
- [ ] Smoke test `web_search` through the gateway: expect `web_search_tool_result` + normal end-of-turn instead of an immediate `tool-calls` finish.

Fallback if v1.6.1 still misbehaves: force raw passthrough by sending `user-agent: claude-code` on Bifrost-routed Anthropic calls (bypasses the conversion pipeline entirely).