### PR TITLE
feat(gitree): direct PullRequest -> File edges

### DIFF
--- a/mcp/src/gitree/fileLinker.ts
+++ b/mcp/src/gitree/fileLinker.ts
@@ -47,9 +47,19 @@ export class FileLinker {
 
     const result = await this.storage.linkConceptsToFiles(undefined, repo);
 
+    // Also create direct PullRequest -> File edges (deterministic, repo-scoped).
+    // This runs in the same bulk pass so both normal ingestion and manual
+    // re-linking (backfill) keep PR->File edges in sync with no extra wiring.
+    const prLink = await this.storage.linkPRsToFiles(repo);
+    result.prsProcessed = prLink.prsProcessed;
+    result.prFileEdges = prLink.edgesLinked;
+
     console.log(`\n✅ Done linking files!`);
     console.log(`   Concepts processed: ${result.conceptsProcessed}`);
     console.log(`   Total files linked: ${result.filesLinked}`);
+    console.log(
+      `   Direct PR→File edges: ${prLink.edgesLinked} across ${prLink.prsProcessed} PRs`
+    );
     console.log(
       `   📚 ${result.filesInDocs} in documentation (importance 0.5-1.0)`
     );

--- a/mcp/src/gitree/store/fileSystemStorage.ts
+++ b/mcp/src/gitree/store/fileSystemStorage.ts
@@ -585,6 +585,12 @@ export class FileSystemStore extends Storage {
     );
   }
 
+  async linkPRsToFiles(_repo?: string): Promise<{ prsProcessed: number; edgesLinked: number }> {
+    throw new Error(
+      "PR-File linking is only supported with GraphStorage. Use --graph flag."
+    );
+  }
+
   // Get Files for Concept (not supported in FileSystemStorage)
   async getFilesForConcept(_conceptId: string, _expand?: string[]): Promise<any[]> {
     throw new Error(

--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -150,6 +150,67 @@ export class GraphStorage extends Storage {
     } finally {
       await session.close();
     }
+
+    // Backfill direct PR->File edges if none exist yet (runs once per DB).
+    await this.backfillPRFileEdges();
+  }
+
+  /**
+   * One-time backfill of direct `PullRequest -[:MODIFIES]-> File` edges.
+   *
+   * Runs on every `initialize()` but short-circuits cheaply: if any such edge
+   * already exists we assume the backfill has happened and do nothing. This
+   * lets every graph server pick up the direct PR->File edges automatically on
+   * boot without an operator having to run the link command manually.
+   *
+   * `linkPRsToFiles()` scopes matching per-PR by repo, so this is safe across
+   * multi-repo swarms.
+   */
+  private async backfillPRFileEdges(): Promise<void> {
+    const session = this.resilientSession();
+    let shouldRun = false;
+    try {
+      // Cheap existence guard (short-circuits, no full scan).
+      const check = await session.run(`
+        RETURN EXISTS { MATCH (:PullRequest)-[:MODIFIES]->(:File) } AS hasEdge
+      `);
+      const hasEdge = check.records[0]?.get("hasEdge") ?? false;
+      if (hasEdge) {
+        return; // Already backfilled.
+      }
+
+      // Only bother if there are PRs with files to link.
+      const prCheck = await session.run(`
+        MATCH (p:PullRequest) WHERE p.files IS NOT NULL AND size(p.files) > 0
+        RETURN count(p) AS prCount
+      `);
+      const prCount = prCheck.records[0]?.get("prCount")?.toNumber?.() ?? 0;
+      if (prCount === 0) {
+        return; // Nothing to link yet.
+      }
+
+      console.log(
+        `===> PR→File backfill: no direct PR→File edges found, linking ${prCount} PR(s) with files...`
+      );
+      shouldRun = true;
+    } catch (error) {
+      console.error("===> PR→File backfill: guard check failed:", error);
+      return;
+    } finally {
+      await session.close();
+    }
+
+    if (!shouldRun) return;
+
+    try {
+      const result = await this.linkPRsToFiles();
+      console.log(
+        `===> PR→File backfill: Complete! Created ${result.edgesLinked} edge(s) across ${result.prsProcessed} PR(s).`
+      );
+    } catch (error) {
+      // Don't throw - allow app to continue even if backfill fails.
+      console.error("===> PR→File backfill: Error during backfill:", error);
+    }
   }
   
   /**
@@ -1847,6 +1908,51 @@ export class GraphStorage extends Storage {
       }
 
       return totalLinked;
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Create direct PullRequest -[:MODIFIES]-> File edges from each PR's stored
+   * `files` array.
+   *
+   * This is fully deterministic (no LLM): it re-projects the file paths already
+   * persisted on every PR node onto the corresponding File nodes. It is safe to
+   * run incrementally after ingestion and as a one-shot backfill for existing
+   * PRs (MERGE makes it idempotent).
+   *
+   * Repo scoping is intrinsic to each PR node: File matching is constrained to
+   * `file.file STARTS WITH p.repo + '/'`, so even a global run (repo = undefined)
+   * will not cross-link Files from a different repo in a multi-repo swarm.
+   * Legacy PRs without a `repo` fall back to the unscoped suffix match.
+   */
+  async linkPRsToFiles(repo?: string): Promise<{ prsProcessed: number; edgesLinked: number }> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(
+        `
+        MATCH (p:PullRequest)
+        WHERE p.files IS NOT NULL
+          AND size(p.files) > 0
+          AND ($repo IS NULL OR p.repo = $repo)
+        UNWIND p.files AS filePath
+        MATCH (file:File)
+        WHERE file.file ENDS WITH filePath
+          AND (p.repo IS NULL OR file.file STARTS WITH p.repo + '/')
+        MERGE (p)-[:MODIFIES]->(file)
+        RETURN count(DISTINCT p) AS prsProcessed, count(*) AS edgesLinked
+        `,
+        { repo: repo || null }
+      );
+
+      const rec = result.records[0];
+      const prsProcessed = rec?.get("prsProcessed");
+      const edgesLinked = rec?.get("edgesLinked");
+      return {
+        prsProcessed: prsProcessed?.toNumber ? prsProcessed.toNumber() : prsProcessed || 0,
+        edgesLinked: edgesLinked?.toNumber ? edgesLinked.toNumber() : edgesLinked || 0,
+      };
     } finally {
       await session.close();
     }

--- a/mcp/src/gitree/store/storage.ts
+++ b/mcp/src/gitree/store/storage.ts
@@ -79,6 +79,12 @@ export abstract class Storage {
   // Link a concept to files by explicit file paths (used by bootstrap)
   abstract linkConceptToFilesByPaths(conceptId: string, filePaths: string[]): Promise<number>;
 
+  // Direct PR->File Linking (deterministic, based on each PR's `files` array).
+  // Scopes matching to each PR's own repo, so a repo-less (null) `repo` arg is
+  // still safe to run across a multi-repo swarm. Used both incrementally after
+  // ingestion and as a backfill for existing PRs.
+  abstract linkPRsToFiles(repo?: string): Promise<{ prsProcessed: number; edgesLinked: number }>;
+
   // Get Files for Concept
   abstract getFilesForConcept(conceptId: string, expand?: string[]): Promise<any[]>;
 

--- a/mcp/src/gitree/types.ts
+++ b/mcp/src/gitree/types.ts
@@ -13,6 +13,9 @@ export interface LinkResult {
     filesInDocs: number;
     filesNotInDocs: number;
   }>;
+  // Direct PullRequest -> File linking (populated by bulk linking)
+  prsProcessed?: number;
+  prFileEdges?: number;
 }
 
 /**


### PR DESCRIPTION
## What

Adds direct `PullRequest -[:MODIFIES]-> File` edges to the gitree graph so the graph-walker can find a feature/PR and know directly which files are relevant to edit — without having to hop through a `Concept`.

Previously the only path was `PR -(TOUCHES)-> Concept -(MODIFIES)-> File`. Concept→File links exist, but there was no direct edge from a PR to the files it changed.

## How

- **`linkPRsToFiles(repo?)`** (`graphStorage.ts`): deterministic, no LLM. Re-projects each PR's already-stored `files` array onto `File` nodes via the same path-matching used for Concept→File.
- **Repo-safe by construction**: matching is scoped per-PR with `file.file STARTS WITH p.repo + '/'`, so even a global run (no `repo` arg) will never cross-link Files from another repo in a multi-repo swarm. Legacy PRs without a repo fall back to the existing unscoped suffix match.
- **Kept in sync**: wired into `FileLinker.linkAllConcepts`, so both normal ingestion (the `link` flag) and manual re-linking create/refresh these edges. `MERGE` makes it idempotent.
- **Auto-backfill on boot**: `GraphStorage.initialize()` now calls `backfillPRFileEdges()`, guarded by an `EXISTS { (:PullRequest)-[:MODIFIES]->(:File) }` check so it runs once per DB with zero operator action. Non-fatal (logs on failure, won't block startup).
- **`FileSystemStorage`**: no-op throw (mirrors the other linkers).
- **`LinkResult`**: gains optional `prsProcessed` / `prFileEdges`.

## Notes

- Reuses the `MODIFIES` edge type. Walker traversal is unchanged for now (still Concept-centric); the edges exist in the graph but aren't yet surfaced by the depth filter — easy follow-up if we want the walker to start from / traverse PRs.
- `EXISTS { ... }` subquery form is already used in the project and supported on the pinned Neo4j 5.19.

## Test plan

- [x] `tsc --noEmit` passes
- [ ] Boot a graph server with existing PRs + ingested File nodes; confirm backfill logs and creates edges once, then short-circuits on subsequent boots