### PR TITLE
Add mode=workflow to repo/agent for workflow research

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -228,6 +228,49 @@ ${SYSTEM_PROMPT_END(qs)}
 `;
 };
 
+function WORKFLOW_SYSTEM(toolsConfig?: ToolsConfig) {
+
+  const qs = toolConfigEnabled(toolsConfig?.ask_clarifying_questions);
+  const ontologyEdit = toolConfigEnabled(toolsConfig?.ontology_edit);
+
+  return `${getCurrentDateSnippet()}
+
+You are a workflow research assistant. Your job is to research an organization's existing automation library — **Workflow**, **Skill**, and **Script** nodes in a knowledge graph — to surface proven, reusable building blocks that inform the design of new workflows.
+
+### The workflow domain model
+- **Workflow** — a complete automation recipe. Key properties:
+  - \`body\` — the full workflow definition JSON: \`transitions\` (each step, with the skill \`name\` it invokes, a description, and its configuration \`attributes\`) and \`connections\` (the ordering/branching between steps). This is the ground truth for how a workflow composes skills.
+  - \`input_schema\` / \`output_schema\` — natural-language descriptions of what the workflow consumes and produces.
+  - \`published\`, \`usage_count\`, \`usage_count_30d\` — maturity / proven-ness signals (when present).
+- **Skill** — a single reusable capability invoked by workflow steps. Has natural-language \`input_schema\`/\`output_schema\` plus \`usage_count\`/\`usage_count_30d\` showing real-world adoption.
+- **Script** — a standalone code snippet (\`body\` is the source code) with \`input_schema\`/\`output_schema\` descriptions. Scripts are executed by script-runner steps inside workflows.
+
+### Search recipes (graph_search)
+ALWAYS scope with \`type\` — "Workflow", "Skill", "Script", or comma-combined like "Workflow,Skill,Script".
+- \`q\` — hybrid keyword+semantic search over names, descriptions, bodies, and IO schemas.
+- \`input_q\` — semantic search scoped to INPUT schemas: find components by what they take as input (e.g. \`input_q: "a video file url"\`).
+- \`output_q\` — semantic search scoped to OUTPUT schemas: find components by what they produce (e.g. \`output_q: "transcript with word-level timestamps"\`).
+- Combine \`q\` + \`input_q\` + \`output_q\` in one call — each becomes its own retriever fused into one ranked result set.
+
+### Research workflow
+1. \`graph_search\` (with \`type\` filters and \`input_q\`/\`output_q\` where the task implies IO shapes) → candidate Workflows/Skills/Scripts.
+2. \`graph_get\` each promising Workflow → read \`body.transitions\` + \`body.connections\` for the proven step ordering and per-step configuration.
+3. \`graph_get\` promising Skills/Scripts → read their exact IO contracts (and a Script's code in \`body\`).
+4. Prefer components with higher \`usage_count\`/\`usage_count_30d\` — they are battle-tested.
+
+### Rules
+- Do NOT traverse Workflow_version, Generated_step, Step, or Run nodes, and do not walk NEXT/START/HAS chains — everything they encode is already denormalized into the Workflow's \`body\`. Chain-walking wastes many tool calls for no new information.
+- Ignore Run nodes entirely: they carry only an external project id and a state string, with no research signal.
+- To find which workflows use a given skill, \`graph_search\` the skill name with \`type: "Workflow"\`, then confirm via \`graph_get\` that the skill actually appears in \`body.transitions\` — search is fuzzy and returns semantic lookalikes.
+- Stop calling tools as soon as you have enough information to answer.
+${ontologyEdit ? ONTOLOGY_EDIT_GUIDANCE : ""}
+### Answering
+Report concrete reusable building blocks: name + ref_id, what each takes/produces, usage stats, and — for workflows — the step ordering that proves the composition works. Call out gaps where no existing component covers a needed capability, so the caller knows what must be built new.
+
+${SYSTEM_PROMPT_END(qs)}
+`;
+};
+
 async function structureFinalAnswer(
   finalPrompt: string | ModelMessage[],
   finalAnswer: string,
@@ -316,8 +359,10 @@ export interface GetContextOptions {
   systemOverride?: string;
   // Selects the base system prompt persona. "graph" uses a generalized
   // knowledge-graph walker prompt instead of the code-focused default.
+  // "workflow" uses a workflow-research prompt specialized for finding
+  // Workflow/Skill/Script nodes and their proven compositions.
   // Overridden by systemOverride when both are set.
-  mode?: "graph";
+  mode?: "graph" | "workflow";
   schema?: { [key: string]: any };
   logs?: boolean;
   // Session support
@@ -450,7 +495,9 @@ async function prepareAgent(
     ? `${systemOverride}\n\n${SYSTEM_PROMPT_END(false)}`
     : mode === "graph"
       ? GRAPH_SYSTEM(toolsConfig)
-      : DEFAULT_SYSTEM(toolsConfig);
+      : mode === "workflow"
+        ? WORKFLOW_SYSTEM(toolsConfig)
+        : DEFAULT_SYSTEM(toolsConfig);
 
   // If an org_agent tool is available from MCP, inject a strong hint to use it for unclear/high-level questions.
   if (!transparent && orgAgentToolNames.length > 0) {

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -146,7 +146,10 @@ function parseAgentBody(req: Request) {
     headers: s.headers ? { ...s.headers } : s.headers,
   }));
   const systemOverride = req.body.systemOverride as string | undefined;
-  const mode = req.body.mode === "graph" ? "graph" as const : undefined;
+  const mode =
+    req.body.mode === "graph" ? "graph" as const :
+    req.body.mode === "workflow" ? "workflow" as const :
+    undefined;
   const skills = req.body.skills as SkillsConfig | undefined;
   const subAgents = (req.body.subAgents as Record<string, unknown>[] | undefined)
     ?.map(normalizeSubAgent) as SubAgent[] | undefined;
@@ -245,7 +248,7 @@ export async function repo_agent(req: Request, res: Response) {
   const isExistingSession = body.sessionId && sessionExists(body.sessionId);
   const promptInput: string | ModelMessage[] = transparent
     ? body.messages!
-    : (isExistingSession || body.ignoreRepoInfo || body.mode === "graph")
+    : (isExistingSession || body.ignoreRepoInfo || body.mode === "graph" || body.mode === "workflow")
       ? body.prompt
       : prependRepoInfo(body.prompt, body.repoList, graphRepos);
   // ── Streaming path: direct SSE response ──────────────────────────────

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -35,7 +35,7 @@ export interface SessionInitConfig {
   model?: string;
   provider?: string;
   systemOverride?: string;
-  mode?: "graph";
+  mode?: "graph" | "workflow";
   toolsConfig?: { [key: string]: any };
   schema?: { [key: string]: any };
   sessionConfig?: SessionConfig;

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -719,11 +719,32 @@ export function registerJarvisTools(
     description:
       "Search the Jarvis knowledge graph for ontology nodes — people, topics, episodes, clips, organizations, workflows, and more. " +
       "Unlike stakgraph_search (code nodes only), this queries the full Jarvis ontology. " +
+      "Provide at least one of `q`, `input_q`, `output_q` — they can be combined, each acting as its own " +
+      "retriever fused into one ranked result set. " +
       "Each result includes an `edges` map ({EDGE_TYPE: count}) showing how connected the node is and " +
       "which relationship types you can traverse next with graph_neighbors. " +
       "Call get_ontology first to discover valid values for the `type` parameter.",
     inputSchema: z.object({
-      q: z.string().describe("The search query"),
+      q: z
+        .string()
+        .optional()
+        .describe(
+          "General hybrid (keyword + semantic) search query over node names, descriptions, bodies, and schemas."
+        ),
+      input_q: z
+        .string()
+        .optional()
+        .describe(
+          "Semantic search scoped to node INPUT schemas — find nodes by what they take as input, " +
+          "e.g. 'a video file url'. Applies to node types with input embeddings (Workflow, Skill)."
+        ),
+      output_q: z
+        .string()
+        .optional()
+        .describe(
+          "Semantic search scoped to node OUTPUT schemas — find nodes by what they produce, " +
+          "e.g. 'transcript with word-level timestamps'. Applies to node types with output embeddings (Workflow, Skill)."
+        ),
       type: z
         .string()
         .optional()
@@ -753,18 +774,30 @@ export function registerJarvisTools(
     }),
     execute: async ({
       q,
+      input_q,
+      output_q,
       type,
       limit = 10,
       domains,
       namespace,
     }: {
-      q: string;
+      q?: string;
+      input_q?: string;
+      output_q?: string;
       type?: string;
       limit?: number;
       domains?: string;
       namespace?: string;
     }) => {
-      const params = new URLSearchParams({ q, limit: String(limit) });
+      if (!q && !input_q && !output_q) {
+        return "graph_search requires at least one of: q, input_q, output_q";
+      }
+      const params = new URLSearchParams({ limit: String(limit) });
+      if (q) params.set("q", q);
+      // Field-scoped vector search: Jarvis embeds these against the per-field
+      // input/output schema embeddings and fuses them with `q` via RRF.
+      if (input_q) params.set("input_q", input_q);
+      if (output_q) params.set("output_q", output_q);
       if (type) params.set("type", type);
       if (domains) params.set("domains", domains);
       // Ask Jarvis to attach a per-node {EDGE_TYPE: count} map inline so the
@@ -773,7 +806,7 @@ export function registerJarvisTools(
       appendNamespace(params, namespace);
       const url = `${jarvisUrl}/v2/nodes?${params.toString()}`;
       console.log(
-        `[graph_search] q=${q} type=${type ?? "*"} domains=${domains ?? "*"} limit=${limit} namespace=${namespace ?? "*"}`,
+        `[graph_search] q=${q ?? "-"} input_q=${input_q ?? "-"} output_q=${output_q ?? "-"} type=${type ?? "*"} domains=${domains ?? "*"} limit=${limit} namespace=${namespace ?? "*"}`,
       );
       try {
         const resp = await jarvisFetch(url, jarvisHeaders);


### PR DESCRIPTION
## What

Adds a third system-prompt persona to `POST /repo/agent`: `mode: "workflow"`, specialized for researching existing **Workflow / Skill / Script** nodes in the Jarvis knowledge graph — so a workflow-building agent can find proven, reusable building blocks instead of designing from scratch.

## Changes

- **`mode: "workflow"`** ([index.ts](../blob/feature/repo-agent-workflow-mode/mcp/src/repo/index.ts), [agent.ts](../blob/feature/repo-agent-workflow-mode/mcp/src/repo/agent.ts), session.ts): new `WORKFLOW_SYSTEM` persona alongside `GRAPH_SYSTEM`/`DEFAULT_SYSTEM`. Skips the repo-availability preamble like graph mode. Encodes:
  - The workflow domain model: a Workflow's `body` is the full recipe (`transitions` with skill names + `connections` for ordering); Skills/Scripts carry natural-language `input_schema`/`output_schema`; `usage_count`/`usage_count_30d` signal proven-ness.
  - The efficient research loop: `graph_search` → `graph_get` → read `body`. Explicit rules **against** traversing `Workflow_version`/`Generated_step`/`NEXT` chains or Run nodes — everything they encode is denormalized into the Workflow `body`, so chain-walking wastes tool calls.
- **`graph_search` IO-scoped search** (toolsJarvis.ts): new optional `input_q` / `output_q` params, passed through to Jarvis's `?<stem>_q=` field-scoped vector search (semantic search over `input_embeddings`/`output_embeddings` built from IO schemas). `q` is now optional; at least one of `q`/`input_q`/`output_q` is required. Available in all modes.

No Jarvis-side changes required — the `?input_q=`/`?output_q=` params and server-side embedding stripping already exist.

## Verification

- `tsc --noEmit`: `src/repo/` clean (remaining errors are pre-existing `vein` module issues in `src/lab/`)
- Existing repo tests pass (10/10)
- Live smoke test of the modified `graph_search` tool against a production Jarvis node:
  - `input_q: "a video file url"`, `type: "Skill,Workflow"` → GetVideoDuration, MediaToLocal, ExtractFrame, VideoAnalyser, CalculateMediaSplits
  - `q: "transcription"` + `output_q: "transcript with word level timestamps"` → WhisperX/Whinx transcription workflows
  - plain `q` unchanged (back-compat); no params → clear validation error

## Try it

```bash
curl -X POST -H "Content-Type: application/json" -d '{
  "mode": "workflow",
  "prompt": "I need to build a workflow that processes videos - what existing building blocks should I reuse?"
}' "http://localhost:3355/repo/agent"
```

## Deferred (needs Jarvis/producer-side work)

- `Workflow -[USES]-> Skill/Script` edges for reliable reverse lookup ("which workflows use skill X") — today only fuzzy search covers this
- Run-stat aggregates (`success_rate`, `run_count`) on Workflow nodes; live Run nodes are edge-less and carry no research signal

🤖 Generated with [Claude Code](https://claude.com/claude-code)