### PR TITLE
fix(gateway): bump core to v1.6.1 to match BIFROST_VERSION

### DIFF
--- a/gateway/go.mod
+++ b/gateway/go.mod
@@ -6,7 +6,7 @@ go 1.26.4
 // point at the local bifrost checkout — this guarantees the plugin and
 // bifrost-http compile against byte-identical core sources, which Go's
 // plugin loader requires.
-require github.com/maximhq/bifrost/core v1.5.18
+require github.com/maximhq/bifrost/core v1.6.1
 
 require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1


### PR DESCRIPTION
## Problem

```
ERR failed to load plugin stakgraph-gateway: failed to load custom plugin:
plugin.Open("/app/plugins/stakgraph-gateway"): plugin was built with a
different version of package github.com/maximhq/bifrost/core/schemas
```

After #1422 bumped `BIFROST_VERSION` to `transports/v1.6.1`, `bifrost-http` started compiling `core` with the version label **`v1.6.1`**. But `gateway/go.mod` still required `core v1.5.18`, so the plugin embedded the label **`v1.5.18`**.

Even though the Docker `replace` directive points both builds at byte-identical `/src/core` source, Go's plugin loader bakes the **module version string** into each package's fingerprint. The mismatched labels made `core/schemas` fingerprints differ → plugin fails to load.

It worked before the bump because `transports/v1.5.11` also required `core v1.5.18` — the labels happened to match. This is the lockstep the comment in `go.mod` warns about.

## Fix

Bump `core` to `v1.6.1` in `gateway/go.mod`. The other pinned transitive versions (sonic, fasthttp, go-redis, mcp-go, etc.) were diff-checked against the `v1.6.1` release and already match — no other changes needed.

## Verification

Full Docker build + container start:

- **Before:** `plugin status: stakgraph-gateway - error` (schemas mismatch)
- **After:** `plugin status: stakgraph-gateway - active`, `Init called`