### PR TITLE
feat: strengthen ontology-edit guidance to reuse types over inventing

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -171,14 +171,23 @@ ${SYSTEM_PROMPT_END(qs)}
  */
 const ONTOLOGY_EDIT_GUIDANCE = `
 ### Ontology Editing (write access — enabled)
-You can modify the graph's schema on the fly. Changes are applied live to the graph immediately.
+You can modify the graph's schema on the fly. Changes are applied live to the graph immediately, so treat every write as production-grade and reversible only with effort.
 - \`ontology_create_type\` / \`ontology_update_type\` / \`ontology_delete_type\` — create, update, or soft-delete NODE types.
 - \`ontology_create_edge\` / \`ontology_update_edge\` / \`ontology_delete_edge\` — create, update, or soft-delete EDGE types (relationships).
 - \`ontology_rename_attribute\` — rename an attribute and migrate existing node data to the new name.
 
-Rules for editing:
-- **Always inspect before you mutate.** Call \`get_ontology\` (with \`include_edges: true\` when touching edges or when you need ref_ids) to confirm current types, domains, inheritance (\`CHILD_OF\`), and whether the target already exists. Never create something that already exists — update it instead.
-- Make the **smallest** change that satisfies the request. Prefer adding attributes over renaming.
+**MANDATORY first step — inspect the existing ontology.** Before ANY write, call \`get_ontology\` (with \`include_edges: true\` when touching edges or when you need ref_ids). Never call a create/update/delete tool without having inspected the current schema in this conversation first. If a first look is inconclusive, use \`graph_search\` to see how the concept is already modeled with real data.
+
+**Reuse before you create — do NOT invent node types out of thin air.** Creating a new node type is a heavyweight, last-resort action. A new type is only justified when NO existing type can represent the concept. Before creating anything, work through this in order:
+1. **Does an existing type already cover this?** Match on meaning, not just exact spelling — check synonyms, plurals, and broader/narrower terms (e.g. don't create \`Podcast\` if \`Episode\` exists; don't create \`Individual\` if \`Person\` exists; don't create \`Org\` if \`Organization\` exists). If yes, use it.
+2. **Can the need be met by extending an existing type?** Prefer adding an attribute (\`ontology_update_type\`) or adding an edge (\`ontology_create_edge\`) to existing types over introducing a new node type.
+3. **Is this really a distinct entity, or just a value/attribute of an existing one?** Attributes and enum-like values do not need their own node type.
+4. **Only if nothing above fits**, create the new type — inherit from the closest existing parent (never default to \`Thing\` if a more specific ancestor exists), keep naming consistent with existing types (casing, singular/plural), and in your response state plainly WHY no existing type worked.
+
+Avoid near-duplicate or overlapping types at all costs — they fragment the graph.
+
+Other rules:
+- Make the **smallest** change that satisfies the request. Prefer adding attributes over renaming; prefer reusing an existing edge type over creating a new one.
 - New node types default to \`domain: "entity"\` and must inherit from an existing parent (the root is \`Thing\`).
 - Attribute values are type descriptors: \`string\`, \`?string\` (optional), \`boolean\`, \`int\`, \`float\`, \`datetime\`, \`list\`, \`complex\`. Use \`delete\` to remove an attribute. Never use reserved names (\`status\`, \`is_deleted\`, \`boost\`, \`algo_*\`) and never touch \`CHILD_OF\` edges.
 - **Destructive changes require explicit user confirmation**: \`ontology_delete_type\`, \`ontology_delete_edge\`, and \`ontology_rename_attribute\` (which migrates live data). If the request is ambiguous, ask before calling them.

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -403,8 +403,14 @@ function registerOntologyWriteTools(
   allTools.ontology_create_type = tool({
     description:
       "Create a new NODE TYPE in the Jarvis ontology (writes live to the graph). " +
-      "Call get_ontology first to confirm the type does not already exist and to pick a valid `parent`. " +
-      "Node types form an inheritance tree rooted at `Thing`; children inherit parent attributes.",
+      "LAST RESORT — only use when NO existing type can represent the concept. " +
+      "You MUST call get_ontology first and confirm no existing type already covers this concept " +
+      "(match on meaning, not just spelling — check synonyms, plurals, and broader/narrower terms, " +
+      "e.g. reuse `Episode` instead of creating `Podcast`, `Person` instead of `Individual`). " +
+      "Prefer extending an existing type (ontology_update_type to add an attribute, or ontology_create_edge) " +
+      "over inventing a new node type. " +
+      "When you do create, inherit from the closest existing `parent` (not `Thing` if a more specific ancestor exists) " +
+      "and keep naming consistent with existing types. Children inherit parent attributes.",
     inputSchema: z.object({
       type: z.string().describe("The new node type name, e.g. 'Statute' (PascalCase)."),
       parent: z
@@ -505,7 +511,9 @@ function registerOntologyWriteTools(
   allTools.ontology_create_edge = tool({
     description:
       "Create a new EDGE TYPE (relationship) between two node types in the Jarvis ontology (writes live to the graph). " +
-      "Call get_ontology first to confirm both source and target types exist. " +
+      "You MUST call get_ontology (include_edges: true) first to confirm both source and target types exist " +
+      "and that no existing edge type already expresses this relationship (reuse an existing edge type when one fits, " +
+      "matching on meaning not just spelling). Do not create near-duplicate relationships. " +
       "Use '*' for source or target to define a wildcard relationship rule.",
     inputSchema: z.object({
       source: z.string().describe("Source node type (or '*' wildcard)."),


### PR DESCRIPTION
## What

Follow-up to #1465. Tightens the ontology-editing guidance so the agent **reuses existing types instead of inventing new ones out of thin air**, and makes inspecting the current ontology a hard prerequisite before any schema write.

## Changes

**`agent.ts` — injected `ONTOLOGY_EDIT_GUIDANCE`:**
- Inspection is now a **mandatory first step**: never call a create/update/delete tool without having inspected the current schema (`get_ontology`, with `graph_search` as a fallback to see how a concept is already modeled).
- Added a **reuse-first decision procedure** (ordered): match existing types by *meaning* (synonyms, plurals, broader/narrower terms — e.g. `Podcast`→`Episode`, `Individual`→`Person`, `Org`→`Organization`) → extend an existing type (add attribute/edge) → only create as a last resort, inheriting from the closest existing parent and justifying why.
- Frames type-creation as a heavyweight, last-resort action and calls out near-duplicates as the thing to avoid.

**`toolsJarvis.ts` — `ontology_create_type` / `ontology_create_edge` descriptions:**
- Strengthened the always-present tool text with the same "LAST RESORT / MUST inspect first / match on meaning / prefer extension" framing (defense-in-depth at call-time).

## Autonomy note

Deliberately does **not** tell the agent to ask the user before creating a type — this keeps autonomous use viable. Callers can still prompt for confirmation if they want it. The separate destructive-op confirmation guardrail (delete type/edge, rename attribute) is unchanged.

## Testing

- `tsc --noEmit` clean