### PR TITLE
gateway: link agent catalog to existing :Prompt nodes

### DIFF
--- a/gateway/internal/adminapi/catalog.go
+++ b/gateway/internal/adminapi/catalog.go
@@ -38,10 +38,13 @@ type catalogPushAgent struct {
 	Skills       []catalogPushSkill  `json:"skills"`
 }
 
+// catalogPushPrompt references an existing `:Prompt` node by name. The
+// gateway does NOT store a prompt body — the body lives on the shared
+// `:Prompt` node (authored by the Stakwork prompt workflow). A push
+// carries only the name so the gateway can wire HiveAgent-[:HAS_PROMPT]
+// ->Prompt; a name with no matching node is skipped silently.
 type catalogPushPrompt struct {
 	Name   string `json:"name"`
-	Role   string `json:"role"`
-	Body   string `json:"body"`
 	Source string `json:"source"` // optional per-item source override
 }
 
@@ -107,12 +110,13 @@ type CatalogListResponse struct {
 	Agents []CatalogAgentSummary `json:"agents"`
 }
 
+// CatalogPrompt is one prompt linked to an agent. name/body come from
+// the shared `:Prompt` node the agent links to; source/updated_at come
+// from the HAS_PROMPT relationship (which system wired it, and when).
 type CatalogPrompt struct {
 	Name      string `json:"name"`
-	Role      string `json:"role"`
 	Body      string `json:"body"`
 	Source    string `json:"source"`
-	Version   string `json:"version,omitempty"`
 	UpdatedAt string `json:"updated_at"`
 }
 
@@ -331,17 +335,15 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 		// is cleared). Children owned by *other* sources survive.
 		sourceSet := map[string]struct{}{req.Source: {}}
 
+		// Prompts are links to existing `:Prompt` nodes, not owned
+		// children — we carry only the name + the wiring source.
 		prompts := make([]map[string]any, 0, len(ag.Prompts))
 		for _, p := range ag.Prompts {
 			src := srcOr(p.Source)
 			sourceSet[src] = struct{}{}
 			prompts = append(prompts, map[string]any{
-				"node_key": nodeKey(ag.Name, src, "prompt", p.Name),
-				"name":     p.Name,
-				"role":     p.Role,
-				"body":     p.Body,
-				"source":   src,
-				"version":  ag.Version,
+				"name":   p.Name,
+				"source": src,
 			})
 		}
 		tools := make([]map[string]any, 0, len(ag.Tools))
@@ -376,11 +378,19 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 		}
 
 		counts.Agents++
+		// Prompt count is the number of links *requested*; a name with
+		// no matching `:Prompt` node is skipped, so the live link count
+		// may be lower. Reads report the true linked set.
 		counts.Prompts += len(prompts)
 		counts.Tools += len(tools)
 		counts.Skills += len(skills)
 
 		stmts = append(stmts,
+			// 1. Upsert the agent + source + DEFINED_BY, then clear this
+			//    push's sources' owned tool/skill child nodes.
+			//    Prompt links are handled separately (statement 2) because
+			//    the linked `:Prompt` nodes are shared and must survive —
+			//    only the HAS_PROMPT relationship is replaced.
 			graphclient.Statement{
 				Statement: fmt.Sprintf(
 					"MERGE (a:%[1]s {name: $name}) "+
@@ -391,10 +401,10 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 						"MERGE (s:%[2]s {name: $source}) SET s.updated_at = $now "+
 						"MERGE (a)-[:%[3]s]->(s) "+
 						"WITH a "+
-						"OPTIONAL MATCH (a)-[:%[4]s|%[5]s|%[6]s]->(c) WHERE c.source IN $sources "+
+						"OPTIONAL MATCH (a)-[:%[4]s|%[5]s]->(c) WHERE c.source IN $sources "+
 						"DETACH DELETE c",
 					graphclient.LabelAgent, graphclient.LabelSource, graphclient.RelDefinedBy,
-					graphclient.RelHasPrompt, graphclient.RelHasTool, graphclient.RelHasSkill),
+					graphclient.RelHasTool, graphclient.RelHasSkill),
 				Parameters: map[string]any{
 					"name":          ag.Name,
 					"display_name":  ag.DisplayName,
@@ -405,8 +415,38 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 					"now":           now,
 				},
 			},
-			unwindCreate(graphclient.RelHasPrompt, graphclient.LabelPrompt, ag.Name, now, prompts,
-				"node_key: row.node_key, name: row.name, role: row.role, body: row.body, source: row.source, version: row.version"),
+			// 2. Replace this push's sources' prompt links: drop the old
+			//    HAS_PROMPT relationships (never the Prompt nodes), then
+			//    re-link. A prompt name with no matching `:Prompt` node is
+			//    skipped silently (the inner MATCH yields no row).
+			graphclient.Statement{
+				Statement: fmt.Sprintf(
+					"MATCH (a:%[1]s {name: $name})-[r:%[2]s]->(:%[3]s) "+
+						"WHERE r.source IN $sources DELETE r",
+					graphclient.LabelAgent, graphclient.RelHasPrompt, graphclient.LabelPrompt),
+				Parameters: map[string]any{
+					"name":    ag.Name,
+					"sources": sources,
+				},
+			},
+			graphclient.Statement{
+				// MERGE keys on `source` too, so a prompt linked by two
+				// sources gets one relationship each (mirroring how
+				// tool/skill child nodes are per-source) rather than one
+				// source clobbering the other's link.
+				Statement: fmt.Sprintf(
+					"MATCH (a:%[1]s {name: $name}) "+
+						"UNWIND $rows AS row "+
+						"MATCH (p:%[3]s {name: row.name}) "+
+						"MERGE (a)-[r:%[2]s {source: row.source}]->(p) "+
+						"SET r.updated_at = $now",
+					graphclient.LabelAgent, graphclient.RelHasPrompt, graphclient.LabelPrompt),
+				Parameters: map[string]any{
+					"name": ag.Name,
+					"rows": prompts,
+					"now":  now,
+				},
+			},
 			unwindCreate(graphclient.RelHasTool, graphclient.LabelTool, ag.Name, now, tools,
 				"node_key: row.node_key, name: row.name, description: row.description, schema: row.schema, source: row.source, version: row.version"),
 			unwindCreate(graphclient.RelHasSkill, graphclient.LabelSkill, ag.Name, now, skills,
@@ -495,8 +535,8 @@ func (h *catalogHandlers) fetchCatalog(ctx context.Context, name string) (*Agent
 			Parameters: p,
 		},
 		graphclient.Statement{
-			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[:%s]->(p:%s) "+
-				"RETURN p.name, p.role, p.body, p.source, p.version, p.updated_at ORDER BY p.source, p.name",
+			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[r:%s]->(p:%s) "+
+				"RETURN p.name, p.body, r.source, r.updated_at ORDER BY r.source, p.name",
 				graphclient.LabelAgent, graphclient.RelHasPrompt, graphclient.LabelPrompt),
 			Parameters: p,
 		},
@@ -538,11 +578,9 @@ func (h *catalogHandlers) fetchCatalog(ctx context.Context, name string) (*Agent
 	for _, row := range results[2].Data {
 		out.Prompts = append(out.Prompts, CatalogPrompt{
 			Name:      rowString(at(row.Row, 0)),
-			Role:      rowString(at(row.Row, 1)),
-			Body:      rowString(at(row.Row, 2)),
-			Source:    rowString(at(row.Row, 3)),
-			Version:   rowString(at(row.Row, 4)),
-			UpdatedAt: rowString(at(row.Row, 5)),
+			Body:      rowString(at(row.Row, 1)),
+			Source:    rowString(at(row.Row, 2)),
+			UpdatedAt: rowString(at(row.Row, 3)),
 		})
 	}
 	for _, row := range results[3].Data {

--- a/gateway/internal/adminapi/catalog_integration_test.go
+++ b/gateway/internal/adminapi/catalog_integration_test.go
@@ -33,18 +33,43 @@ func TestCatalogIntegration(t *testing.T) {
 	ctx := context.Background()
 
 	const agent = "test-catalog-agent"
+	// The catalog links to *existing* `:Prompt` nodes (authored by the
+	// prompt workflow) — it never creates them. Seed a couple here so
+	// the push has something to link, plus assert a missing name is
+	// skipped silently.
+	const promptA = "TEST_CATALOG_PROMPT_A"
+	const promptB = "TEST_CATALOG_PROMPT_B"
+	promptNames := []any{promptA, promptB}
 	cleanup := func() {
-		_, err := graph.Query(ctx,
-			fmt.Sprintf("MATCH (a:%s {name:$n}) OPTIONAL MATCH (a)-->(c) DETACH DELETE a, c", graphclient.LabelAgent),
-			map[string]any{"n": agent})
-		if err != nil {
-			t.Fatalf("cleanup: %v", err)
+		// Delete the agent + its *owned* tool/skill children (DETACH on
+		// the agent drops its HAS_PROMPT rels but leaves Prompt nodes).
+		if _, err := graph.Query(ctx,
+			fmt.Sprintf("MATCH (a:%s {name:$n}) OPTIONAL MATCH (a)-[:%s|%s]->(c) DETACH DELETE a, c",
+				graphclient.LabelAgent, graphclient.RelHasTool, graphclient.RelHasSkill),
+			map[string]any{"n": agent}); err != nil {
+			t.Fatalf("cleanup agent: %v", err)
+		}
+		// Remove the seeded shared Prompt nodes.
+		if _, err := graph.Query(ctx,
+			fmt.Sprintf("MATCH (p:%s) WHERE p.name IN $names DETACH DELETE p", graphclient.LabelPrompt),
+			map[string]any{"names": promptNames}); err != nil {
+			t.Fatalf("cleanup prompts: %v", err)
 		}
 	}
 	cleanup()
 	t.Cleanup(cleanup)
 
-	// ── push from "hive": tools (+ one prompt, one skill) ──
+	// Seed the shared `:Prompt` nodes the catalog will link to.
+	if _, err := graph.Query(ctx,
+		fmt.Sprintf("UNWIND $rows AS row CREATE (:%s {name: row.name, body: row.body})", graphclient.LabelPrompt),
+		map[string]any{"rows": []map[string]any{
+			{"name": promptA, "body": "You are prompt A."},
+			{"name": promptB, "body": "Be careful (prompt B)."},
+		}}); err != nil {
+		t.Fatalf("seed prompts: %v", err)
+	}
+
+	// ── push from "hive": links promptA (+ a missing name), tools, skill ──
 	hivePush := map[string]any{
 		"source": "hive",
 		"agents": []map[string]any{{
@@ -54,7 +79,8 @@ func TestCatalogIntegration(t *testing.T) {
 			"default_model": "sonnet",
 			"version":       "git:abc123",
 			"prompts": []map[string]any{
-				{"name": "system", "role": "system", "body": "You are a test."},
+				{"name": promptA},
+				{"name": "TEST_CATALOG_PROMPT_MISSING"}, // no such node → skipped
 			},
 			"tools": []map[string]any{
 				{"name": "read_file", "description": "Read a file",
@@ -66,8 +92,10 @@ func TestCatalogIntegration(t *testing.T) {
 			},
 		}},
 	}
+	// Written.Prompts is the *requested* link count (2); the missing one
+	// is skipped, so only 1 link is live — asserted via the read below.
 	wrote := doPush(t, cat, hivePush)
-	if wrote.Written.Agents != 1 || wrote.Written.Prompts != 1 || wrote.Written.Tools != 2 || wrote.Written.Skills != 1 {
+	if wrote.Written.Agents != 1 || wrote.Written.Prompts != 2 || wrote.Written.Tools != 2 || wrote.Written.Skills != 1 {
 		t.Fatalf("unexpected write counts: %+v", wrote.Written)
 	}
 
@@ -77,6 +105,14 @@ func TestCatalogIntegration(t *testing.T) {
 	}
 	if got.DefaultModel != "sonnet" {
 		t.Errorf("default_model = %q, want sonnet", got.DefaultModel)
+	}
+	// Only promptA linked (the missing name was skipped), and its body
+	// comes from the shared `:Prompt` node.
+	if len(got.Prompts) != 1 {
+		t.Fatalf("prompts = %d, want 1 (missing name skipped silently)", len(got.Prompts))
+	}
+	if got.Prompts[0].Name != promptA || got.Prompts[0].Body != "You are prompt A." {
+		t.Errorf("prompt = %+v, want name=%s body from node", got.Prompts[0], promptA)
 	}
 	if len(got.Tools) != 2 {
 		t.Fatalf("tools = %d, want 2", len(got.Tools))
@@ -100,21 +136,21 @@ func TestCatalogIntegration(t *testing.T) {
 			len(got.Tools), len(got.Prompts), len(got.Skills))
 	}
 
-	// ── second source (prompt-manager) contributes a prompt ──
+	// ── second source (prompt-manager) links another prompt ──
 	doPush(t, cat, map[string]any{
 		"source": "prompt-manager",
 		"agents": []map[string]any{{
 			"name":    agent,
 			"version": "rev-42",
-			"prompts": []map[string]any{{"name": "guardrails", "role": "system", "body": "Be careful."}},
+			"prompts": []map[string]any{{"name": promptB}},
 		}},
 	})
 	got = doRead(t, cat, agent, http.StatusOK)
 	if len(got.Sources) != 2 {
 		t.Errorf("sources = %v, want hive + prompt-manager", got.Sources)
 	}
-	if len(got.Prompts) != 2 { // hive's system + prompt-manager's guardrails
-		t.Errorf("prompts = %d, want 2 (hive's preserved across other source's push)", len(got.Prompts))
+	if len(got.Prompts) != 2 { // hive's promptA link + prompt-manager's promptB link
+		t.Errorf("prompts = %d, want 2 (hive's link preserved across other source's push)", len(got.Prompts))
 	}
 	// hive's tools must survive prompt-manager's push (replace-by-source).
 	if len(got.Tools) != 2 {

--- a/gateway/internal/adminapi/ui/src/api/types.ts
+++ b/gateway/internal/adminapi/ui/src/api/types.ts
@@ -319,12 +319,13 @@ export interface AgentBudgetResponse {
 // the budget view's "what is it _allowed to spend_?". Sourced from the
 // neo4j Hive* catalog subgraph via GET /_plugin/agents/:name/catalog.
 
+// A prompt linked to an agent. name/body come from the shared `:Prompt`
+// node the agent links to (authored by the Stakwork prompt workflow);
+// source/updated_at come from the HAS_PROMPT relationship.
 export interface CatalogPrompt {
   name: string;
-  role: string;
   body: string;
   source: string;
-  version?: string;
   updated_at: string;
 }
 

--- a/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
@@ -401,10 +401,9 @@ function PromptsView({ prompts }: { prompts: CatalogPrompt[] }) {
         <details key={p.source + "/" + p.name} class="card catalog-card">
           <summary class="catalog-summary">
             <span class="catalog-summary-main">
-              <span class={"badge role-" + (p.role || "system")}>{p.role || "—"}</span>
               <span class="mono">{p.name}</span>
             </span>
-            <SourceChip source={p.source} version={p.version} />
+            <SourceChip source={p.source} />
           </summary>
           <pre class="catalog-body mono">{p.body}</pre>
         </details>

--- a/gateway/internal/graphclient/schema.go
+++ b/gateway/internal/graphclient/schema.go
@@ -2,18 +2,25 @@ package graphclient
 
 // Label and relationship-type names for the agent catalog subgraph.
 //
-// All labels are PascalCase with a `Hive` prefix so they never collide
-// with the generic Agent/Prompt/Tool/Skill nodes other systems may
-// push into the shared graph. Hive catalog nodes deliberately do NOT
-// carry the `Data_Bank` label (that label drives mcp's code full-text
-// + vector indexes; the catalog must not pollute code search).
+// The Hive-owned nodes (HiveAgent/HiveTool/HiveSkill/HiveSource) are
+// PascalCase with a `Hive` prefix so they never collide with the
+// generic Agent/Tool/Skill nodes other systems may push into the
+// shared graph. They deliberately do NOT carry the `Data_Bank` label
+// (that label drives mcp's code full-text + vector indexes; the
+// catalog must not pollute code search).
+//
+// Prompts are the exception: a HiveAgent links to the *existing*
+// generic `:Prompt` nodes (written by the Stakwork prompt workflow,
+// keyed by `name`) via HAS_PROMPT. The gateway never creates or
+// deletes Prompt nodes — it only wires/unwires the relationship — so
+// there is no `HivePrompt` label.
 //
 // This is the one place label/edge names are defined — every Cypher
 // string in this package interpolates these constants so a rename is a
 // single-edit affair. See gateway/plans/agent-catalog.md "Data model".
 const (
 	LabelAgent  = "HiveAgent"
-	LabelPrompt = "HivePrompt"
+	LabelPrompt = "Prompt" // shared node authored elsewhere; linked, not owned
 	LabelTool   = "HiveTool"
 	LabelSkill  = "HiveSkill"
 	LabelSource = "HiveSource"
@@ -34,8 +41,9 @@ func SchemaStatements() []Statement {
 	return []Statement{
 		{Statement: "CREATE CONSTRAINT hive_agent_name IF NOT EXISTS " +
 			"FOR (a:" + LabelAgent + ") REQUIRE a.name IS UNIQUE"},
-		{Statement: "CREATE INDEX hive_prompt_key IF NOT EXISTS " +
-			"FOR (p:" + LabelPrompt + ") ON (p.node_key)"},
+		// No index on :Prompt here — those nodes (and their indexes) are
+		// owned by the mcp/prompt-workflow writers; the catalog only
+		// MATCHes them by `name` to link.
 		{Statement: "CREATE INDEX hive_tool_key IF NOT EXISTS " +
 			"FOR (t:" + LabelTool + ") ON (t.node_key)"},
 		{Statement: "CREATE INDEX hive_skill_key IF NOT EXISTS " +

--- a/gateway/plans/agent-catalog.md
+++ b/gateway/plans/agent-catalog.md
@@ -98,15 +98,24 @@ below). ~100 lines, no third-party deps.
 
 ## Data model
 
-All labels are **PascalCase with a `Hive` prefix** so they never
-collide with the generic `Agent`/`Prompt`/`Tool`/`Skill` nodes other
+The Hive-owned labels are **PascalCase with a `Hive` prefix** so they
+never collide with the generic `Agent`/`Tool`/`Skill` nodes other
 systems may push into the shared graph. Hive nodes deliberately do
 **not** carry the `Data_Bank` label (that label drives mcp's code
 full-text + vector indexes; the catalog must not pollute code search).
 
+**Prompts are the exception.** A `HiveAgent` links to the **existing**
+generic `:Prompt` nodes — the ones the Stakwork prompt workflow already
+writes into the graph, keyed by `name` and carrying the prompt `body`.
+There is **no `HivePrompt` label**: the gateway never creates or
+deletes `:Prompt` nodes, it only wires/unwires the `HAS_PROMPT`
+relationship. A pushed prompt name with no matching `:Prompt` node is
+**skipped silently**. The relationship carries `source` + `updated_at`
+so replace-by-source and provenance work the same as for tools/skills.
+
 ```
-(:HiveAgent  { name, display_name, description, updated_at })
-   -[:HAS_PROMPT]-> (:HivePrompt { node_key, name, role, body, source, version, updated_at })
+(:HiveAgent  { name, display_name, description, default_model, updated_at })
+   -[:HAS_PROMPT { source, updated_at }]-> (:Prompt { name, body, … })   ← existing, shared node
    -[:HAS_TOOL]->   (:HiveTool   { node_key, name, description, schema, source, version, updated_at })
    -[:HAS_SKILL]->  (:HiveSkill  { node_key, name, description, source, version, updated_at })
 
@@ -118,7 +127,7 @@ Label/edge names live in one place — `graphclient/schema.go`:
 ```go
 const (
     LabelAgent   = "HiveAgent"
-    LabelPrompt  = "HivePrompt"
+    LabelPrompt  = "Prompt"     // shared node authored elsewhere; linked, not owned
     LabelTool    = "HiveTool"
     LabelSkill   = "HiveSkill"
     LabelSource  = "HiveSource"
@@ -135,9 +144,10 @@ const (
 - **`HiveAgent.name`** is the merge key and the join to cost/budget
   data. Stable, URL-safe, lowercase-with-hyphens — same string as the
   `x-bf-dim-agent-name` header.
-- **`node_key`** on prompt/tool/skill nodes is a deterministic hash of
+- **`node_key`** on tool/skill nodes is a deterministic hash of
   `(agent_name, source, kind, name)` so re-pushing is idempotent and a
-  child belongs to exactly one (agent, source) pairing.
+  child belongs to exactly one (agent, source) pairing. Prompts have no
+  `node_key` — they are pre-existing shared nodes matched by `name`.
 - **`source`** records which system contributed the node (`hive`,
   `prompt-manager`, `ai-sdk`, `goose`). Multiple sources can describe
   the same agent without clobbering each other — see reconciliation.
@@ -152,10 +162,13 @@ const (
 ```cypher
 CREATE CONSTRAINT hive_agent_name IF NOT EXISTS
   FOR (a:HiveAgent) REQUIRE a.name IS UNIQUE;
-CREATE INDEX hive_prompt_key IF NOT EXISTS FOR (p:HivePrompt) ON (p.node_key);
 CREATE INDEX hive_tool_key   IF NOT EXISTS FOR (t:HiveTool)   ON (t.node_key);
 CREATE INDEX hive_skill_key  IF NOT EXISTS FOR (s:HiveSkill)  ON (s.node_key);
 ```
+
+No index on `:Prompt` is created here — those nodes (and their
+indexes) are owned by the prompt-workflow writers; the catalog only
+`MATCH`es them by `name`.
 
 ## Write path — `POST /_plugin/agents`
 
@@ -176,7 +189,7 @@ read-only UI; writes are server-to-server).
       "description": "Writes and modifies code.",
       "version": "git:9f3a1c2",      // optional; source's own stamp
       "prompts": [
-        { "name": "system", "role": "system", "body": "You are..." }
+        { "name": "CODER_SYSTEM_PROMPT" }   // links an existing :Prompt node by name
       ],
       "tools": [
         { "name": "read_file", "description": "Read a file",
@@ -199,13 +212,20 @@ the gateway deletes that source's existing children for the agent and
 re-creates them in one transaction. Other sources' contributions to the
 same agent are untouched.
 
+For **tools/skills** the child *nodes* are Hive-owned, so cleanup
+`DETACH DELETE`s them. For **prompts** the linked `:Prompt` node is
+shared and must survive — so cleanup deletes only the `HAS_PROMPT`
+*relationships* for this source, then re-links by matching `:Prompt`
+nodes by name (a missing name is skipped).
+
 ```
 For each agent in body.agents:
   MERGE (:HiveAgent {name})            -- create-or-update scalar props
   MERGE (:HiveSource {name: body.source})
   MERGE (agent)-[:DEFINED_BY]->(source)
-  DETACH DELETE this source's existing HAS_PROMPT/TOOL/SKILL children for this agent
-  CREATE the prompt/tool/skill children from the payload, wiring node_key + source + version
+  DETACH DELETE this source's existing HAS_TOOL/HAS_SKILL child nodes
+  DELETE this source's existing HAS_PROMPT relationships (leave :Prompt nodes)
+  CREATE tool/skill children (node_key + source + version); MATCH+link :Prompt by name
 ```
 
 All statements for one request go in a single `tx/commit` batch.
@@ -234,9 +254,8 @@ Returns the merged view across all sources for one agent.
   "display_name": "Coder",
   "description": "Writes and modifies code.",
   "sources": ["hive", "prompt-manager"],
-  "prompts": [ { "name": "system", "role": "system", "body": "...",
-                 "source": "prompt-manager", "version": "rev-42",
-                 "updated_at": "..." } ],
+  "prompts": [ { "name": "CODER_SYSTEM_PROMPT", "body": "...",
+                 "source": "hive", "updated_at": "..." } ],
   "tools":   [ { "name": "read_file", "description": "...", "schema": {...},
                  "source": "hive", "version": "git:9f3a1c2", "updated_at": "..." } ],
   "skills":  [ { "name": "security-review", "description": "...",
@@ -307,14 +326,19 @@ push supplies a non-empty value (a blank push never clobbers it).
 Hive's `BIFROST_AGENT_NAMES` stays the compile-time source of truth for
 *which* agents exist (every LLM call site is typed against it). On the
 first LLM call per swarm, Hive's orchestrator pushes those names — with
-display name, description, and `default_model` — to the swarm's gateway
-via `POST /_plugin/agents` (`source="hive"`). The two join by name; the
-catalog owns the *capabilities* (prompts/tools/skills), authored later.
+display name, description, `default_model`, **and the prompt names each
+agent uses** — to the swarm's gateway via `POST /_plugin/agents`
+(`source="hive"`). The two join by name; the prompt names come from
+Hive's `Prompt.agentNames` column and link `HiveAgent-[:HAS_PROMPT]->
+Prompt` against the graph's existing `:Prompt` nodes (a name with no
+node yet is skipped). Tools/skills are authored later.
 
 The push is **content-addressed**: Hive hashes the default-agent
 manifest and stamps it on `Swarm.bifrostAgentsSeedHash`. A cache hit is
-a single DB read with no HTTP; the manifest re-seeds only when the set
-or a default model changes. It rides the same lazy, best-effort,
+a couple of DB reads (the `Prompt.agentNames` links + the `Swarm` row)
+with no HTTP; the manifest re-seeds only when the set, a default model,
+or an agent's prompt-name set changes. It rides the same lazy,
+best-effort,
 per-workspace-locked path as the trust reconciler
 (`ensureBifrostAgentCatalog`, mirroring `ensureBifrostTrust`); a `503`
 (neo4j unset on the swarm) is a benign skip, and any failure is logged


### PR DESCRIPTION
## What

Replaces the catalog's self-owned `HivePrompt` nodes with links to the **existing** shared `:Prompt` nodes (authored by the Stakwork prompt workflow). An agent's prompts are now `HiveAgent-[:HAS_PROMPT]->(:Prompt {name})`.

## Why

Prompt content already lives in the graph's `:Prompt` nodes (with `name` + `body`). Duplicating role/body into a parallel `HivePrompt` label was redundant. Hive already tracks which agents a prompt belongs to via `Prompt.agentNames`, so it just sends prompt **names** and the gateway links them.

## Changes

- **schema.go**: `LabelPrompt = "Prompt"` (linked, not owned); dropped the `hive_prompt_key` index and the `HivePrompt` label.
- **catalog.go**:
  - Push payload carries prompt **names** only (`{name, source?}`).
  - Cleanup deletes `HAS_PROMPT` **relationships** for the source (never the shared `:Prompt` nodes), then re-links via `MATCH (p:Prompt {name})` + `MERGE`. A name with no matching node is **skipped silently**. MERGE keys on `source` so sources don't steal each other's links.
  - Reads return `name`+`body` from the Prompt node and `source`/`updated_at` from the relationship. `CatalogPrompt` drops `role`/`version`.
  - List prompt count now via `(a)-[:HAS_PROMPT]->(:Prompt)`.
- **UI**: `CatalogPrompt` type + `PromptsView` drop the role badge / version chip.
- Updated the neo4j integration test (incl. a skip-silently assertion) and `plans/agent-catalog.md`.

## Companion PR

Requires the Hive side that sends prompt names: stakwork/hive#catalog-seed-prompt-names.

## Testing

- `go vet ./internal/adminapi/ ./internal/graphclient/` clean.
- UI `tsc` + `vite build` clean.
- neo4j integration test updated (runs under `RUN_NEO4J_TESTS=1`).

Note: `written.prompts` in the push response is the requested link count; unmatched names are skipped, so the live count (from reads) may be lower.