### PR TITLE
Rename stakwork_run_steps → stakwork_inspect_run

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -238,7 +238,7 @@ function WORKFLOW_SYSTEM(toolsConfig?: ToolsConfig, hasRunTools?: boolean) {
   const runStepGuidance = runStepEnabled
     ? `- \`stakwork_run_step\` — EXECUTE one step of a published workflow with your own inputs (a live, billable run — use deliberately to test a specific step, never for browsing).
 
-Flow for testing a step: \`stakwork_run_step(workflow_id, step_id: S)\` with NO params first — the response enumerates every required ancestor key (the step's exact input shape). Fill values from a real run (\`stakwork_run_steps(project_id, step_name: S)\`) or your own test data, then relaunch with \`params: { "<ancestor_id>": { "<output.path>": value } }\` and read the returned outputs. Values are seeded as literals into a synthesized set_var step, so no prior run or ancestor execution is needed; \`{{SECRET}}\` aliases resolve server-side — pass them through unchanged, never inline real secret values. \`mock_mode: true\` uses stored mock outputs instead of live execution. If the tool returns \`in_progress\`, call it again with the returned \`project_id\` to keep waiting instead of launching a new run.
+Flow for testing a step: \`stakwork_run_step(workflow_id, step_id: S)\` with NO params first — the response enumerates every required ancestor key (the step's exact input shape). Fill values from a real run (\`stakwork_inspect_run(project_id, step_name: S)\`) or your own test data, then relaunch with \`params: { "<ancestor_id>": { "<output.path>": value } }\` and read the returned outputs. Values are seeded as literals into a synthesized set_var step, so no prior run or ancestor execution is needed; \`{{SECRET}}\` aliases resolve server-side — pass them through unchanged, never inline real secret values. \`mock_mode: true\` uses stored mock outputs instead of live execution. If the tool returns \`in_progress\`, call it again with the returned \`project_id\` to keep waiting instead of launching a new run.
 `
     : "";
 
@@ -248,11 +248,11 @@ Flow for testing a step: \`stakwork_run_step(workflow_id, step_id: S)\` with NO 
 The graph tells you how workflows are DEFINED; these tools tell you how they actually RAN:
 - \`stakwork_skill_usage\` — usage stats for a skill by name, the workflows that invoke it ({workflow_id, use_count} from real run telemetry), and curated input/output examples.
 - \`stakwork_workflow_runs\` — recent runs of a workflow_id with state (completed/error/halted/stopped) and timing.
-- \`stakwork_run_steps\` — the executed steps of one run: skill_name plus the ACTUAL params sent and output produced (previews; pass \`step_name\` for one step's full IO, \`skill_name\` to filter).
+- \`stakwork_inspect_run\` — the executed steps of one run: skill_name plus the ACTUAL params sent and output produced (previews; pass \`step_name\` for one step's full IO, \`skill_name\` to filter).
 ${runStepGuidance}
 Use them to (a) verify a candidate workflow actually runs successfully and recently before recommending it, and (b) cite real working configurations — exact URL formats, variable interpolations like \`[#(step).output.var]\` — instead of guessing from schemas. Runs and stats are scoped to this customer's own executions.
 
-Flow for "how is skill X actually used": \`stakwork_skill_usage(X)\` → top workflow by use_count → \`stakwork_workflow_runs\` → pick a recent completed run → \`stakwork_run_steps(project_id, skill_name: X)\`. A run with \`workflow_state: "error"\` is also useful evidence — its steps show what data shape caused the failure.
+Flow for "how is skill X actually used": \`stakwork_skill_usage(X)\` → top workflow by use_count → \`stakwork_workflow_runs\` → pick a recent completed run → \`stakwork_inspect_run(project_id, skill_name: X)\`. A run with \`workflow_state: "error"\` is also useful evidence — its steps show what data shape caused the failure.
 `
     : "";
 
@@ -407,7 +407,7 @@ export interface GetContextOptions {
   // GGNN integration
   ggnn?: GgnnConfig;
   // Stakwork API access for run-research tools (stakwork_skill_usage,
-  // stakwork_workflow_runs, stakwork_run_steps). The key arrives on the
+  // stakwork_workflow_runs, stakwork_inspect_run). The key arrives on the
   // request body server-to-server and is never an LLM-visible parameter.
   stakwork?: { apiKey: string; baseUrl?: string };
   // Real-time step event callback (for SSE streaming)

--- a/mcp/src/repo/toolsStakwork.ts
+++ b/mcp/src/repo/toolsStakwork.ts
@@ -115,7 +115,7 @@ export function registerStakworkTools(
       "and the breakdown of which workflows actually invoke it ({workflow_id, use_count}), computed from run telemetry. " +
       "Optionally includes curated input/output examples for the skill. " +
       "Use this as the entry point for 'how is skill X actually used' — then follow the top workflow_id " +
-      "into stakwork_workflow_runs → stakwork_run_steps to see real params from a live run.",
+      "into stakwork_workflow_runs → stakwork_inspect_run to see real params from a live run.",
     inputSchema: z.object({
       skill_name: z
         .string()
@@ -169,7 +169,7 @@ export function registerStakworkTools(
       "List recent execution runs of a Stakwork workflow by workflow_id (the same id cited from graph results). " +
       "Each run has an id (project_id), workflow_state (completed | error | halted | stopped | in-flight states), " +
       "started_at and duration. Use it to verify a workflow actually runs successfully and recently, " +
-      "then feed a run's id into stakwork_run_steps to inspect the real data it processed. " +
+      "then feed a run's id into stakwork_inspect_run to inspect the real data it processed. " +
       "Only runs owned by this customer are visible.",
     inputSchema: z.object({
       workflow_id: z.number().describe("Stakwork workflow id, e.g. 55639."),
@@ -192,7 +192,7 @@ export function registerStakworkTools(
     },
   });
 
-  allTools.stakwork_run_steps = tool({
+  allTools.stakwork_inspect_run = tool({
     description:
       "Inspect the executed steps of one Stakwork run (project): per step the skill invoked (skill_name) and the " +
       "ACTUAL params sent and output produced — ground truth for how a skill is configured in practice " +
@@ -210,7 +210,7 @@ export function registerStakworkTools(
         .string()
         .optional()
         .describe(
-          "A step's `name` from a prior stakwork_run_steps call. When set, returns that single step's FULL inputs/outputs instead of the step list."
+          "A step's `name` from a prior stakwork_inspect_run call. When set, returns that single step's FULL inputs/outputs instead of the step list."
         ),
       limit: z
         .number()
@@ -230,14 +230,14 @@ export function registerStakworkTools(
       limit?: number;
     }) => {
       console.log(
-        `[stakwork_run_steps] project_id=${project_id} skill_name=${skill_name ?? "*"} step_name=${step_name ?? "-"}`,
+        `[stakwork_inspect_run] project_id=${project_id} skill_name=${skill_name ?? "*"} step_name=${step_name ?? "-"}`,
       );
       try {
         // Drill-down: one step's full IO (still capped to protect context).
         if (step_name) {
           const url = `${baseUrl}/projects/${encodeURIComponent(String(project_id))}/steps/${encodeURIComponent(step_name)}/io`;
           const resp = await stakworkGet(url, apiKey);
-          if (!resp.ok) return errorResult("stakwork_run_steps", resp.status, resp.body);
+          if (!resp.ok) return errorResult("stakwork_inspect_run", resp.status, resp.body);
           const io = resp.body?.data ?? resp.body;
           return JSON.stringify({
             step_name,
@@ -249,7 +249,7 @@ export function registerStakworkTools(
 
         const url = `${baseUrl}/projects/${encodeURIComponent(String(project_id))}/steps?limit=${encodeURIComponent(String(limit))}`;
         const resp = await stakworkGet(url, apiKey);
-        if (!resp.ok) return errorResult("stakwork_run_steps", resp.status, resp.body);
+        if (!resp.ok) return errorResult("stakwork_inspect_run", resp.status, resp.body);
         const data = resp.body?.data ?? resp.body;
         let steps: any[] = data?.steps ?? [];
         if (skill_name) {
@@ -269,7 +269,7 @@ export function registerStakworkTools(
           })),
         });
       } catch (err: any) {
-        return `stakwork_run_steps failed: ${err?.message ?? String(err)}`;
+        return `stakwork_inspect_run failed: ${err?.message ?? String(err)}`;
       }
     },
   });
@@ -283,7 +283,7 @@ export function registerStakworkTools(
         "[$(ancestor).output.path] reference the step consumes (flat \"ancestor_id.output.path\" keys also accepted). " +
         "Stakwork seeds them as literals into a synthesized set_var step, so NO prior run or ancestor execution is needed. " +
         "DISCOVERY: call with workflow_id + step_id and NO params — the response lists every required ancestor key, which is " +
-        "exactly the input shape to fill in. Or read a real run first via stakwork_run_steps to copy actual values. " +
+        "exactly the input shape to fill in. Or read a real run first via stakwork_inspect_run to copy actual values. " +
         "{{SECRET_NAME}} aliases resolve server-side at execution (pass them through unchanged, never inline real secrets); " +
         "set mock_mode: true to use stored mock step outputs instead of live execution. " +
         "The tool polls until the run reaches a terminal state or wait_seconds elapses; on timeout it returns status in_progress — " +
@@ -415,6 +415,6 @@ export function registerStakworkTools(
   }
 
   console.log(
-    `===> registered stakwork run tools: stakwork_skill_usage, stakwork_workflow_runs, stakwork_run_steps${options.runStep ? ", stakwork_run_step" : ""}`,
+    `===> registered stakwork run tools: stakwork_skill_usage, stakwork_workflow_runs, stakwork_inspect_run${options.runStep ? ", stakwork_run_step" : ""}`,
   );
 }


### PR DESCRIPTION
## What

`stakwork_run_steps` (read-only: inspect the executed steps of one run) and `stakwork_run_step` (opt-in: EXECUTE one step, a billable run) differed by a single trailing character with opposite semantics — an easy tool-selection misfire for the LLM.

This renames the read-only inspector to `stakwork_inspect_run`: the verb makes read-only explicit, and it reads naturally in the discovery flow (`stakwork_workflow_runs` → pick a run → `stakwork_inspect_run(project_id)`).

The execute tool keeps its name because it doubles as the opt-in gate key (`toolsConfig.stakwork_run_step`). Pure rename — 14 references across the tool registration, descriptions, and `WORKFLOW_SYSTEM` prompt guidance; no behavior change. `stakwork_run_steps` was never a `toolsConfig` key, so no caller config can reference it by name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)