### PR TITLE
gateway: operator toggles for catalog tools & skills, prompt roles

### DIFF
--- a/gateway/internal/adminapi/catalog.go
+++ b/gateway/internal/adminapi/catalog.go
@@ -46,6 +46,11 @@ type catalogPushAgent struct {
 type catalogPushPrompt struct {
 	Name   string `json:"name"`
 	Source string `json:"source"` // optional per-item source override
+	// Role is the slot this prompt fills for the agent: "SYSTEM" (the
+	// system prompt) vs "USER" (the main/task prompt). The shared
+	// `:Prompt` node is authored elsewhere, so this is stored on the
+	// HAS_PROMPT relationship the catalog owns. Empty ⇒ unknown.
+	Role string `json:"role"`
 }
 
 type catalogPushTool struct {
@@ -114,8 +119,12 @@ type CatalogListResponse struct {
 // the shared `:Prompt` node the agent links to; source/updated_at come
 // from the HAS_PROMPT relationship (which system wired it, and when).
 type CatalogPrompt struct {
-	Name      string `json:"name"`
-	Body      string `json:"body"`
+	Name string `json:"name"`
+	Body string `json:"body"`
+	// Role is the prompt's slot for this agent — "SYSTEM" or "USER"
+	// (the main/task prompt). Stored on the HAS_PROMPT relationship;
+	// empty when the wiring source didn't classify it.
+	Role      string `json:"role,omitempty"`
 	Source    string `json:"source"`
 	UpdatedAt string `json:"updated_at"`
 }
@@ -126,7 +135,11 @@ type CatalogTool struct {
 	Schema      json.RawMessage `json:"schema,omitempty"`
 	Source      string          `json:"source"`
 	Version     string          `json:"version,omitempty"`
-	UpdatedAt   string          `json:"updated_at"`
+	// Enabled is the per-swarm operator toggle, mirroring skills:
+	// seeded enabled, flipped in the dashboard, preserved across
+	// Hive re-seeds. Legacy nodes with no value read back as true.
+	Enabled   bool   `json:"enabled"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 type CatalogSkill struct {
@@ -134,7 +147,13 @@ type CatalogSkill struct {
 	Description string `json:"description"`
 	Source      string `json:"source"`
 	Version     string `json:"version,omitempty"`
-	UpdatedAt   string `json:"updated_at"`
+	// Enabled is the per-swarm operator toggle. Skills seed enabled by
+	// default; an operator flips this in the dashboard and the gateway
+	// preserves it across Hive re-seeds (a push only refreshes the
+	// palette + metadata, never the toggle). Legacy nodes with no
+	// stored value read back as true (coalesce on the read query).
+	Enabled   bool   `json:"enabled"`
+	UpdatedAt string `json:"updated_at"`
 }
 
 // ─── handler ─────────────────────────────────────────────────────────
@@ -252,6 +271,105 @@ func (h *catalogHandlers) read(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, out)
 }
 
+// ─── tool / skill enable/disable toggle ──────────────────────────────
+
+// childToggleRequest is the PATCH /_plugin/agents/:name/{tools,skills}
+// body. A child is addressed by (agent, source, name) — the same tuple
+// the node_key hashes — so the UI sends back the source/name it read
+// from the catalog view plus the desired state.
+type childToggleRequest struct {
+	Name    string `json:"name"`
+	Source  string `json:"source"`
+	Enabled bool   `json:"enabled"`
+}
+
+// childToggleResponse echoes the applied state.
+type childToggleResponse struct {
+	Name    string `json:"name"`
+	Source  string `json:"source"`
+	Enabled bool   `json:"enabled"`
+}
+
+// toggleTool handles PATCH /_plugin/agents/:name/tools.
+func (h *catalogHandlers) toggleTool(w http.ResponseWriter, r *http.Request) {
+	h.toggleChild(w, r, "tools", "tool", graphclient.RelHasTool, graphclient.LabelTool)
+}
+
+// toggleSkill handles PATCH /_plugin/agents/:name/skills.
+func (h *catalogHandlers) toggleSkill(w http.ResponseWriter, r *http.Request) {
+	h.toggleChild(w, r, "skills", "skill", graphclient.RelHasSkill, graphclient.LabelSkill)
+}
+
+// toggleChild flips one tool/skill's `enabled` flag — cookie-or-bearer
+// (an operator action in the dashboard, unlike the bearer-only catalog
+// push). This is the one piece of catalog state the gateway owns rather
+// than a source: Hive seeds the palette (enabled by default) and
+// re-seeds preserve the toggle, so an operator's on/off choice survives
+// deploys. `view` is the URL segment ("tools"/"skills"), `kind` the
+// node_key discriminator, and rel/label locate the child in the graph.
+func (h *catalogHandlers) toggleChild(w http.ResponseWriter, r *http.Request, view, kind, rel, label string) {
+	if r.Method != http.MethodPatch {
+		methodNotAllowed(w, http.MethodPatch)
+		return
+	}
+	if h.graph == nil {
+		writeError(w, http.StatusServiceUnavailable, "catalog_unavailable",
+			"agent catalog not configured (neo4j unset on this swarm)")
+		return
+	}
+
+	const prefix = "/_plugin/agents/"
+	rest := strings.TrimPrefix(r.URL.Path, prefix)
+	parts := strings.Split(rest, "/")
+	if len(parts) != 2 || parts[0] == "" || parts[1] != view {
+		http.NotFound(w, r)
+		return
+	}
+	agent := parts[0]
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+	var req childToggleRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" || strings.TrimSpace(req.Source) == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "name and source are required")
+		return
+	}
+
+	key := nodeKey(agent, req.Source, kind, req.Name)
+	now := time.Now().UTC().Format(time.RFC3339)
+	results, err := h.graph.Run(r.Context(), graphclient.Statement{
+		Statement: fmt.Sprintf(
+			"MATCH (a:%[1]s {name: $name})-[:%[2]s]->(c:%[3]s {node_key: $key}) "+
+				"SET c.enabled = $enabled, c.updated_at = $now "+
+				"RETURN c.node_key",
+			graphclient.LabelAgent, rel, label),
+		Parameters: map[string]any{
+			"name":    agent,
+			"key":     key,
+			"enabled": req.Enabled,
+			"now":     now,
+		},
+	})
+	if err != nil {
+		pluginlog.Errf("adminapi: %s toggle agent=%s name=%s: %v", kind, agent, req.Name, err)
+		writeError(w, http.StatusBadGateway, "catalog_write_failed", "neo4j write failed")
+		return
+	}
+	if len(results) == 0 || len(results[0].Data) == 0 {
+		writeError(w, http.StatusNotFound, "not_found", "no such "+kind+" for agent")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, childToggleResponse{
+		Name:    req.Name,
+		Source:  req.Source,
+		Enabled: req.Enabled,
+	})
+}
+
 // list handles GET /_plugin/agents/catalog — cookie-or-bearer. Returns
 // every agent in the registry with child counts, so the /agents list
 // can union the catalog with spend-derived agents (seeded agents that
@@ -344,14 +462,18 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 			prompts = append(prompts, map[string]any{
 				"name":   p.Name,
 				"source": src,
+				"role":   p.Role,
 			})
 		}
 		tools := make([]map[string]any, 0, len(ag.Tools))
+		toolKeys := make([]string, 0, len(ag.Tools))
 		for _, t := range ag.Tools {
 			src := srcOr(t.Source)
 			sourceSet[src] = struct{}{}
+			key := nodeKey(ag.Name, src, "tool", t.Name)
+			toolKeys = append(toolKeys, key)
 			tools = append(tools, map[string]any{
-				"node_key":    nodeKey(ag.Name, src, "tool", t.Name),
+				"node_key":    key,
 				"name":        t.Name,
 				"description": t.Description,
 				"schema":      rawToString(t.Schema),
@@ -360,11 +482,14 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 			})
 		}
 		skills := make([]map[string]any, 0, len(ag.Skills))
+		skillKeys := make([]string, 0, len(ag.Skills))
 		for _, s := range ag.Skills {
 			src := srcOr(s.Source)
 			sourceSet[src] = struct{}{}
+			key := nodeKey(ag.Name, src, "skill", s.Name)
+			skillKeys = append(skillKeys, key)
 			skills = append(skills, map[string]any{
-				"node_key":    nodeKey(ag.Name, src, "skill", s.Name),
+				"node_key":    key,
 				"name":        s.Name,
 				"description": s.Description,
 				"source":      src,
@@ -386,11 +511,11 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 		counts.Skills += len(skills)
 
 		stmts = append(stmts,
-			// 1. Upsert the agent + source + DEFINED_BY, then clear this
-			//    push's sources' owned tool/skill child nodes.
-			//    Prompt links are handled separately (statement 2) because
-			//    the linked `:Prompt` nodes are shared and must survive —
-			//    only the HAS_PROMPT relationship is replaced.
+			// 1. Upsert the agent + source + DEFINED_BY. No child cleanup
+			//    here anymore: prompts are replaced in statement 2, and
+			//    tools/skills self-prune in their own merge-preserve pairs
+			//    (statements 4-5 / 6-7) so their per-swarm `enabled`
+			//    toggle survives re-seeds.
 			graphclient.Statement{
 				Statement: fmt.Sprintf(
 					"MERGE (a:%[1]s {name: $name}) "+
@@ -399,19 +524,14 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 						"a.description = CASE WHEN $description <> '' THEN $description ELSE a.description END, "+
 						"a.default_model = CASE WHEN $default_model <> '' THEN $default_model ELSE a.default_model END "+
 						"MERGE (s:%[2]s {name: $source}) SET s.updated_at = $now "+
-						"MERGE (a)-[:%[3]s]->(s) "+
-						"WITH a "+
-						"OPTIONAL MATCH (a)-[:%[4]s|%[5]s]->(c) WHERE c.source IN $sources "+
-						"DETACH DELETE c",
-					graphclient.LabelAgent, graphclient.LabelSource, graphclient.RelDefinedBy,
-					graphclient.RelHasTool, graphclient.RelHasSkill),
+						"MERGE (a)-[:%[3]s]->(s)",
+					graphclient.LabelAgent, graphclient.LabelSource, graphclient.RelDefinedBy),
 				Parameters: map[string]any{
 					"name":          ag.Name,
 					"display_name":  ag.DisplayName,
 					"description":   ag.Description,
 					"default_model": ag.DefaultModel,
 					"source":        req.Source,
-					"sources":       sources,
 					"now":           now,
 				},
 			},
@@ -439,7 +559,7 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 						"UNWIND $rows AS row "+
 						"MATCH (p:%[3]s {name: row.name}) "+
 						"MERGE (a)-[r:%[2]s {source: row.source}]->(p) "+
-						"SET r.updated_at = $now",
+						"SET r.updated_at = $now, r.role = row.role",
 					graphclient.LabelAgent, graphclient.RelHasPrompt, graphclient.LabelPrompt),
 				Parameters: map[string]any{
 					"name": ag.Name,
@@ -447,30 +567,81 @@ func buildCatalogWrite(req catalogPushRequest) ([]graphclient.Statement, struct 
 					"now":  now,
 				},
 			},
-			unwindCreate(graphclient.RelHasTool, graphclient.LabelTool, ag.Name, now, tools,
-				"node_key: row.node_key, name: row.name, description: row.description, schema: row.schema, source: row.source, version: row.version"),
-			unwindCreate(graphclient.RelHasSkill, graphclient.LabelSkill, ag.Name, now, skills,
-				"node_key: row.node_key, name: row.name, description: row.description, source: row.source, version: row.version"),
 		)
+		// 4-5. Tools and 6-7. skills: both are Hive-owned child nodes
+		//      whose per-swarm `enabled` toggle must survive re-seeds, so
+		//      each gets a prune-removed + merge-preserve pair rather than
+		//      a destructive delete+recreate. Tools additionally carry a
+		//      `schema` column.
+		stmts = append(stmts, childMergePreserve(childWrite{
+			rel: graphclient.RelHasTool, label: graphclient.LabelTool,
+			agentName: ag.Name, now: now, rows: tools, keys: toolKeys, sources: sources,
+			setProps: "c.name = row.name, c.description = row.description, " +
+				"c.schema = row.schema, c.source = row.source, c.version = row.version",
+		})...)
+		stmts = append(stmts, childMergePreserve(childWrite{
+			rel: graphclient.RelHasSkill, label: graphclient.LabelSkill,
+			agentName: ag.Name, now: now, rows: skills, keys: skillKeys, sources: sources,
+			setProps: "c.name = row.name, c.description = row.description, " +
+				"c.source = row.source, c.version = row.version",
+		})...)
 	}
 	return stmts, counts
 }
 
-// unwindCreate builds a single UNWIND-CREATE statement for one child
-// kind. Over an empty `rows` slice it creates nothing (UNWIND of [] is
-// a no-op) — so an agent that dropped all its tools still runs the
-// statement harmlessly after cleanup cleared the old ones.
-func unwindCreate(rel, label, agentName, now string, rows []map[string]any, props string) graphclient.Statement {
-	return graphclient.Statement{
-		Statement: fmt.Sprintf(
-			"MATCH (a:%[1]s {name: $name}) "+
-				"UNWIND $rows AS row "+
-				"CREATE (a)-[:%[2]s]->(:%[3]s {%[4]s, updated_at: $now})",
-			graphclient.LabelAgent, rel, label, props),
-		Parameters: map[string]any{
-			"name": agentName,
-			"rows": rows,
-			"now":  now,
+// childWrite is the input to childMergePreserve — everything needed to
+// emit one owned child kind's prune + merge pair.
+type childWrite struct {
+	rel       string           // HAS_TOOL / HAS_SKILL
+	label     string           // HiveTool / HiveSkill
+	agentName string           // owning agent
+	now       string           // RFC3339 stamp
+	rows      []map[string]any // one map per child (must carry node_key + the setProps columns)
+	keys      []string         // node_keys in this push (the survivor set)
+	sources   []string         // sources this push touches
+	setProps  string           // comma-joined `c.<col> = row.<col>` (NEVER `enabled`)
+}
+
+// childMergePreserve builds the two-statement pair for a Hive-owned
+// child kind (tool/skill) whose per-swarm `enabled` toggle must survive
+// re-seeds:
+//
+//  1. Prune — delete this push's sources' children whose node_key is no
+//     longer in the manifest. Survivors (and other sources') keep their
+//     toggle. Over an empty push this clears the source's kind entirely
+//     (`NOT c.node_key IN []` is true for every row).
+//  2. Merge — MERGE by node_key (not delete+create) so an existing
+//     child keeps its operator-set `enabled`; only a brand-new node
+//     defaults to enabled=true. `setProps` refresh every push; UNWIND
+//     of [] is a harmless no-op.
+func childMergePreserve(c childWrite) []graphclient.Statement {
+	return []graphclient.Statement{
+		{
+			Statement: fmt.Sprintf(
+				"MATCH (a:%[1]s {name: $name})-[:%[2]s]->(c:%[3]s) "+
+					"WHERE c.source IN $sources AND NOT c.node_key IN $keys "+
+					"DETACH DELETE c",
+				graphclient.LabelAgent, c.rel, c.label),
+			Parameters: map[string]any{
+				"name":    c.agentName,
+				"sources": c.sources,
+				"keys":    c.keys,
+			},
+		},
+		{
+			Statement: fmt.Sprintf(
+				"MATCH (a:%[1]s {name: $name}) "+
+					"UNWIND $rows AS row "+
+					"MERGE (c:%[3]s {node_key: row.node_key}) "+
+					"ON CREATE SET c.enabled = true "+
+					"SET %[4]s, c.updated_at = $now "+
+					"MERGE (a)-[:%[2]s]->(c)",
+				graphclient.LabelAgent, c.rel, c.label, c.setProps),
+			Parameters: map[string]any{
+				"name": c.agentName,
+				"rows": c.rows,
+				"now":  c.now,
+			},
 		},
 	}
 }
@@ -536,19 +707,21 @@ func (h *catalogHandlers) fetchCatalog(ctx context.Context, name string) (*Agent
 		},
 		graphclient.Statement{
 			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[r:%s]->(p:%s) "+
-				"RETURN p.name, p.body, r.source, r.updated_at ORDER BY r.source, p.name",
+				"RETURN p.name, p.body, r.source, r.updated_at, r.role ORDER BY r.source, p.name",
 				graphclient.LabelAgent, graphclient.RelHasPrompt, graphclient.LabelPrompt),
 			Parameters: p,
 		},
 		graphclient.Statement{
 			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[:%s]->(t:%s) "+
-				"RETURN t.name, t.description, t.schema, t.source, t.version, t.updated_at ORDER BY t.source, t.name",
+				"RETURN t.name, t.description, t.schema, t.source, t.version, coalesce(t.enabled, true), t.updated_at "+
+				"ORDER BY t.source, t.name",
 				graphclient.LabelAgent, graphclient.RelHasTool, graphclient.LabelTool),
 			Parameters: p,
 		},
 		graphclient.Statement{
 			Statement: fmt.Sprintf("MATCH (a:%s {name: $name})-[:%s]->(k:%s) "+
-				"RETURN k.name, k.description, k.source, k.version, k.updated_at ORDER BY k.source, k.name",
+				"RETURN k.name, k.description, k.source, k.version, coalesce(k.enabled, true), k.updated_at "+
+				"ORDER BY k.source, k.name",
 				graphclient.LabelAgent, graphclient.RelHasSkill, graphclient.LabelSkill),
 			Parameters: p,
 		},
@@ -581,6 +754,7 @@ func (h *catalogHandlers) fetchCatalog(ctx context.Context, name string) (*Agent
 			Body:      rowString(at(row.Row, 1)),
 			Source:    rowString(at(row.Row, 2)),
 			UpdatedAt: rowString(at(row.Row, 3)),
+			Role:      rowString(at(row.Row, 4)),
 		})
 	}
 	for _, row := range results[3].Data {
@@ -590,7 +764,8 @@ func (h *catalogHandlers) fetchCatalog(ctx context.Context, name string) (*Agent
 			Schema:      stringToRaw(rowString(at(row.Row, 2))),
 			Source:      rowString(at(row.Row, 3)),
 			Version:     rowString(at(row.Row, 4)),
-			UpdatedAt:   rowString(at(row.Row, 5)),
+			Enabled:     rowBool(at(row.Row, 5), true),
+			UpdatedAt:   rowString(at(row.Row, 6)),
 		})
 	}
 	for _, row := range results[4].Data {
@@ -599,7 +774,8 @@ func (h *catalogHandlers) fetchCatalog(ctx context.Context, name string) (*Agent
 			Description: rowString(at(row.Row, 1)),
 			Source:      rowString(at(row.Row, 2)),
 			Version:     rowString(at(row.Row, 3)),
-			UpdatedAt:   rowString(at(row.Row, 4)),
+			Enabled:     rowBool(at(row.Row, 4), true),
+			UpdatedAt:   rowString(at(row.Row, 5)),
 		})
 	}
 	return out, true, nil
@@ -660,6 +836,20 @@ func rowInt(raw json.RawMessage) int {
 		return 0
 	}
 	return n
+}
+
+// rowBool decodes a single returned cell into a bool. A neo4j null
+// (unset property — e.g. a legacy skill node written before `enabled`
+// existed) or a decode failure falls back to `def`.
+func rowBool(raw json.RawMessage, def bool) bool {
+	if len(raw) == 0 {
+		return def
+	}
+	var b bool
+	if err := json.Unmarshal(raw, &b); err != nil {
+		return def
+	}
+	return b
 }
 
 // rowStrings decodes a returned cell that is a JSON array of strings

--- a/gateway/internal/adminapi/catalog_integration_test.go
+++ b/gateway/internal/adminapi/catalog_integration_test.go
@@ -79,7 +79,7 @@ func TestCatalogIntegration(t *testing.T) {
 			"default_model": "sonnet",
 			"version":       "git:abc123",
 			"prompts": []map[string]any{
-				{"name": promptA},
+				{"name": promptA, "role": "SYSTEM"},
 				{"name": "TEST_CATALOG_PROMPT_MISSING"}, // no such node → skipped
 			},
 			"tools": []map[string]any{
@@ -114,6 +114,9 @@ func TestCatalogIntegration(t *testing.T) {
 	if got.Prompts[0].Name != promptA || got.Prompts[0].Body != "You are prompt A." {
 		t.Errorf("prompt = %+v, want name=%s body from node", got.Prompts[0], promptA)
 	}
+	if got.Prompts[0].Role != "SYSTEM" {
+		t.Errorf("prompt role = %q, want SYSTEM (stored on HAS_PROMPT rel)", got.Prompts[0].Role)
+	}
 	if len(got.Tools) != 2 {
 		t.Fatalf("tools = %d, want 2", len(got.Tools))
 	}
@@ -128,6 +131,16 @@ func TestCatalogIntegration(t *testing.T) {
 		t.Errorf("read_file schema didn't round-trip: %+v", schemaTool)
 	}
 
+	// Freshly-seeded skills and tools default to enabled.
+	if len(got.Skills) != 1 || !got.Skills[0].Enabled {
+		t.Fatalf("skill should seed enabled: %+v", got.Skills)
+	}
+	for i := range got.Tools {
+		if !got.Tools[i].Enabled {
+			t.Fatalf("tool %q should seed enabled: %+v", got.Tools[i].Name, got.Tools[i])
+		}
+	}
+
 	// ── idempotency: re-push the same hive manifest ──
 	doPush(t, cat, hivePush)
 	got = doRead(t, cat, agent, http.StatusOK)
@@ -135,6 +148,44 @@ func TestCatalogIntegration(t *testing.T) {
 		t.Fatalf("re-push duplicated children: tools=%d prompts=%d skills=%d",
 			len(got.Tools), len(got.Prompts), len(got.Skills))
 	}
+
+	// ── operator disables the skill, then Hive re-seeds ──
+	// The toggle is the one piece of catalog state the gateway owns; a
+	// re-push must NOT resurrect the operator's off choice.
+	doToggleSkill(t, cat, agent, "hive", "security-review", false, http.StatusOK)
+	got = doRead(t, cat, agent, http.StatusOK)
+	if len(got.Skills) != 1 || got.Skills[0].Enabled {
+		t.Fatalf("skill should be disabled after toggle: %+v", got.Skills)
+	}
+	doPush(t, cat, hivePush) // re-seed the palette
+	got = doRead(t, cat, agent, http.StatusOK)
+	if len(got.Skills) != 1 || got.Skills[0].Enabled {
+		t.Fatalf("re-seed clobbered the operator's disabled toggle: %+v", got.Skills)
+	}
+	// Re-enable so downstream assertions see the original state.
+	doToggleSkill(t, cat, agent, "hive", "security-review", true, http.StatusOK)
+
+	// Toggling an unknown skill is a 404.
+	doToggleSkill(t, cat, agent, "hive", "no-such-skill", false, http.StatusNotFound)
+
+	// ── tools behave identically: toggle survives a re-seed ──
+	doToggleTool(t, cat, agent, "hive", "write_file", false, http.StatusOK)
+	doPush(t, cat, hivePush) // re-seed
+	got = doRead(t, cat, agent, http.StatusOK)
+	var wf *CatalogTool
+	for i := range got.Tools {
+		if got.Tools[i].Name == "write_file" {
+			wf = &got.Tools[i]
+		}
+	}
+	if wf == nil || wf.Enabled {
+		t.Fatalf("re-seed clobbered the tool's disabled toggle: %+v", wf)
+	}
+	if len(got.Tools) != 2 {
+		t.Fatalf("re-seed changed tool count: %d", len(got.Tools))
+	}
+	doToggleTool(t, cat, agent, "hive", "write_file", true, http.StatusOK)
+	doToggleTool(t, cat, agent, "hive", "no-such-tool", false, http.StatusNotFound)
 
 	// ── second source (prompt-manager) links another prompt ──
 	doPush(t, cat, map[string]any{
@@ -206,6 +257,28 @@ func doPush(t *testing.T, cat *catalogHandlers, body any) catalogWriteResponse {
 		t.Fatalf("push decode: %v", err)
 	}
 	return out
+}
+
+func doToggleSkill(t *testing.T, cat *catalogHandlers, agent, source, skill string, enabled bool, wantStatus int) {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]any{"name": skill, "source": source, "enabled": enabled})
+	req := httptest.NewRequest(http.MethodPatch, "/_plugin/agents/"+agent+"/skills", strings.NewReader(string(raw)))
+	rec := httptest.NewRecorder()
+	cat.toggleSkill(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("toggle %s/%s status = %d (want %d), body = %s", agent, skill, rec.Code, wantStatus, rec.Body.String())
+	}
+}
+
+func doToggleTool(t *testing.T, cat *catalogHandlers, agent, source, tool string, enabled bool, wantStatus int) {
+	t.Helper()
+	raw, _ := json.Marshal(map[string]any{"name": tool, "source": source, "enabled": enabled})
+	req := httptest.NewRequest(http.MethodPatch, "/_plugin/agents/"+agent+"/tools", strings.NewReader(string(raw)))
+	rec := httptest.NewRecorder()
+	cat.toggleTool(rec, req)
+	if rec.Code != wantStatus {
+		t.Fatalf("toggle tool %s/%s status = %d (want %d), body = %s", agent, tool, rec.Code, wantStatus, rec.Body.String())
+	}
 }
 
 func doRead(t *testing.T, cat *catalogHandlers, name string, wantStatus int) AgentCatalogResponse {

--- a/gateway/internal/adminapi/server.go
+++ b/gateway/internal/adminapi/server.go
@@ -294,6 +294,18 @@ func registerRoutes(mux *http.ServeMux, deps routeDeps) {
 			cat.read(w, r)
 			return
 		}
+		// `<name>/tools` and `<name>/skills` (PATCH) toggle a child's
+		// enabled flag. Operator dashboard actions, so they ride the same
+		// cookie-or-bearer auth as the reads (the catalog *push* stays
+		// bearer-only).
+		if len(parts) == 2 && parts[0] != "" && parts[1] == "skills" {
+			cat.toggleSkill(w, r)
+			return
+		}
+		if len(parts) == 2 && parts[0] != "" && parts[1] == "tools" {
+			cat.toggleTool(w, r)
+			return
+		}
 		// Default: the budget handler owns `<name>/budget` and 404s
 		// the rest.
 		bgt.budget(w, r)

--- a/gateway/internal/adminapi/ui/src/api/client.ts
+++ b/gateway/internal/adminapi/ui/src/api/client.ts
@@ -40,7 +40,7 @@ export class ApiCallError extends Error {
 }
 
 export interface ApiFetchOptions {
-  method?: "GET" | "POST" | "DELETE";
+  method?: "GET" | "POST" | "PATCH" | "DELETE";
   body?: unknown;
   /** Extra headers (e.g. Authorization: Basic on the login call). */
   headers?: Record<string, string>;

--- a/gateway/internal/adminapi/ui/src/api/queries.ts
+++ b/gateway/internal/adminapi/ui/src/api/queries.ts
@@ -3,7 +3,12 @@
 // or retry policy. Those decisions live here, in one place, so
 // "should the dashboard poll every 30s" stays a one-line edit.
 
-import { useQueries, useQuery } from "@tanstack/react-query";
+import {
+  useMutation,
+  useQueries,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
 
 import { apiFetch, ApiCallError } from "./client";
 import type {
@@ -240,6 +245,66 @@ export function useAgentCatalog(name: string | undefined) {
     refetchInterval: 5 * 60_000,
     retry: false,
   });
+}
+
+// ─── PATCH /agents/:name/{tools,skills} (toggle enabled) ────────────
+//
+// The one mutable piece of catalog state the gateway owns (Hive seeds
+// the palette; the operator toggles which tools/skills are active). On
+// success we invalidate this agent's catalog query so the switch
+// reflects the persisted state. Optimistic update keeps the toggle
+// snappy and rolls back if the PATCH fails. Tools and skills share the
+// exact same shape, so one internal hook drives both `view`s.
+
+interface ChildToggleArgs {
+  source: string;
+  name: string;
+  enabled: boolean;
+}
+
+function useToggleCatalogChild(agentName: string, view: "tools" | "skills") {
+  const qc = useQueryClient();
+  const key = ["agents", agentName, "catalog"];
+  return useMutation({
+    mutationFn: (args: ChildToggleArgs) =>
+      apiFetch<{ name: string; source: string; enabled: boolean }>(
+        `/agents/${encodeURIComponent(agentName)}/${view}`,
+        { method: "PATCH", body: args },
+      ),
+    onMutate: async (args) => {
+      await qc.cancelQueries({ queryKey: key });
+      const prev = qc.getQueryData<AgentCatalogResponse | null>(key);
+      if (prev) {
+        const flip = <T extends ChildToggleArgs>(items: T[]) =>
+          items.map((it) =>
+            it.source === args.source && it.name === args.name
+              ? { ...it, enabled: args.enabled }
+              : it,
+          );
+        qc.setQueryData<AgentCatalogResponse | null>(key, {
+          ...prev,
+          ...(view === "tools"
+            ? { tools: flip(prev.tools) }
+            : { skills: flip(prev.skills) }),
+        });
+      }
+      return { prev };
+    },
+    onError: (_err, _args, ctx) => {
+      if (ctx?.prev !== undefined) qc.setQueryData(key, ctx.prev);
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: key });
+    },
+  });
+}
+
+export function useToggleSkill(agentName: string) {
+  return useToggleCatalogChild(agentName, "skills");
+}
+
+export function useToggleTool(agentName: string) {
+  return useToggleCatalogChild(agentName, "tools");
 }
 
 // ─── /users/:id ─────────────────────────────────────────────────────

--- a/gateway/internal/adminapi/ui/src/api/types.ts
+++ b/gateway/internal/adminapi/ui/src/api/types.ts
@@ -325,6 +325,9 @@ export interface AgentBudgetResponse {
 export interface CatalogPrompt {
   name: string;
   body: string;
+  /** Prompt slot for this agent: "SYSTEM" or "USER" (the main/task
+   *  prompt). Absent when the wiring source didn't classify it. */
+  role?: string;
   source: string;
   updated_at: string;
 }
@@ -337,6 +340,9 @@ export interface CatalogTool {
   schema?: unknown;
   source: string;
   version?: string;
+  /** Per-swarm operator toggle. Seeded enabled; preserved across
+   *  Hive re-seeds. Flip via PATCH /_plugin/agents/:name/tools. */
+  enabled: boolean;
   updated_at: string;
 }
 
@@ -345,6 +351,9 @@ export interface CatalogSkill {
   description: string;
   source: string;
   version?: string;
+  /** Per-swarm operator toggle. Seeded enabled; preserved across
+   *  Hive re-seeds. Flip via PATCH /_plugin/agents/:name/skills. */
+  enabled: boolean;
   updated_at: string;
 }
 

--- a/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
@@ -27,6 +27,8 @@ import {
   useAgentBudget,
   useAgentCatalog,
   useHistogramCost,
+  useToggleSkill,
+  useToggleTool,
 } from "../api/queries";
 import type { HistogramCostResponse, Window } from "../api/types";
 import { windowToSeconds } from "../api/window";
@@ -378,8 +380,8 @@ function CatalogPanel({ tab, catalog, loading, unavailable, error }: PanelProps)
   }
 
   if (tab === "prompts") return <PromptsView prompts={catalog.prompts} />;
-  if (tab === "tools") return <ToolsView tools={catalog.tools} />;
-  return <SkillsView skills={catalog.skills} />;
+  if (tab === "tools") return <ToolsView agentName={catalog.name} tools={catalog.tools} />;
+  return <SkillsView agentName={catalog.name} skills={catalog.skills} />;
 }
 
 // SourceChip is the source + version provenance marker shared by all
@@ -393,6 +395,48 @@ function SourceChip({ source, version }: { source: string; version?: string }) {
   );
 }
 
+// PromptRoleBadge marks which slot a prompt fills — the SYSTEM prompt
+// vs the USER (main/task) prompt. Reuses the role-badge pills that the
+// chat-message roles already style.
+function PromptRoleBadge({ role }: { role: string }) {
+  const lower = role.toLowerCase();
+  const cls = lower === "system" ? "badge role-system" : "badge role-user";
+  const label = lower === "system" ? "system" : "main";
+  return <span class={cls}>{label}</span>;
+}
+
+// EnabledSwitch is the accessible toggle shared by the tools and skills
+// tabs. `stopPropagation` is set inside <summary> (tools) so flipping
+// the switch doesn't also expand/collapse the details card.
+function EnabledSwitch({
+  enabled,
+  pending,
+  onChange,
+  stopPropagation,
+}: {
+  enabled: boolean;
+  pending: boolean;
+  onChange: (enabled: boolean) => void;
+  stopPropagation?: boolean;
+}) {
+  return (
+    <label
+      class="switch"
+      title={enabled ? "Enabled" : "Disabled"}
+      onClick={stopPropagation ? (e) => e.stopPropagation() : undefined}
+    >
+      <input
+        type="checkbox"
+        checked={enabled}
+        disabled={pending}
+        onChange={(e) => onChange((e.target as HTMLInputElement).checked)}
+      />
+      <span class="switch-track" />
+      <span class="switch-knob" />
+    </label>
+  );
+}
+
 function PromptsView({ prompts }: { prompts: CatalogPrompt[] }) {
   if (prompts.length === 0) return <div class="empty">No prompts.</div>;
   return (
@@ -402,6 +446,7 @@ function PromptsView({ prompts }: { prompts: CatalogPrompt[] }) {
           <summary class="catalog-summary">
             <span class="catalog-summary-main">
               <span class="mono">{p.name}</span>
+              {p.role ? <PromptRoleBadge role={p.role} /> : null}
             </span>
             <SourceChip source={p.source} />
           </summary>
@@ -412,13 +457,31 @@ function PromptsView({ prompts }: { prompts: CatalogPrompt[] }) {
   );
 }
 
-function ToolsView({ tools }: { tools: CatalogTool[] }) {
+function ToolsView({
+  agentName,
+  tools,
+}: {
+  agentName: string;
+  tools: CatalogTool[];
+}) {
+  const toggle = useToggleTool(agentName);
   if (tools.length === 0) return <div class="empty">No tools.</div>;
   return (
     <div class="catalog-list">
       {tools.map((t) => (
-        <details key={t.source + "/" + t.name} class="card catalog-card">
+        <details
+          key={t.source + "/" + t.name}
+          class={"card catalog-card" + (t.enabled ? "" : " is-disabled")}
+        >
           <summary class="catalog-summary">
+            <EnabledSwitch
+              enabled={t.enabled}
+              pending={toggle.isPending}
+              stopPropagation
+              onChange={(enabled) =>
+                toggle.mutate({ source: t.source, name: t.name, enabled })
+              }
+            />
             <span class="catalog-summary-main">
               <span class="mono">{t.name}</span>
               <span class="text-dim">{t.description}</span>
@@ -440,13 +503,21 @@ function ToolsView({ tools }: { tools: CatalogTool[] }) {
   );
 }
 
-function SkillsView({ skills }: { skills: CatalogSkill[] }) {
+function SkillsView({
+  agentName,
+  skills,
+}: {
+  agentName: string;
+  skills: CatalogSkill[];
+}) {
+  const toggle = useToggleSkill(agentName);
   if (skills.length === 0) return <div class="empty">No skills.</div>;
   return (
     <div class="table-wrap">
       <table class="table">
         <thead>
           <tr>
+            <th style="width: 70px">Enabled</th>
             <th>Skill</th>
             <th>Description</th>
             <th>Source</th>
@@ -454,7 +525,19 @@ function SkillsView({ skills }: { skills: CatalogSkill[] }) {
         </thead>
         <tbody>
           {skills.map((s) => (
-            <tr key={s.source + "/" + s.name}>
+            <tr
+              key={s.source + "/" + s.name}
+              class={s.enabled ? undefined : "is-disabled"}
+            >
+              <td>
+                <EnabledSwitch
+                  enabled={s.enabled}
+                  pending={toggle.isPending}
+                  onChange={(enabled) =>
+                    toggle.mutate({ source: s.source, name: s.name, enabled })
+                  }
+                />
+              </td>
               <td>
                 <span class="mono">{s.name}</span>
               </td>

--- a/gateway/internal/adminapi/ui/src/styles/components.css
+++ b/gateway/internal/adminapi/ui/src/styles/components.css
@@ -1150,3 +1150,68 @@ details[open] > .catalog-summary::before {
   color: var(--warning);
   border: 1px solid rgba(245, 184, 108, 0.3);
 }
+
+/* ─── skill enable/disable switch ────────────────────────────── */
+/* A minimal toggle: a track + knob driven by a visually-hidden
+   checkbox so the control stays keyboard-accessible. */
+.switch {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  width: 34px;
+  height: 18px;
+  flex: none;
+}
+.switch input {
+  position: absolute;
+  opacity: 0;
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  cursor: pointer;
+}
+.switch input:disabled {
+  cursor: default;
+}
+.switch .switch-track {
+  position: absolute;
+  inset: 0;
+  border-radius: 999px;
+  background: var(--surface-2);
+  border: 1px solid var(--border-strong);
+  transition: background 0.15s ease, border-color 0.15s ease;
+}
+.switch .switch-knob {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  transition: transform 0.15s ease, background 0.15s ease;
+}
+.switch input:checked ~ .switch-track {
+  background: rgba(110, 168, 255, 0.25);
+  border-color: rgba(110, 168, 255, 0.55);
+}
+.switch input:checked ~ .switch-knob {
+  transform: translateX(16px);
+  background: var(--accent);
+}
+.switch input:focus-visible ~ .switch-track {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+.switch input:disabled ~ .switch-track {
+  opacity: 0.5;
+}
+tr.is-disabled td .mono,
+tr.is-disabled td.text-dim {
+  opacity: 0.5;
+}
+/* Disabled tool card: dim the summary's name/description but keep the
+   switch itself at full opacity so it stays easy to flip back on. */
+.catalog-card.is-disabled .catalog-summary-main {
+  opacity: 0.5;
+}


### PR DESCRIPTION
## What

Adds a per-swarm **enabled/disabled toggle** for agent-catalog tools and skills that **survives Hive re-seeds**, plus stores a prompt **role** (system/main) on the catalog. Companion to the Hive PR that seeds the tool/skill palettes and derives prompt roles.

## The core problem
Hive seeds the *palette* of possible tools/skills, but which are *active* is an operator choice. The catalog push is replace-by-source (delete + recreate on every re-seed), which would clobber that choice. This PR makes the toggle a piece of state the **gateway owns** and preserves.

## Changes (`internal/adminapi`)

**Storage — preserve-on-merge**
- `HiveTool`/`HiveSkill` gain an `enabled` property.
- The push now MERGEs children by `node_key` with `ON CREATE SET enabled = true` (never on match), and prunes only children the source stopped sending — instead of the old destructive delete+recreate. So re-seeds refresh name/description/schema/version but never reset an operator's toggle.
- Extracted a shared `childMergePreserve` helper (replaces `unwindCreate`); statement 1 no longer deletes any children.

**Toggle endpoint**
- `PATCH /_plugin/agents/:name/tools` and `.../skills` flip a single child's `enabled`, addressed by (agent, source, name). Cookie-or-bearer (a dashboard action; the catalog *push* stays bearer-only). Backed by a generalized `toggleChild` handler; 404s an unknown child.

**Prompt role**
- `CatalogPrompt.role` stored on the `HAS_PROMPT` relationship (the gateway can't write the shared `:Prompt` node it doesn't own) and returned on read.

**UI**
- `enabled` switch on the Tools and Skills tabs (shared `EnabledSwitch`, optimistic mutation with rollback + catalog invalidation).
- system/main role badge on prompt cards.

## Compatibility
- Read queries use `coalesce(enabled, true)`, so skill/tool nodes written before this change read back as enabled.
- Other sources' children are untouched (prune is scoped to the pushing source's node_keys).

## Test
`go test ./internal/adminapi/` passes; UI `tsc` clean; gofmt clean. The neo4j integration test (`RUN_NEO4J_TESTS=1`) now covers enabled defaults, toggle-survives-reseed for both tools and skills, and prompt-role round-trip.