### PR TITLE
fix: bake agent skills outside /root so swarm's volume can't shadow them

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -125,18 +125,25 @@ RUN cd web && npm install && npm run build
 COPY ./benchmark ./benchmark
 RUN cd benchmark && npm install && npm run build
 
-# Install agent skills
-RUN npx -y skills add https://github.com/anthropics/skills --skill frontend-design -y -g
-RUN npx -y skills add https://github.com/getsentry/skills --skill code-simplifier -y -g
-RUN npx -y skills add https://github.com/getsentry/skills --skill security-review -y -g
+# Install agent skills. Baked OUTSIDE /root and exposed via SKILLS_ROOT:
+# sphinx-swarm mounts a named volume over /root, which is initialized from the
+# image only once and then shadows /root/.agents/skills on every image update —
+# skills shipped in newer images silently never appear (stale-volume bug).
+RUN npx -y skills add https://github.com/anthropics/skills --skill frontend-design -y -g && \
+    npx -y skills add https://github.com/getsentry/skills --skill code-simplifier -y -g && \
+    npx -y skills add https://github.com/getsentry/skills --skill security-review -y -g && \
+    mkdir -p /usr/src/skills && \
+    cp -r /root/.agents/skills/. /usr/src/skills/ && \
+    rm -rf /root/.agents/skills
+ENV SKILLS_ROOT=/usr/src/skills
 
-# Vendored skill packs (./skills -> ~/.agents/skills). COPY merges into the
-# existing directory, so the npx-installed skills above survive alongside them.
+# Vendored skill packs (./skills -> SKILLS_ROOT). COPY merges into the existing
+# directory, so the npx-installed skills above survive alongside them.
 # A directory with a SKILL.md is a skill; a directory of skill directories is a
 # pack contributing ONE line to the prompt index. Regenerate with
 # `node scripts/vendor-skills.mjs`. Placed late: skill markdown changes far more
 # often than the dep installs above it.
-COPY ./skills /root/.agents/skills
+COPY ./skills /usr/src/skills
 
 # Download fastembed models (~128MB) - only on amd64
 RUN ARCH=$(dpkg --print-architecture) && \

--- a/mcp/scripts/vendor-skills.mjs
+++ b/mcp/scripts/vendor-skills.mjs
@@ -1,7 +1,8 @@
 #!/usr/bin/env node
 /**
  * Vendor skill packs from upstream plugin repos into ./skills, which the
- * Dockerfile copies to ~/.agents/skills.
+ * Dockerfile copies to $SKILLS_ROOT (/usr/src/skills — deliberately outside
+ * /root, which sphinx-swarm shadows with a named volume).
  *
  * Upstream repos are Claude Code *plugins*: each top-level plugin holds a
  * skills/ dir plus a large CLAUDE.md that its skills assume is loaded. We


### PR DESCRIPTION
## Problem

On prod (swarm deployments), `list_skills {"pack":"commercial-legal"}` returned empty even though the running container was created from the current `stakgraph-mcp:latest` image — verified by digest (`79bbddc2...`), and both arch variants of that image contain all 13 vendored legal packs.

## Root cause

sphinx-swarm mounts a **named volume over `/root`** in the repo2graph container (`root_volume: "/root"` in `repo2graph.rs`). Docker initializes a named volume from the image only **once**, when the volume is first created; after that it persists and shadows the image's `/root` forever. The prod volume was initialized from a pre-v0.4.158 image (only the 3 npx-installed skills), so the legal packs shipped at `/root/.agents/skills` in newer images never became visible:

```
$ docker exec repo2graph.sphinx ls /root/.agents/skills
code-simplifier
frontend-design
security-review
```

## Fix

Bake skills outside `/root` and point the loader there via image ENV (no sphinx-swarm change needed — the `/root` volume is intentional and can stay):

- npx-installed skills are moved to `/usr/src/skills` after install
- vendored packs `COPY` into the same directory
- `ENV SKILLS_ROOT=/usr/src/skills` — `skillsRoot()` already honors this env var; local dev without it still falls back to `~/.agents/skills`

## Verification

- Built the modified layers in a stub image: all 16 entries (13 packs + 3 npx skills) land in `/usr/src/skills`, `SKILLS_ROOT` set, nothing left under `/root/.agents`
- All 17 tests in `src/__tests__/skills.test.ts` pass

After release + swarm pull/recreate, expect:

```
$ docker exec repo2graph.sphinx sh -c 'ls $SKILLS_ROOT | wc -l'
16
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)