### PR TITLE
Fix cross-server Authorization leakage by cloning headers in getMcpTools and parseAgentBody

### DIFF
--- a/mcp/src/repo/__tests__/mcpServers.test.ts
+++ b/mcp/src/repo/__tests__/mcpServers.test.ts
@@ -112,4 +112,45 @@ test.describe("getMcpTools logging", () => {
     expect(connectLine).toBeTruthy();
     expect(connectLine).toContain("(no credential)");
   });
+
+  test("shared headers object is not mutated when servers share the same reference", async () => {
+    const { getMcpTools } = await import("../mcpServers.js");
+    const shared: Record<string, string> = {};
+    const servers = [
+      { name: "a", url: "http://localhost:19999", token: "tokenAAA", headers: shared },
+      { name: "b", url: "http://localhost:19999", token: "tokenBBB", headers: shared },
+    ];
+
+    try {
+      await getMcpTools(servers);
+    } catch {
+      // connection failure is expected in test env
+    }
+
+    expect(shared.Authorization).toBeUndefined();
+  });
+
+  test("no token leak across servers sharing headers when only one has a token", async () => {
+    const { getMcpTools } = await import("../mcpServers.js");
+    const shared: Record<string, string> = {};
+    const logs: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => { logs.push(args.join(" ")); };
+
+    try {
+      await getMcpTools([
+        { name: "a", url: "http://localhost:19999", token: "tokenAAA", headers: shared },
+        { name: "b", url: "http://localhost:19999", headers: shared },
+      ]);
+    } catch {
+      // connection failure is expected in test env
+    } finally {
+      console.log = orig;
+    }
+
+    const connectLineB = logs.find((l) => l.includes("[MCP] Connecting to b"));
+    expect(connectLineB).toBeTruthy();
+    expect(connectLineB).toContain("(no credential)");
+    expect(connectLineB).not.toContain("tokenAAA");
+  });
 });

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -140,7 +140,10 @@ function parseAgentBody(req: Request) {
   const logs = req.body.logs as boolean | undefined;
   const sessionId = (req.body.sessionId as string | undefined) || randomUUID();
   const sessionConfig = req.body.sessionConfig as SessionConfig | undefined;
-  const mcpServers = req.body.mcpServers as McpServer[] | undefined;
+  const mcpServers = (req.body.mcpServers as McpServer[] | undefined)?.map((s) => ({
+    ...s,
+    headers: s.headers ? { ...s.headers } : s.headers,
+  }));
   const systemOverride = req.body.systemOverride as string | undefined;
   const mode = req.body.mode === "graph" ? "graph" as const : undefined;
   const skills = req.body.skills as SkillsConfig | undefined;

--- a/mcp/src/repo/mcpServers.ts
+++ b/mcp/src/repo/mcpServers.ts
@@ -77,7 +77,7 @@ export async function getMcpTools(
   for (const server of mcpServers) {
     try {
       // Build headers: token takes precedence, then headers
-      const headers: Record<string, string> = server.headers || {};
+      const headers: Record<string, string> = { ...(server.headers || {}) };
       if (server.token) {
         headers.Authorization = `Bearer ${server.token}`;
       }


### PR DESCRIPTION
Generated with Hive: Fix cross-server Authorization leakage by cloning headers in getMcpTools and parseAgentBody