### PR TITLE
Add opt-in stakwork_run_step tool — execute one workflow step with literal inputs

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -233,6 +233,14 @@ function WORKFLOW_SYSTEM(toolsConfig?: ToolsConfig, hasRunTools?: boolean) {
 
   const qs = toolConfigEnabled(toolsConfig?.ask_clarifying_questions);
   const ontologyEdit = toolConfigEnabled(toolsConfig?.ontology_edit);
+  const runStepEnabled = Boolean(hasRunTools) && toolConfigEnabled(toolsConfig?.stakwork_run_step);
+
+  const runStepGuidance = runStepEnabled
+    ? `- \`stakwork_run_step\` — EXECUTE one step with your own inputs (a live, billable run — use deliberately to test a specific step, never for browsing).
+
+Flow for testing a step: \`stakwork_run_steps(project_id, step_name: S)\` on a real run to see the step's resolved inputs → copy that shape, modify the values under test → \`stakwork_run_step(workflow_id, step_id: S, attributes: {...}, params: {...})\` → read the returned outputs. Overrides are literal: they replace \`[$(ancestor).output.x]\` interpolations, so no ancestor steps are needed; \`{{SECRET}}\` aliases resolve server-side — pass them through unchanged, never inline real secret values. If the tool returns \`in_progress\`, call it again with the returned \`project_id\` to keep waiting instead of launching a new run.
+`
+    : "";
 
   const runToolsGuidance = hasRunTools
     ? `
@@ -241,7 +249,7 @@ The graph tells you how workflows are DEFINED; these tools tell you how they act
 - \`stakwork_skill_usage\` — usage stats for a skill by name, the workflows that invoke it ({workflow_id, use_count} from real run telemetry), and curated input/output examples.
 - \`stakwork_workflow_runs\` — recent runs of a workflow_id with state (completed/error/halted/stopped) and timing.
 - \`stakwork_run_steps\` — the executed steps of one run: skill_name plus the ACTUAL params sent and output produced (previews; pass \`step_name\` for one step's full IO, \`skill_name\` to filter).
-
+${runStepGuidance}
 Use them to (a) verify a candidate workflow actually runs successfully and recently before recommending it, and (b) cite real working configurations — exact URL formats, variable interpolations like \`[#(step).output.var]\` — instead of guessing from schemas. Runs and stats are scoped to this customer's own executions.
 
 Flow for "how is skill X actually used": \`stakwork_skill_usage(X)\` → top workflow by use_count → \`stakwork_workflow_runs\` → pick a recent completed run → \`stakwork_run_steps(project_id, skill_name: X)\`. A run with \`workflow_state: "error"\` is also useful evidence — its steps show what data shape caused the failure.

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -95,7 +95,8 @@ type ToolName =
   | "apply_patch"
   | "generate_docx"
   | "generate_xlsx"
-  | "generate_xlsx_computed";
+  | "generate_xlsx_computed"
+  | "stakwork_run_step";
 
 /**
  * Object form of a per-tool config value. Lets a caller pass a description
@@ -155,6 +156,7 @@ const TOOL_NAMES: Set<string> = new Set<string>([
   "graph_sub_agent", "ontology_edit",
   "str_replace_based_edit_tool", "apply_patch",
   "generate_docx", "generate_xlsx", "generate_xlsx_computed",
+  "stakwork_run_step",
 ]);
 
 export type SkillsConfig = Partial<Record<string, boolean>>;
@@ -296,6 +298,7 @@ Rules:
     "results (e.g. a column sum) can feed later entries (e.g. percent_of_total). " +
     "Returns 'Generated: /repo/agent/file?path=...' on success. " +
     "On failure returns a non-fatal 'generate_xlsx_computed failed: ...' string.",
+  stakwork_run_step: '', // opt-in; default lives in toolsStakwork.ts; string value here overrides it.
 };
 
 export async function get_tools(
@@ -736,9 +739,14 @@ export async function get_tools(
 
   // Register Stakwork run-research tools (read-only, gated on the caller
   // supplying a Stakwork API key — plumbed via the request body, never an
-  // LLM-visible parameter).
+  // LLM-visible parameter). The execute tool stakwork_run_step additionally
+  // requires an explicit truthy toolsConfig.stakwork_run_step opt-in, since
+  // it launches real (billable) step executions.
   if (stakwork?.apiKey) {
-    registerStakworkTools(allTools, stakwork);
+    registerStakworkTools(allTools, {
+      ...stakwork,
+      runStep: toolConfigEnabled(toolsConfig?.stakwork_run_step),
+    });
   }
 
   // Register sub-agent tools (remote agent delegation)

--- a/mcp/src/repo/toolsStakwork.ts
+++ b/mcp/src/repo/toolsStakwork.ts
@@ -12,6 +12,10 @@ import axios from "axios";
  * body (`stakworkApiKey`) — the key is plumbed server-to-server and is never
  * an LLM-visible parameter. All endpoints are GETs; runs/stats are scoped by
  * Stakwork to the customer that owns the API key.
+ *
+ * Exception: `stakwork_run_step` EXECUTES a single workflow step (a real,
+ * billable run). It is double-gated — the API key must be present AND the
+ * caller must opt in with a truthy `toolsConfig.stakwork_run_step`.
  */
 
 const DEFAULT_STAKWORK_API_URL = "https://jobs.stakwork.com/api/v1";
@@ -26,7 +30,16 @@ const EXAMPLE_FIELD_CHARS = 1500;
 export interface StakworkToolsOptions {
   apiKey: string;
   baseUrl?: string;
+  /** Opt-in for the execute tool stakwork_run_step (launches real runs). */
+  runStep?: boolean;
 }
+
+/** Poll interval and wait bounds for stakwork_run_step. */
+const RUN_STEP_POLL_MS = 5000;
+const RUN_STEP_DEFAULT_WAIT_S = 120;
+const RUN_STEP_MAX_WAIT_S = 600;
+/** Project states after which a run will not progress further. */
+const TERMINAL_RUN_STATES = new Set(["completed", "error", "halted", "stopped", "failed"]);
 
 async function stakworkGet(
   url: string,
@@ -34,6 +47,31 @@ async function stakworkGet(
 ): Promise<{ ok: boolean; status: number; body: any }> {
   const resp = await axios.get(url, {
     headers: { Authorization: `Token token=${apiKey}` },
+    validateStatus: () => true,
+    responseType: "text",
+    timeout: 60_000,
+  });
+  const text: string =
+    typeof resp.data === "string" ? resp.data : JSON.stringify(resp.data);
+  let body: any = text;
+  try {
+    body = JSON.parse(text);
+  } catch (_) {
+    // leave as raw text
+  }
+  return { ok: resp.status >= 200 && resp.status < 300, status: resp.status, body };
+}
+
+async function stakworkPost(
+  url: string,
+  apiKey: string,
+  payload: unknown,
+): Promise<{ ok: boolean; status: number; body: any }> {
+  const resp = await axios.post(url, payload, {
+    headers: {
+      Authorization: `Token token=${apiKey}`,
+      "Content-Type": "application/json",
+    },
     validateStatus: () => true,
     responseType: "text",
     timeout: 60_000,
@@ -234,7 +272,129 @@ export function registerStakworkTools(
     },
   });
 
+  if (options.runStep) {
+    allTools.stakwork_run_step = tool({
+      description:
+        "EXECUTE one Stakwork workflow step with your own literal inputs and return its output. " +
+        "This launches a REAL run that consumes execution resources — use it deliberately for testing a specific step, never for browsing. " +
+        "Flow: study a real run first (stakwork_run_steps with step_name for that step's resolved inputs), copy the input shape, " +
+        "modify the values you want to test, and pass them as params/attributes overrides. Overrides are literal — they replace " +
+        "[$(ancestor).output.x] interpolations, so NO ancestor steps or prior outputs are needed; {{SECRET_NAME}} aliases are still " +
+        "resolved server-side at execution time (pass them through unchanged, never inline real secrets). " +
+        "The tool polls until the run reaches a terminal state or wait_seconds elapses; on timeout it returns status in_progress — " +
+        "call it again with the returned project_id (plus step_id) to continue waiting without launching a new run.",
+      inputSchema: z.object({
+        step_id: z
+          .string()
+          .describe("The step's id in the workflow spec (its transition id, e.g. 'call_swarm_agent')."),
+        workflow_id: z
+          .number()
+          .optional()
+          .describe("Workflow that defines the step. Required to LAUNCH a run; omit when resuming with project_id."),
+        params: z
+          .record(z.string(), z.any())
+          .optional()
+          .describe("Literal overrides merged over the step's `params` before execution."),
+        attributes: z
+          .record(z.string(), z.any())
+          .optional()
+          .describe("Literal overrides merged over the step's `attributes`, e.g. { vars: { prompt: '...' } }."),
+        project_id: z
+          .number()
+          .optional()
+          .describe("A project_id returned by a previous stakwork_run_step call: resume waiting on that run instead of launching a new one."),
+        wait_seconds: z
+          .number()
+          .optional()
+          .default(RUN_STEP_DEFAULT_WAIT_S)
+          .describe(`How long to wait for the run to finish before returning in_progress (max ${RUN_STEP_MAX_WAIT_S}).`),
+      }),
+      execute: async ({
+        step_id,
+        workflow_id,
+        params,
+        attributes,
+        project_id,
+        wait_seconds = RUN_STEP_DEFAULT_WAIT_S,
+      }: {
+        step_id: string;
+        workflow_id?: number;
+        params?: Record<string, unknown>;
+        attributes?: Record<string, unknown>;
+        project_id?: number;
+        wait_seconds?: number;
+      }) => {
+        console.log(
+          `[stakwork_run_step] workflow_id=${workflow_id ?? "-"} step_id=${step_id} project_id=${project_id ?? "-"}`,
+        );
+        try {
+          let runId = project_id;
+
+          if (runId === undefined) {
+            if (workflow_id === undefined) {
+              return "stakwork_run_step failed: pass workflow_id + step_id to launch a run, or project_id to resume waiting on one.";
+            }
+            const overrides: Record<string, unknown> = {};
+            if (params !== undefined) overrides.params = params;
+            if (attributes !== undefined) overrides.attributes = attributes;
+
+            const launch = await stakworkPost(`${baseUrl}/workflow_steps/run`, apiKey, {
+              workflow_id,
+              step_id,
+              ...(Object.keys(overrides).length > 0 ? { overrides } : {}),
+            });
+            if (!launch.ok) return errorResult("stakwork_run_step", launch.status, launch.body);
+            runId = (launch.body?.data ?? launch.body)?.project_id;
+            if (runId === undefined) {
+              return `stakwork_run_step failed: launch response had no project_id: ${truncateJson(launch.body, 500)}`;
+            }
+          }
+
+          const waitMs = Math.min(Math.max(wait_seconds, 0), RUN_STEP_MAX_WAIT_S) * 1000;
+          const deadline = Date.now() + waitMs;
+          let status = "unknown";
+
+          for (;;) {
+            const st = await stakworkGet(
+              `${baseUrl}/projects/${encodeURIComponent(String(runId))}/status`,
+              apiKey,
+            );
+            if (st.ok) status = String((st.body?.data ?? st.body)?.status ?? "unknown");
+            if (TERMINAL_RUN_STATES.has(status) || Date.now() >= deadline) break;
+            await new Promise((r) => setTimeout(r, RUN_STEP_POLL_MS));
+          }
+
+          if (!TERMINAL_RUN_STATES.has(status)) {
+            return JSON.stringify({
+              project_id: runId,
+              step_id,
+              status,
+              note: "Run still in progress — call stakwork_run_step again with this project_id (and step_id) to continue waiting.",
+            });
+          }
+
+          const io = await stakworkGet(
+            `${baseUrl}/projects/${encodeURIComponent(String(runId))}/steps/${encodeURIComponent(step_id)}/io`,
+            apiKey,
+          );
+          const ioData = io.ok ? (io.body?.data ?? io.body) : undefined;
+
+          return JSON.stringify({
+            project_id: runId,
+            step_id,
+            status,
+            inputs: truncateJson(ioData?.inputs, STEP_IO_FIELD_CHARS),
+            outputs: truncateJson(ioData?.outputs, STEP_IO_FIELD_CHARS),
+            ...(io.ok ? {} : { io_error: errorResult("step io read", io.status, io.body) }),
+          });
+        } catch (err: any) {
+          return `stakwork_run_step failed: ${err?.message ?? String(err)}`;
+        }
+      },
+    });
+  }
+
   console.log(
-    "===> registered stakwork run tools: stakwork_skill_usage, stakwork_workflow_runs, stakwork_run_steps",
+    `===> registered stakwork run tools: stakwork_skill_usage, stakwork_workflow_runs, stakwork_run_steps${options.runStep ? ", stakwork_run_step" : ""}`,
   );
 }


### PR DESCRIPTION
## What

An execute counterpart to the read-only Stakwork run-research tools: `stakwork_run_step` runs ONE workflow step with LLM-supplied literal inputs and returns its output.

**Double-gated.** The tool registers only when the caller supplies the Stakwork API key AND passes a truthy `toolsConfig.stakwork_run_step` (standard `toolConfigEnabled` semantics: `true`, non-empty string, or object without `enabled: false`). The `WORKFLOW_SYSTEM` prompt guidance for it is gated behind the same flag, so non-opted-in callers see no mention of step execution. A string/object config value overrides the tool description via the existing override loop (`stakwork_run_step` is registered as a proper `ToolName`).

## How it works

- **Launch**: `workflow_id + step_id` (+ literal `params`/`attributes` overrides) → `POST /workflow_steps/run` on the Stakwork API (added in stakwork/senza-lnd#7948), which wraps the step in an ephemeral single-transition workflow and runs it as a normal project.
- **Wait**: polls `GET /projects/:id/status` every 5s (default 120s, capped 600s). On timeout returns `in_progress` with the `project_id`; calling again with that `project_id` resumes waiting instead of launching a duplicate run.
- **Read**: on a terminal state, returns the step's full `GET /projects/:id/steps/:step_id/io` (inputs/outputs, truncated at the existing 12KB caps).

Overrides are literal — they replace `[$(ancestor).output.x)]` interpolations, so no ancestor steps or prior outputs are needed; `{{SECRET}}` aliases pass through and resolve server-side at execution. The tool description and prompt guidance both steer the agent to study a real run first via `stakwork_run_steps` and to treat this as a deliberate, billable action.

## Dependency

404s until stakwork/senza-lnd#7948 deploys — the read-only tools are unaffected either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)