### PR TITLE
gateway: Evals tab in the agent view

### DIFF
--- a/gateway/internal/adminapi/evals.go
+++ b/gateway/internal/adminapi/evals.go
@@ -1,0 +1,577 @@
+package adminapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/stakwork/stakgraph/gateway/internal/graphclient"
+	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
+)
+
+// evals.go serves the agent-detail "Evals" tab.
+//
+// Split of responsibility (see hivecallback.go for the why):
+//   - READS come straight from neo4j. The Eval* subgraph
+//     (EvalSet-[:HAS_REQUIREMENT]->EvalRequirement-[:HAS_TRIGGER]->
+//     EvalTrigger-[:HAS_OUTPUT]->EvalTriggerOutput) lives in the same
+//     graph as the agent catalog, so the dashboard renders without a
+//     Hive round-trip. Eval sets surface under an agent via the
+//     gateway-owned HiveAgent-[:HAS_EVAL_SET]->EvalSet edge.
+//   - The HAS_EVAL_SET edge is written directly (edge-only, both
+//     endpoints already exist — no Jarvis node schema involved).
+//   - NODE mutations (create/update/delete a set or requirement) and
+//     RUNs are delegated to Hive, which owns the Jarvis write path and
+//     the Stakwork run orchestration.
+
+// ─── read wire shapes ────────────────────────────────────────────────
+
+// EvalSetSummary is one row of an agent's eval-set list.
+type EvalSetSummary struct {
+	RefID        string `json:"ref_id"`
+	Name         string `json:"name,omitempty"`
+	Description  string `json:"description,omitempty"`
+	Requirements int    `json:"requirements"`
+}
+
+// AgentEvalsResponse is the agent-detail Evals tab payload — the sets
+// linked to this agent via HAS_EVAL_SET.
+type AgentEvalsResponse struct {
+	Agent string           `json:"agent"`
+	Sets  []EvalSetSummary `json:"sets"`
+}
+
+// EvalTriggerSummary is one captured trigger under a requirement, plus
+// the outcome of its most-recent run (nil-ish fields when never run).
+type EvalTriggerSummary struct {
+	RefID       string  `json:"ref_id"`
+	Agent       string  `json:"agent,omitempty"`
+	Source      string  `json:"source,omitempty"`
+	Environment string  `json:"environment,omitempty"`
+	ChangeType  string  `json:"change_type,omitempty"`
+	LastResult  string  `json:"last_result,omitempty"` // "pass" / "fail" / ""
+	LastScore   float64 `json:"last_score,omitempty"`
+	LastNotes   string  `json:"last_notes,omitempty"`
+	LastAttempt int     `json:"last_attempt,omitempty"`
+}
+
+// EvalRequirementDetail is a requirement with its triggers.
+type EvalRequirementDetail struct {
+	RefID         string               `json:"ref_id"`
+	Name          string               `json:"name,omitempty"`
+	Description   string               `json:"description,omitempty"`
+	PromptSnippet string               `json:"prompt_snippet,omitempty"`
+	Order         int                  `json:"order"`
+	Triggers      []EvalTriggerSummary `json:"triggers"`
+}
+
+// EvalSetDetailResponse is the expanded view of one set.
+type EvalSetDetailResponse struct {
+	RefID        string                  `json:"ref_id"`
+	Name         string                  `json:"name,omitempty"`
+	Description  string                  `json:"description,omitempty"`
+	Requirements []EvalRequirementDetail `json:"requirements"`
+}
+
+// ─── write wire shapes ───────────────────────────────────────────────
+
+// evalSetWriteRequest is the create/link/update body. On the agent
+// route: a non-empty SetID links an existing set; otherwise Name
+// creates a new one (and links it). On the set route: Name/Description
+// update.
+type evalSetWriteRequest struct {
+	SetID       string `json:"set_id,omitempty"`
+	Name        string `json:"name,omitempty"`
+	Description string `json:"description,omitempty"`
+}
+
+type evalRequirementWriteRequest struct {
+	Name             string   `json:"name,omitempty"`
+	Description      string   `json:"description,omitempty"`
+	PromptSnippet    string   `json:"prompt_snippet,omitempty"`
+	DesirableCases   []string `json:"desirable_cases,omitempty"`
+	UndesirableCases []string `json:"undesirable_cases,omitempty"`
+}
+
+type evalRunRequest struct {
+	Agent string `json:"agent,omitempty"`
+}
+
+// evalRefResponse is the create/link acknowledgement.
+type evalRefResponse struct {
+	RefID  string `json:"ref_id"`
+	Linked bool   `json:"linked,omitempty"`
+}
+
+type evalRunResponse struct {
+	ProjectID any `json:"project_id,omitempty"`
+}
+
+// ─── handler ─────────────────────────────────────────────────────────
+
+// evalHandlers owns the graph client (reads + the HAS_EVAL_SET edge)
+// and the Hive callback (node mutations + runs). graph is nil when
+// neo4j is unconfigured → reads 503; hive backs the delegated writes.
+type evalHandlers struct {
+	graph *graphclient.Client
+	hive  *hiveCallbackHandlers
+}
+
+func newEvalHandlers(graph *graphclient.Client, hive *hiveCallbackHandlers) *evalHandlers {
+	return &evalHandlers{graph: graph, hive: hive}
+}
+
+func (h *evalHandlers) graphReady(w http.ResponseWriter) bool {
+	if h.graph == nil {
+		writeError(w, http.StatusServiceUnavailable, "catalog_unavailable",
+			"eval graph not configured (neo4j unset on this swarm)")
+		return false
+	}
+	return true
+}
+
+// ─── agent-scoped: /_plugin/agents/:name/evals[/:setId] ──────────────
+
+// agentEvals dispatches the agent-scoped eval routes:
+//
+//	GET    /_plugin/agents/:name/evals          → list sets for agent
+//	POST   /_plugin/agents/:name/evals          → create+link OR link a set
+//	DELETE /_plugin/agents/:name/evals/:setId   → unlink a set (keep it)
+func (h *evalHandlers) agentEvals(w http.ResponseWriter, r *http.Request, agent string, rest []string) {
+	switch {
+	case len(rest) == 0 && r.Method == http.MethodGet:
+		h.listForAgent(w, r, agent)
+	case len(rest) == 0 && r.Method == http.MethodPost:
+		h.createOrLinkForAgent(w, r, agent)
+	case len(rest) == 1 && rest[0] != "" && r.Method == http.MethodDelete:
+		h.unlinkFromAgent(w, r, agent, rest[0])
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *evalHandlers) listForAgent(w http.ResponseWriter, r *http.Request, agent string) {
+	if !h.graphReady(w) {
+		return
+	}
+	res, err := h.graph.Query(r.Context(), fmt.Sprintf(
+		"MATCH (a:%[1]s {name: $name})-[:%[2]s]->(es:%[3]s) "+
+			"RETURN es.ref_id, es.name, es.description, "+
+			"COUNT { (es)-[:%[4]s]->(:%[5]s) } AS reqs "+
+			"ORDER BY coalesce(es.name, es.ref_id)",
+		graphclient.LabelAgent, graphclient.RelHasEvalSet, graphclient.LabelEvalSet,
+		graphclient.RelHasRequirement, graphclient.LabelEvalRequirement,
+	), map[string]any{"name": agent})
+	if err != nil {
+		pluginlog.Errf("adminapi: evals listForAgent agent=%s: %v", agent, err)
+		writeError(w, http.StatusBadGateway, "catalog_read_failed", "neo4j read failed")
+		return
+	}
+	out := AgentEvalsResponse{Agent: agent, Sets: []EvalSetSummary{}}
+	for _, row := range res.Data {
+		out.Sets = append(out.Sets, EvalSetSummary{
+			RefID:        rowString(at(row.Row, 0)),
+			Name:         rowString(at(row.Row, 1)),
+			Description:  rowString(at(row.Row, 2)),
+			Requirements: rowInt(at(row.Row, 3)),
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+func (h *evalHandlers) createOrLinkForAgent(w http.ResponseWriter, r *http.Request, agent string) {
+	if !h.graphReady(w) {
+		return
+	}
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+	var req evalSetWriteRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return
+	}
+	ctx := r.Context()
+
+	// Link an existing set: edge-only, no Hive round-trip.
+	if strings.TrimSpace(req.SetID) != "" {
+		if err := h.linkEdge(ctx, agent, req.SetID); err != nil {
+			pluginlog.Errf("adminapi: evals link agent=%s set=%s: %v", agent, req.SetID, err)
+			writeError(w, http.StatusBadGateway, "catalog_write_failed", "neo4j write failed")
+			return
+		}
+		writeJSON(w, http.StatusOK, evalRefResponse{RefID: req.SetID, Linked: true})
+		return
+	}
+
+	// Create a new set via Hive, then link it.
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "name (or set_id) is required")
+		return
+	}
+	var created evalRefResponse
+	if err := h.hive.call(ctx, http.MethodPost, "/api/gateway/evals",
+		map[string]any{"name": req.Name, "description": req.Description}, &created); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	if created.RefID == "" {
+		writeError(w, http.StatusBadGateway, "hive_error", "Hive did not return a ref_id")
+		return
+	}
+	if err := h.linkEdge(ctx, agent, created.RefID); err != nil {
+		// The set exists in Jarvis; only the agent link failed. Surface
+		// it so the operator can retry the link rather than silently
+		// orphaning the set.
+		pluginlog.Errf("adminapi: evals link-after-create agent=%s set=%s: %v", agent, created.RefID, err)
+		writeError(w, http.StatusBadGateway, "catalog_write_failed",
+			"set created but linking to agent failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, evalRefResponse{RefID: created.RefID})
+}
+
+// linkEdge MERGEs HiveAgent-[:HAS_EVAL_SET]->EvalSet. No-op (0 rows,
+// no error) if either endpoint is missing.
+func (h *evalHandlers) linkEdge(ctx context.Context, agent, setID string) error {
+	_, err := h.graph.Query(ctx, fmt.Sprintf(
+		"MATCH (a:%[1]s {name: $name}) MATCH (es:%[2]s {ref_id: $ref}) "+
+			"MERGE (a)-[:%[3]s]->(es)",
+		graphclient.LabelAgent, graphclient.LabelEvalSet, graphclient.RelHasEvalSet,
+	), map[string]any{"name": agent, "ref": setID})
+	return err
+}
+
+func (h *evalHandlers) unlinkFromAgent(w http.ResponseWriter, r *http.Request, agent, setID string) {
+	if !h.graphReady(w) {
+		return
+	}
+	_, err := h.graph.Query(r.Context(), fmt.Sprintf(
+		"MATCH (a:%[1]s {name: $name})-[e:%[2]s]->(:%[3]s {ref_id: $ref}) DELETE e",
+		graphclient.LabelAgent, graphclient.RelHasEvalSet, graphclient.LabelEvalSet,
+	), map[string]any{"name": agent, "ref": setID})
+	if err != nil {
+		pluginlog.Errf("adminapi: evals unlink agent=%s set=%s: %v", agent, setID, err)
+		writeError(w, http.StatusBadGateway, "catalog_write_failed", "neo4j write failed")
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// ─── set-scoped: /_plugin/evals[/:setId[/requirements[/:reqId[/run]]]] ─
+
+// dispatch is the /_plugin/evals/ subtree router.
+func (h *evalHandlers) dispatch(w http.ResponseWriter, r *http.Request) {
+	rest := strings.TrimPrefix(r.URL.Path, "/_plugin/evals")
+	rest = strings.TrimPrefix(rest, "/")
+	parts := splitNonEmpty(rest)
+
+	switch {
+	// POST /_plugin/evals — create a set (not yet linked to an agent).
+	case len(parts) == 0 && r.Method == http.MethodPost:
+		h.createSet(w, r)
+
+	// /_plugin/evals/:setId — GET detail, PATCH update, DELETE.
+	case len(parts) == 1:
+		switch r.Method {
+		case http.MethodGet:
+			h.setDetail(w, r, parts[0])
+		case http.MethodPatch:
+			h.updateSet(w, r, parts[0])
+		case http.MethodDelete:
+			h.deleteSet(w, r, parts[0])
+		default:
+			methodNotAllowed(w, http.MethodGet, http.MethodPatch, http.MethodDelete)
+		}
+
+	// /_plugin/evals/:setId/requirements — POST create.
+	case len(parts) == 2 && parts[1] == "requirements" && r.Method == http.MethodPost:
+		h.createRequirement(w, r, parts[0])
+
+	// /_plugin/evals/:setId/requirements/:reqId — PATCH / DELETE.
+	case len(parts) == 3 && parts[1] == "requirements":
+		switch r.Method {
+		case http.MethodPatch:
+			h.updateRequirement(w, r, parts[0], parts[2])
+		case http.MethodDelete:
+			h.deleteRequirement(w, r, parts[0], parts[2])
+		default:
+			methodNotAllowed(w, http.MethodPatch, http.MethodDelete)
+		}
+
+	// /_plugin/evals/:setId/requirements/:reqId/run — POST.
+	case len(parts) == 4 && parts[1] == "requirements" && parts[3] == "run" && r.Method == http.MethodPost:
+		h.runRequirement(w, r, parts[0], parts[2])
+
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (h *evalHandlers) setDetail(w http.ResponseWriter, r *http.Request, setID string) {
+	if !h.graphReady(w) {
+		return
+	}
+	p := map[string]any{"ref": setID}
+	results, err := h.graph.Run(r.Context(),
+		graphclient.Statement{
+			Statement: fmt.Sprintf(
+				"MATCH (es:%s {ref_id: $ref}) RETURN es.ref_id, es.name, es.description",
+				graphclient.LabelEvalSet),
+			Parameters: p,
+		},
+		graphclient.Statement{
+			Statement: fmt.Sprintf(
+				"MATCH (es:%[1]s {ref_id: $ref})-[hr:%[2]s]->(r:%[3]s) "+
+					"RETURN r.ref_id, r.name, r.description, r.prompt_snippet, "+
+					"toInteger(coalesce(hr.order, 0)) AS ord "+
+					"ORDER BY ord, r.name",
+				graphclient.LabelEvalSet, graphclient.RelHasRequirement, graphclient.LabelEvalRequirement),
+			Parameters: p,
+		},
+		graphclient.Statement{
+			// Latest output per trigger: order outputs by attempt desc
+			// and keep the head. requirements with no trigger simply
+			// contribute no rows here.
+			Statement: fmt.Sprintf(
+				"MATCH (es:%[1]s {ref_id: $ref})-[:%[2]s]->(r:%[3]s)-[:%[4]s]->(t:%[5]s) "+
+					"OPTIONAL MATCH (t)-[:%[6]s]->(o:%[7]s) "+
+					"WITH r, t, o ORDER BY toInteger(coalesce(o.attempt_number, 0)) DESC "+
+					"WITH r, t, head(collect(o)) AS last "+
+					"RETURN r.ref_id, t.ref_id, t.agent, t.source, t.environment, t.change_type, "+
+					"last.result, last.score, last.judge_notes, "+
+					"toInteger(coalesce(last.attempt_number, 0)) "+
+					"ORDER BY r.ref_id, t.ref_id",
+				graphclient.LabelEvalSet, graphclient.RelHasRequirement, graphclient.LabelEvalRequirement,
+				graphclient.RelHasTrigger, graphclient.LabelEvalTrigger,
+				graphclient.RelHasOutput, graphclient.LabelEvalOutput),
+			Parameters: p,
+		},
+	)
+	if err != nil {
+		pluginlog.Errf("adminapi: evals setDetail set=%s: %v", setID, err)
+		writeError(w, http.StatusBadGateway, "catalog_read_failed", "neo4j read failed")
+		return
+	}
+	if len(results) < 3 || len(results[0].Data) == 0 {
+		writeError(w, http.StatusNotFound, "not_found", "no such eval set")
+		return
+	}
+
+	setRow := results[0].Data[0].Row
+	out := &EvalSetDetailResponse{
+		RefID:        rowString(at(setRow, 0)),
+		Name:         rowString(at(setRow, 1)),
+		Description:  rowString(at(setRow, 2)),
+		Requirements: []EvalRequirementDetail{},
+	}
+
+	// Requirements, preserving order; index by ref for trigger attach.
+	byRef := map[string]*EvalRequirementDetail{}
+	for _, row := range results[1].Data {
+		req := EvalRequirementDetail{
+			RefID:         rowString(at(row.Row, 0)),
+			Name:          rowString(at(row.Row, 1)),
+			Description:   rowString(at(row.Row, 2)),
+			PromptSnippet: rowString(at(row.Row, 3)),
+			Order:         rowInt(at(row.Row, 4)),
+			Triggers:      []EvalTriggerSummary{},
+		}
+		out.Requirements = append(out.Requirements, req)
+		byRef[req.RefID] = &out.Requirements[len(out.Requirements)-1]
+	}
+	for _, row := range results[2].Data {
+		reqRef := rowString(at(row.Row, 0))
+		req, ok := byRef[reqRef]
+		if !ok {
+			continue
+		}
+		req.Triggers = append(req.Triggers, EvalTriggerSummary{
+			RefID:       rowString(at(row.Row, 1)),
+			Agent:       rowString(at(row.Row, 2)),
+			Source:      rowString(at(row.Row, 3)),
+			Environment: rowString(at(row.Row, 4)),
+			ChangeType:  rowString(at(row.Row, 5)),
+			LastResult:  rowString(at(row.Row, 6)),
+			LastScore:   rowFloat(at(row.Row, 7)),
+			LastNotes:   rowString(at(row.Row, 8)),
+			LastAttempt: rowInt(at(row.Row, 9)),
+		})
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// createSet creates a standalone set (no agent link yet). Delegated to
+// Hive. Agent-scoped creation goes through createOrLinkForAgent.
+func (h *evalHandlers) createSet(w http.ResponseWriter, r *http.Request) {
+	req, ok := decodeSetWrite(w, r)
+	if !ok {
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "name is required")
+		return
+	}
+	var created evalRefResponse
+	if err := h.hive.call(r.Context(), http.MethodPost, "/api/gateway/evals",
+		map[string]any{"name": req.Name, "description": req.Description}, &created); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, created)
+}
+
+func (h *evalHandlers) updateSet(w http.ResponseWriter, r *http.Request, setID string) {
+	req, ok := decodeSetWrite(w, r)
+	if !ok {
+		return
+	}
+	if err := h.hive.call(r.Context(), http.MethodPatch,
+		"/api/gateway/evals/"+urlSeg(setID),
+		map[string]any{"name": req.Name, "description": req.Description}, nil); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *evalHandlers) deleteSet(w http.ResponseWriter, r *http.Request, setID string) {
+	// Drop the gateway-owned agent links first (best-effort — Jarvis's
+	// node delete is DETACH, but clearing here keeps the graph tidy even
+	// if the Hive call fails midway).
+	if h.graph != nil {
+		if _, err := h.graph.Query(r.Context(), fmt.Sprintf(
+			"MATCH (:%[1]s)-[e:%[2]s]->(:%[3]s {ref_id: $ref}) DELETE e",
+			graphclient.LabelAgent, graphclient.RelHasEvalSet, graphclient.LabelEvalSet,
+		), map[string]any{"ref": setID}); err != nil {
+			pluginlog.Warnf("adminapi: evals deleteSet unlink set=%s: %v", setID, err)
+		}
+	}
+	if err := h.hive.call(r.Context(), http.MethodDelete,
+		"/api/gateway/evals/"+urlSeg(setID), nil, nil); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *evalHandlers) createRequirement(w http.ResponseWriter, r *http.Request, setID string) {
+	req, ok := decodeReqWrite(w, r)
+	if !ok {
+		return
+	}
+	if strings.TrimSpace(req.Name) == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "name is required")
+		return
+	}
+	var created evalRefResponse
+	if err := h.hive.call(r.Context(), http.MethodPost,
+		"/api/gateway/evals/"+urlSeg(setID)+"/requirements", req, &created); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, created)
+}
+
+func (h *evalHandlers) updateRequirement(w http.ResponseWriter, r *http.Request, setID, reqID string) {
+	req, ok := decodeReqWrite(w, r)
+	if !ok {
+		return
+	}
+	if err := h.hive.call(r.Context(), http.MethodPatch,
+		"/api/gateway/evals/"+urlSeg(setID)+"/requirements/"+urlSeg(reqID), req, nil); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (h *evalHandlers) deleteRequirement(w http.ResponseWriter, r *http.Request, setID, reqID string) {
+	if err := h.hive.call(r.Context(), http.MethodDelete,
+		"/api/gateway/evals/"+urlSeg(setID)+"/requirements/"+urlSeg(reqID), nil, nil); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// runRequirement dispatches an eval run for a requirement. Hive fires
+// the Stakwork workflow (Bifrost creds + Stakwork key are Hive-side)
+// and the results are written back into Jarvis as EvalTriggerOutput
+// nodes, which the setDetail read then surfaces.
+func (h *evalHandlers) runRequirement(w http.ResponseWriter, r *http.Request, setID, reqID string) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+	var req evalRunRequest
+	// Body is optional (agent override) — tolerate an empty body.
+	if r.ContentLength != 0 {
+		if err := decodeJSON(r, &req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+			return
+		}
+	}
+	var out evalRunResponse
+	if err := h.hive.call(r.Context(), http.MethodPost,
+		"/api/gateway/evals/"+urlSeg(setID)+"/requirements/"+urlSeg(reqID)+"/run",
+		map[string]any{"agent": req.Agent}, &out); err != nil {
+		relayHiveError(w, err)
+		return
+	}
+	writeJSON(w, http.StatusOK, out)
+}
+
+// ─── helpers ─────────────────────────────────────────────────────────
+
+func decodeSetWrite(w http.ResponseWriter, r *http.Request) (evalSetWriteRequest, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+	var req evalSetWriteRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return req, false
+	}
+	return req, true
+}
+
+func decodeReqWrite(w http.ResponseWriter, r *http.Request) (evalRequirementWriteRequest, bool) {
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+	var req evalRequirementWriteRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return req, false
+	}
+	return req, true
+}
+
+// splitNonEmpty splits a cleaned path tail on "/" dropping empties, so
+// a trailing slash doesn't produce a phantom segment.
+func splitNonEmpty(s string) []string {
+	if s == "" {
+		return nil
+	}
+	raw := strings.Split(s, "/")
+	out := make([]string, 0, len(raw))
+	for _, p := range raw {
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// urlSeg escapes a single path segment for the Hive callback URL.
+func urlSeg(s string) string {
+	// ref_ids are uuid4 (safe already) but escape defensively.
+	return strings.ReplaceAll(strings.ReplaceAll(s, "/", "%2F"), " ", "%20")
+}
+
+// rowFloat decodes a returned cell into a float64. neo4j numbers arrive
+// as JSON numbers; null / garbage ⇒ 0.
+func rowFloat(raw json.RawMessage) float64 {
+	if len(raw) == 0 {
+		return 0
+	}
+	var f float64
+	if err := json.Unmarshal(raw, &f); err != nil {
+		return 0
+	}
+	return f
+}

--- a/gateway/internal/adminapi/evals.go
+++ b/gateway/internal/adminapi/evals.go
@@ -106,7 +106,9 @@ type evalRefResponse struct {
 }
 
 type evalRunResponse struct {
-	ProjectID any `json:"project_id,omitempty"`
+	// A requirement fans out to N triggers, so Hive dispatches one
+	// Stakwork project per trigger and returns them all.
+	ProjectIDs []any `json:"project_ids,omitempty"`
 }
 
 // ─── handler ─────────────────────────────────────────────────────────
@@ -421,12 +423,15 @@ func (h *evalHandlers) createSet(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, created)
 }
 
+// updateSet is reached by an inbound PATCH from the SPA (apiFetch only
+// speaks GET/POST/PATCH/DELETE) but forwards to Hive as PUT, which is
+// the verb the /api/gateway/evals contract uses.
 func (h *evalHandlers) updateSet(w http.ResponseWriter, r *http.Request, setID string) {
 	req, ok := decodeSetWrite(w, r)
 	if !ok {
 		return
 	}
-	if err := h.hive.call(r.Context(), http.MethodPatch,
+	if err := h.hive.call(r.Context(), http.MethodPut,
 		"/api/gateway/evals/"+urlSeg(setID),
 		map[string]any{"name": req.Name, "description": req.Description}, nil); err != nil {
 		relayHiveError(w, err)
@@ -478,7 +483,7 @@ func (h *evalHandlers) updateRequirement(w http.ResponseWriter, r *http.Request,
 	if !ok {
 		return
 	}
-	if err := h.hive.call(r.Context(), http.MethodPatch,
+	if err := h.hive.call(r.Context(), http.MethodPut,
 		"/api/gateway/evals/"+urlSeg(setID)+"/requirements/"+urlSeg(reqID), req, nil); err != nil {
 		relayHiveError(w, err)
 		return

--- a/gateway/internal/adminapi/hivecallback.go
+++ b/gateway/internal/adminapi/hivecallback.go
@@ -1,0 +1,243 @@
+package adminapi
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
+	"github.com/stakwork/stakgraph/gateway/internal/redisclient"
+)
+
+// hivecallback.go wires the gateway's one outbound relationship with
+// Hive.
+//
+// Why it exists
+// -------------
+// The Evals tab lets an operator create / edit / delete eval sets and
+// *run* them from inside the gateway dashboard. Reads come straight
+// out of neo4j (see evals.go), but every WRITE and every RUN is
+// delegated back to Hive:
+//
+//   - eval nodes are Jarvis-authored (schema + node_key + Data_Bank +
+//     namespace machinery). The gateway must not forge them with raw
+//     Cypher, so it asks Hive — which already owns the Jarvis write
+//     path — to do it.
+//   - runs dispatch a Stakwork workflow with Bifrost creds + the
+//     Stakwork API key, all of which live Hive-side.
+//
+// Config source
+// -------------
+// Hive pushes its callback base URL + a workspace-scoped API key to
+// POST /_plugin/hive-callback (bearer-only) during agent-catalog
+// reconciliation. We stash both in Redis so they survive across
+// requests without an env redeploy and can be rotated by simply
+// re-pushing. When Redis is in observability mode (no URL) the config
+// can't be persisted and the write/run endpoints answer 503 — reads
+// still work.
+//
+// Auth model of the callback
+// ---------------------------
+// The gateway calls Hive with `Authorization: Bearer <workspace_key>`.
+// Hive validates the key, resolves the workspace itself, and performs
+// the Jarvis / Stakwork action scoped to THAT workspace. The gateway
+// never sends a workspace id — the key IS the scope. This mirrors how
+// Hive already authenticates its error-ingest + MCP surfaces.
+
+// Redis keys for the pushed Hive callback config. Namespaced under the
+// shared `bifrost:` prefix like every other plugin key.
+const (
+	hiveCallbackURLKey = "hive:callback:url"
+	hiveCallbackKeyKey = "hive:callback:api_key"
+)
+
+// hiveCallbackTimeout bounds a single gateway→Hive round-trip. Runs
+// dispatch a Stakwork project (Hive returns as soon as the project is
+// accepted, not when the eval finishes), and CRUD is one Jarvis write,
+// so a few seconds is plenty.
+const hiveCallbackTimeout = 12 * time.Second
+
+// ─── inbound: POST /_plugin/hive-callback (store config) ─────────────
+
+// hiveCallbackConfigRequest is what Hive pushes during reconciliation.
+type hiveCallbackConfigRequest struct {
+	// HiveURL is Hive's base origin (no trailing slash needed — we
+	// normalise). All callback paths are appended to it.
+	HiveURL string `json:"hive_url"`
+	// APIKey is a workspace-scoped Hive API key (`hive_…`). It is the
+	// bearer the gateway presents on every callback; Hive resolves the
+	// workspace from it.
+	APIKey string `json:"api_key"`
+}
+
+type hiveCallbackConfigResponse struct {
+	Stored bool `json:"stored"`
+}
+
+// hiveCallbackHandlers persists + reads the callback config and issues
+// the outbound calls. redis may be nil (observability mode) — then the
+// config can't be stored and callers degrade to 503.
+type hiveCallbackHandlers struct {
+	http *http.Client
+}
+
+func newHiveCallbackHandlers() *hiveCallbackHandlers {
+	return &hiveCallbackHandlers{
+		http: &http.Client{Timeout: hiveCallbackTimeout},
+	}
+}
+
+// storeConfig handles POST /_plugin/hive-callback — bearer-only, the
+// same server-to-server posture as the catalog push. Idempotent:
+// re-pushing overwrites, which is how key rotation works.
+func (h *hiveCallbackHandlers) storeConfig(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		methodNotAllowed(w, http.MethodPost)
+		return
+	}
+	rc := redisclient.Client()
+	if rc == nil {
+		writeError(w, http.StatusServiceUnavailable, "callback_unavailable",
+			"hive callback config store not available (redis unset on this swarm)")
+		return
+	}
+
+	r.Body = http.MaxBytesReader(w, r.Body, 1<<16)
+	var req hiveCallbackConfigRequest
+	if err := decodeJSON(r, &req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", err.Error())
+		return
+	}
+	url := strings.TrimRight(strings.TrimSpace(req.HiveURL), "/")
+	key := strings.TrimSpace(req.APIKey)
+	if url == "" || key == "" {
+		writeError(w, http.StatusBadRequest, "missing_field", "hive_url and api_key are required")
+		return
+	}
+
+	ctx := r.Context()
+	if err := rc.Set(ctx, redisclient.Key(hiveCallbackURLKey), url, 0).Err(); err != nil {
+		pluginlog.Errf("adminapi: hive callback store url: %v", err)
+		writeError(w, http.StatusBadGateway, "callback_store_failed", "redis write failed")
+		return
+	}
+	if err := rc.Set(ctx, redisclient.Key(hiveCallbackKeyKey), key, 0).Err(); err != nil {
+		pluginlog.Errf("adminapi: hive callback store key: %v", err)
+		writeError(w, http.StatusBadGateway, "callback_store_failed", "redis write failed")
+		return
+	}
+	writeJSON(w, http.StatusOK, hiveCallbackConfigResponse{Stored: true})
+}
+
+// ─── outbound: gateway → Hive ────────────────────────────────────────
+
+// config reads the pushed base URL + api key from Redis. ok is false
+// when Redis is down or the config was never pushed — callers surface
+// that as 503 so the UI can prompt "connect this swarm to Hive".
+func (h *hiveCallbackHandlers) config(ctx context.Context) (baseURL, apiKey string, ok bool) {
+	rc := redisclient.Client()
+	if rc == nil {
+		return "", "", false
+	}
+	vals, err := rc.MGet(ctx,
+		redisclient.Key(hiveCallbackURLKey),
+		redisclient.Key(hiveCallbackKeyKey),
+	).Result()
+	if err != nil || len(vals) != 2 {
+		return "", "", false
+	}
+	u, _ := vals[0].(string)
+	k, _ := vals[1].(string)
+	if u == "" || k == "" {
+		return "", "", false
+	}
+	return u, k, true
+}
+
+// hiveError carries the status + parsed error code from a failed
+// callback so the gateway handler can relay a faithful status to the
+// SPA rather than a flat 502.
+type hiveError struct {
+	status int
+	code   string
+	msg    string
+}
+
+func (e *hiveError) Error() string { return fmt.Sprintf("hive %d %s: %s", e.status, e.code, e.msg) }
+
+// call issues one JSON request to Hive and decodes the response into
+// `out` (may be nil to ignore the body). method/path are appended to
+// the pushed base URL; `body` is JSON-encoded when non-nil.
+//
+// Errors:
+//   - *hiveError when the config is missing (status 503) or Hive
+//     answers non-2xx (its status + code relayed).
+//   - a plain error for transport/timeouts.
+func (h *hiveCallbackHandlers) call(ctx context.Context, method, path string, body, out any) error {
+	baseURL, apiKey, ok := h.config(ctx)
+	if !ok {
+		return &hiveError{status: http.StatusServiceUnavailable, code: "hive_not_connected",
+			msg: "this swarm is not connected to Hive yet (no callback config pushed)"}
+	}
+
+	var reader io.Reader
+	if body != nil {
+		b, err := json.Marshal(body)
+		if err != nil {
+			return fmt.Errorf("hivecallback: marshal: %w", err)
+		}
+		reader = bytes.NewReader(b)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, method, baseURL+path, reader)
+	if err != nil {
+		return fmt.Errorf("hivecallback: build request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+apiKey)
+	req.Header.Set("Accept", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := h.http.Do(req)
+	if err != nil {
+		return fmt.Errorf("hivecallback: %s %s: %w", method, path, err)
+	}
+	defer resp.Body.Close()
+
+	raw, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20))
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		code, msg := "hive_error", strings.TrimSpace(string(raw))
+		// Hive returns `{ "error": "…" }`; surface it when present.
+		var env struct {
+			Error string `json:"error"`
+		}
+		if json.Unmarshal(raw, &env) == nil && env.Error != "" {
+			msg = env.Error
+		}
+		return &hiveError{status: resp.StatusCode, code: code, msg: msg}
+	}
+	if out != nil && len(raw) > 0 {
+		if err := json.Unmarshal(raw, out); err != nil {
+			return fmt.Errorf("hivecallback: decode response: %w", err)
+		}
+	}
+	return nil
+}
+
+// relayHiveError translates a callback failure into an HTTP response
+// on the SPA-facing side, preserving Hive's status when it was an
+// *hiveError so a 404 stays a 404 (not a blanket 502).
+func relayHiveError(w http.ResponseWriter, err error) {
+	if he, ok := err.(*hiveError); ok {
+		writeError(w, he.status, he.code, he.msg)
+		return
+	}
+	pluginlog.Errf("adminapi: hive callback: %v", err)
+	writeError(w, http.StatusBadGateway, "hive_unreachable", "could not reach Hive")
+}

--- a/gateway/internal/adminapi/server.go
+++ b/gateway/internal/adminapi/server.go
@@ -273,6 +273,8 @@ func registerRoutes(mux *http.ServeMux, deps routeDeps) {
 	// `:name/kill` live under the same prefix later).
 	bgt := newBudgetHandlers(deps.logstore)
 	cat := newCatalogHandlers(deps.graph)
+	hiveCb := newHiveCallbackHandlers()
+	evals := newEvalHandlers(deps.graph, hiveCb)
 
 	// The `/_plugin/agents/` subtree is shared: ServeMux allows only
 	// one handler per pattern, so a small dispatcher fans the trailing
@@ -306,6 +308,13 @@ func registerRoutes(mux *http.ServeMux, deps routeDeps) {
 			cat.toggleTool(w, r)
 			return
 		}
+		// `<name>/evals` and `<name>/evals/<setId>`: the agent-scoped
+		// Evals tab. GET lists the sets linked to the agent; POST
+		// creates/links; DELETE unlinks. agentEvals picks by method.
+		if len(parts) >= 2 && parts[0] != "" && parts[1] == "evals" {
+			evals.agentEvals(w, r, parts[0], parts[2:])
+			return
+		}
 		// Default: the budget handler owns `<name>/budget` and 404s
 		// the rest.
 		bgt.budget(w, r)
@@ -318,6 +327,19 @@ func registerRoutes(mux *http.ServeMux, deps routeDeps) {
 	// unconfigured so the handler can answer 503 rather than ServeMux
 	// 301-redirecting to the subtree.
 	mux.HandleFunc("/_plugin/agents", bearer(cat.push))
+
+	// Eval set / requirement CRUD + runs. Cookie-or-bearer: these are
+	// operator dashboard actions (the CSRF header guards cookie-authed
+	// mutations). Reads hit neo4j directly; node mutations + runs are
+	// delegated to Hive via the pushed callback config. The exact and
+	// subtree patterns both route through one dispatcher.
+	mux.HandleFunc("/_plugin/evals", cookieOrBearer(evals.dispatch))
+	mux.HandleFunc("/_plugin/evals/", cookieOrBearer(evals.dispatch))
+
+	// Hive callback config push: Hive sends its base URL + a
+	// workspace-scoped API key during agent-catalog reconciliation.
+	// Bearer-only (server-to-server), same posture as the catalog push.
+	mux.HandleFunc("/_plugin/hive-callback", bearer(hiveCb.storeConfig))
 
 	// SPA — served WITHOUT middleware auth. The SPA itself probes
 	// /_plugin/me at boot and redirects to /login on 401; gating

--- a/gateway/internal/adminapi/ui/src/api/queries.ts
+++ b/gateway/internal/adminapi/ui/src/api/queries.ts
@@ -14,6 +14,9 @@ import { apiFetch, ApiCallError } from "./client";
 import type {
   AgentBudgetResponse,
   AgentCatalogResponse,
+  AgentEvalsResponse,
+  EvalRefResponse,
+  EvalSetDetailResponse,
   CatalogListResponse,
   CallDetailResponse,
   HistogramCostResponse,
@@ -420,5 +423,168 @@ export function useRunCall(
     enabled: !!runID && !!callID,
     staleTime: Infinity,
     retry: false, // 404 on cross-run / unknown id is meaningful; no retry
+  });
+}
+
+// ─── Evals (agent-detail tab) ───────────────────────────────────────
+//
+// Reads (list-for-agent, set detail) hit neo4j directly through the
+// gateway. Writes (create / link / update / delete / run) are
+// delegated by the gateway to Hive, so a mutation's success is only
+// as fresh as the subsequent read — we invalidate the relevant query
+// on settle rather than optimistically patching.
+//
+// A 503 "hive_not_connected" from a write means this swarm hasn't had
+// its Hive callback config pushed yet; the error bubbles up so the
+// EvalsView can show a "connect to Hive" notice.
+
+const AGENT_EVALS_KEY = (name: string) => ["agents", name, "evals"];
+const EVAL_SET_KEY = (setId: string) => ["evals", setId];
+
+export function useAgentEvals(name: string | undefined) {
+  return useQuery({
+    queryKey: ["agents", name, "evals"],
+    queryFn: () =>
+      apiFetch<AgentEvalsResponse>(`/agents/${encodeURIComponent(name!)}/evals`),
+    enabled: !!name,
+    staleTime: 60_000,
+    retry: false,
+  });
+}
+
+export function useEvalSet(setId: string | undefined) {
+  return useQuery({
+    queryKey: ["evals", setId],
+    queryFn: () =>
+      apiFetch<EvalSetDetailResponse>(`/evals/${encodeURIComponent(setId!)}`),
+    enabled: !!setId,
+    staleTime: 30_000,
+    retry: false,
+  });
+}
+
+// Create a new eval set and link it to this agent (or link an existing
+// one when `setId` is provided). Backed by POST /agents/:name/evals.
+export function useCreateOrLinkEvalSet(agentName: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { name?: string; description?: string; setId?: string }) =>
+      apiFetch<EvalRefResponse>(`/agents/${encodeURIComponent(agentName)}/evals`, {
+        method: "POST",
+        body: {
+          name: args.name,
+          description: args.description,
+          set_id: args.setId,
+        },
+      }),
+    onSettled: () =>
+      qc.invalidateQueries({ queryKey: AGENT_EVALS_KEY(agentName) }),
+  });
+}
+
+// Remove a set from this agent (unlink only — the set itself survives).
+export function useUnlinkEvalSet(agentName: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (setId: string) =>
+      apiFetch<void>(
+        `/agents/${encodeURIComponent(agentName)}/evals/${encodeURIComponent(setId)}`,
+        { method: "DELETE" },
+      ),
+    onSettled: () =>
+      qc.invalidateQueries({ queryKey: AGENT_EVALS_KEY(agentName) }),
+  });
+}
+
+// Delete a set outright (via Hive) and refresh the agent's list.
+export function useDeleteEvalSet(agentName: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (setId: string) =>
+      apiFetch<void>(`/evals/${encodeURIComponent(setId)}`, { method: "DELETE" }),
+    onSettled: () =>
+      qc.invalidateQueries({ queryKey: AGENT_EVALS_KEY(agentName) }),
+  });
+}
+
+export function useUpdateEvalSet(setId: string, agentName: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { name?: string; description?: string }) =>
+      apiFetch<void>(`/evals/${encodeURIComponent(setId)}`, {
+        method: "PATCH",
+        body: args,
+      }),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: EVAL_SET_KEY(setId) });
+      qc.invalidateQueries({ queryKey: AGENT_EVALS_KEY(agentName) });
+    },
+  });
+}
+
+interface RequirementWrite {
+  name?: string;
+  description?: string;
+  prompt_snippet?: string;
+  desirable_cases?: string[];
+  undesirable_cases?: string[];
+}
+
+export function useCreateRequirement(setId: string, agentName: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: RequirementWrite) =>
+      apiFetch<EvalRefResponse>(
+        `/evals/${encodeURIComponent(setId)}/requirements`,
+        { method: "POST", body: args },
+      ),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: EVAL_SET_KEY(setId) });
+      qc.invalidateQueries({ queryKey: AGENT_EVALS_KEY(agentName) });
+    },
+  });
+}
+
+export function useUpdateRequirement(setId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { reqId: string } & RequirementWrite) => {
+      const { reqId, ...body } = args;
+      return apiFetch<void>(
+        `/evals/${encodeURIComponent(setId)}/requirements/${encodeURIComponent(reqId)}`,
+        { method: "PATCH", body },
+      );
+    },
+    onSettled: () => qc.invalidateQueries({ queryKey: EVAL_SET_KEY(setId) }),
+  });
+}
+
+export function useDeleteRequirement(setId: string, agentName: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (reqId: string) =>
+      apiFetch<void>(
+        `/evals/${encodeURIComponent(setId)}/requirements/${encodeURIComponent(reqId)}`,
+        { method: "DELETE" },
+      ),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: EVAL_SET_KEY(setId) });
+      qc.invalidateQueries({ queryKey: AGENT_EVALS_KEY(agentName) });
+    },
+  });
+}
+
+// Dispatch an eval run for a requirement. Hive fires the Stakwork
+// workflow; outputs land back in Jarvis, so we invalidate the set
+// detail on settle to pick up the new results on the next poll.
+export function useRunRequirement(setId: string) {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (args: { reqId: string; agent?: string }) =>
+      apiFetch<{ project_id?: unknown }>(
+        `/evals/${encodeURIComponent(setId)}/requirements/${encodeURIComponent(args.reqId)}/run`,
+        { method: "POST", body: { agent: args.agent } },
+      ),
+    onSettled: () => qc.invalidateQueries({ queryKey: EVAL_SET_KEY(setId) }),
   });
 }

--- a/gateway/internal/adminapi/ui/src/api/queries.ts
+++ b/gateway/internal/adminapi/ui/src/api/queries.ts
@@ -581,7 +581,7 @@ export function useRunRequirement(setId: string) {
   const qc = useQueryClient();
   return useMutation({
     mutationFn: (args: { reqId: string; agent?: string }) =>
-      apiFetch<{ project_id?: unknown }>(
+      apiFetch<{ project_ids?: unknown[] }>(
         `/evals/${encodeURIComponent(setId)}/requirements/${encodeURIComponent(args.reqId)}/run`,
         { method: "POST", body: { agent: args.agent } },
       ),

--- a/gateway/internal/adminapi/ui/src/api/types.ts
+++ b/gateway/internal/adminapi/ui/src/api/types.ts
@@ -390,6 +390,57 @@ export interface AgentCatalogResponse {
   skills: CatalogSkill[];
 }
 
+// ─── Evals (agent-detail tab) ───────────────────────────────────────
+// Mirror of the Go structs in internal/adminapi/evals.go. Eval sets are
+// Jarvis-authored nodes surfaced under an agent via HAS_EVAL_SET; the
+// gateway reads them from neo4j and delegates writes/runs to Hive.
+
+export interface EvalSetSummary {
+  ref_id: string;
+  name?: string;
+  description?: string;
+  requirements: number;
+}
+
+export interface AgentEvalsResponse {
+  agent: string;
+  sets: EvalSetSummary[];
+}
+
+export interface EvalTriggerSummary {
+  ref_id: string;
+  agent?: string;
+  source?: string;
+  environment?: string;
+  change_type?: string;
+  last_result?: string; // "pass" | "fail" | ""
+  last_score?: number;
+  last_notes?: string;
+  last_attempt?: number;
+}
+
+export interface EvalRequirementDetail {
+  ref_id: string;
+  name?: string;
+  description?: string;
+  prompt_snippet?: string;
+  order: number;
+  triggers: EvalTriggerSummary[];
+}
+
+export interface EvalSetDetailResponse {
+  ref_id: string;
+  name?: string;
+  description?: string;
+  requirements: EvalRequirementDetail[];
+}
+
+// Acknowledgement for create/link (ref_id of the set/requirement).
+export interface EvalRefResponse {
+  ref_id: string;
+  linked?: boolean;
+}
+
 // Phase-7 error envelope (returned on 4xx/5xx).
 export interface ApiError {
   error: {

--- a/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/AgentDetail.tsx
@@ -26,18 +26,20 @@ import { ApiCallError, getErrorMessage } from "../api/client";
 import {
   useAgentBudget,
   useAgentCatalog,
+  useAgentEvals,
   useHistogramCost,
   useToggleSkill,
   useToggleTool,
 } from "../api/queries";
 import type { HistogramCostResponse, Window } from "../api/types";
 import { windowToSeconds } from "../api/window";
+import { EvalsView } from "./EvalsView";
 
 interface Props {
   name: string;
 }
 
-type Tab = "overview" | "prompts" | "tools" | "skills";
+type Tab = "overview" | "prompts" | "tools" | "skills" | "evals";
 
 const fmtUSD = (v: number) => {
   if (v === 0) return "$0.00";
@@ -101,6 +103,7 @@ export function AgentDetail({ name }: Props) {
 
   const [tab, setTab] = useState<Tab>("overview");
   const catalog = useAgentCatalog(name);
+  const evals = useAgentEvals(name);
   // 503 ⇒ neo4j not wired on this swarm: the catalog tabs render a
   // "not configured" notice rather than an error banner.
   const catalogUnavailable =
@@ -152,9 +155,18 @@ export function AgentDetail({ name }: Props) {
           label="Skills"
           count={cat?.skills.length}
         />
+        <TabButton
+          id="evals"
+          active={tab}
+          onSelect={setTab}
+          label="Evals"
+          count={evals.data?.sets.length}
+        />
       </nav>
 
-      {tab !== "overview" ? (
+      {tab === "evals" ? (
+        <EvalsView agentName={name} />
+      ) : tab !== "overview" ? (
         <CatalogPanel
           tab={tab}
           catalog={cat}

--- a/gateway/internal/adminapi/ui/src/pages/EvalsView.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/EvalsView.tsx
@@ -1,0 +1,302 @@
+// EvalsView — the agent-detail "Evals" tab.
+//
+// Reads (the set list + each set's requirements/triggers/outputs) come
+// from the gateway's neo4j traversal. Writes and runs are delegated by
+// the gateway to Hive, so a mutation may fail with "hive_not_connected"
+// when this swarm hasn't had its Hive callback config pushed yet — we
+// surface that inline rather than as a fatal error.
+
+import { useState } from "preact/hooks";
+
+import { ApiCallError, getErrorMessage } from "../api/client";
+import {
+  useAgentEvals,
+  useCreateOrLinkEvalSet,
+  useCreateRequirement,
+  useDeleteEvalSet,
+  useDeleteRequirement,
+  useEvalSet,
+  useRunRequirement,
+  useUnlinkEvalSet,
+} from "../api/queries";
+import type {
+  EvalRequirementDetail,
+  EvalSetSummary,
+  EvalTriggerSummary,
+} from "../api/types";
+
+export function EvalsView({ agentName }: { agentName: string }) {
+  const evals = useAgentEvals(agentName);
+  const createOrLink = useCreateOrLinkEvalSet(agentName);
+  const [newName, setNewName] = useState("");
+  const [openSet, setOpenSet] = useState<string | null>(null);
+
+  const unavailable =
+    evals.error instanceof ApiCallError &&
+    evals.error.code === "catalog_unavailable";
+
+  if (unavailable) {
+    return (
+      <div class="empty">
+        Eval graph not wired on this swarm. Set{" "}
+        <span class="mono">NEO4J_PASSWORD</span> on the gateway to enable evals.
+      </div>
+    );
+  }
+  if (evals.isLoading) return <div class="loading">Loading…</div>;
+  if (evals.isError) {
+    return <div class="error-banner">{getErrorMessage(evals.error)}</div>;
+  }
+
+  const sets = evals.data?.sets ?? [];
+
+  const submitCreate = (e: Event) => {
+    e.preventDefault();
+    const name = newName.trim();
+    if (!name) return;
+    createOrLink.mutate(
+      { name },
+      { onSuccess: () => setNewName("") },
+    );
+  };
+
+  return (
+    <div class="evals-view">
+      <form class="eval-create" onSubmit={submitCreate}>
+        <input
+          class="input"
+          type="text"
+          placeholder="New eval set name…"
+          value={newName}
+          onInput={(e) => setNewName((e.target as HTMLInputElement).value)}
+        />
+        <button
+          type="submit"
+          class="btn is-primary"
+          disabled={createOrLink.isPending || !newName.trim()}
+        >
+          {createOrLink.isPending ? "Creating…" : "Create eval set"}
+        </button>
+      </form>
+      {createOrLink.isError ? (
+        <div class="error-banner">{getErrorMessage(createOrLink.error)}</div>
+      ) : null}
+
+      {sets.length === 0 ? (
+        <div class="empty">No eval sets linked to this agent yet.</div>
+      ) : (
+        <div class="catalog-list">
+          {sets.map((s) => (
+            <SetCard
+              key={s.ref_id}
+              agentName={agentName}
+              set={s}
+              open={openSet === s.ref_id}
+              onToggle={() =>
+                setOpenSet(openSet === s.ref_id ? null : s.ref_id)
+              }
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SetCard({
+  agentName,
+  set,
+  open,
+  onToggle,
+}: {
+  agentName: string;
+  set: EvalSetSummary;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const unlink = useUnlinkEvalSet(agentName);
+  const del = useDeleteEvalSet(agentName);
+
+  return (
+    <div class="card catalog-card">
+      <div class="catalog-summary" style="cursor: default">
+        <button type="button" class="eval-disclosure" onClick={onToggle}>
+          <span class="mono">{set.name || set.ref_id}</span>
+          <span class="pill pill-accent">{set.requirements} req</span>
+        </button>
+        <div class="btn-group">
+          <button
+            type="button"
+            class="btn"
+            title="Remove from this agent (keeps the set)"
+            disabled={unlink.isPending}
+            onClick={() => unlink.mutate(set.ref_id)}
+          >
+            Unlink
+          </button>
+          <button
+            type="button"
+            class="btn"
+            title="Delete the eval set entirely"
+            disabled={del.isPending}
+            onClick={() => {
+              if (confirm(`Delete eval set "${set.name || set.ref_id}"?`)) {
+                del.mutate(set.ref_id);
+              }
+            }}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+      {del.isError ? (
+        <div class="error-banner">{getErrorMessage(del.error)}</div>
+      ) : null}
+      {open ? <SetDetail setId={set.ref_id} agentName={agentName} /> : null}
+    </div>
+  );
+}
+
+function SetDetail({
+  setId,
+  agentName,
+}: {
+  setId: string;
+  agentName: string;
+}) {
+  const detail = useEvalSet(setId);
+  const createReq = useCreateRequirement(setId, agentName);
+  const [reqName, setReqName] = useState("");
+
+  if (detail.isLoading) return <div class="loading">Loading…</div>;
+  if (detail.isError) {
+    return <div class="error-banner">{getErrorMessage(detail.error)}</div>;
+  }
+
+  const reqs = detail.data?.requirements ?? [];
+
+  const submitReq = (e: Event) => {
+    e.preventDefault();
+    const name = reqName.trim();
+    if (!name) return;
+    createReq.mutate({ name }, { onSuccess: () => setReqName("") });
+  };
+
+  return (
+    <div class="eval-detail">
+      {reqs.length === 0 ? (
+        <div class="empty">No requirements yet.</div>
+      ) : (
+        reqs.map((r) => (
+          <RequirementRow
+            key={r.ref_id}
+            setId={setId}
+            agentName={agentName}
+            req={r}
+          />
+        ))
+      )}
+
+      <form class="eval-create" onSubmit={submitReq}>
+        <input
+          class="input"
+          type="text"
+          placeholder="New requirement…"
+          value={reqName}
+          onInput={(e) => setReqName((e.target as HTMLInputElement).value)}
+        />
+        <button
+          type="submit"
+          class="btn"
+          disabled={createReq.isPending || !reqName.trim()}
+        >
+          Add requirement
+        </button>
+      </form>
+      {createReq.isError ? (
+        <div class="error-banner">{getErrorMessage(createReq.error)}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function RequirementRow({
+  setId,
+  agentName,
+  req,
+}: {
+  setId: string;
+  agentName: string;
+  req: EvalRequirementDetail;
+}) {
+  const run = useRunRequirement(setId);
+  const del = useDeleteRequirement(setId, agentName);
+
+  return (
+    <div class="eval-req">
+      <div class="eval-req-head">
+        <span class="eval-req-name">{req.name || req.ref_id}</span>
+        <div class="btn-group">
+          <button
+            type="button"
+            class="btn is-primary"
+            disabled={run.isPending}
+            onClick={() => run.mutate({ reqId: req.ref_id })}
+          >
+            {run.isPending ? "Running…" : "Run"}
+          </button>
+          <button
+            type="button"
+            class="btn"
+            disabled={del.isPending}
+            onClick={() => del.mutate(req.ref_id)}
+          >
+            Delete
+          </button>
+        </div>
+      </div>
+      {req.description ? (
+        <div class="text-dim eval-req-desc">{req.description}</div>
+      ) : null}
+      {run.isError ? (
+        <div class="error-banner">{getErrorMessage(run.error)}</div>
+      ) : null}
+      {req.triggers.length > 0 ? (
+        <div class="eval-triggers">
+          {req.triggers.map((t) => (
+            <TriggerChip key={t.ref_id} trigger={t} />
+          ))}
+        </div>
+      ) : (
+        <div class="text-dim eval-req-desc">No captured triggers.</div>
+      )}
+    </div>
+  );
+}
+
+function TriggerChip({ trigger }: { trigger: EvalTriggerSummary }) {
+  const result = (trigger.last_result || "").toLowerCase();
+  const badge =
+    result === "pass"
+      ? "badge badge-ok"
+      : result === "fail"
+        ? "badge badge-warning"
+        : "badge";
+  const label =
+    result === "pass"
+      ? "pass"
+      : result === "fail"
+        ? "fail"
+        : "not run";
+  return (
+    <span class="eval-trigger" title={trigger.last_notes || undefined}>
+      <span class={badge}>{label}</span>
+      {trigger.source ? (
+        <span class="text-dim mono">{trigger.source}</span>
+      ) : null}
+      {result && typeof trigger.last_score === "number" ? (
+        <span class="text-dim">{trigger.last_score.toFixed(2)}</span>
+      ) : null}
+    </span>
+  );
+}

--- a/gateway/internal/adminapi/ui/src/styles/components.css
+++ b/gateway/internal/adminapi/ui/src/styles/components.css
@@ -1215,3 +1215,61 @@ tr.is-disabled td.text-dim {
 .catalog-card.is-disabled .catalog-summary-main {
   opacity: 0.5;
 }
+
+/* ── Evals tab ─────────────────────────────────────────────────────── */
+.eval-create {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 16px;
+}
+.eval-create .input {
+  flex: 1;
+}
+.eval-disclosure {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  padding: 0;
+}
+.eval-detail {
+  margin-top: 12px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border, #2a2a2a);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.eval-req {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.eval-req-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.eval-req-name {
+  font-weight: 600;
+}
+.eval-req-desc {
+  font-size: 12px;
+}
+.eval-triggers {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+.eval-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}

--- a/gateway/internal/graphclient/schema.go
+++ b/gateway/internal/graphclient/schema.go
@@ -29,6 +29,28 @@ const (
 	RelHasTool   = "HAS_TOOL"
 	RelHasSkill  = "HAS_SKILL"
 	RelDefinedBy = "DEFINED_BY"
+
+	// ── Evals subgraph ────────────────────────────────────────────────
+	//
+	// The Eval* nodes are NOT gateway-owned: Jarvis (jarvis-backend)
+	// authors them through its schema/node_key/Data_Bank machinery, so
+	// the gateway only READS them (agent-detail Evals tab) and never
+	// creates/updates them via raw Cypher — mutations are delegated to
+	// Hive (see internal/adminapi/hivecallback.go). The one exception is
+	// HAS_EVAL_SET: that edge anchors a gateway-owned :HiveAgent to a
+	// Jarvis-owned :EvalSet, so the gateway MERGEs it directly (edge
+	// only, no node schema involved). Jarvis stamps every Eval* node
+	// with a `ref_id` (uuid4) which is how we address them.
+	LabelEvalSet         = "EvalSet"
+	LabelEvalRequirement = "EvalRequirement"
+	LabelEvalTrigger     = "EvalTrigger"
+	LabelEvalOutput      = "EvalTriggerOutput"
+
+	RelHasEvalSet     = "HAS_EVAL_SET" // HiveAgent -> EvalSet (gateway-owned)
+	RelHasRequirement = "HAS_REQUIREMENT"
+	RelHasTrigger     = "HAS_TRIGGER"
+	RelHasOutput      = "HAS_OUTPUT"
+	RelAttributedTo   = "ATTRIBUTED_TO" // EvalTrigger -> HiveAgent
 )
 
 // SchemaStatements are the constraint/index DDL the catalog needs.


### PR DESCRIPTION
## Summary

Adds an **Evals** tab to the gateway's agent-detail dashboard. Eval sets surface under an agent via a new `HiveAgent-[:HAS_EVAL_SET]->EvalSet` edge.

**Split of responsibility** (see `hivecallback.go`/`evals.go` package docs):
- **Reads** (set list + requirements → triggers → outputs) come straight from neo4j — the eval subgraph lives in the same graph as the agent catalog, so the tab renders without a Hive round-trip.
- **The `HAS_EVAL_SET` edge** is gateway-owned and written directly (edge-only, no Jarvis node schema involved).
- **Node CRUD + runs** are delegated to Hive, which owns the Jarvis write path (schema / node_key / Data_Bank / namespace) and the Stakwork run orchestration. Writing eval nodes as raw Cypher would bypass all of that, so the gateway asks Hive instead.

## How the callback is wired
Hive pushes `{ hive_url, api_key }` (a workspace-scoped API key) to `POST /_plugin/hive-callback` (bearer-only) during agent-catalog reconciliation. The gateway stores it in Redis and calls Hive with `Authorization: Bearer <key>`; Hive resolves the workspace from the key and performs the mutation/run scoped to it.

## Changes
**Backend**
- `graphclient/schema.go` — Eval* labels + relationship constants.
- `adminapi/evals.go` — neo4j reads + Hive-delegated CRUD/run handlers; `/_plugin/agents/:name/evals[/:setId]` and `/_plugin/evals[/…]`.
- `adminapi/hivecallback.go` — Redis-backed callback config + outbound Hive client + `POST /_plugin/hive-callback`.
- `adminapi/server.go` — route wiring.

**UI**
- `api/types.ts`, `api/queries.ts` — eval types + hooks.
- `pages/EvalsView.tsx` + `AgentDetail.tsx` — Evals tab: list, create/link, add requirement, per-requirement Run, pass/fail badges.

## Depends on (separate Hive PR)
The write/run paths need Hive to (1) push the callback config during Bifrost reconciliation and (2) expose `/api/gateway/evals/*` routes authenticated by the workspace API key. Reads and the agent↔set link work without it.

## Testing
- `go build ./internal/...`, `go vet`, `go test ./internal/adminapi/` pass.
- UI `tsc -b --noEmit` + `vite build` pass.
- gofmt clean.

Note: `dist/` bundle is gitignored/CI-built, so only source is included here.