### PR TITLE
docs: mention namespace param for graph_search in graph prompts

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -209,7 +209,7 @@ Try to match the tone of the user. If the user asks a technical question, resear
 
 ### Graph Tools (your primary tools)
 - \`get_ontology\` — List the available node types (grouped by domain) and valid \`domains\` in the graph. Call this FIRST to discover valid \`type\`/\`domains\` values before searching. Relationship edges are omitted by default; pass \`include_edges: true\` only if you need the full relationship map (graph_neighbors already surfaces edge types as you traverse).
-- \`graph_search\` — Search the graph by keyword. Returns compact results (ref_id, name, node_type, description). Filter with \`type\` (from \`get_ontology\`) and optionally \`domains\`.
+- \`graph_search\` — Search the graph by keyword. Returns compact results (ref_id, name, node_type, description). Filter with \`type\` (from \`get_ontology\`) and optionally \`domains\`. Scope to a data partition with \`namespace\` when one applies.
 - \`graph_neighbors\` — Return all nodes one hop away from a node, with \`edge_type\` and \`direction\`. Filter with \`node_type\` / \`edge_type\`. This is how you traverse relationships between entities.
 - \`graph_get\` — Resolve a single ref_id to its full node content.
 

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -290,7 +290,7 @@ const GRAPH_SUBAGENT_SYSTEM = `You are a focused knowledge-graph exploration sub
 
 You traverse a knowledge graph of interconnected entities (people, topics, episodes, organizations, workflows, code, and their relationships) using these tools:
 - \`get_ontology\` — list node types (grouped by domain) and valid \`domains\`. Call FIRST if you don't already know the relevant types.
-- \`graph_search\` — keyword search. Returns compact results (ref_id, name, node_type, description, edges). Scope with \`type\`/\`domains\`.
+- \`graph_search\` — keyword search. Returns compact results (ref_id, name, node_type, description, edges). Scope with \`type\`/\`domains\`, and \`namespace\` (data partition) when one applies.
 - \`graph_neighbors\` — nodes one hop away, with \`edge_type\` and \`direction\`. This is how you follow relationships.
 - \`graph_get\` — resolve a single ref_id to its full content.
 - \`graph_sub_agent\` (only if available) — delegate an even more focused subtask to a further child agent.


### PR DESCRIPTION
## Why

An agent running `/repo/agent` with `mode=graph` incorrectly claimed:

> graph_search accepts domains, limit, q, and type parameters, but not namespace directly—that parameter is only available in graph_neighbors and graph_get for edge counts.

`graph_search` **does** accept `namespace` (added in #1450), but the prompts never mention it:

- GRAPH_SYSTEM describes `graph_search` as scoping only with `type`/`domains`
- The graph sub-agent prompt says the same ("Scope with `type`/`domains`")
- The only prose mentions of `namespace` the model sees are the `graph_get`/`graph_neighbors` param descriptions, which frame it as edge-count-only

When asked what its tools accept, the model reproduced the prompt summary instead of the schema — verbatim the wrong claim above.

## What

One-line additions to both prompts noting that `graph_search` can scope to a data partition with `namespace`. No behavior change; schemas were already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)