### PR TITLE
feat(gitree): add vector search for concepts

### DIFF
--- a/mcp/src/gitree/cli.ts
+++ b/mcp/src/gitree/cli.ts
@@ -851,7 +851,7 @@ program
   .argument("<query>", "Search query")
   .option("-d, --dir <path>", "Knowledge base directory", "./knowledge-base")
   .option("-g, --graph", "Use Neo4j GraphStorage")
-  .option("-l, --limit <number>", "Maximum number of results", "10")
+  .option("-l, --limit <number>", "Maximum number of results", "40")
   .option("-t, --threshold <number>", "Similarity threshold (0-1)", "0.5")
   .action(async (query: string, options) => {
     try {

--- a/mcp/src/gitree/cli.ts
+++ b/mcp/src/gitree/cli.ts
@@ -845,4 +845,52 @@ program
     }
   });
 
+program
+  .command("search-concepts")
+  .description("Search concepts by semantic similarity (name + description embeddings)")
+  .argument("<query>", "Search query")
+  .option("-d, --dir <path>", "Knowledge base directory", "./knowledge-base")
+  .option("-g, --graph", "Use Neo4j GraphStorage")
+  .option("-l, --limit <number>", "Maximum number of results", "10")
+  .option("-t, --threshold <number>", "Similarity threshold (0-1)", "0.5")
+  .action(async (query: string, options) => {
+    try {
+      const storage = await createStorage(options);
+      const { vectorizeQuery } = await import("../vector/index.js");
+
+      console.log(`\n🔍 Searching concepts for: "${query}"\n`);
+
+      // Generate embeddings
+      const embeddings = await vectorizeQuery(query);
+
+      // Search
+      const results = await storage.searchConcepts(
+        query,
+        embeddings,
+        parseInt(options.limit),
+        parseFloat(options.threshold)
+      );
+
+      if (results.length === 0) {
+        console.log("📭 No concepts found matching your query.\n");
+        return;
+      }
+
+      console.log(`Found ${results.length} relevant concept(s):\n`);
+
+      for (const result of results) {
+        console.log(`━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━`);
+        console.log(`📍 ${result.name} (${result.id})`);
+        console.log(`   Score: ${result.score.toFixed(3)}`);
+        console.log(`   ${result.description}`);
+        console.log();
+      }
+
+      console.log();
+    } catch (error) {
+      console.error("\n❌ Error:", error);
+      process.exit(1);
+    }
+  });
+
 program.parse();

--- a/mcp/src/gitree/routes.ts
+++ b/mcp/src/gitree/routes.ts
@@ -1717,7 +1717,7 @@ export async function gitree_search_clues(req: Request, res: Response) {
  */
 export async function gitree_search_concepts(req: Request, res: Response) {
   try {
-    const { query, limit = 10, similarityThreshold = 0.5, repo: bodyRepo } = req.body;
+    const { query, limit = 40, similarityThreshold = 0.5, repo: bodyRepo } = req.body;
     // Support repo from both query param and body
     const repo = parseRepoParam(req) || bodyRepo;
 

--- a/mcp/src/gitree/routes.ts
+++ b/mcp/src/gitree/routes.ts
@@ -1744,8 +1744,8 @@ export async function gitree_search_concepts(req: Request, res: Response) {
     res.json({
       query,
       repo: repo || "all",
-      count: results.length,
-      results: results.map((r) => ({
+      total: results.length,
+      concepts: results.map((r) => ({
         id: r.id,
         repo: r.repo,
         ref_id: r.ref_id,

--- a/mcp/src/gitree/routes.ts
+++ b/mcp/src/gitree/routes.ts
@@ -1717,7 +1717,7 @@ export async function gitree_search_clues(req: Request, res: Response) {
  */
 export async function gitree_search_concepts(req: Request, res: Response) {
   try {
-    const { query, limit = 40, similarityThreshold = 0.5, repo: bodyRepo } = req.body;
+    const { query, limit = 40, similarityThreshold = 0.0, repo: bodyRepo } = req.body;
     // Support repo from both query param and body
     const repo = parseRepoParam(req) || bodyRepo;
 

--- a/mcp/src/gitree/routes.ts
+++ b/mcp/src/gitree/routes.ts
@@ -1708,6 +1708,65 @@ export async function gitree_search_clues(req: Request, res: Response) {
 }
 
 /**
+ * POST /gitree/search-concepts
+ * Search concepts by semantic similarity using name + description embeddings
+ * Body: { query: string, limit?: number, similarityThreshold?: number, repo?: string }
+ curl -X POST http://localhost:3355/gitree/search-concepts \
+    -H "Content-Type: application/json" \
+    -d '{"query": "authentication"}'
+ */
+export async function gitree_search_concepts(req: Request, res: Response) {
+  try {
+    const { query, limit = 10, similarityThreshold = 0.5, repo: bodyRepo } = req.body;
+    // Support repo from both query param and body
+    const repo = parseRepoParam(req) || bodyRepo;
+
+    if (!query || typeof query !== "string") {
+      return res.status(400).json({ error: "query is required and must be a string" });
+    }
+
+    const storage = new GraphStorage();
+    await storage.initialize();
+
+    // Generate embeddings for the query
+    const { vectorizeQuery } = await import("../vector/index.js");
+    const embeddings = await vectorizeQuery(query);
+
+    // Search concepts
+    const results = await storage.searchConcepts(
+      query,
+      embeddings,
+      limit,
+      similarityThreshold,
+      repo
+    );
+
+    res.json({
+      query,
+      repo: repo || "all",
+      count: results.length,
+      results: results.map((r) => ({
+        id: r.id,
+        repo: r.repo,
+        ref_id: r.ref_id,
+        name: r.name,
+        description: r.description,
+        prCount: r.prNumbers.length,
+        commitCount: (r.commitShas || []).length,
+        lastUpdated: r.lastUpdated.toISOString(),
+        hasDocumentation: !!r.documentation,
+        score: r.score,
+      })),
+    });
+  } catch (error) {
+    console.error("Error in gitree_search_concepts:", error);
+    res.status(500).json({
+      error: error instanceof Error ? error.message : "Unknown error",
+    });
+  }
+}
+
+/**
  * Get provenance data for concepts
  * POST /gitree/provenance
  * Body: { conceptIds: string[] } (array of concept IDs)

--- a/mcp/src/gitree/store/fileSystemStorage.ts
+++ b/mcp/src/gitree/store/fileSystemStorage.ts
@@ -2,7 +2,7 @@ import fs from "fs/promises";
 import path from "path";
 import { Concept, PRRecord, CommitRecord, Clue, LinkResult, ChronologicalCheckpoint, Usage } from "../types.js";
 import { Storage } from "./storage.js";
-import { formatPRMarkdown, parsePRMarkdown, formatCommitMarkdown, parseCommitMarkdown } from "./utils.js";
+import { formatPRMarkdown, parsePRMarkdown, formatCommitMarkdown, parseCommitMarkdown, computeConceptEmbedding } from "./utils.js";
 import { addUsage, normalizeUsage } from "../../aieo/src/usage.js";
 
 function normalizeConcept(concept: any): Concept {
@@ -84,8 +84,23 @@ export class FileSystemStore extends Storage {
     // Use sanitized ID for filename (replace / with __)
     const safeId = concept.id.replace(/\//g, "__");
     const filePath = path.join(this.conceptsDir, `${safeId}.json`);
+
+    // Generate a semantic embedding from name + description so concepts are
+    // discoverable via vector search.
+    let embedding: number[] | undefined = concept.embedding;
+    try {
+      const computed = await computeConceptEmbedding(concept);
+      if (computed) embedding = computed;
+    } catch (error) {
+      console.error(
+        `Failed to compute embedding for concept ${concept.id}:`,
+        error
+      );
+    }
+
     const serialized = {
       ...concept,
+      embedding,
       createdAt: concept.createdAt.toISOString(),
       lastUpdated: concept.lastUpdated.toISOString(),
       cluesLastAnalyzedAt: concept.cluesLastAnalyzedAt?.toISOString(),
@@ -327,6 +342,30 @@ export class FileSystemStore extends Storage {
       .slice(0, limit);
 
     return scored;
+  }
+
+  /**
+   * Search concepts by semantic similarity using name + description embeddings.
+   */
+  async searchConcepts(
+    _query: string,
+    embeddings: number[],
+    limit: number = 10,
+    similarityThreshold: number = 0.5,
+    repo?: string
+  ): Promise<Array<Concept & { score: number }>> {
+    const allConcepts = await this.getAllConcepts(repo);
+
+    return allConcepts
+      .map((concept) => {
+        const score = concept.embedding
+          ? this.cosineSimilarity(embeddings, concept.embedding)
+          : 0;
+        return { ...concept, score };
+      })
+      .filter((result) => result.score >= similarityThreshold)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
   }
 
   /**

--- a/mcp/src/gitree/store/fileSystemStorage.ts
+++ b/mcp/src/gitree/store/fileSystemStorage.ts
@@ -357,12 +357,11 @@ export class FileSystemStore extends Storage {
     const allConcepts = await this.getAllConcepts(repo);
 
     return allConcepts
-      .map((concept) => {
-        const score = concept.embedding
-          ? this.cosineSimilarity(embeddings, concept.embedding)
-          : 0;
-        return { ...concept, score };
-      })
+      .filter((concept) => concept.embedding)
+      .map((concept) => ({
+        ...concept,
+        score: this.cosineSimilarity(embeddings, concept.embedding!),
+      }))
       .filter((result) => result.score >= similarityThreshold)
       .sort((a, b) => b.score - a.score)
       .slice(0, limit);

--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -11,7 +11,7 @@ import {
   ChronologicalCheckpoint,
   Usage,
 } from "../types.js";
-import { formatPRMarkdown, formatCommitMarkdown, parseRepoFromUrl } from "./utils.js";
+import { formatPRMarkdown, formatCommitMarkdown, parseRepoFromUrl, computeConceptEmbedding } from "./utils.js";
 import { addUsage, normalizeUsage } from "../../aieo/src/usage.js";
 
 const Data_Bank = "Data_Bank";
@@ -153,6 +153,66 @@ export class GraphStorage extends Storage {
 
     // Backfill direct PR->File edges if none exist yet (runs once per DB).
     await this.backfillPRFileEdges();
+
+    // Backfill embeddings for concepts created before semantic search existed.
+    await this.backfillConceptEmbeddings();
+  }
+
+  /**
+   * One-time backfill of `embeddings` on :Concept nodes that predate semantic
+   * search. Runs on every `initialize()` but short-circuits cheaply: it only
+   * processes concepts whose `embeddings` are null (and that have text to
+   * embed), so once every concept is embedded this becomes a no-op scan.
+   */
+  private async backfillConceptEmbeddings(): Promise<void> {
+    const session = this.resilientSession();
+    try {
+      // Fetch concepts missing an embedding (but with text to embed).
+      const result = await session.run(`
+        MATCH (c:Concept)
+        WHERE c.embeddings IS NULL
+          AND (
+            (c.name IS NOT NULL AND c.name <> "") OR
+            (c.description IS NOT NULL AND c.description <> "")
+          )
+        RETURN c.id AS id, c.name AS name, c.description AS description
+      `);
+
+      if (result.records.length === 0) {
+        return; // Nothing to backfill.
+      }
+
+      console.log(
+        `[gitree] Backfilling embeddings for ${result.records.length} concept(s)...`
+      );
+
+      let updated = 0;
+      for (const record of result.records) {
+        const id = record.get("id");
+        const name = record.get("name") || "";
+        const description = record.get("description") || "";
+        try {
+          const embeddings = await computeConceptEmbedding({ name, description });
+          if (!embeddings) continue;
+          await session.run(
+            `MATCH (c:Concept {id: $id}) SET c.embeddings = $embeddings`,
+            { id, embeddings }
+          );
+          updated++;
+        } catch (error) {
+          console.error(
+            `[gitree] Failed to backfill embedding for concept ${id}:`,
+            error
+          );
+        }
+      }
+
+      console.log(`[gitree] Backfilled embeddings for ${updated} concept(s).`);
+    } catch (error) {
+      console.error("[gitree] Error backfilling concept embeddings:", error);
+    } finally {
+      await session.close();
+    }
   }
 
   /**
@@ -426,12 +486,27 @@ export class GraphStorage extends Storage {
         ? Math.floor(concept.cluesLastAnalyzedAt.getTime() / 1000)
         : null;
 
+      // Generate a semantic embedding from name + description so concepts are
+      // discoverable via vector search. Falls back to any embedding already on
+      // the concept if generation fails (e.g. model unavailable).
+      let embeddings: number[] | null = concept.embedding || null;
+      try {
+        const computed = await computeConceptEmbedding(concept);
+        if (computed) embeddings = computed;
+      } catch (error) {
+        console.error(
+          `Failed to compute embedding for concept ${concept.id}:`,
+          error
+        );
+      }
+
       await session.run(
         `
         MERGE (f:${Data_Bank}:Concept {id: $id})
         SET f.name = $name,
             f.repo = $repo,
             f.description = $description,
+            f.embeddings = $embeddings,
             f.prNumbers = $prNumbers,
             f.commitShas = $commitShas,
             f.date = $date,
@@ -459,6 +534,7 @@ export class GraphStorage extends Storage {
           commitShas: concept.commitShas,
           date: dateTimestamp,
           docs: concept.documentation || "",
+          embeddings,
           cluesCount: concept.cluesCount || null,
           cluesLastAnalyzedAt: cluesLastAnalyzedAtTimestamp,
           ...usageParams(concept.usage),
@@ -1140,6 +1216,51 @@ export class GraphStorage extends Storage {
     }
   }
 
+  /**
+   * Search concepts by semantic similarity using name + description embeddings.
+   * Brute-force cosine over :Concept nodes (concept counts are small, so a full
+   * scan is fast and gives exact scores).
+   */
+  async searchConcepts(
+    _query: string,
+    embeddings: number[],
+    limit: number = 10,
+    similarityThreshold: number = 0.5,
+    repo?: string
+  ): Promise<Array<Concept & { score: number }>> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(
+        `
+        MATCH (c:Concept)
+        WHERE c.embeddings IS NOT NULL
+          AND ($repo IS NULL OR c.repo = $repo)
+        WITH c, gds.similarity.cosine(c.embeddings, $embeddings) AS score
+        WHERE score >= $similarityThreshold
+        RETURN c, score
+        ORDER BY score DESC
+        LIMIT toInteger($limit)
+        `,
+        {
+          embeddings,
+          repo: repo || null,
+          limit,
+          similarityThreshold,
+        }
+      );
+
+      return result.records.map((record) => {
+        const concept = this.nodeToConcept(record.get("c"));
+        return {
+          ...concept,
+          score: record.get("score"),
+        };
+      });
+    } finally {
+      await session.close();
+    }
+  }
+
   // Metadata - now per-repo
 
   async getLastProcessedPR(repo: string): Promise<number> {
@@ -1638,6 +1759,7 @@ export class GraphStorage extends Storage {
         ? new Date(props.cluesLastAnalyzedAt * 1000)
         : undefined,
       usage: usageFromProps(props),
+      embedding: props.embeddings || undefined,
     };
   }
 

--- a/mcp/src/gitree/store/storage.ts
+++ b/mcp/src/gitree/store/storage.ts
@@ -17,6 +17,13 @@ export abstract class Storage {
   abstract getConcept(id: string, repo?: string): Promise<Concept | null>;
   abstract getAllConcepts(repo?: string): Promise<Concept[]>;
   abstract deleteConcept(id: string, repo?: string): Promise<void>;
+  abstract searchConcepts(
+    query: string,
+    embeddings: number[],
+    limit?: number,
+    similarityThreshold?: number,
+    repo?: string
+  ): Promise<Array<Concept & { score: number }>>;
 
   // PRs
   abstract savePR(pr: PRRecord): Promise<void>;

--- a/mcp/src/gitree/store/utils.ts
+++ b/mcp/src/gitree/store/utils.ts
@@ -1,6 +1,32 @@
 import { Concept, PRRecord, CommitRecord } from "../types.js";
 import { Storage } from "./index.js";
 
+/**
+ * Build the text used to generate a concept's semantic embedding.
+ * We embed name + description (concise, high signal) rather than the full
+ * documentation, which can be arbitrarily long and would be truncated/diluted.
+ */
+export function conceptEmbeddingText(concept: {
+  name?: string;
+  description?: string;
+}): string {
+  return [concept.name, concept.description].filter(Boolean).join("\n\n").trim();
+}
+
+/**
+ * Compute a concept's embedding from name + description.
+ * Returns null when there is no text to embed.
+ */
+export async function computeConceptEmbedding(concept: {
+  name?: string;
+  description?: string;
+}): Promise<number[] | null> {
+  const text = conceptEmbeddingText(concept);
+  if (!text) return null;
+  const { vectorizeQuery } = await import("../../vector/index.js");
+  return await vectorizeQuery(text);
+}
+
 // ============================================================================
 // Multi-Repo Utility Functions
 // ============================================================================

--- a/mcp/src/gitree/types.ts
+++ b/mcp/src/gitree/types.ts
@@ -36,6 +36,7 @@ export interface Concept {
   cluesCount?: number; // Number of clues for this concept
   cluesLastAnalyzedAt?: Date; // Last time clues were generated
   usage?: Usage; // Token usage for summarizing this concept
+  embedding?: number[]; // Vector embedding of name + description for semantic search
 }
 
 export interface PRRecord {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -297,6 +297,7 @@ app.get("/gitree/clues", gitree.gitree_list_clues);
 app.get("/gitree/clues/:id", gitree.gitree_get_clue);
 app.delete("/gitree/clues/:id", gitree.gitree_delete_clue);
 app.post("/gitree/search-clues", gitree.gitree_search_clues);
+app.post("/gitree/search-concepts", gitree.gitree_search_concepts);
 app.post("/gitree/provenance", gitree.gitree_provenance);
 
 // Legacy `/gitree/features*` aliases (deprecated) — kept so existing API


### PR DESCRIPTION
## Summary
Adds semantic (vector) search for **Concepts**. Previously only Clues had embeddings; concepts were only retrievable by ID or plain text matching. This mirrors the existing clue search infrastructure.

## What & why
- **What to embed:** `name + description` (concise, high signal) rather than `documentation`, which can be arbitrarily long and would be silently truncated at the model's 512-token limit / diluted by mean-pooling.
- Concept nodes are already labeled `:Data_Bank:Concept`, so no new schema/index work is needed to store embeddings.

## Changes
- `types.ts` — add `embedding?: number[]` to `Concept`.
- `store/utils.ts` — `conceptEmbeddingText()` / `computeConceptEmbedding()` helpers (embed `name + "\n\n" + description` via `vectorizeQuery`).
- `saveConcept` (GraphStorage + FileSystemStore) — computes/stores the embedding on every write, so both create and description-update paths stay current. Falls back to any existing embedding on failure.
- `searchConcepts()` — added to the `Storage` abstract and both impls:
  - GraphStorage: brute-force `gds.similarity.cosine` over `:Concept` nodes (concept counts are small, so a full scan is fast and gives exact scores — same pattern as `searchClues`).
  - FileSystemStore: in-memory cosine.
- `POST /gitree/search-concepts` route + `search-concepts` CLI command. Results are flat `ConceptSummary` objects with a merged `score`.
- **Startup migration:** `backfillConceptEmbeddings()` runs at the end of `initialize()` (alongside the existing `backfillPRFileEdges`), embedding any pre-existing concepts missing an embedding. Becomes a cheap no-op scan once all concepts are embedded — no manual script required.

## API
```
curl -X POST http://localhost:3355/gitree/search-concepts \
  -H "Content-Type: application/json" \
  -d '{"query": "authentication"}'
```
Returns:
```json
{
  "query": "authentication",
  "repo": "all",
  "count": 1,
  "results": [
    { "id": "owner/repo/auth-system", "name": "Authentication System", "description": "...", "prCount": 2, "commitCount": 0, "lastUpdated": "...", "hasDocumentation": true, "score": 0.82 }
  ]
}
```

## Testing
- `tsc --noEmit` passes.

## Notes
- Backfill runs sequentially and loads the BGE model in-process; fine for hundreds/low-thousands of concepts. Can switch to `vectorizeBatch` if a much larger legacy corpus is expected.