### PR TITLE
gateway: inline two-step confirm for destructive eval actions

### DIFF
--- a/gateway/internal/adminapi/ui/src/pages/EvalsView.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/EvalsView.tsx
@@ -6,7 +6,7 @@
 // when this swarm hasn't had its Hive callback config pushed yet — we
 // surface that inline rather than as a fatal error.
 
-import { useState } from "preact/hooks";
+import { useEffect, useState } from "preact/hooks";
 
 import { ApiCallError, getErrorMessage } from "../api/client";
 import {
@@ -24,6 +24,55 @@ import type {
   EvalSetSummary,
   EvalTriggerSummary,
 } from "../api/types";
+
+// ConfirmButton is a two-step destructive button: the first click arms
+// it (danger styling + confirm label), a second click within the
+// window fires, and it auto-disarms after a few seconds. We can't use
+// window.confirm() here — Hive embeds this SPA in a sandboxed iframe
+// without `allow-modals`, where confirm() is silently suppressed and
+// returns false, turning the button into a no-op.
+const CONFIRM_DISARM_MS = 4000;
+
+function ConfirmButton({
+  label,
+  confirmLabel,
+  title,
+  disabled,
+  onConfirm,
+}: {
+  label: string;
+  confirmLabel: string;
+  title?: string;
+  disabled?: boolean;
+  onConfirm: () => void;
+}) {
+  const [armed, setArmed] = useState(false);
+
+  useEffect(() => {
+    if (!armed) return;
+    const t = setTimeout(() => setArmed(false), CONFIRM_DISARM_MS);
+    return () => clearTimeout(t);
+  }, [armed]);
+
+  return (
+    <button
+      type="button"
+      class={"btn" + (armed ? " is-danger" : "")}
+      title={armed ? undefined : title}
+      disabled={disabled}
+      onClick={() => {
+        if (!armed) {
+          setArmed(true);
+          return;
+        }
+        setArmed(false);
+        onConfirm();
+      }}
+    >
+      {armed ? confirmLabel : label}
+    </button>
+  );
+}
 
 export function EvalsView({ agentName }: { agentName: string }) {
   const evals = useAgentEvals(agentName);
@@ -125,28 +174,20 @@ function SetCard({
           <span class="pill pill-accent">{set.requirements} req</span>
         </button>
         <div class="btn-group">
-          <button
-            type="button"
-            class="btn"
+          <ConfirmButton
+            label="Unlink"
+            confirmLabel="Confirm unlink?"
             title="Remove from this agent (keeps the set)"
             disabled={unlink.isPending}
-            onClick={() => unlink.mutate(set.ref_id)}
-          >
-            Unlink
-          </button>
-          <button
-            type="button"
-            class="btn"
+            onConfirm={() => unlink.mutate(set.ref_id)}
+          />
+          <ConfirmButton
+            label="Delete"
+            confirmLabel="Confirm delete?"
             title="Delete the eval set entirely"
             disabled={del.isPending}
-            onClick={() => {
-              if (confirm(`Delete eval set "${set.name || set.ref_id}"?`)) {
-                del.mutate(set.ref_id);
-              }
-            }}
-          >
-            Delete
-          </button>
+            onConfirm={() => del.mutate(set.ref_id)}
+          />
         </div>
       </div>
       {del.isError ? (
@@ -245,14 +286,13 @@ function RequirementRow({
           >
             {run.isPending ? "Running…" : "Run"}
           </button>
-          <button
-            type="button"
-            class="btn"
+          <ConfirmButton
+            label="Delete"
+            confirmLabel="Confirm delete?"
+            title="Delete this requirement"
             disabled={del.isPending}
-            onClick={() => del.mutate(req.ref_id)}
-          >
-            Delete
-          </button>
+            onConfirm={() => del.mutate(req.ref_id)}
+          />
         </div>
       </div>
       {req.description ? (

--- a/gateway/internal/adminapi/ui/src/styles/components.css
+++ b/gateway/internal/adminapi/ui/src/styles/components.css
@@ -263,6 +263,14 @@ table.table {
 .btn.is-primary:disabled:hover {
   background: var(--accent);
 }
+/* Armed state of the two-step destructive confirm (see EvalsView). */
+.btn.is-danger {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+.btn.is-danger:hover {
+  background: var(--surface-2);
+}
 .btn:disabled:hover {
   background: var(--surface-2);
 }


### PR DESCRIPTION
## Problem

Destructive actions on the Evals tab had inconsistent — and in the embed, broken — confirmation behavior:

- **Delete (eval set)** used `window.confirm()`. Hive embeds this SPA in a sandboxed iframe (`allow-same-origin allow-scripts allow-forms allow-popups`) **without `allow-modals`**, where browsers silently suppress `confirm()` and make it return `false` — so in the embed, Delete was a dead button (no dialog, no request).
- **Unlink** and **requirement Delete** had no confirmation at all and fired immediately on click.

## Changes

Replace all three with an inline two-step `ConfirmButton`:

- First click arms the button — danger styling (`.btn.is-danger`, bordered/colored with `var(--danger)`) and a "Confirm unlink?" / "Confirm delete?" label.
- Second click within 4 seconds fires the mutation; otherwise it auto-disarms back to normal.

No native modals anywhere, so behavior is identical whether the SPA runs standalone or inside Hive's sandboxed iframe — the SPA can't control what sandbox its embedder grants it.

Follows up on #1441.

🤖 Generated with [Claude Code](https://claude.com/claude-code)