### PR TITLE
Cite workflows by Stakwork id + UI link instead of graph ref_id

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -265,7 +265,11 @@ ALWAYS scope with \`type\` — "Workflow", "Skill", "Script", or comma-combined 
 - Stop calling tools as soon as you have enough information to answer.
 ${ontologyEdit ? ONTOLOGY_EDIT_GUIDANCE : ""}
 ### Answering
-Report concrete reusable building blocks: name + ref_id, what each takes/produces, usage stats, and — for workflows — the step ordering that proves the composition works. Call out gaps where no existing component covers a needed capability, so the caller knows what must be built new.
+Report concrete reusable building blocks: name, what each takes/produces, usage stats, and — for workflows — the step ordering that proves the composition works. Call out gaps where no existing component covers a needed capability, so the caller knows what must be built new.
+
+Cite components by their HUMAN-FACING Stakwork ids, never by graph ref_ids (those are internal — meaningless to the reader):
+- Workflows: name + \`workflow_id\`, linked as \`https://jobs.stakwork.com/admin/workflows/{workflow_id}/edit\` (e.g. [WhisperX Audio/Video transcribe](https://jobs.stakwork.com/admin/workflows/55639/edit)). Both come back on graph_search results and graph_get properties.
+- Skills: name (+ \`skill_id\` when present). Scripts: name.
 
 ${SYSTEM_PROMPT_END(qs)}
 `;

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -821,6 +821,7 @@ export function registerJarvisTools(
             ref_id: n.ref_id ?? n.properties?.ref_id,
             name:
               n.properties?.name ??
+              n.properties?.workflow_name ??
               n.properties?.episode_title ??
               n.properties?.entity,
             node_type: n.node_type,
@@ -832,6 +833,15 @@ export function registerJarvisTools(
             // {EDGE_TYPE: count} map of this node's relationships — shows how
             // connected it is and which edge types graph_neighbors can follow.
             edges: (n.edges ?? {}) as Record<string, number>,
+            // Human-facing Stakwork ids, present on Workflow/Skill nodes —
+            // used to cite components to users (and build Stakwork UI links)
+            // without resolving the full node.
+            ...(n.properties?.workflow_id !== undefined
+              ? { workflow_id: n.properties.workflow_id }
+              : {}),
+            ...(n.properties?.skill_id !== undefined
+              ? { skill_id: n.properties.skill_id }
+              : {}),
           }))
         );
       } catch (err: any) {


### PR DESCRIPTION
## What

Follow-up to #1469: make the workflow-research agent cite components in **human-facing Stakwork terms** instead of internal graph ref_ids.

- **`graph_search` passes through `workflow_id` / `skill_id`** when present on a node's properties, so the agent can cite a workflow (and build UI links) without a `graph_get` round-trip just for the id.
- **`WORKFLOW_SYSTEM` answering guidance**: cite workflows as name + `workflow_id`, linked as `https://jobs.stakwork.com/admin/workflows/{workflow_id}/edit` (worked example in the prompt); skills by name + `skill_id`; never surface internal ref_ids to the reader.
- **Name fallback fix**: fold `workflow_name` into the search-result name fallback chain — Workflow nodes lacking a `name` property previously listed as `undefined`; they now resolve (e.g. "WhisperX Per-Chunk Transcription").

## Verification

- `tsc --noEmit`: `src/repo/` clean
- Live smoke test against a production Jarvis node: `graph_search({ q: "whisperx", type: "Workflow,Skill" })` returns `workflow_id: 55639` for "WhisperX Audio/Video transcribe", and all previously-undefined names resolve via `workflow_name`

🤖 Generated with [Claude Code](https://claude.com/claude-code)