### PR TITLE
Add Stakwork run-research tools to repo agent (workflow mode)

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -229,10 +229,24 @@ ${SYSTEM_PROMPT_END(qs)}
 `;
 };
 
-function WORKFLOW_SYSTEM(toolsConfig?: ToolsConfig) {
+function WORKFLOW_SYSTEM(toolsConfig?: ToolsConfig, hasRunTools?: boolean) {
 
   const qs = toolConfigEnabled(toolsConfig?.ask_clarifying_questions);
   const ontologyEdit = toolConfigEnabled(toolsConfig?.ontology_edit);
+
+  const runToolsGuidance = hasRunTools
+    ? `
+### Ground-truth run data (Stakwork API tools)
+The graph tells you how workflows are DEFINED; these tools tell you how they actually RAN:
+- \`stakwork_skill_usage\` — usage stats for a skill by name, the workflows that invoke it ({workflow_id, use_count} from real run telemetry), and curated input/output examples.
+- \`stakwork_workflow_runs\` — recent runs of a workflow_id with state (completed/error/halted/stopped) and timing.
+- \`stakwork_run_steps\` — the executed steps of one run: skill_name plus the ACTUAL params sent and output produced (previews; pass \`step_name\` for one step's full IO, \`skill_name\` to filter).
+
+Use them to (a) verify a candidate workflow actually runs successfully and recently before recommending it, and (b) cite real working configurations — exact URL formats, variable interpolations like \`[#(step).output.var]\` — instead of guessing from schemas. Runs and stats are scoped to this customer's own executions.
+
+Flow for "how is skill X actually used": \`stakwork_skill_usage(X)\` → top workflow by use_count → \`stakwork_workflow_runs\` → pick a recent completed run → \`stakwork_run_steps(project_id, skill_name: X)\`. A run with \`workflow_state: "error"\` is also useful evidence — its steps show what data shape caused the failure.
+`
+    : "";
 
   return `${getCurrentDateSnippet()}
 
@@ -258,10 +272,11 @@ ALWAYS scope with \`type\` — "Workflow", "Skill", "Script", or comma-combined 
 2. \`graph_get\` each promising Workflow → read \`body.transitions\` + \`body.connections\` for the proven step ordering and per-step configuration.
 3. \`graph_get\` promising Skills/Scripts → read their exact IO contracts (and a Script's code in \`body\`).
 4. Prefer components with higher \`usage_count\`/\`usage_count_30d\` — they are battle-tested.
+${runToolsGuidance}
 
 ### Rules
 - Do NOT traverse Workflow_version, Generated_step, Step, or Run nodes, and do not walk NEXT/START/HAS chains — everything they encode is already denormalized into the Workflow's \`body\`. Chain-walking wastes many tool calls for no new information.
-- Ignore Run nodes entirely: they carry only an external project id and a state string, with no research signal.
+- Ignore Run nodes entirely: they carry only an external project id and a state string, with no research signal.${hasRunTools ? " For real execution data use the stakwork_* API tools instead — the graph's run data is stale." : ""}
 - To find which workflows use a given skill, \`graph_search\` the skill name with \`type: "Workflow"\`, then confirm via \`graph_get\` that the skill actually appears in \`body.transitions\` — search is fuzzy and returns semantic lookalikes.
 - Stop calling tools as soon as you have enough information to answer.
 ${ontologyEdit ? ONTOLOGY_EDIT_GUIDANCE : ""}
@@ -383,6 +398,10 @@ export interface GetContextOptions {
   subAgents?: SubAgent[];
   // GGNN integration
   ggnn?: GgnnConfig;
+  // Stakwork API access for run-research tools (stakwork_skill_usage,
+  // stakwork_workflow_runs, stakwork_run_steps). The key arrives on the
+  // request body server-to-server and is never an LLM-visible parameter.
+  stakwork?: { apiKey: string; baseUrl?: string };
   // Real-time step event callback (for SSE streaming)
   onStepEvent?: (content: any[]) => void;
   // Source label persisted to the session file
@@ -484,6 +503,7 @@ async function prepareAgent(
     messagesRef,
     provenanceCollector,
     modelName,
+    opts.stakwork,
   );
 
   // Load and merge MCP server tools if configured
@@ -501,7 +521,7 @@ async function prepareAgent(
     : mode === "graph"
       ? GRAPH_SYSTEM(toolsConfig)
       : mode === "workflow"
-        ? WORKFLOW_SYSTEM(toolsConfig)
+        ? WORKFLOW_SYSTEM(toolsConfig, Boolean(opts.stakwork?.apiKey))
         : DEFAULT_SYSTEM(toolsConfig);
 
   // If an org_agent tool is available from MCP, inject a strong hint to use it for unclear/high-level questions.

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -158,6 +158,10 @@ function parseAgentBody(req: Request) {
   const maxTurns = typeof req.body.maxTurns === "number" ? req.body.maxTurns : undefined;
   const headers = normalizeHeaders(req.body.headers);
   const ignoreRepoInfo = req.body.ignoreRepoInfo as boolean | undefined;
+  // Stakwork API key for the run-research tools. Server-to-server secret
+  // (like `pat`/`apiKey`): read off the body, never exposed to the LLM.
+  const stakworkApiKey = req.body.stakworkApiKey as string | undefined;
+  const stakworkBaseUrl = req.body.stakworkBaseUrl as string | undefined;
   const attachments = Array.isArray(req.body.attachments)
     ? (req.body.attachments as unknown[]).filter(
         (a): a is string => typeof a === "string" && a.trim().length > 0,
@@ -175,6 +179,7 @@ function parseAgentBody(req: Request) {
     modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, mcpServers,
     systemOverride, mode, skills, subAgents, ggnn, stream, repoList, maxTurns, headers,
     ignoreRepoInfo, attachments, _metadata,
+    stakwork: stakworkApiKey ? { apiKey: stakworkApiKey, baseUrl: stakworkBaseUrl } : undefined,
   };
 }
 
@@ -228,6 +233,7 @@ export async function repo_agent(req: Request, res: Response) {
     hasSchema: Boolean(req.body?.jsonSchema),
     hasSystemOverride: Boolean(req.body?.systemOverride),
     mcpServers: mcpServersCount,
+    hasStakworkApiKey: Boolean(req.body?.stakworkApiKey),
   });
 
   const body = parseAgentBody(req);
@@ -284,6 +290,7 @@ export async function repo_agent(req: Request, res: Response) {
           skills: body.skills,
           subAgents: body.subAgents,
           ggnn: body.ggnn,
+          stakwork: body.stakwork,
           source: "repo_agent",
           abortSignal: abortController.signal,
           maxTurns: body.maxTurns,
@@ -406,6 +413,7 @@ export async function repo_agent(req: Request, res: Response) {
           skills: body.skills,
           subAgents: body.subAgents,
           ggnn: body.ggnn,
+          stakwork: body.stakwork,
           source: "repo_agent",
           abortSignal: abortController.signal,
           maxTurns: body.maxTurns,

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -21,6 +21,7 @@ import { listConcepts, getConceptDocumentation } from "../gitree/service.js";
 import { db } from "../graph/neo4j.js";
 import { callRemoteAgent, subAgentRepoNames, type SubAgent } from "./subagent.js";
 import { registerJarvisTools } from "./toolsJarvis.js";
+import { registerStakworkTools, type StakworkToolsOptions } from "./toolsStakwork.js";
 import * as stak from "../tools/stakgraph/index.js";
 import { search as graphSearch, searchWithProvenance } from "../graph/graph.js";
 import type { SearchProvenance } from "../graph/graph.js";
@@ -309,6 +310,7 @@ export async function get_tools(
   messagesRef?: MessagesRef,
   provenanceCollector?: ProvenanceCollector,
   modelName?: ModelName,
+  stakwork?: StakworkToolsOptions,
 ) {
   const repoArr = repoPath.split("/");
   const isMultiRepo = repoPath === "/tmp";
@@ -731,6 +733,13 @@ export async function get_tools(
     // Opt-in ontology write tools (create/update/delete node & edge types).
     ontologyEdit: toolConfigEnabled(toolsConfig?.ontology_edit),
   });
+
+  // Register Stakwork run-research tools (read-only, gated on the caller
+  // supplying a Stakwork API key — plumbed via the request body, never an
+  // LLM-visible parameter).
+  if (stakwork?.apiKey) {
+    registerStakworkTools(allTools, stakwork);
+  }
 
   // Register sub-agent tools (remote agent delegation)
   if (subAgents && subAgents.length > 0) {

--- a/mcp/src/repo/toolsStakwork.ts
+++ b/mcp/src/repo/toolsStakwork.ts
@@ -1,0 +1,240 @@
+import { tool, Tool } from "ai";
+import { z } from "zod";
+import axios from "axios";
+
+/**
+ * Stakwork run-research tools — read-only lookups against the Stakwork API
+ * (jobs.stakwork.com) for ground-truth workflow execution data: which
+ * workflows actually run, their success/error states, and the real params
+ * and outputs each step sent and received.
+ *
+ * Registered only when the caller supplies a Stakwork API key on the request
+ * body (`stakworkApiKey`) — the key is plumbed server-to-server and is never
+ * an LLM-visible parameter. All endpoints are GETs; runs/stats are scoped by
+ * Stakwork to the customer that owns the API key.
+ */
+
+const DEFAULT_STAKWORK_API_URL = "https://jobs.stakwork.com/api/v1";
+
+/** Cap for params/output previews in the per-step list view. */
+const STEP_FIELD_PREVIEW_CHARS = 1500;
+/** Cap for each side (inputs/outputs) of a single-step IO drill-down. */
+const STEP_IO_FIELD_CHARS = 12000;
+/** Cap for each curated skill example's input/output. */
+const EXAMPLE_FIELD_CHARS = 1500;
+
+export interface StakworkToolsOptions {
+  apiKey: string;
+  baseUrl?: string;
+}
+
+async function stakworkGet(
+  url: string,
+  apiKey: string,
+): Promise<{ ok: boolean; status: number; body: any }> {
+  const resp = await axios.get(url, {
+    headers: { Authorization: `Token token=${apiKey}` },
+    validateStatus: () => true,
+    responseType: "text",
+    timeout: 60_000,
+  });
+  const text: string =
+    typeof resp.data === "string" ? resp.data : JSON.stringify(resp.data);
+  let body: any = text;
+  try {
+    body = JSON.parse(text);
+  } catch (_) {
+    // leave as raw text
+  }
+  return { ok: resp.status >= 200 && resp.status < 300, status: resp.status, body };
+}
+
+/** Stringify a value and truncate with an explicit marker so the agent knows data was elided. */
+export function truncateJson(value: unknown, maxChars: number): string {
+  if (value === null || value === undefined) return "null";
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const text = typeof body === "string" ? body : JSON.stringify(body);
+  return `${label} failed: HTTP ${status}: ${truncateJson(text, 500)}`;
+}
+
+export function registerStakworkTools(
+  allTools: Record<string, Tool<any, any>>,
+  options: StakworkToolsOptions,
+): void {
+  const baseUrl = (options.baseUrl || process.env.STAKWORK_API_URL || DEFAULT_STAKWORK_API_URL).replace(/\/$/, "");
+  const apiKey = options.apiKey;
+
+  allTools.stakwork_skill_usage = tool({
+    description:
+      "Look up real-world usage of a Stakwork skill by NAME: total + last-30-days use counts, " +
+      "and the breakdown of which workflows actually invoke it ({workflow_id, use_count}), computed from run telemetry. " +
+      "Optionally includes curated input/output examples for the skill. " +
+      "Use this as the entry point for 'how is skill X actually used' — then follow the top workflow_id " +
+      "into stakwork_workflow_runs → stakwork_run_steps to see real params from a live run.",
+    inputSchema: z.object({
+      skill_name: z
+        .string()
+        .describe("Exact skill name, e.g. 'AzureOCR' (as it appears in workflow transitions)."),
+      include_examples: z
+        .boolean()
+        .optional()
+        .default(true)
+        .describe("Also fetch curated input/output examples for the skill (first page)."),
+    }),
+    execute: async ({
+      skill_name,
+      include_examples = true,
+    }: {
+      skill_name: string;
+      include_examples?: boolean;
+    }) => {
+      console.log(`[stakwork_skill_usage] skill_name=${skill_name} examples=${include_examples}`);
+      try {
+        const statsUrl = `${baseUrl}/skills/${encodeURIComponent(skill_name)}/stats`;
+        const stats = await stakworkGet(statsUrl, apiKey);
+        if (!stats.ok) return errorResult("stakwork_skill_usage", stats.status, stats.body);
+        const data = stats.body?.data ?? stats.body;
+
+        let examples: unknown[] | undefined;
+        if (include_examples && data?.id !== undefined) {
+          const exResp = await stakworkGet(
+            `${baseUrl}/skills/${encodeURIComponent(String(data.id))}/examples?limit=5`,
+            apiKey,
+          );
+          if (exResp.ok) {
+            const exData = exResp.body?.data ?? exResp.body;
+            examples = (exData?.results ?? []).map((ex: any) => ({
+              id: ex.id,
+              description: ex.description,
+              input: truncateJson(ex.input, EXAMPLE_FIELD_CHARS),
+              output: truncateJson(ex.output, EXAMPLE_FIELD_CHARS),
+            }));
+          }
+        }
+
+        return JSON.stringify({ ...data, ...(examples ? { examples } : {}) });
+      } catch (err: any) {
+        return `stakwork_skill_usage failed: ${err?.message ?? String(err)}`;
+      }
+    },
+  });
+
+  allTools.stakwork_workflow_runs = tool({
+    description:
+      "List recent execution runs of a Stakwork workflow by workflow_id (the same id cited from graph results). " +
+      "Each run has an id (project_id), workflow_state (completed | error | halted | stopped | in-flight states), " +
+      "started_at and duration. Use it to verify a workflow actually runs successfully and recently, " +
+      "then feed a run's id into stakwork_run_steps to inspect the real data it processed. " +
+      "Only runs owned by this customer are visible.",
+    inputSchema: z.object({
+      workflow_id: z.number().describe("Stakwork workflow id, e.g. 55639."),
+      limit: z
+        .number()
+        .optional()
+        .default(10)
+        .describe("Max runs to return, newest first (1-100)."),
+    }),
+    execute: async ({ workflow_id, limit = 10 }: { workflow_id: number; limit?: number }) => {
+      console.log(`[stakwork_workflow_runs] workflow_id=${workflow_id} limit=${limit}`);
+      try {
+        const url = `${baseUrl}/workflows/${encodeURIComponent(String(workflow_id))}/runs?limit=${encodeURIComponent(String(limit))}`;
+        const resp = await stakworkGet(url, apiKey);
+        if (!resp.ok) return errorResult("stakwork_workflow_runs", resp.status, resp.body);
+        return JSON.stringify(resp.body?.data ?? resp.body);
+      } catch (err: any) {
+        return `stakwork_workflow_runs failed: ${err?.message ?? String(err)}`;
+      }
+    },
+  });
+
+  allTools.stakwork_run_steps = tool({
+    description:
+      "Inspect the executed steps of one Stakwork run (project): per step the skill invoked (skill_name) and the " +
+      "ACTUAL params sent and output produced — ground truth for how a skill is configured in practice " +
+      "(exact URL formats, variable interpolations like [#(step).output.var], attribute values). " +
+      "Params/outputs are previews truncated to ~1.5KB each; pass step_name to drill into ONE step's full inputs/outputs. " +
+      "Filter with skill_name to keep only steps that invoked that skill. " +
+      "Only runs owned by this customer are visible.",
+    inputSchema: z.object({
+      project_id: z.number().describe("Run id from stakwork_workflow_runs (a Stakwork project id)."),
+      skill_name: z
+        .string()
+        .optional()
+        .describe("Only return steps whose skill_name matches (case-insensitive)."),
+      step_name: z
+        .string()
+        .optional()
+        .describe(
+          "A step's `name` from a prior stakwork_run_steps call. When set, returns that single step's FULL inputs/outputs instead of the step list."
+        ),
+      limit: z
+        .number()
+        .optional()
+        .default(50)
+        .describe("Max steps to return in list mode."),
+    }),
+    execute: async ({
+      project_id,
+      skill_name,
+      step_name,
+      limit = 50,
+    }: {
+      project_id: number;
+      skill_name?: string;
+      step_name?: string;
+      limit?: number;
+    }) => {
+      console.log(
+        `[stakwork_run_steps] project_id=${project_id} skill_name=${skill_name ?? "*"} step_name=${step_name ?? "-"}`,
+      );
+      try {
+        // Drill-down: one step's full IO (still capped to protect context).
+        if (step_name) {
+          const url = `${baseUrl}/projects/${encodeURIComponent(String(project_id))}/steps/${encodeURIComponent(step_name)}/io`;
+          const resp = await stakworkGet(url, apiKey);
+          if (!resp.ok) return errorResult("stakwork_run_steps", resp.status, resp.body);
+          const io = resp.body?.data ?? resp.body;
+          return JSON.stringify({
+            step_name,
+            inputs: truncateJson(io?.inputs, STEP_IO_FIELD_CHARS),
+            outputs: truncateJson(io?.outputs, STEP_IO_FIELD_CHARS),
+            prompt_resolutions: truncateJson(io?.prompt_resolutions, STEP_IO_FIELD_CHARS),
+          });
+        }
+
+        const url = `${baseUrl}/projects/${encodeURIComponent(String(project_id))}/steps?limit=${encodeURIComponent(String(limit))}`;
+        const resp = await stakworkGet(url, apiKey);
+        if (!resp.ok) return errorResult("stakwork_run_steps", resp.status, resp.body);
+        const data = resp.body?.data ?? resp.body;
+        let steps: any[] = data?.steps ?? [];
+        if (skill_name) {
+          const want = skill_name.toLowerCase();
+          steps = steps.filter((s) => String(s.skill_name ?? "").toLowerCase() === want);
+        }
+        return JSON.stringify({
+          pagination: data?.pagination,
+          ...(skill_name ? { filtered_by_skill: skill_name } : {}),
+          steps: steps.map((s) => ({
+            name: s.name,
+            skill_name: s.skill_name,
+            has_output: s.has_output,
+            created_at: s.created_at,
+            params: truncateJson(s.params, STEP_FIELD_PREVIEW_CHARS),
+            output: truncateJson(s.output, STEP_FIELD_PREVIEW_CHARS),
+          })),
+        });
+      } catch (err: any) {
+        return `stakwork_run_steps failed: ${err?.message ?? String(err)}`;
+      }
+    },
+  });
+
+  console.log(
+    "===> registered stakwork run tools: stakwork_skill_usage, stakwork_workflow_runs, stakwork_run_steps",
+  );
+}


### PR DESCRIPTION
## What

Gives the `mode=workflow` repo agent access to **ground-truth run data** from the Stakwork API (`jobs.stakwork.com/api/v1`), so it can cite real, working step configurations (exact URL formats, var interpolations) and verify a workflow actually runs — instead of guessing from schemas. Common workflow failures (missing `https://`, wrong addresses/servers) are diagnosable from what past runs actually sent.

Three read-only tools, registered only when the caller supplies `stakworkApiKey` on the `/repo/agent` request body (server-to-server secret like `pat`/`apiKey` — never an LLM-visible parameter; only `hasStakworkApiKey` is logged):

| Tool | Endpoint | Returns |
|---|---|---|
| `stakwork_skill_usage` | `GET /skills/{name}/stats` + `/skills/{id}/examples` | usage counts, `{workflow_id, use_count}` breakdown from run telemetry, curated IO examples |
| `stakwork_workflow_runs` | `GET /workflows/{id}/runs` | recent runs with `workflow_state` (completed/error/…) and timing |
| `stakwork_run_steps` | `GET /projects/{id}/steps` (+ `/steps/{name}/io`) | per-step `skill_name` and the ACTUAL params/outputs |

**Size safety**: the Stakwork steps API returns full untruncated params/outputs (a single step's IO measured 154KB live). The tools truncate defensively with explicit `…[truncated, N chars total]` markers: 1.5KB per field in list mode, 12KB per side in single-step drill-down, curated examples 1.5KB.

`WORKFLOW_SYSTEM` gains a "Ground-truth run data" section (rendered only when the tools are registered) teaching the skill-first flow: `stakwork_skill_usage(X)` → top workflow by `use_count` → `stakwork_workflow_runs` → `stakwork_run_steps(project_id, skill_name: X)`. The graph's own `Run`/`Run_step` nodes remain excluded from research — that ingestion was a two-day experiment in January and is stale; the API is the source of truth.

## Plumbing

`index.ts` (body parse, both stream + async paths) → `GetContextOptions.stakwork` → `get_tools` (new optional trailing param, backward-compatible) → `registerStakworkTools`. Optional `stakworkBaseUrl` body field / `STAKWORK_API_URL` env for non-prod hosts.

## Testing

- `tsc --noEmit` clean
- Live smoke test through the real tool `execute` functions against jobs.stakwork.com: skill stats + workflow breakdown returned, today's runs listed, step-list truncation markers intact, 154KB IO capped to 25.7KB, skill filter correct on no-match

Companion PR (hive): passes the stakwork workspace's decrypted `stakworkApiKey` from `workflow_explorer_agent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)