### PR TITLE
mcp: skip repo info in graph mode + make get_ontology edges opt-in

### DIFF
--- a/mcp/src/repo/__tests__/toolsJarvis.test.ts
+++ b/mcp/src/repo/__tests__/toolsJarvis.test.ts
@@ -79,26 +79,34 @@ test.describe("buildOntologyPayload", () => {
     expect(orphan?.domain).toBeNull();
   });
 
-  test("edges are deduped compact triples sorted by edge_type", () => {
+  test("edges are omitted by default", () => {
     const payload = buildOntologyPayload(fixtureSchemaData);
+    expect(payload.edges).toBeUndefined();
+  });
+
+  test("edges are deduped compact triples sorted by edge_type when includeEdges=true", () => {
+    const payload = buildOntologyPayload(fixtureSchemaData, true);
     // KNOWS appears twice in fixture — should appear once
-    const knowsEdges = payload.edges.filter((e) => e.edge_type === "KNOWS");
+    const knowsEdges = payload.edges!.filter((e) => e.edge_type === "KNOWS");
     expect(knowsEdges).toHaveLength(1);
 
     // Only compact fields: edge_type, source_type, target_type
-    for (const edge of payload.edges) {
+    for (const edge of payload.edges!) {
       expect(Object.keys(edge)).toEqual(["edge_type", "source_type", "target_type"]);
     }
 
     // Sorted by edge_type: ABOUT, AUTHORED, KNOWS
-    expect(payload.edges.map((e) => e.edge_type)).toEqual(["ABOUT", "AUTHORED", "KNOWS"]);
+    expect(payload.edges!.map((e) => e.edge_type)).toEqual(["ABOUT", "AUTHORED", "KNOWS"]);
   });
 
   test("handles missing schemas and edges gracefully", () => {
     const payload = buildOntologyPayload({});
     expect(payload.domains).toEqual([]);
     expect(payload.node_types).toEqual({});
-    expect(payload.edges).toEqual([]);
+    expect(payload.edges).toBeUndefined();
+
+    const withEdges = buildOntologyPayload({}, true);
+    expect(withEdges.edges).toEqual([]);
   });
 
   test("node types include description field", () => {

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -175,7 +175,7 @@ You are a knowledge-graph exploration assistant. Your job is to answer questions
 Try to match the tone of the user. If the user asks a technical question, research deeper and respond with technical details. If the user's question is high-level (non-specific), then do not answer with too much detail!
 
 ### Graph Tools (your primary tools)
-- \`get_ontology\` — List the available node types in the graph. Call this FIRST to discover valid \`type\` values before searching.
+- \`get_ontology\` — List the available node types (grouped by domain) and valid \`domains\` in the graph. Call this FIRST to discover valid \`type\`/\`domains\` values before searching. Relationship edges are omitted by default; pass \`include_edges: true\` only if you need the full relationship map (graph_neighbors already surfaces edge types as you traverse).
 - \`graph_search\` — Search the graph by keyword. Returns compact results (ref_id, name, node_type, description). Filter with \`type\` (from \`get_ontology\`) and optionally \`domains\`.
 - \`graph_neighbors\` — Return all nodes one hop away from a node, with \`edge_type\` and \`direction\`. Filter with \`node_type\` / \`edge_type\`. This is how you traverse relationships between entities.
 - \`graph_get\` — Resolve a single ref_id to its full node content.

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -241,7 +241,7 @@ export async function repo_agent(req: Request, res: Response) {
   const isExistingSession = body.sessionId && sessionExists(body.sessionId);
   const promptInput: string | ModelMessage[] = transparent
     ? body.messages!
-    : (isExistingSession || body.ignoreRepoInfo)
+    : (isExistingSession || body.ignoreRepoInfo || body.mode === "graph")
       ? body.prompt
       : prependRepoInfo(body.prompt, body.repoList, graphRepos);
   // ── Streaming path: direct SSE response ──────────────────────────────

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -96,7 +96,7 @@ export interface OntologyEdge {
 export interface OntologyPayload {
   domains: string[];
   node_types: Record<string, OntologyNodeType[]>;
-  edges: OntologyEdge[];
+  edges?: OntologyEdge[];
 }
 
 /**
@@ -107,9 +107,13 @@ export interface OntologyPayload {
  * - Lowercases the per-entry `domain` so it matches `graph_search`'s `domains` param.
  * - Groups node types by domain; null-domain types land in the `"ungrouped"` bucket.
  * - `domains` list is the distinct, non-null, lowercased, sorted set.
- * - Edges are deduped compact triples sorted by `edge_type`.
+ * - Edges are omitted by default (they dominate the payload); pass
+ *   `includeEdges` to append deduped compact triples sorted by `edge_type`.
  */
-export function buildOntologyPayload(schemaData: any): OntologyPayload {
+export function buildOntologyPayload(
+  schemaData: any,
+  includeEdges = false,
+): OntologyPayload {
   const schemas: any[] = schemaData?.schemas ?? [];
   const rawEdges: any[] = schemaData?.edges ?? [];
 
@@ -135,6 +139,10 @@ export function buildOntologyPayload(schemaData: any): OntologyPayload {
     const key = nt.domain ?? "ungrouped";
     if (!grouped[key]) grouped[key] = [];
     grouped[key].push(nt);
+  }
+
+  if (!includeEdges) {
+    return { domains, node_types: grouped };
   }
 
   // Build deduped compact edge triples sorted by edge_type
@@ -183,14 +191,26 @@ export function registerJarvisTools(
 
   allTools.get_ontology = tool({
     description:
-      "Fetch the full ontology of the Jarvis knowledge graph: node types (with their domain), " +
-      "relationship edges, and the canonical list of valid `domains`. " +
+      "Fetch the ontology of the Jarvis knowledge graph: node types (with their domain) " +
+      "and the canonical list of valid `domains`. " +
       "Call this once before graph_search to discover valid values for both the `type` and `domains` parameters. " +
-      "Node types are grouped by domain; types in the `ungrouped` bucket have no domain and cannot be scoped with `domains`.",
-    inputSchema: z.object({}),
-    execute: async () => {
+      "Node types are grouped by domain; types in the `ungrouped` bucket have no domain and cannot be scoped with `domains`. " +
+      "Relationship edges are omitted by default — graph_neighbors returns edge types live as you traverse. " +
+      "Set `include_edges` to also get the full relationship map (source_type -> target_type triples).",
+    inputSchema: z.object({
+      include_edges: z
+        .boolean()
+        .optional()
+        .default(false)
+        .describe(
+          "Include the full list of relationship edges (source_type/edge_type/target_type triples). " +
+          "Off by default — the edge list is large and graph_neighbors surfaces edge types live. " +
+          "Only enable when you need the complete relationship map up front."
+        ),
+    }),
+    execute: async ({ include_edges = false }: { include_edges?: boolean }) => {
       const url = `${jarvisUrl}/v2/schema`;
-      console.log(`[get_ontology] fetching ${url}`);
+      console.log(`[get_ontology] fetching ${url} include_edges=${include_edges}`);
       try {
         const resp = await jarvisFetch(url, jarvisHeaders);
         if (!resp.ok) {
@@ -198,7 +218,7 @@ export function registerJarvisTools(
           return `HTTP ${resp.status}: ${text}`;
         }
         const data = (await resp.json()) as any;
-        return JSON.stringify(buildOntologyPayload(data));
+        return JSON.stringify(buildOntologyPayload(data, include_edges));
       } catch (err: any) {
         return `get_ontology failed: ${err?.message ?? String(err)}`;
       }


### PR DESCRIPTION
## Summary

Two fixes for the graph-mode repo agent:

1. **Skip `prependRepoInfo` in graph mode.** `mode=graph` now bypasses repo-info prepending on the first message, matching existing `ignoreRepoInfo` behavior. (repo/index.ts)

2. **Make `get_ontology` edges opt-in.** The edges block dominated the ontology payload (~250 source→target triples ≈ 22KB vs ~130 node types ≈ 9KB). Since `graph_neighbors` already returns `edge_type` live during traversal and its `edge_type` filter is optional, the full edge list is reference material, not load-bearing.
   - `buildOntologyPayload(schemaData, includeEdges = false)` omits edges by default.
   - `get_ontology` gains an `include_edges` boolean param (default `false`) to pull the full relationship map when needed.
   - `GRAPH_SYSTEM` prompt updated to reflect the new behavior.

Default payload drops from ~31KB to ~9KB.

## Test plan
- `yarn tsc --noEmit` clean
- `yarn playwright test src/repo/__tests__/toolsJarvis.test.ts` — 10 passed (added a default-omits-edges test; edge-triple test now passes `true`)