### PR TITLE
Sweep orphaned pending requests on startup and fire their webhooks

### DIFF
--- a/mcp/src/graph/reqs.ts
+++ b/mcp/src/graph/reqs.ts
@@ -1,5 +1,13 @@
 import * as uuid from "uuid";
-import { existsSync, mkdirSync, writeFileSync, readFileSync, unlinkSync } from "fs";
+import {
+  existsSync,
+  mkdirSync,
+  writeFileSync,
+  readFileSync,
+  unlinkSync,
+  readdirSync,
+  statSync,
+} from "fs";
 import path from "path";
 
 const REQS_DIR = process.env.REQS_DIR || ".reqs";
@@ -21,6 +29,9 @@ interface Request {
   result?: any;
   error?: any;
   progress?: any;
+  // Caller's terminal callback, persisted so the startup sweep can still
+  // notify the receiver about runs orphaned by a process restart.
+  webhookUrl?: string;
 }
 
 function ensureDir(): string {
@@ -61,7 +72,7 @@ function deleteFromDisk(id: string): void {
   } catch (_) {}
 }
 
-export function startReq(): string {
+export function startReq(webhookUrl?: string): string {
   const key = uuid.v4();
 
   // Evict oldest if at limit
@@ -76,9 +87,86 @@ export function startReq(): string {
   META[key] = { status: "pending" };
   REQ_ORDER.push(key);
 
-  writeToDisk(key, { status: "pending" });
+  writeToDisk(key, { status: "pending", ...(webhookUrl && { webhookUrl }) });
 
   return key;
+}
+
+export interface OrphanedReq {
+  request_id: string;
+  error: string;
+  webhookUrl?: string;
+}
+
+const RESTART_ORPHAN_ERROR = "server restarted while request was in-flight";
+
+/**
+ * Startup reconciliation for the on-disk request store. The in-memory META /
+ * REQ_ORDER index dies with the process, which leaves two problems after a
+ * restart: pre-restart files are never evicted (startReq only evicts ids it
+ * knows about), and runs that were in-flight sit at "pending" forever because
+ * the work driving them is gone.
+ *
+ * This re-adopts every surviving file into the eviction index (oldest first,
+ * trimming past MAX_REQS) and flips still-"pending" files to "failed".
+ * Returns the flipped entries so the caller can fire their terminal webhooks.
+ */
+export function sweepOrphanedReqs(): OrphanedReq[] {
+  const dir = ensureDir();
+  let files: string[];
+  try {
+    files = readdirSync(dir).filter((f) => f.endsWith(".json"));
+  } catch (e) {
+    console.error("[reqs] Startup sweep failed to list dir:", e);
+    return [];
+  }
+
+  // Oldest first so re-adopted eviction order matches creation order
+  const byAge = files
+    .map((f) => {
+      try {
+        return { f, mtime: statSync(path.join(dir, f)).mtimeMs };
+      } catch (_) {
+        return null;
+      }
+    })
+    .filter((x): x is { f: string; mtime: number } => x !== null)
+    .sort((a, b) => a.mtime - b.mtime);
+
+  const orphaned: OrphanedReq[] = [];
+  for (const { f } of byAge) {
+    const id = f.slice(0, -".json".length);
+    const data = readFromDisk(id);
+    if (!data) continue;
+
+    if (data.status === "pending") {
+      failReq(id, RESTART_ORPHAN_ERROR);
+      orphaned.push({
+        request_id: id,
+        error: RESTART_ORPHAN_ERROR,
+        ...(data.webhookUrl && { webhookUrl: data.webhookUrl }),
+      });
+    }
+
+    if (!META[id]) {
+      if (REQ_ORDER.length >= MAX_REQS) {
+        const oldestKey = REQ_ORDER.shift();
+        if (oldestKey) {
+          delete META[oldestKey];
+          deleteFromDisk(oldestKey);
+        }
+      }
+      META[id] = { status: data.status === "pending" ? "failed" : data.status };
+      REQ_ORDER.push(id);
+    }
+  }
+
+  if (orphaned.length > 0) {
+    console.log(
+      `[reqs] Startup sweep marked ${orphaned.length} orphaned pending request(s) as failed`,
+    );
+  }
+  return orphaned;
 }
 
 // Terminal writes always hit disk, even when the in-memory META entry was
@@ -113,5 +201,9 @@ export function checkReq(id: string): Request {
   // Disk is authoritative: the in-memory META gate previously rejected any
   // id created before a process restart, 404ing completed runs whose
   // .reqs/<id>.json file physically survived.
-  return readFromDisk(id) as Request;
+  const data = readFromDisk(id);
+  if (!data) return data as unknown as Request;
+  // webhookUrl is internal bookkeeping, not part of the /progress shape
+  const { webhookUrl: _webhookUrl, ...rest } = data;
+  return rest;
 }

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -361,6 +361,9 @@ app.listen(port, host, () => {
   // Prune expired agent artifacts (>7 days) on startup, then every 6 hours
   pruneExpiredArtifacts();
   setInterval(pruneExpiredArtifacts, 6 * 60 * 60 * 1000);
+
+  // Mark requests orphaned by the restart as failed and fire their webhooks
+  rr.sweepOrphanedRuns();
 });
 
 //

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -278,6 +278,24 @@ async function postTerminalWebhook(
   );
 }
 
+/**
+ * Startup reconciliation: mark runs orphaned by a process restart as failed
+ * (their driving work died with the old process) and deliver the terminal
+ * webhook for any that registered a webhookUrl, so callers waiting on a
+ * callback instead of polling still hear about the failure.
+ */
+export function sweepOrphanedRuns(): void {
+  for (const orphan of asyncReqs.sweepOrphanedReqs()) {
+    if (orphan.webhookUrl) {
+      void postTerminalWebhook(orphan.webhookUrl, {
+        request_id: orphan.request_id,
+        status: "failed",
+        error: orphan.error,
+      });
+    }
+  }
+}
+
 // modelName can be a shortcut like "kimi" or a full model name like "anthropic/claude-sonnet-4-5" or "openrouter/moonshotai/kimi-k2.6"
 export async function repo_agent(req: Request, res: Response) {
   // curl -X POST -H "Content-Type: application/json" -d '{"repo_url": "https://github.com/stakwork/hive", "prompt": "how does auth work in the repo"}' "http://localhost:3355/repo/agent"
@@ -447,7 +465,9 @@ export async function repo_agent(req: Request, res: Response) {
   }
 
   // ── Non-streaming path: async job with event bus ─────────────────────
-  const request_id = asyncReqs.startReq();
+  // webhookUrl is persisted into the .reqs file so the startup sweep can
+  // still deliver a terminal callback if a restart orphans this run.
+  const request_id = asyncReqs.startReq(body.webhookUrl);
 
   // Create an event bus for real-time SSE streaming of this request
   const bus = createBus(request_id);


### PR DESCRIPTION
## Problem

Since #1482, request state survives restarts as `.reqs/<id>.json` files — but only for runs that reached a terminal state. A restart mid-run left zombies:

- The disk file stayed `{"status":"pending"}` forever; nothing resumed the run or marked it failed, so `GET /progress` pollers hung indefinitely.
- The `webhookUrl` terminal callback never fired — delivery only happened from the in-process finish/fail path, and the URL wasn't persisted anywhere.
- Pre-restart files were never evicted: `startReq` only evicts ids in the in-memory `REQ_ORDER`, which dies with the process.

## Fix

- **`startReq(webhookUrl?)`** persists the caller's webhook URL into the `.reqs` file (existing no-arg callers unaffected; `checkReq` strips it so the `/progress` response shape is unchanged).
- **`sweepOrphanedReqs()`** (reqs.ts) runs at boot: flips still-`pending` files to `{status: "failed", error: "server restarted while request was in-flight"}` and re-adopts all surviving files into the eviction index, oldest first, so pre-restart files churn out under `MAX_REQS` again.
- **`sweepOrphanedRuns()`** (repo/index.ts) wraps the sweep and POSTs the standard terminal payload to each orphan's recorded webhook via the existing retrying `postTerminalWebhook`. Invoked from the `app.listen` callback.

## Verified

`tsc --noEmit` clean. Exercised the sweep against a temp `REQS_DIR` simulating a restart: pending files (with and without webhook) flipped to failed and returned as orphans with the right webhook URLs, completed files untouched, fresh `startReq` writes `webhookUrl` to disk while `checkReq` omits it.

Note: this covers process restarts; container restarts still need `REQS_DIR` on a mounted volume for the files to survive at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)