### PR TITLE
mcp: add graph mode + append end marker to systemOverride

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -164,6 +164,39 @@ ${SYSTEM_PROMPT_END(qs)}
 `;
 };
 
+function GRAPH_SYSTEM(toolsConfig?: ToolsConfig) {
+
+  const qs = toolsConfig?.ask_clarifying_questions ? true : false;
+
+  return `${getCurrentDateSnippet()}
+
+You are a knowledge-graph exploration assistant. Your job is to answer questions by traversing a **knowledge graph** of interconnected entities — people, topics, episodes, organizations, workflows, code, and the relationships between them.
+
+Try to match the tone of the user. If the user asks a technical question, research deeper and respond with technical details. If the user's question is high-level (non-specific), then do not answer with too much detail!
+
+### Graph Tools (your primary tools)
+- \`get_ontology\` — List the available node types in the graph. Call this FIRST to discover valid \`type\` values before searching.
+- \`graph_search\` — Search the graph by keyword. Returns compact results (ref_id, name, node_type, description). Filter with \`type\` (from \`get_ontology\`) and optionally \`domains\`.
+- \`graph_neighbors\` — Return all nodes one hop away from a node, with \`edge_type\` and \`direction\`. Filter with \`node_type\` / \`edge_type\`. This is how you traverse relationships between entities.
+- \`graph_get\` — Resolve a single ref_id to its full node content.
+
+### Workflow
+1. \`get_ontology\` → discover the node types available in this graph.
+2. \`graph_search\` → find relevant nodes by keyword (scope with \`type\` when you know it).
+3. \`graph_neighbors\` → walk outward hop-by-hop, filtering by \`node_type\`/\`edge_type\`, to follow relationships between entities.
+4. \`graph_get\` → read the full content of a specific node when you need its details.
+
+You also have code-graph tools (\`stakgraph_search\`, \`stakgraph_map\`, \`stakgraph_code\`), file tools, and bash available if a question turns out to need them — but lead with the graph tools above; they understand the entity relationships this graph is built to expose.
+
+## Rules
+- Start broad with \`get_ontology\` and \`graph_search\`, then narrow by walking neighbors.
+- Use the \`name\` on neighbor results to decide which node to follow next without resolving every one.
+- Stop calling tools as soon as you have enough information to answer. More calls rarely improve a complete answer.
+
+${SYSTEM_PROMPT_END(qs)}
+`;
+};
+
 async function structureFinalAnswer(
   finalPrompt: string | ModelMessage[],
   finalAnswer: string,
@@ -250,6 +283,10 @@ export interface GetContextOptions {
   pat?: string | undefined;
   toolsConfig?: ToolsConfig;
   systemOverride?: string;
+  // Selects the base system prompt persona. "graph" uses a generalized
+  // knowledge-graph walker prompt instead of the code-focused default.
+  // Overridden by systemOverride when both are set.
+  mode?: "graph";
   schema?: { [key: string]: any };
   logs?: boolean;
   // Session support
@@ -332,6 +369,7 @@ async function prepareAgent(
     pat,
     toolsConfig,
     systemOverride,
+    mode,
     sessionId: inputSessionId,
     sessionConfig,
     mcpServers,
@@ -377,7 +415,11 @@ async function prepareAgent(
     orgAgentToolNames = Object.keys(mcpTools).filter(name => /_org_agent$/i.test(name));
   }
 
-  let instructions = systemOverride || DEFAULT_SYSTEM(toolsConfig);
+  let instructions = systemOverride
+    ? `${systemOverride}\n\n${SYSTEM_PROMPT_END(false)}`
+    : mode === "graph"
+      ? GRAPH_SYSTEM(toolsConfig)
+      : DEFAULT_SYSTEM(toolsConfig);
 
   // If an org_agent tool is available from MCP, inject a strong hint to use it for unclear/high-level questions.
   if (!transparent && orgAgentToolNames.length > 0) {

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -542,6 +542,7 @@ Apply the guidance from each skill throughout your response.`;
         model: modelId,
         provider,
         systemOverride: opts.systemOverride,
+        mode: opts.mode,
         toolsConfig: opts.toolsConfig,
         schema: opts.schema,
         sessionConfig: opts.sessionConfig,

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -142,6 +142,7 @@ function parseAgentBody(req: Request) {
   const sessionConfig = req.body.sessionConfig as SessionConfig | undefined;
   const mcpServers = req.body.mcpServers as McpServer[] | undefined;
   const systemOverride = req.body.systemOverride as string | undefined;
+  const mode = req.body.mode === "graph" ? "graph" as const : undefined;
   const skills = req.body.skills as SkillsConfig | undefined;
   const subAgents = (req.body.subAgents as Record<string, unknown>[] | undefined)
     ?.map(normalizeSubAgent) as SubAgent[] | undefined;
@@ -165,7 +166,7 @@ function parseAgentBody(req: Request) {
   return {
     repoUrl, username, pat, commitList, prompt, messages, toolsConfig, schema,
     modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, mcpServers,
-    systemOverride, skills, subAgents, ggnn, stream, repoList, maxTurns, headers,
+    systemOverride, mode, skills, subAgents, ggnn, stream, repoList, maxTurns, headers,
     ignoreRepoInfo, attachments, _metadata,
   };
 }
@@ -272,6 +273,7 @@ export async function repo_agent(req: Request, res: Response) {
           mcpServers: body.mcpServers,
           repos: effectiveRepos,
           systemOverride: body.systemOverride,
+          mode: body.mode,
           skills: body.skills,
           subAgents: body.subAgents,
           ggnn: body.ggnn,
@@ -393,6 +395,7 @@ export async function repo_agent(req: Request, res: Response) {
           mcpServers: body.mcpServers,
           repos: effectiveRepos,
           systemOverride: body.systemOverride,
+          mode: body.mode,
           skills: body.skills,
           subAgents: body.subAgents,
           ggnn: body.ggnn,

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -35,6 +35,7 @@ export interface SessionInitConfig {
   model?: string;
   provider?: string;
   systemOverride?: string;
+  mode?: "graph";
   toolsConfig?: { [key: string]: any };
   schema?: { [key: string]: any };
   sessionConfig?: SessionConfig;


### PR DESCRIPTION
## What

Two small changes to the repo agent (`mcp/src/repo`):

### 1. Append the end marker even when `systemOverride` is used
`SYSTEM_PROMPT_END` (the `normalEnd` block instructing the model to finish with `[END_OF_ANSWER]`) was only appended to `DEFAULT_SYSTEM`. When a caller supplied `systemOverride`, that termination instruction was dropped, so overridden prompts could fail to end correctly. Now the end marker is appended to the override too.

### 2. New `mode: "graph"` request param
Adds a generalized knowledge-graph walker system prompt (`GRAPH_SYSTEM`) as an alternative to the code-focused `DEFAULT_SYSTEM`. The default prompt heavily evangelizes the code tools (`stakgraph_*`, "do NOT use bash to search", etc.); `GRAPH_SYSTEM` instead leads with the Jarvis graph walker flow (`get_ontology` → `graph_search` → `graph_neighbors` → `graph_get`) for a more general-purpose graph agent.

- **Toolset is unchanged** — every tool stays registered, so the agent can always fall back to code/file/bash tools; the prompt just doesn't push them.
- Prompt precedence: `systemOverride` wins → else `mode === "graph"` uses `GRAPH_SYSTEM` → else `DEFAULT_SYSTEM`.
- `mode` is threaded through `parseAgentBody` and both the streaming and non-streaming call sites.

## Notes
- `skills` was considered but rejected: skills only *append* to the base prompt, so they can't undo the code-tool bias baked into `DEFAULT_SYSTEM`.
- `tsc --noEmit` passes.