### PR TITLE
Recover agent runs that stall without delivering an answer

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -59,7 +59,7 @@
     "@noble/ed25519": "2.3.0",
     "@noble/hashes": "1.7.1",
     "@octokit/rest": "22.0.1",
-    "@openrouter/ai-sdk-provider": "6.0.0-alpha.1",
+    "@openrouter/ai-sdk-provider": "2.10.0",
     "@playwright/test": "1.58.1",
     "ai": "6.0.175",
     "archy": "1.0.0",

--- a/mcp/src/aieo/package.json
+++ b/mcp/src/aieo/package.json
@@ -25,10 +25,10 @@
   "license": "ISC",
   "description": "typescript ai utils",
   "dependencies": {
-    "@ai-sdk/anthropic": "3.0.92",
+    "@ai-sdk/anthropic": "3.0.105",
     "@ai-sdk/google": "3.0.67",
     "@ai-sdk/openai": "3.0.61",
-    "@openrouter/ai-sdk-provider": "6.0.0-alpha.1",
+    "@openrouter/ai-sdk-provider": "2.10.0",
     "ai": "6.0.175",
     "zod": "4.3.6"
   },

--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -522,8 +522,14 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   // OpenAI
   "gpt-5": 128_000,
   "gpt-4.1-mini": 1_000_000,
-  // OpenRouter
-  "moonshotai/kimi-k2.6": 128_000,
+  // OpenRouter — values from the OpenRouter model catalog
+  // (https://openrouter.ai/api/v1/models, context_length).
+  "moonshotai/kimi-k3": 1_048_576,
+  "moonshotai/kimi-k2.7-code": 262_144,
+  "moonshotai/kimi-k2.6": 262_144,
+  "moonshotai/kimi-k2.5": 262_144,
+  "moonshotai/kimi-k2-thinking": 262_144,
+  "moonshotai/kimi-k2": 131_072,
 };
 
 const DEFAULT_CONTEXT_LIMITS: Record<Provider, number> = {

--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -358,6 +358,63 @@ export function getModelDetails(
   return { model, provider, apiKey, contextLimit, modelId }
 }
 
+/**
+ * Workaround for the v6-alpha @openrouter/ai-sdk-provider: its Responses-API
+ * path silently drops modelOptions and extraBody, so OpenRouter provider
+ * routing preferences never reach the request. Kimi/Moonshot models must be
+ * routed to Moonshot's own endpoint to get automatic prompt caching — every
+ * other kimi host re-bills the full conversation on each agent step.
+ *
+ * This patches globalThis.fetch ONCE, rewriting only POST bodies to
+ * OpenRouter's /responses endpoint for kimi/moonshot models that don't
+ * already carry a provider preference. Any parse failure falls through to the
+ * original request untouched. Remove when the SDK forwards model options.
+ */
+let openrouterFetchPatched = false;
+function patchOpenRouterFetchForProviderRouting(): void {
+  if (openrouterFetchPatched) return;
+  openrouterFetchPatched = true;
+  const realFetch = globalThis.fetch.bind(globalThis);
+  globalThis.fetch = (async (input: any, init?: any) => {
+    try {
+      const url: string | undefined =
+        typeof input === "string"
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input?.url;
+      if (url && url.startsWith("https://openrouter.ai/api/v1/responses")) {
+        let raw: string | undefined;
+        if (typeof init?.body === "string") {
+          raw = init.body;
+        } else if (typeof Request !== "undefined" && input instanceof Request) {
+          raw = await input.clone().text();
+        }
+        if (raw) {
+          const body = JSON.parse(raw);
+          const model = typeof body?.model === "string" ? body.model : "";
+          const isMoonshot =
+            model.startsWith("moonshotai/") ||
+            model.toLowerCase().includes("kimi");
+          if (isMoonshot && !body.provider) {
+            // Wire format (snake_case) — this bypasses the SDK's serializers
+            body.provider = { order: ["moonshotai"], allow_fallbacks: true };
+            const patched = JSON.stringify(body);
+            if (typeof init?.body === "string") {
+              init = { ...init, body: patched };
+            } else {
+              input = new Request(input, { body: patched });
+            }
+          }
+        }
+      }
+    } catch {
+      // fall through with the original request
+    }
+    return realFetch(input, init);
+  }) as typeof fetch;
+}
+
 export function getModel(
   provider: Provider,
   opts?: string | GetModelOptions
@@ -471,7 +528,14 @@ export function getModel(
       // caching (reads at 0.25x, writes free). Left unpinned, long agentic
       // runs get routed to non-caching hosts and re-pay the full conversation
       // on every step. Prefer Moonshot, keep fallbacks for availability.
-      // usage.include surfaces cached-token counts in the response usage.
+      //
+      // The v6-alpha @openrouter/ai-sdk-provider drops modelOptions AND
+      // extraBody on its Responses-API path (verified by inspecting request
+      // bodies), so routing preferences cannot be passed through the SDK —
+      // they are injected at the fetch layer instead (see
+      // patchOpenRouterFetchForProviderRouting). The model options below are
+      // kept so this starts working through the SDK once it forwards them.
+      patchOpenRouterFetchForProviderRouting();
       const isMoonshot =
         modelId.startsWith("moonshotai/") ||
         modelId.toLowerCase().includes("kimi");

--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -460,13 +460,29 @@ export function getModel(
         ...(extraHeaders && { headers: extraHeaders }),
       });
       return openai(modelId);
-    case "openrouter":
+    case "openrouter": {
       const openrouter = createOpenRouter({
         apiKey,
         ...(baseURL && { baseURL }),
         ...(extraHeaders && { headers: extraHeaders }),
       });
-      return openrouter(modelId);
+      // Kimi models are served by many OpenRouter hosts (Fireworks, Together,
+      // Chutes, ...) but only Moonshot's own endpoint has automatic prompt
+      // caching (reads at 0.25x, writes free). Left unpinned, long agentic
+      // runs get routed to non-caching hosts and re-pay the full conversation
+      // on every step. Prefer Moonshot, keep fallbacks for availability.
+      // usage.include surfaces cached-token counts in the response usage.
+      const isMoonshot =
+        modelId.startsWith("moonshotai/") ||
+        modelId.toLowerCase().includes("kimi");
+      const modelOptions: OpenRouterModelOptions = {
+        usage: { include: true },
+        ...(isMoonshot
+          ? { provider: { order: ["moonshotai"], allowFallbacks: true } }
+          : {}),
+      };
+      return openrouter(modelId, modelOptions);
+    }
     // case "claude_code":
     //   try {
     //     const customProvider = createClaudeCode({

--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -6,7 +6,7 @@ import {
 import { createOpenAI, OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
 import { LanguageModel } from "ai";
 import { Logger } from "./logger.js";
-import { createOpenRouter, OpenRouterModelOptions } from "@openrouter/ai-sdk-provider";
+import { createOpenRouter, OpenRouterChatSettings } from "@openrouter/ai-sdk-provider";
 
 export type Provider = "anthropic" | "google" | "openai" | "openrouter";
 
@@ -358,63 +358,6 @@ export function getModelDetails(
   return { model, provider, apiKey, contextLimit, modelId }
 }
 
-/**
- * Workaround for the v6-alpha @openrouter/ai-sdk-provider: its Responses-API
- * path silently drops modelOptions and extraBody, so OpenRouter provider
- * routing preferences never reach the request. Kimi/Moonshot models must be
- * routed to Moonshot's own endpoint to get automatic prompt caching — every
- * other kimi host re-bills the full conversation on each agent step.
- *
- * This patches globalThis.fetch ONCE, rewriting only POST bodies to
- * OpenRouter's /responses endpoint for kimi/moonshot models that don't
- * already carry a provider preference. Any parse failure falls through to the
- * original request untouched. Remove when the SDK forwards model options.
- */
-let openrouterFetchPatched = false;
-function patchOpenRouterFetchForProviderRouting(): void {
-  if (openrouterFetchPatched) return;
-  openrouterFetchPatched = true;
-  const realFetch = globalThis.fetch.bind(globalThis);
-  globalThis.fetch = (async (input: any, init?: any) => {
-    try {
-      const url: string | undefined =
-        typeof input === "string"
-          ? input
-          : input instanceof URL
-            ? input.href
-            : input?.url;
-      if (url && url.startsWith("https://openrouter.ai/api/v1/responses")) {
-        let raw: string | undefined;
-        if (typeof init?.body === "string") {
-          raw = init.body;
-        } else if (typeof Request !== "undefined" && input instanceof Request) {
-          raw = await input.clone().text();
-        }
-        if (raw) {
-          const body = JSON.parse(raw);
-          const model = typeof body?.model === "string" ? body.model : "";
-          const isMoonshot =
-            model.startsWith("moonshotai/") ||
-            model.toLowerCase().includes("kimi");
-          if (isMoonshot && !body.provider) {
-            // Wire format (snake_case) — this bypasses the SDK's serializers
-            body.provider = { order: ["moonshotai"], allow_fallbacks: true };
-            const patched = JSON.stringify(body);
-            if (typeof init?.body === "string") {
-              init = { ...init, body: patched };
-            } else {
-              input = new Request(input, { body: patched });
-            }
-          }
-        }
-      }
-    } catch {
-      // fall through with the original request
-    }
-    return realFetch(input, init);
-  }) as typeof fetch;
-}
-
 export function getModel(
   provider: Provider,
   opts?: string | GetModelOptions
@@ -528,24 +471,17 @@ export function getModel(
       // caching (reads at 0.25x, writes free). Left unpinned, long agentic
       // runs get routed to non-caching hosts and re-pay the full conversation
       // on every step. Prefer Moonshot, keep fallbacks for availability.
-      //
-      // The v6-alpha @openrouter/ai-sdk-provider drops modelOptions AND
-      // extraBody on its Responses-API path (verified by inspecting request
-      // bodies), so routing preferences cannot be passed through the SDK —
-      // they are injected at the fetch layer instead (see
-      // patchOpenRouterFetchForProviderRouting). The model options below are
-      // kept so this starts working through the SDK once it forwards them.
-      patchOpenRouterFetchForProviderRouting();
+      // usage.include surfaces cached-token counts in the response usage.
       const isMoonshot =
         modelId.startsWith("moonshotai/") ||
         modelId.toLowerCase().includes("kimi");
-      const modelOptions: OpenRouterModelOptions = {
+      const settings: OpenRouterChatSettings = {
         usage: { include: true },
         ...(isMoonshot
-          ? { provider: { order: ["moonshotai"], allowFallbacks: true } }
+          ? { provider: { order: ["moonshotai"], allow_fallbacks: true } }
           : {}),
       };
-      return openrouter(modelId, modelOptions);
+      return openrouter(modelId, settings);
     }
     // case "claude_code":
     //   try {
@@ -740,7 +676,7 @@ export function getProviderOptions(
       };
     case "openrouter":
       return {
-        openrouter: { usage: { include: true } } satisfies OpenRouterModelOptions,
+        openrouter: { usage: { include: true } } satisfies OpenRouterChatSettings,
       };
     default:
       throw new Error(`Unsupported provider: ${provider}`);

--- a/mcp/src/aieo/src/usage.ts
+++ b/mcp/src/aieo/src/usage.ts
@@ -87,6 +87,29 @@ export function normalizeUsage(raw?: RawUsage | null): AiUsageWithLegacy {
   });
 }
 
+/**
+ * Fold provider-metadata cache info into a normalized usage. The v6-alpha
+ * OpenRouter provider drops inputTokensDetails from the SDK usage object
+ * (cached-token counts survive only in providerMetadata.openrouter.usage),
+ * so without this every OpenRouter step reports cache_read 0 regardless of
+ * whether the upstream host actually cached.
+ */
+export function withProviderCacheUsage(
+  usage: AiUsageWithLegacy,
+  providerMetadata?: Record<string, any> | null
+): AiUsageWithLegacy {
+  const cached =
+    providerMetadata?.openrouter?.usage?.promptTokensDetails?.cachedTokens;
+  if (typeof cached !== "number" || cached <= 0 || usage.cache_read > 0) {
+    return usage;
+  }
+  return withLegacyUsage({
+    ...usage,
+    input: Math.max(usage.input - cached, 0),
+    cache_read: cached,
+  });
+}
+
 export function addUsage(...usages: Array<AiUsage | undefined | null>): AiUsage {
   return usages.reduce<AiUsage>((total, usage) => {
     if (!usage) return total;

--- a/mcp/src/busy.ts
+++ b/mcp/src/busy.ts
@@ -8,7 +8,8 @@ interface TrackedOperation {
   externalAbortController?: AbortController;
 }
 
-const TIMEOUT_MINUTES = parseInt(process.env.BUSY_TIMEOUT_MINUTES || "", 10) || 120;
+export const BUSY_TIMEOUT_MINUTES = parseInt(process.env.BUSY_TIMEOUT_MINUTES || "", 10) || 120;
+const TIMEOUT_MINUTES = BUSY_TIMEOUT_MINUTES;
 const TIMEOUT_MS = TIMEOUT_MINUTES * 60 * 1000;
 const activeOperations = new Map<string, TrackedOperation>();
 let operationCounter = 0;

--- a/mcp/src/graph_agent/agent.ts
+++ b/mcp/src/graph_agent/agent.ts
@@ -32,7 +32,7 @@ import {
   createHasEndMarkerCondition,
   extractMessagesFromSteps,
   truncateOldToolResults,
-  MAX_OUTPUT_TOKENS,
+  maxOutputTokensFor,
 } from "../repo/utils.js";
 import { get_graph_tools, GraphToolsConfig } from "./tools.js";
 
@@ -262,9 +262,10 @@ async function prepareGraphAgent(
 function buildCallParams(prepared: PreparedGraphAgent) {
   const { finalPrompt, previousMessages, userMessage, provider, modelId, abortSignal } = prepared;
   const providerOptions = getProviderOptions(provider as any, undefined, modelId);
+  const maxOutputTokens = maxOutputTokensFor(provider);
   const base = abortSignal
-    ? { providerOptions, abortSignal, maxOutputTokens: MAX_OUTPUT_TOKENS }
-    : { providerOptions, maxOutputTokens: MAX_OUTPUT_TOKENS };
+    ? { providerOptions, abortSignal, maxOutputTokens }
+    : { providerOptions, maxOutputTokens };
 
   if (previousMessages.length > 0) {
     const messagesToSend =

--- a/mcp/src/graph_agent/agent.ts
+++ b/mcp/src/graph_agent/agent.ts
@@ -215,6 +215,7 @@ async function prepareGraphAgent(
         step: stepMetas.length,
         turn: turnIndex,
         finishReason: sf.finishReason,
+        rawFinishReason: sf.rawFinishReason,
         usage: u,
         cumulativeInput: cumInput,
         cumulativeOutput: cumOutput,

--- a/mcp/src/graph_agent/agent.ts
+++ b/mcp/src/graph_agent/agent.ts
@@ -9,6 +9,7 @@ import {
 import {
   addUsage,
   normalizeUsage,
+  withProviderCacheUsage,
   getModelDetails,
   getProviderOptions,
   ModelName,
@@ -204,7 +205,10 @@ async function prepareGraphAgent(
       if (onStepEvent) {
         try { onStepEvent(sf.content); } catch (_) {}
       }
-      const u = normalizeUsage(sf.usage);
+      const u = withProviderCacheUsage(
+        normalizeUsage(sf.usage),
+        sf.providerMetadata as Record<string, any> | undefined
+      );
       cumInput += u.inputTokens ?? 0;
       cumOutput += u.outputTokens ?? 0;
       stepMetas.push({

--- a/mcp/src/repo/__tests__/docgen.test.ts
+++ b/mcp/src/repo/__tests__/docgen.test.ts
@@ -6,7 +6,7 @@
  */
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, rmSync, mkdtempSync } from "node:fs";
+import { existsSync, rmSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { execSync } from "node:child_process";
@@ -151,6 +151,26 @@ describe("runDocx — integration", { skip: !hasPandoc ? "pandoc not installed" 
     const filePath = decodeURIComponent(match[1]);
     assert.ok(filePath.endsWith(".docx"), "output must be a .docx file");
     assert.ok(existsSync(filePath), `file must exist at ${filePath}`);
+  });
+
+  it("converts from markdownPath, resolving relative paths against repoPath", async () => {
+    const { runDocx } = await import("../docgen.js?t=path" + Date.now());
+    const repoDir = mkdtempSync(join(tmpdir(), "docgen-repo-"));
+    try {
+      writeFileSync(join(repoDir, "doc.md"), "# From File\n\nBuilt incrementally.", "utf8");
+      const result = await runDocx({ markdownPath: "doc.md" }, repoDir);
+      assert.match(result, /Generated:.*\/repo\/agent\/file\?path=/, "result must contain download path");
+    } finally {
+      try { rmSync(repoDir, { recursive: true, force: true }); } catch {}
+    }
+  });
+
+  it("returns non-fatal errors for a missing markdownPath file and for neither input", async () => {
+    const { runDocx } = await import("../docgen.js");
+    const missing = await runDocx({ markdownPath: "/nonexistent/nope.md" });
+    assert.match(missing, /generate_docx failed: could not read markdownPath/);
+    const neither = await runDocx({});
+    assert.match(neither, /generate_docx failed: provide either/);
   });
 
   it("returns a non-fatal error string on invalid input (empty markdown is ok, pandoc error would be bad args)", async () => {

--- a/mcp/src/repo/__tests__/utils.test.ts
+++ b/mcp/src/repo/__tests__/utils.test.ts
@@ -4,7 +4,36 @@ import {
   extractLeadingJsonObject,
   matchesSchemaShape,
   collectEnumConstraints,
+  extractFinalAnswer,
+  needsContinuation,
 } from "../utils.js";
+import type { StepResult, ToolSet } from "ai";
+
+// Minimal StepResult factory — only the fields the functions under test read.
+function step(opts: {
+  content?: any[];
+  toolCalls?: any[];
+  finishReason?: string;
+  rawFinishReason?: string;
+}): StepResult<ToolSet> {
+  return {
+    content: opts.content ?? [],
+    toolCalls: opts.toolCalls ?? [],
+    finishReason: opts.finishReason ?? "stop",
+    rawFinishReason: opts.rawFinishReason,
+  } as unknown as StepResult<ToolSet>;
+}
+
+const toolCallStep = (narration?: string) =>
+  step({
+    content: [
+      ...(narration ? [{ type: "text", text: narration }] : []),
+      { type: "tool-call", toolName: "bash" },
+      { type: "tool-result", toolName: "bash", output: "ok" },
+    ],
+    toolCalls: [{ toolName: "bash" }],
+    finishReason: "tool-calls",
+  });
 
 test.describe("deepParseJsonStrings", () => {
   test("should parse stringified array into parsed array", () => {
@@ -334,5 +363,138 @@ test.describe("collectEnumConstraints", () => {
     expect(collectEnumConstraints(schema)).toEqual([
       { path: "choice", values: ["x", "y"] },
     ]);
+  });
+});
+
+test.describe("extractFinalAnswer", () => {
+  test("marker in final text: narration before the last tool call is excluded", () => {
+    const steps = [
+      toolCallStep("Let me look at the code."),
+      toolCallStep("Now reading session.ts."),
+      step({
+        content: [
+          { type: "text", text: "# Report\nThe answer.\n[END_OF_ANSWER]" },
+        ],
+      }),
+    ];
+    const result = extractFinalAnswer(steps);
+    expect(result.answer).toBe("# Report\nThe answer.");
+    expect(result.tool_use).toBe("text_with_end_marker");
+  });
+
+  test("answer that QUOTES the marker mid-text is not truncated at the quote", () => {
+    const steps = [
+      toolCallStep(),
+      step({
+        content: [
+          {
+            type: "text",
+            text:
+              'The agent uses stopSequences: ["[END_OF_ANSWER]"] to stop generation.\n' +
+              "That is the whole mechanism.\n[END_OF_ANSWER]",
+          },
+        ],
+      }),
+    ];
+    const result = extractFinalAnswer(steps);
+    expect(result.answer).toContain("That is the whole mechanism.");
+    expect(result.answer).toContain('stopSequences: ["[END_OF_ANSWER]"]');
+  });
+
+  test("no marker (stripped by stop sequence): falls back to text after last tool call", () => {
+    const steps = [
+      toolCallStep("Investigating."),
+      step({ content: [{ type: "text", text: "Final answer without marker." }] }),
+    ];
+    const result = extractFinalAnswer(steps);
+    expect(result.answer).toBe("Final answer without marker.");
+  });
+
+  test("no tools at all: falls back to all text", () => {
+    const steps = [
+      step({ content: [{ type: "text", text: "Just a direct reply." }] }),
+    ];
+    expect(extractFinalAnswer(steps).answer).toBe("Just a direct reply.");
+  });
+});
+
+test.describe("needsContinuation", () => {
+  test("anthropic stop_sequence finish is a proper termination", () => {
+    const steps = [
+      toolCallStep(),
+      step({
+        content: [{ type: "text", text: "The answer." }],
+        rawFinishReason: "stop_sequence",
+      }),
+    ];
+    expect(needsContinuation(steps, false)).toBe(false);
+  });
+
+  test("anthropic end_turn with only a plan is a stall", () => {
+    const steps = [
+      toolCallStep(),
+      step({
+        content: [{ type: "text", text: "Let me now run six graph searches." }],
+        rawFinishReason: "end_turn",
+      }),
+    ];
+    expect(needsContinuation(steps, false)).toBe(true);
+  });
+
+  test("truncation (length) is a stall", () => {
+    const steps = [
+      toolCallStep(),
+      step({ content: [{ type: "reasoning", text: "hmm" }], finishReason: "length" }),
+    ];
+    expect(needsContinuation(steps, false)).toBe(true);
+  });
+
+  test("marker mode: plain stop without marker is a stall", () => {
+    const steps = [
+      toolCallStep(),
+      step({
+        content: [{ type: "text", text: "Batch 1 (parallel): 6 searches." }],
+        rawFinishReason: "stop",
+      }),
+    ];
+    expect(needsContinuation(steps, true)).toBe(true);
+  });
+
+  test("marker mode: marker in text is a proper termination", () => {
+    const steps = [
+      toolCallStep(),
+      step({
+        content: [{ type: "text", text: "Answer.\n[END_OF_ANSWER]" }],
+        rawFinishReason: "stop",
+      }),
+    ];
+    expect(needsContinuation(steps, true)).toBe(false);
+  });
+
+  test("non-marker mode: ambiguous raw stop is left alone", () => {
+    const steps = [
+      toolCallStep(),
+      step({
+        content: [{ type: "text", text: "Some answer." }],
+        rawFinishReason: "stop",
+      }),
+    ];
+    expect(needsContinuation(steps, false)).toBe(false);
+  });
+
+  test("last step with tool calls (e.g. maxTurns stop) is not a stall", () => {
+    const steps = [toolCallStep(), toolCallStep()];
+    expect(needsContinuation(steps, true)).toBe(false);
+  });
+
+  test("ask_clarifying_questions is a proper termination", () => {
+    const steps = [
+      step({
+        content: [
+          { type: "tool-result", toolName: "ask_clarifying_questions", output: "{}" },
+        ],
+      }),
+    ];
+    expect(needsContinuation(steps, true)).toBe(false);
   });
 });

--- a/mcp/src/repo/__tests__/utils.test.ts
+++ b/mcp/src/repo/__tests__/utils.test.ts
@@ -367,10 +367,9 @@ test.describe("collectEnumConstraints", () => {
 });
 
 test.describe("extractFinalAnswer", () => {
-  test("marker in final text: narration before the last tool call is excluded", () => {
+  test("marker in text: answer is everything before [END_OF_ANSWER]", () => {
     const steps = [
-      toolCallStep("Let me look at the code."),
-      toolCallStep("Now reading session.ts."),
+      toolCallStep("Investigating."),
       step({
         content: [
           { type: "text", text: "# Report\nThe answer.\n[END_OF_ANSWER]" },
@@ -378,27 +377,9 @@ test.describe("extractFinalAnswer", () => {
       }),
     ];
     const result = extractFinalAnswer(steps);
-    expect(result.answer).toBe("# Report\nThe answer.");
+    expect(result.answer.endsWith("The answer.")).toBe(true);
+    expect(result.answer).not.toContain("[END_OF_ANSWER]");
     expect(result.tool_use).toBe("text_with_end_marker");
-  });
-
-  test("answer that QUOTES the marker mid-text is not truncated at the quote", () => {
-    const steps = [
-      toolCallStep(),
-      step({
-        content: [
-          {
-            type: "text",
-            text:
-              'The agent uses stopSequences: ["[END_OF_ANSWER]"] to stop generation.\n' +
-              "That is the whole mechanism.\n[END_OF_ANSWER]",
-          },
-        ],
-      }),
-    ];
-    const result = extractFinalAnswer(steps);
-    expect(result.answer).toContain("That is the whole mechanism.");
-    expect(result.answer).toContain('stopSequences: ["[END_OF_ANSWER]"]');
   });
 
   test("no marker (stripped by stop sequence): falls back to text after last tool call", () => {
@@ -427,7 +408,7 @@ test.describe("needsContinuation", () => {
         rawFinishReason: "stop_sequence",
       }),
     ];
-    expect(needsContinuation(steps, false)).toBe(false);
+    expect(needsContinuation(steps)).toBe(false);
   });
 
   test("anthropic end_turn with only a plan is a stall", () => {
@@ -438,7 +419,7 @@ test.describe("needsContinuation", () => {
         rawFinishReason: "end_turn",
       }),
     ];
-    expect(needsContinuation(steps, false)).toBe(true);
+    expect(needsContinuation(steps)).toBe(true);
   });
 
   test("truncation (length) is a stall", () => {
@@ -446,32 +427,10 @@ test.describe("needsContinuation", () => {
       toolCallStep(),
       step({ content: [{ type: "reasoning", text: "hmm" }], finishReason: "length" }),
     ];
-    expect(needsContinuation(steps, false)).toBe(true);
+    expect(needsContinuation(steps)).toBe(true);
   });
 
-  test("marker mode: plain stop without marker is a stall", () => {
-    const steps = [
-      toolCallStep(),
-      step({
-        content: [{ type: "text", text: "Batch 1 (parallel): 6 searches." }],
-        rawFinishReason: "stop",
-      }),
-    ];
-    expect(needsContinuation(steps, true)).toBe(true);
-  });
-
-  test("marker mode: marker in text is a proper termination", () => {
-    const steps = [
-      toolCallStep(),
-      step({
-        content: [{ type: "text", text: "Answer.\n[END_OF_ANSWER]" }],
-        rawFinishReason: "stop",
-      }),
-    ];
-    expect(needsContinuation(steps, true)).toBe(false);
-  });
-
-  test("non-marker mode: ambiguous raw stop is left alone", () => {
+  test("ambiguous raw stop (OpenAI-compatible providers) is left alone", () => {
     const steps = [
       toolCallStep(),
       step({
@@ -479,12 +438,12 @@ test.describe("needsContinuation", () => {
         rawFinishReason: "stop",
       }),
     ];
-    expect(needsContinuation(steps, false)).toBe(false);
+    expect(needsContinuation(steps)).toBe(false);
   });
 
   test("last step with tool calls (e.g. maxTurns stop) is not a stall", () => {
     const steps = [toolCallStep(), toolCallStep()];
-    expect(needsContinuation(steps, true)).toBe(false);
+    expect(needsContinuation(steps)).toBe(false);
   });
 
   test("ask_clarifying_questions is a proper termination", () => {
@@ -495,6 +454,17 @@ test.describe("needsContinuation", () => {
         ],
       }),
     ];
-    expect(needsContinuation(steps, true)).toBe(false);
+    expect(needsContinuation(steps)).toBe(false);
+  });
+
+  test("text containing [END_OF_ANSWER] is a proper termination", () => {
+    const steps = [
+      toolCallStep(),
+      step({
+        content: [{ type: "text", text: "Answer.\n[END_OF_ANSWER]" }],
+        rawFinishReason: "end_turn",
+      }),
+    ];
+    expect(needsContinuation(steps)).toBe(false);
   });
 });

--- a/mcp/src/repo/__tests__/utils.test.ts
+++ b/mcp/src/repo/__tests__/utils.test.ts
@@ -432,6 +432,14 @@ test.describe("needsContinuation", () => {
     expect(needsContinuation(steps)).toBe(true);
   });
 
+  test("mid-stream error step (e.g. connection drop after reasoning) is a stall", () => {
+    const steps = [
+      toolCallStep(),
+      step({ content: [{ type: "reasoning", text: "I now have all six documents..." }], finishReason: "error" }),
+    ];
+    expect(needsContinuation(steps)).toBe(true);
+  });
+
   test("ambiguous raw stop (OpenAI-compatible providers) is left alone", () => {
     const steps = [
       toolCallStep(),

--- a/mcp/src/repo/__tests__/utils.test.ts
+++ b/mcp/src/repo/__tests__/utils.test.ts
@@ -6,6 +6,7 @@ import {
   collectEnumConstraints,
   extractFinalAnswer,
   needsContinuation,
+  isContinuationNudge,
 } from "../utils.js";
 import type { StepResult, ToolSet } from "ai";
 
@@ -466,5 +467,28 @@ test.describe("needsContinuation", () => {
       }),
     ];
     expect(needsContinuation(steps)).toBe(false);
+  });
+});
+
+test.describe("isContinuationNudge", () => {
+  test("detects a tagged nudge message", () => {
+    expect(
+      isContinuationNudge({
+        role: "user",
+        content: "You ended your turn without completing the task...",
+        providerOptions: { stakgraph: { continuationNudge: true } },
+      })
+    ).toBe(true);
+  });
+
+  test("real user messages are not nudges", () => {
+    expect(isContinuationNudge({ role: "user", content: "hi" })).toBe(false);
+    expect(
+      isContinuationNudge({
+        role: "user",
+        content: "hi",
+        providerOptions: { anthropic: { cacheControl: { type: "ephemeral" } } },
+      })
+    ).toBe(false);
   });
 });

--- a/mcp/src/repo/__tests__/utils.test.ts
+++ b/mcp/src/repo/__tests__/utils.test.ts
@@ -7,6 +7,7 @@ import {
   extractFinalAnswer,
   needsContinuation,
   isContinuationNudge,
+  timeBudgetNudge,
 } from "../utils.js";
 import type { StepResult, ToolSet } from "ai";
 
@@ -467,6 +468,47 @@ test.describe("needsContinuation", () => {
       }),
     ];
     expect(needsContinuation(steps)).toBe(false);
+  });
+});
+
+test.describe("timeBudgetNudge", () => {
+  const MIN = 60_000;
+
+  test("nothing before 50% of budget", () => {
+    expect(timeBudgetNudge(59 * MIN, 120, new Set(), false)).toBe(null);
+  });
+
+  test("each threshold fires once, in order, with escalating urgency", () => {
+    const fired = new Set<number>();
+    const first = timeBudgetNudge(61 * MIN, 120, fired, false);
+    expect(first).toContain("61 of 120 minutes");
+    expect(timeBudgetNudge(62 * MIN, 120, fired, false)).toBe(null);
+    const second = timeBudgetNudge(91 * MIN, 120, fired, false);
+    expect(second).toContain("Start converging");
+    const third = timeBudgetNudge(111 * MIN, 120, fired, false);
+    expect(third).toContain("~9 minutes remain");
+    expect(third).toContain("[END_OF_ANSWER]");
+    expect(timeBudgetNudge(115 * MIN, 120, fired, false)).toBe(null);
+  });
+
+  test("a slow step that jumps past several thresholds fires only the most urgent", () => {
+    const fired = new Set<number>();
+    const nudge = timeBudgetNudge(112 * MIN, 120, fired, false);
+    expect(nudge).toContain("minutes remain");
+    expect(timeBudgetNudge(113 * MIN, 120, fired, false)).toBe(null);
+  });
+
+  test("final warning offers ask_clarifying_questions when enabled", () => {
+    const withAsk = timeBudgetNudge(111 * MIN, 120, new Set(), true);
+    expect(withAsk).toContain("ask_clarifying_questions");
+    const withoutAsk = timeBudgetNudge(111 * MIN, 120, new Set(), false);
+    expect(withoutAsk).not.toContain("ask_clarifying_questions");
+  });
+
+  test("thresholds scale with a non-default budget", () => {
+    const fired = new Set<number>();
+    expect(timeBudgetNudge(14 * MIN, 30, fired, false)).toBe(null);
+    expect(timeBudgetNudge(15 * MIN, 30, fired, false)).toContain("15 of 30 minutes");
   });
 });
 

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -25,7 +25,7 @@ import { ContextResult } from "../tools/types.js";
 import {
   logStep,
   extractFinalAnswer,
-  MAX_OUTPUT_TOKENS,
+  maxOutputTokensFor,
   needsContinuation,
   isContinuationNudge,
   createHasEndMarkerCondition,
@@ -871,12 +871,16 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
 }
 
 /**
- * Max number of continuation nudges after the model ends its turn without a
- * proper termination (no [END_OF_ANSWER], no ask_clarifying_questions, no
- * pending tool calls) — e.g. a text-only "Let me now..." plan (raw stop
- * reason "end_turn") or a step truncated mid-thinking ("length").
+ * Continuation allowances after the model ends its turn without a proper
+ * termination (no [END_OF_ANSWER], no ask_clarifying_questions, no pending
+ * tool calls). Voluntary stalls (raw "end_turn" — a text-only "Let me
+ * now..." plan) get few nudges: a model still narrating after two won't be
+ * fixed by a third. Token-limit truncations ("length") get more, because
+ * each continuation verifiably extends the answer and a large deliverable
+ * may need several segments; a progress gate in the loop stops empty ones.
  */
-const MAX_CONTINUATIONS = 2;
+const MAX_STALL_NUDGES = 2;
+const MAX_LENGTH_CONTINUATIONS = 5;
 
 /**
  * The two stall types need different instructions. After a token-limit
@@ -919,9 +923,10 @@ function initialModelMessages(prepared: PreparedAgent): ModelMessage[] {
 function continueCallParams(prepared: PreparedAgent, messages: ModelMessage[]) {
   const { provider, modelId, abortSignal } = prepared;
   const providerOptions = getProviderOptions(provider as any, undefined, modelId);
+  const maxOutputTokens = maxOutputTokensFor(provider);
   const base = abortSignal
-    ? { providerOptions, abortSignal, maxOutputTokens: MAX_OUTPUT_TOKENS }
-    : { providerOptions, maxOutputTokens: MAX_OUTPUT_TOKENS };
+    ? { providerOptions, abortSignal, maxOutputTokens }
+    : { providerOptions, maxOutputTokens };
   return { messages, ...base };
 }
 
@@ -929,9 +934,10 @@ function continueCallParams(prepared: PreparedAgent, messages: ModelMessage[]) {
 function buildCallParams(prepared: PreparedAgent) {
   const { finalPrompt, previousMessages, userMessage, provider, modelId, abortSignal } = prepared;
   const providerOptions = getProviderOptions(provider as any, undefined, modelId);
+  const maxOutputTokens = maxOutputTokensFor(provider);
   const base = abortSignal
-    ? { providerOptions, abortSignal, maxOutputTokens: MAX_OUTPUT_TOKENS }
-    : { providerOptions, maxOutputTokens: MAX_OUTPUT_TOKENS };
+    ? { providerOptions, abortSignal, maxOutputTokens }
+    : { providerOptions, maxOutputTokens };
   if (previousMessages.length > 0) {
     const messagesToSend =
       typeof finalPrompt === "string"
@@ -1032,14 +1038,27 @@ export async function get_context(
 
     // The model occasionally ends its turn with a text-only statement of
     // intent ("Let me now run X...") without emitting the tool calls, or a
-    // step gets truncated mid-thinking — either way the tool loop exits with
-    // no real answer. Nudge it to continue, at most MAX_CONTINUATIONS times.
-    for (let attempt = 1; attempt <= MAX_CONTINUATIONS; attempt++) {
+    // step gets truncated by the output token limit — either way the tool
+    // loop exits with no real answer. Nudge it to continue. The two cases
+    // get separate allowances: a truncation continuation verifiably makes
+    // forward progress (each segment appends answer text), so a large
+    // deliverable may legitimately need several; a voluntary stall that two
+    // nudges didn't fix won't be fixed by a third.
+    let stallNudges = 0;
+    let lengthContinuations = 0;
+    for (;;) {
       const allSteps = segments.flatMap((s) => s.steps);
       if (!needsContinuation(allSteps)) break;
-      const generated = (await run.streamResult.response).messages as ModelMessage[];
       const truncated =
         allSteps[allSteps.length - 1]?.finishReason === "length";
+      if (truncated) {
+        if (lengthContinuations >= MAX_LENGTH_CONTINUATIONS) break;
+        lengthContinuations++;
+      } else {
+        if (stallNudges >= MAX_STALL_NUDGES) break;
+        stallNudges++;
+      }
+      const generated = (await run.streamResult.response).messages as ModelMessage[];
       // Tagged via providerOptions so session consumers (transcript rendering,
       // turn counting) can tell this synthetic message from a real user turn;
       // model providers only read their own providerOptions key and ignore it.
@@ -1052,7 +1071,11 @@ export async function get_context(
       console.warn(
         `===> agent ended turn without finishing (rawFinishReason: ${
           allSteps[allSteps.length - 1]?.rawFinishReason
-        }); continuation attempt ${attempt}/${MAX_CONTINUATIONS}`
+        }); ${
+          truncated
+            ? `length continuation ${lengthContinuations}/${MAX_LENGTH_CONTINUATIONS}`
+            : `stall nudge ${stallNudges}/${MAX_STALL_NUDGES}`
+        }`
       );
       run = await runWithBadRequestRetry(
         continueCallParams(prepared, convo),
@@ -1065,6 +1088,18 @@ export async function get_context(
       });
       sent = run.effectiveSent;
       streamTotalUsage = await run.streamResult.totalUsage;
+      // Progress gate: a continuation that generated nothing new will not do
+      // better next round — stop rather than loop on empty segments.
+      const segmentOutput = run.segSteps.reduce(
+        (n, s) => n + (s.usage?.outputTokens ?? 0),
+        0
+      );
+      if (segmentOutput === 0) {
+        console.warn(
+          "===> continuation produced no output tokens; stopping continuation loop"
+        );
+        break;
+      }
     }
 
     steps = segments.flatMap((s) => s.steps);

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -484,13 +484,29 @@ interface PreparedAgent {
   startTime: number;
   stepMetas: StepMeta[];
   turnIndex: number;
-  // True when the provider can't report stop-sequence matches (any
-  // OpenAI-compatible backend): stopSequences is disabled so [END_OF_ANSWER]
-  // stays in the generated text and completion is detected from the text.
-  markerInText: boolean;
+  // Live view of the in-flight step's message array (updated by prepareStep);
+  // used to resume from the exact failure point on a 400 retry.
+  messagesRef: MessagesRef;
   provenanceCollector: ProvenanceCollector;
   abortSignal: AbortSignal | undefined;
   mcpClients: McpToolsResult["clients"];
+}
+
+/**
+ * Append the API response body to an error's message when the message alone
+ * is uninformative (e.g. a bare "Bad Request"). Mutates the error so every
+ * downstream consumer of err.message — session end records, async request
+ * records, webhooks — sees the real reason.
+ */
+function enrichErrorMessage(err: unknown): void {
+  if (!(err instanceof Error)) return;
+  const body =
+    (err as any)?.responseBody ?? (err as any)?.cause?.responseBody;
+  if (!body) return;
+  const detail = String(body).slice(0, 600);
+  if (!err.message.includes(detail.slice(0, 40))) {
+    err.message = `${err.message} — ${detail}`;
+  }
 }
 
 /** Returns true if the error was caused by an AbortSignal. */
@@ -756,15 +772,6 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     previousMessages.filter((m) => m.role === "user").length +
     (hasSystemTurn ? 2 : 1);
 
-  // Anthropic reports a matched stop sequence (raw stop_reason
-  // "stop_sequence" + providerMetadata), so we can strip the marker from
-  // output via stopSequences and still detect proper completion. OpenAI-
-  // compatible providers (OpenRouter/Kimi, GPT, Gemini) report a plain "stop"
-  // either way — for those, leave stopSequences off so [END_OF_ANSWER]
-  // remains in the text as the completion signal (extractFinalAnswer strips
-  // it from the returned answer).
-  const markerInText = provider !== "anthropic";
-
   const agent = new ToolLoopAgent({
     model,
     // Transparent replay: no code-generated system prompt — the system turn
@@ -772,7 +779,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     instructions: transparent ? undefined : instructions,
     tools,
     stopWhen,
-    ...(markerInText ? {} : { stopSequences: ["[END_OF_ANSWER]"] }),
+    stopSequences: ["[END_OF_ANSWER]"],
     onStepFinish: (sf) => {
       logStep(sf.content);
       if (onStepEvent) {
@@ -788,6 +795,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
         step: stepMetas.length,
         turn: turnIndex,
         finishReason: sf.finishReason,
+        rawFinishReason: sf.rawFinishReason,
         usage: u,
         cumulativeInput: cumInput,
         cumulativeOutput: cumOutput,
@@ -849,7 +857,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     startTime,
     stepMetas,
     turnIndex,
-    markerInText,
+    messagesRef,
     provenanceCollector,
     abortSignal: opts.abortSignal,
     mcpClients,
@@ -935,44 +943,102 @@ export async function get_context(
   let streamTotalUsage: LanguageModelUsage | undefined;
   // Each segment pairs the user-facing message that started it (the real user
   // message, then continuation nudges) with the steps it produced, so session
-  // persistence can interleave them faithfully.
-  const segments: { userMessage: ModelMessage; steps: StepResult<ToolSet>[] }[] = [];
+  // persistence can interleave them faithfully. priorMessages holds messages
+  // recovered from a 400-retried attempt (see runWithBadRequestRetry).
+  const segments: {
+    userMessage: ModelMessage;
+    priorMessages: ModelMessage[];
+    steps: StepResult<ToolSet>[];
+  }[] = [];
+
+  // Retry a model call once when the API rejects it with a 400 mid-run. The
+  // AI SDK only auto-retries 408/409/429/5xx, so a transient 400 sixty steps
+  // into a run otherwise kills it outright (observed in prod; replaying the
+  // identical conversation succeeded). prepareStep keeps messagesRef.current
+  // pointed at the exact messages of the in-flight step, so the retry resumes
+  // from the failure point — prompt caching makes the re-send cheap. Returns
+  // the messages generated during the failed attempt (recovered) so
+  // persistence and later continuations can account for them.
+  let badRequestRetried = false;
+  const runWithBadRequestRetry = async (
+    params: ReturnType<typeof buildCallParams>,
+    sentMessages: ModelMessage[]
+  ): Promise<{
+    streamResult: Awaited<ReturnType<typeof agent.stream>>;
+    segSteps: StepResult<ToolSet>[];
+    effectiveSent: ModelMessage[];
+  }> => {
+    try {
+      const streamResult = await agent.stream(params);
+      const segSteps = [...(((await streamResult.steps) as StepResult<ToolSet>[]) ?? [])];
+      return { streamResult, segSteps, effectiveSent: sentMessages };
+    } catch (err) {
+      const statusCode =
+        (err as any)?.statusCode ?? (err as any)?.cause?.statusCode;
+      const current = prepared.messagesRef.current as ModelMessage[];
+      if (badRequestRetried || statusCode !== 400 || current.length <= sentMessages.length) {
+        throw err;
+      }
+      badRequestRetried = true;
+      console.warn(
+        `===> model call rejected with 400 at message ${current.length} (sent ${sentMessages.length}); retrying once from the failure point`
+      );
+      const retryMessages = [...current];
+      const streamResult = await agent.stream(
+        continueCallParams(prepared, retryMessages)
+      );
+      const segSteps = [...(((await streamResult.steps) as StepResult<ToolSet>[]) ?? [])];
+      return { streamResult, segSteps, effectiveSent: retryMessages };
+    }
+  };
+
   try {
-    let streamResult = await agent.stream(buildCallParams(prepared));
+    let sent = initialModelMessages(prepared);
+    let run = await runWithBadRequestRetry(buildCallParams(prepared), sent);
     segments.push({
       userMessage: prepared.storageUserMessage,
-      steps: [...(((await streamResult.steps) as StepResult<ToolSet>[]) ?? [])],
+      priorMessages: run.effectiveSent.slice(sent.length),
+      steps: run.segSteps,
     });
-    streamTotalUsage = await streamResult.totalUsage;
+    sent = run.effectiveSent;
+    streamTotalUsage = await run.streamResult.totalUsage;
 
     // The model occasionally ends its turn with a text-only statement of
     // intent ("Let me now run X...") without emitting the tool calls, or a
     // step gets truncated mid-thinking — either way the tool loop exits with
     // no real answer. Nudge it to continue, at most MAX_CONTINUATIONS times.
-    let convo: ModelMessage[] | undefined;
     for (let attempt = 1; attempt <= MAX_CONTINUATIONS; attempt++) {
       const allSteps = segments.flatMap((s) => s.steps);
-      if (!needsContinuation(allSteps, prepared.markerInText)) break;
-      const generated = (await streamResult.response).messages as ModelMessage[];
-      if (!convo) convo = initialModelMessages(prepared);
+      if (!needsContinuation(allSteps)) break;
+      const generated = (await run.streamResult.response).messages as ModelMessage[];
       const nudge: ModelMessage = { role: "user", content: CONTINUATION_NUDGE };
-      convo = [...convo, ...generated, nudge];
+      const convo = [...sent, ...generated, nudge];
       console.warn(
         `===> agent ended turn without finishing (rawFinishReason: ${
           allSteps[allSteps.length - 1]?.rawFinishReason
         }); continuation attempt ${attempt}/${MAX_CONTINUATIONS}`
       );
-      streamResult = await agent.stream(continueCallParams(prepared, convo));
+      run = await runWithBadRequestRetry(
+        continueCallParams(prepared, convo),
+        convo
+      );
       segments.push({
         userMessage: nudge,
-        steps: [...(((await streamResult.steps) as StepResult<ToolSet>[]) ?? [])],
+        priorMessages: run.effectiveSent.slice(convo.length),
+        steps: run.segSteps,
       });
-      streamTotalUsage = await streamResult.totalUsage;
+      sent = run.effectiveSent;
+      streamTotalUsage = await run.streamResult.totalUsage;
     }
 
     steps = segments.flatMap((s) => s.steps);
   } catch (err) {
     const aborted = isAbortError(err);
+    // Surface the API's error detail: some failures (e.g. 400s) carry only a
+    // generic statusText in err.message while the real reason is in the
+    // response body. Enrich the error itself so both the session record and
+    // the async-request record (which persist err.message) get the detail.
+    enrichErrorMessage(err);
     if (sessionId) {
       const endTime = new Date();
       await appendSessionEnd(sessionId, {
@@ -1005,9 +1071,14 @@ export async function get_context(
   // response messages only cover that call, and the nudge user messages must
   // be interleaved for the transcript to replay correctly.
   if (sessionId) {
-    const newMessages = segments.flatMap((seg) =>
-      extractMessagesFromSteps(seg.userMessage, seg.steps, sessionConfig)
-    );
+    const newMessages = segments.flatMap((seg) => {
+      const extracted = extractMessagesFromSteps(seg.userMessage, seg.steps, sessionConfig);
+      // Messages recovered from a 400-retried attempt sit between the user
+      // message and the retry call's own response messages.
+      return seg.priorMessages.length > 0
+        ? [extracted[0], ...seg.priorMessages, ...extracted.slice(1)]
+        : extracted;
+    });
     appendMessages(sessionId, newMessages);
     appendStepMeta(sessionId, stepMetas);
     if (provenanceCollector.entries.length > 0) {
@@ -1119,6 +1190,7 @@ export async function stream_context(
         });
       } catch (e) {
         const aborted = isAbortError(e);
+        enrichErrorMessage(e);
         if (aborted) {
           console.log("[stream_context] Stream aborted by client");
         } else {

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -919,12 +919,17 @@ const MAX_LENGTH_CONTINUATIONS = 5;
  * without it, a model that stalled because it genuinely needs input gets
  * pushed toward fabricating an answer instead of asking.
  */
+type ContinuationKind = "stall" | "length" | "error";
+
 function continuationNudge(
   askQuestionsEnabled: boolean,
-  truncated: boolean,
+  kind: ContinuationKind,
   maxOutputTokens: number
 ): string {
-  if (truncated) {
+  if (kind === "error") {
+    return "Your previous message was interrupted mid-stream by a transient connection error; nothing after the interruption was received. Continue from where the conversation actually is: any tool call you were about to make never executed — issue it now, and do not repeat text already written. When the answer is complete, end with [END_OF_ANSWER].";
+  }
+  if (kind === "length") {
     return `Your previous message was cut off by the output token limit (${maxOutputTokens} tokens per message, thinking included). Continue from where the conversation actually is: if a tool call was cut off, it never executed — re-issue it, splitting large writes into several calls each well under that limit. If you were writing your final answer, continue from the exact point it was cut off — do not repeat anything already written. When the answer is complete, end with [END_OF_ANSWER].`;
   }
   const askPath = askQuestionsEnabled
@@ -1076,9 +1081,17 @@ export async function get_context(
     for (;;) {
       const allSteps = segments.flatMap((s) => s.steps);
       if (!needsContinuation(allSteps)) break;
-      const truncated =
-        allSteps[allSteps.length - 1]?.finishReason === "length";
-      if (truncated) {
+      const lastFinish = allSteps[allSteps.length - 1]?.finishReason;
+      const kind: ContinuationKind =
+        lastFinish === "length"
+          ? "length"
+          : lastFinish === "error"
+            ? "error"
+            : "stall";
+      // Involuntary interruptions (truncation, mid-stream connection errors)
+      // share the larger progress-gated allowance; only voluntary stalls are
+      // capped at MAX_STALL_NUDGES.
+      if (kind !== "stall") {
         if (lengthContinuations >= MAX_LENGTH_CONTINUATIONS) break;
         lengthContinuations++;
       } else {
@@ -1093,18 +1106,18 @@ export async function get_context(
         role: "user",
         content: continuationNudge(
           prepared.askQuestionsEnabled,
-          truncated,
+          kind,
           maxOutputTokensFor(prepared.provider)
         ),
         providerOptions: { stakgraph: { continuationNudge: true } },
       };
       const convo = [...sent, ...generated, nudge];
       console.warn(
-        `===> agent ended turn without finishing (rawFinishReason: ${
+        `===> agent ended turn without finishing (finishReason: ${lastFinish}, raw: ${
           allSteps[allSteps.length - 1]?.rawFinishReason
         }); ${
-          truncated
-            ? `length continuation ${lengthContinuations}/${MAX_LENGTH_CONTINUATIONS}`
+          kind !== "stall"
+            ? `${kind} continuation ${lengthContinuations}/${MAX_LENGTH_CONTINUATIONS}`
             : `stall nudge ${stallNudges}/${MAX_STALL_NUDGES}`
         }`
       );

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -28,6 +28,7 @@ import {
   maxOutputTokensFor,
   needsContinuation,
   isContinuationNudge,
+  timeBudgetNudge,
   createHasEndMarkerCondition,
   createHasAskQuestionsCondition,
   ensureAdditionalPropertiesFalse,
@@ -40,6 +41,7 @@ import {
   getCurrentDateSnippet,
 } from "./utils.js";
 import { LanguageModel } from "ai";
+import { BUSY_TIMEOUT_MINUTES } from "../busy.js";
 import {
   createSession as createNewSession,
   appendSessionEnd,
@@ -772,6 +774,8 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
   const stepMetas: StepMeta[] = [];
   let cumInput = 0;
   let cumOutput = 0;
+  const askQuestionsEnabled = toolConfigEnabled(toolsConfig?.ask_clarifying_questions);
+  const firedTimeNudges = new Set<number>();
   const turnIndex =
     previousMessages.filter(
       (m) => m.role === "user" && !isContinuationNudge(m)
@@ -810,9 +814,31 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     },
     prepareStep: async ({ steps, messages }) => {
       messagesRef.current = messages as ModelMessage[];
+      // Time-budget nudge: model-facing only (appended per step, not
+      // persisted), so it must not leak into messagesRef used by the
+      // 400-retry resume.
+      const timeNudge = timeBudgetNudge(
+        Date.now() - startTime,
+        BUSY_TIMEOUT_MINUTES,
+        firedTimeNudges,
+        askQuestionsEnabled
+      );
+      if (timeNudge) {
+        console.warn(`===> time-budget nudge injected: ${timeNudge}`);
+      }
+      const withNudge: ModelMessage[] = timeNudge
+        ? [
+            ...(messages as ModelMessage[]),
+            {
+              role: "user",
+              content: timeNudge,
+              providerOptions: { stakgraph: { timeNudge: true } },
+            },
+          ]
+        : (messages as ModelMessage[]);
       const lastStep = steps.length > 0 ? steps[steps.length - 1] : null;
       const inputTokens = lastStep?.usage?.inputTokens ?? 0;
-      const truncated = await truncateOldToolResults(messages, inputTokens, contextLimit);
+      const truncated = await truncateOldToolResults(withNudge, inputTokens, contextLimit);
       if (truncated === messages) return undefined;
       return { messages: truncated };
     },
@@ -863,7 +889,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     stepMetas,
     turnIndex,
     messagesRef,
-    askQuestionsEnabled: toolConfigEnabled(toolsConfig?.ask_clarifying_questions),
+    askQuestionsEnabled,
     provenanceCollector,
     abortSignal: opts.abortSignal,
     mcpClients,

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -16,6 +16,7 @@ import {
   getModelDetails,
   getProviderOptions,
   normalizeUsage,
+  withProviderCacheUsage,
 } from "../aieo/src/index.js";
 import { get_tools, ToolsConfig, SkillsConfig, GgnnConfig, MessagesRef, ProvenanceCollector, toolConfigEnabled, redactToolsConfig } from "./tools.js";
 import { SKILLS, enabledEntries, renderSkillIndex } from "./skills.js";
@@ -777,7 +778,10 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
       if (onStepEvent) {
         try { onStepEvent(sf.content); } catch (_) {}
       }
-      const u = normalizeUsage(sf.usage);
+      const u = withProviderCacheUsage(
+        normalizeUsage(sf.usage),
+        sf.providerMetadata as Record<string, any> | undefined
+      );
       cumInput += u.inputTokens ?? 0;
       cumOutput += u.outputTokens ?? 0;
       stepMetas.push({

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -895,10 +895,11 @@ const MAX_LENGTH_CONTINUATIONS = 5;
  */
 function continuationNudge(
   askQuestionsEnabled: boolean,
-  truncated: boolean
+  truncated: boolean,
+  maxOutputTokens: number
 ): string {
   if (truncated) {
-    return "Your previous message was cut off by the output token limit. Continue from where the conversation actually is: if a tool call was cut off, it never executed — re-issue it, splitting large writes into several smaller calls. If you were writing your final answer, continue from the exact point it was cut off — do not repeat anything already written. When the answer is complete, end with [END_OF_ANSWER].";
+    return `Your previous message was cut off by the output token limit (${maxOutputTokens} tokens per message, thinking included). Continue from where the conversation actually is: if a tool call was cut off, it never executed — re-issue it, splitting large writes into several calls each well under that limit. If you were writing your final answer, continue from the exact point it was cut off — do not repeat anything already written. When the answer is complete, end with [END_OF_ANSWER].`;
   }
   const askPath = askQuestionsEnabled
     ? "call ask_clarifying_questions"
@@ -1064,7 +1065,11 @@ export async function get_context(
       // model providers only read their own providerOptions key and ignore it.
       const nudge: ModelMessage = {
         role: "user",
-        content: continuationNudge(prepared.askQuestionsEnabled, truncated),
+        content: continuationNudge(
+          prepared.askQuestionsEnabled,
+          truncated,
+          maxOutputTokensFor(prepared.provider)
+        ),
         providerOptions: { stakgraph: { continuationNudge: true } },
       };
       const convo = [...sent, ...generated, nudge];

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -879,11 +879,23 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
 const MAX_CONTINUATIONS = 2;
 
 /**
- * The nudge must leave the model a legitimate way to ask the user something:
+ * The two stall types need different instructions. After a token-limit
+ * truncation ("length"), telling the model to "write the final answer" makes
+ * it restart the answer from the top and re-truncate; it must instead pick up
+ * from the cutoff (partial text is already in the conversation and in the
+ * extracted answer, so repeating it duplicates; a cut-off tool call never
+ * executed, so it must be re-issued). After a voluntary stop ("end_turn"),
+ * the nudge must also leave a legitimate way to ask the user something:
  * without it, a model that stalled because it genuinely needs input gets
  * pushed toward fabricating an answer instead of asking.
  */
-function continuationNudge(askQuestionsEnabled: boolean): string {
+function continuationNudge(
+  askQuestionsEnabled: boolean,
+  truncated: boolean
+): string {
+  if (truncated) {
+    return "Your previous message was cut off by the output token limit. Continue from where the conversation actually is: if a tool call was cut off, it never executed — re-issue it, splitting large writes into several smaller calls. If you were writing your final answer, continue from the exact point it was cut off — do not repeat anything already written. When the answer is complete, end with [END_OF_ANSWER].";
+  }
   const askPath = askQuestionsEnabled
     ? "call ask_clarifying_questions"
     : "ask your question and end with [END_OF_ANSWER]";
@@ -1026,12 +1038,14 @@ export async function get_context(
       const allSteps = segments.flatMap((s) => s.steps);
       if (!needsContinuation(allSteps)) break;
       const generated = (await run.streamResult.response).messages as ModelMessage[];
+      const truncated =
+        allSteps[allSteps.length - 1]?.finishReason === "length";
       // Tagged via providerOptions so session consumers (transcript rendering,
       // turn counting) can tell this synthetic message from a real user turn;
       // model providers only read their own providerOptions key and ignore it.
       const nudge: ModelMessage = {
         role: "user",
-        content: continuationNudge(prepared.askQuestionsEnabled),
+        content: continuationNudge(prepared.askQuestionsEnabled, truncated),
         providerOptions: { stakgraph: { continuationNudge: true } },
       };
       const convo = [...sent, ...generated, nudge];

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -4,6 +4,7 @@ import {
   ToolLoopAgent,
   ModelMessage,
   StopCondition,
+  StepResult,
   ToolSet,
   jsonSchema,
   stepCountIs,
@@ -24,6 +25,7 @@ import {
   logStep,
   extractFinalAnswer,
   MAX_OUTPUT_TOKENS,
+  needsContinuation,
   createHasEndMarkerCondition,
   createHasAskQuestionsCondition,
   ensureAdditionalPropertiesFalse,
@@ -64,7 +66,11 @@ import {
 import type { TextPart } from "ai";
 
 function SYSTEM_PROMPT_END(qs: boolean) {
+  const antiStall = `Never end your turn on a plan or a statement of intent. If you are about to write "Let me now..." or "Next I will...", do those things in this same turn by calling the tools instead of describing them. End your turn only once your final answer is written${qs ? ", or you have called ask_clarifying_questions" : ""}.`;
+
   const normalEnd = `CRITICAL: When you are ready to provide your final answer, output your complete response followed by [END_OF_ANSWER] on a new line. Don't start your answer with preamble like "Ok! I have all the information I need. Let me create a plan...". Just start with your answer.
+
+  ${antiStall}
 
   Write your answer directly as text and end with [END_OF_ANSWER].`;
   
@@ -85,7 +91,9 @@ function SYSTEM_PROMPT_END(qs: boolean) {
   - Comparison table: Use questionArtifact with type "comparison_table" to compare approaches with pros/cons
   - Color picker: Use questionArtifact with type "color_swatch" to show a color picker
   
-  Otherwise, provide your answer directly followed by [END_OF_ANSWER]. Don't start your answer with preamble like "Ok! I have all the information I need. Let me create a plan...". Just write your answer.`
+  Otherwise, provide your answer directly followed by [END_OF_ANSWER]. Don't start your answer with preamble like "Ok! I have all the information I need. Let me create a plan...". Just write your answer.
+
+  ${antiStall}`
 
   return qs ? qsEnd : normalEnd;
 }
@@ -475,6 +483,10 @@ interface PreparedAgent {
   startTime: number;
   stepMetas: StepMeta[];
   turnIndex: number;
+  // True when the provider can't report stop-sequence matches (any
+  // OpenAI-compatible backend): stopSequences is disabled so [END_OF_ANSWER]
+  // stays in the generated text and completion is detected from the text.
+  markerInText: boolean;
   provenanceCollector: ProvenanceCollector;
   abortSignal: AbortSignal | undefined;
   mcpClients: McpToolsResult["clients"];
@@ -743,6 +755,15 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     previousMessages.filter((m) => m.role === "user").length +
     (hasSystemTurn ? 2 : 1);
 
+  // Anthropic reports a matched stop sequence (raw stop_reason
+  // "stop_sequence" + providerMetadata), so we can strip the marker from
+  // output via stopSequences and still detect proper completion. OpenAI-
+  // compatible providers (OpenRouter/Kimi, GPT, Gemini) report a plain "stop"
+  // either way — for those, leave stopSequences off so [END_OF_ANSWER]
+  // remains in the text as the completion signal (extractFinalAnswer strips
+  // it from the returned answer).
+  const markerInText = provider !== "anthropic";
+
   const agent = new ToolLoopAgent({
     model,
     // Transparent replay: no code-generated system prompt — the system turn
@@ -750,7 +771,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     instructions: transparent ? undefined : instructions,
     tools,
     stopWhen,
-    stopSequences: ["[END_OF_ANSWER]"],
+    ...(markerInText ? {} : { stopSequences: ["[END_OF_ANSWER]"] }),
     onStepFinish: (sf) => {
       logStep(sf.content);
       if (onStepEvent) {
@@ -824,10 +845,45 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     startTime,
     stepMetas,
     turnIndex,
+    markerInText,
     provenanceCollector,
     abortSignal: opts.abortSignal,
     mcpClients,
   };
+}
+
+/**
+ * Max number of continuation nudges after the model ends its turn without a
+ * proper termination (no [END_OF_ANSWER], no ask_clarifying_questions, no
+ * pending tool calls) — e.g. a text-only "Let me now..." plan (raw stop
+ * reason "end_turn") or a step truncated mid-thinking ("length").
+ */
+const MAX_CONTINUATIONS = 2;
+
+const CONTINUATION_NUDGE =
+  "You ended your turn without completing the task. Do not stop to describe a plan or intention — execute it now: make the tool calls you described, and when you have the final answer, write it followed by [END_OF_ANSWER].";
+
+/** The exact messages sent to the model on the initial call (model-facing, not storage). */
+function initialModelMessages(prepared: PreparedAgent): ModelMessage[] {
+  const { finalPrompt, previousMessages, userMessage } = prepared;
+  if (previousMessages.length > 0) {
+    return typeof finalPrompt === "string"
+      ? [...previousMessages, userMessage]
+      : [...previousMessages, ...finalPrompt];
+  }
+  return typeof finalPrompt === "string"
+    ? [{ role: "user", content: finalPrompt }]
+    : [...finalPrompt];
+}
+
+/** Call params for a continuation retry: full conversation so far + nudge. */
+function continueCallParams(prepared: PreparedAgent, messages: ModelMessage[]) {
+  const { provider, modelId, abortSignal } = prepared;
+  const providerOptions = getProviderOptions(provider as any, undefined, modelId);
+  const base = abortSignal
+    ? { providerOptions, abortSignal, maxOutputTokens: MAX_OUTPUT_TOKENS }
+    : { providerOptions, maxOutputTokens: MAX_OUTPUT_TOKENS };
+  return { messages, ...base };
 }
 
 /** Build the generate/stream call params from the prepared agent state. */
@@ -873,10 +929,44 @@ export async function get_context(
 
   let steps: Awaited<ReturnType<typeof agent.generate>>["steps"] = [];
   let streamTotalUsage: LanguageModelUsage | undefined;
+  // Each segment pairs the user-facing message that started it (the real user
+  // message, then continuation nudges) with the steps it produced, so session
+  // persistence can interleave them faithfully.
+  const segments: { userMessage: ModelMessage; steps: StepResult<ToolSet>[] }[] = [];
   try {
-    const streamResult = await agent.stream(buildCallParams(prepared));
-    steps = (await streamResult.steps) ?? [];
+    let streamResult = await agent.stream(buildCallParams(prepared));
+    segments.push({
+      userMessage: prepared.storageUserMessage,
+      steps: [...(((await streamResult.steps) as StepResult<ToolSet>[]) ?? [])],
+    });
     streamTotalUsage = await streamResult.totalUsage;
+
+    // The model occasionally ends its turn with a text-only statement of
+    // intent ("Let me now run X...") without emitting the tool calls, or a
+    // step gets truncated mid-thinking — either way the tool loop exits with
+    // no real answer. Nudge it to continue, at most MAX_CONTINUATIONS times.
+    let convo: ModelMessage[] | undefined;
+    for (let attempt = 1; attempt <= MAX_CONTINUATIONS; attempt++) {
+      const allSteps = segments.flatMap((s) => s.steps);
+      if (!needsContinuation(allSteps, prepared.markerInText)) break;
+      const generated = (await streamResult.response).messages as ModelMessage[];
+      if (!convo) convo = initialModelMessages(prepared);
+      const nudge: ModelMessage = { role: "user", content: CONTINUATION_NUDGE };
+      convo = [...convo, ...generated, nudge];
+      console.warn(
+        `===> agent ended turn without finishing (rawFinishReason: ${
+          allSteps[allSteps.length - 1]?.rawFinishReason
+        }); continuation attempt ${attempt}/${MAX_CONTINUATIONS}`
+      );
+      streamResult = await agent.stream(continueCallParams(prepared, convo));
+      segments.push({
+        userMessage: nudge,
+        steps: [...(((await streamResult.steps) as StepResult<ToolSet>[]) ?? [])],
+      });
+      streamTotalUsage = await streamResult.totalUsage;
+    }
+
+    steps = segments.flatMap((s) => s.steps);
   } catch (err) {
     const aborted = isAbortError(err);
     if (sessionId) {
@@ -907,12 +997,12 @@ export async function get_context(
   const endTime = Date.now();
   const duration = endTime - startTime;
 
-  // Save to session if enabled
+  // Save to session if enabled. Extract per segment: each continuation call's
+  // response messages only cover that call, and the nudge user messages must
+  // be interleaved for the transcript to replay correctly.
   if (sessionId) {
-    const newMessages = extractMessagesFromSteps(
-      storageUserMessage,
-      steps,
-      sessionConfig
+    const newMessages = segments.flatMap((seg) =>
+      extractMessagesFromSteps(seg.userMessage, seg.steps, sessionConfig)
     );
     appendMessages(sessionId, newMessages);
     appendStepMeta(sessionId, stepMetas);

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -27,6 +27,7 @@ import {
   extractFinalAnswer,
   MAX_OUTPUT_TOKENS,
   needsContinuation,
+  isContinuationNudge,
   createHasEndMarkerCondition,
   createHasAskQuestionsCondition,
   ensureAdditionalPropertiesFalse,
@@ -487,6 +488,9 @@ interface PreparedAgent {
   // Live view of the in-flight step's message array (updated by prepareStep);
   // used to resume from the exact failure point on a 400 retry.
   messagesRef: MessagesRef;
+  // Whether the ask_clarifying_questions tool is available this run; selects
+  // the escape hatch offered in the continuation nudge.
+  askQuestionsEnabled: boolean;
   provenanceCollector: ProvenanceCollector;
   abortSignal: AbortSignal | undefined;
   mcpClients: McpToolsResult["clients"];
@@ -769,8 +773,9 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
   let cumInput = 0;
   let cumOutput = 0;
   const turnIndex =
-    previousMessages.filter((m) => m.role === "user").length +
-    (hasSystemTurn ? 2 : 1);
+    previousMessages.filter(
+      (m) => m.role === "user" && !isContinuationNudge(m)
+    ).length + (hasSystemTurn ? 2 : 1);
 
   const agent = new ToolLoopAgent({
     model,
@@ -858,6 +863,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     stepMetas,
     turnIndex,
     messagesRef,
+    askQuestionsEnabled: toolConfigEnabled(toolsConfig?.ask_clarifying_questions),
     provenanceCollector,
     abortSignal: opts.abortSignal,
     mcpClients,
@@ -872,8 +878,17 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
  */
 const MAX_CONTINUATIONS = 2;
 
-const CONTINUATION_NUDGE =
-  "You ended your turn without completing the task. Do not stop to describe a plan or intention — execute it now: make the tool calls you described, and when you have the final answer, write it followed by [END_OF_ANSWER].";
+/**
+ * The nudge must leave the model a legitimate way to ask the user something:
+ * without it, a model that stalled because it genuinely needs input gets
+ * pushed toward fabricating an answer instead of asking.
+ */
+function continuationNudge(askQuestionsEnabled: boolean): string {
+  const askPath = askQuestionsEnabled
+    ? "call ask_clarifying_questions"
+    : "ask your question and end with [END_OF_ANSWER]";
+  return `You ended your turn without completing the task. Do not stop to describe a plan or intention — execute it now: make the tool calls you described, and when you have the final answer, write it followed by [END_OF_ANSWER]. If you are blocked on information only the user can provide, ${askPath} instead of guessing.`;
+}
 
 /** The exact messages sent to the model on the initial call (model-facing, not storage). */
 function initialModelMessages(prepared: PreparedAgent): ModelMessage[] {
@@ -1011,7 +1026,14 @@ export async function get_context(
       const allSteps = segments.flatMap((s) => s.steps);
       if (!needsContinuation(allSteps)) break;
       const generated = (await run.streamResult.response).messages as ModelMessage[];
-      const nudge: ModelMessage = { role: "user", content: CONTINUATION_NUDGE };
+      // Tagged via providerOptions so session consumers (transcript rendering,
+      // turn counting) can tell this synthetic message from a real user turn;
+      // model providers only read their own providerOptions key and ignore it.
+      const nudge: ModelMessage = {
+        role: "user",
+        content: continuationNudge(prepared.askQuestionsEnabled),
+        providerOptions: { stakgraph: { continuationNudge: true } },
+      };
       const convo = [...sent, ...generated, nudge];
       console.warn(
         `===> agent ended turn without finishing (rawFinishReason: ${

--- a/mcp/src/repo/docgen.ts
+++ b/mcp/src/repo/docgen.ts
@@ -33,7 +33,15 @@ function resolveTemplate(template: string): string {
 }
 
 export interface DocxInput {
-  markdown: string;
+  // Inline Markdown content. For large documents prefer markdownPath: a
+  // single tool call carrying a whole document as one JSON string must fit
+  // in one model message (output-token capped) and fails for models that
+  // can't reliably emit huge arguments.
+  markdown?: string;
+  // Path to a Markdown file to convert instead of inline content — build it
+  // incrementally (e.g. bash appends), then convert. Relative paths resolve
+  // against the repo directory.
+  markdownPath?: string;
   template?: string;
 }
 
@@ -160,8 +168,24 @@ export function injectParaIds(documentXml: string): { xml: string; count: number
  * Generate a .docx file from Markdown via Pandoc.
  * Returns a string with the download path on success, or a non-fatal error string.
  */
-export async function runDocx(input: DocxInput): Promise<string> {
-  const base = input.markdown
+export async function runDocx(input: DocxInput, repoPath?: string): Promise<string> {
+  let markdown: string;
+  if (input.markdownPath) {
+    const resolved = path.isAbsolute(input.markdownPath)
+      ? input.markdownPath
+      : path.join(repoPath ?? process.cwd(), input.markdownPath);
+    try {
+      markdown = readFileSync(resolved, "utf8");
+    } catch (e) {
+      return `generate_docx failed: could not read markdownPath "${resolved}": ${(e as Error).message}`;
+    }
+  } else if (input.markdown) {
+    markdown = input.markdown;
+  } else {
+    return "generate_docx failed: provide either 'markdown' (inline) or 'markdownPath' (path to a .md file).";
+  }
+
+  const base = markdown
     .split("\n")[0]
     .replace(/^#+\s*/, "")
     .trim()
@@ -173,7 +197,7 @@ export async function runDocx(input: DocxInput): Promise<string> {
 
   console.log(`===> generate_docx: ${outFile}`);
 
-  writeFileSync(tmpMd, input.markdown, "utf8");
+  writeFileSync(tmpMd, markdown, "utf8");
 
   const args = [tmpMd, "-o", outFile];
 

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -60,6 +60,10 @@ export interface StepMeta {
   turn: number;
   label?: string;
   finishReason?: string;
+  // Raw provider stop reason (e.g. Anthropic "end_turn" vs "stop_sequence") —
+  // the unified finishReason maps both to "stop", hiding the difference
+  // between a proper [END_OF_ANSWER] finish and a stall.
+  rawFinishReason?: string;
   usage: AiUsageWithLegacy;
   cumulativeInput: number;
   cumulativeOutput: number;

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -348,10 +348,14 @@ Rules:
     "Apply a unified-diff patch string to the cloned repo via `git apply`. " +
     "Patch must be valid unified-diff format. Returns success message or error details.",
   generate_docx:
-    "Generate a Word (.docx) document from Markdown content using Pandoc. " +
-    "Input: { markdown: string; template?: string } where 'template' is an optional " +
-    "bundled reference-doc name for styling. Writes the file to the durable artifacts " +
-    "directory and returns a download path: 'Generated: /repo/agent/file?path=...' " +
+    "Generate a Word (.docx) document from Markdown using Pandoc. " +
+    "Input: { markdown?: string; markdownPath?: string; template?: string } — provide exactly one " +
+    "of 'markdown' (inline content) or 'markdownPath' (path to a .md file; relative paths resolve " +
+    "against the repo directory). For anything longer than a couple of pages, ALWAYS use markdownPath: " +
+    "write the document to a .md file incrementally with bash (several appends), then convert it — " +
+    "a large inline 'markdown' argument must fit in a single message and will be cut off. " +
+    "'template' is an optional bundled reference-doc name for styling. Writes the file to the durable " +
+    "artifacts directory and returns a download path: 'Generated: /repo/agent/file?path=...' " +
     "On failure returns a non-fatal 'generate_docx failed: ...' string.",
   generate_xlsx:
     "Generate an Excel (.xlsx) workbook from a structured definition using openpyxl. " +
@@ -1276,10 +1280,11 @@ export async function get_tools(
           toolConfigDescription(toolsConfig.generate_docx) ??
           defaultDescriptions.generate_docx,
         inputSchema: z.object({
-          markdown: z.string().describe("Markdown content to convert to .docx"),
+          markdown: z.string().optional().describe("Inline Markdown content to convert to .docx (small documents only)"),
+          markdownPath: z.string().optional().describe("Path to a Markdown file to convert (preferred for large documents — build it incrementally with bash first); relative paths resolve against the repo directory"),
           template: z.string().optional().describe("Optional bundled reference-doc template name for styling"),
         }),
-        execute: async (input) => runDocx(input),
+        execute: async (input) => runDocx(input, repoPath),
       });
     }
     // generate_xlsx — openpyxl-based Excel workbook generation

--- a/mcp/src/repo/utils.ts
+++ b/mcp/src/repo/utils.ts
@@ -46,9 +46,6 @@ export function createHasEndMarkerCondition<
 >(): StopCondition<T> {
   return ({ steps }) => {
     for (const step of steps) {
-      // A step that also makes tool calls isn't done — marker text there is a
-      // quotation (e.g. an answer describing this codebase), not a terminator.
-      if (step.content.some((item) => item.type === "tool-call")) continue;
       for (const item of step.content) {
         if (item.type === "text" && item.text?.includes("[END_OF_ANSWER]")) {
           return true;
@@ -68,17 +65,12 @@ export function createHasEndMarkerCondition<
  * "end_turn" — the model narrated a plan or emitted only reasoning and quit)
  * or a truncation ("length"); both are recoverable by asking it to continue.
  *
- * OpenAI-compatible providers report raw "stop" for a stop-sequence match and
- * a natural stop alike, so for them stopSequences is disabled and the marker
- * is expected in the generated text (`markerInText`). In that mode a plain
- * "stop" with no marker and no tool calls IS a stall. Without that mode
- * (Anthropic), "stop" is only a stall when the raw reason is "end_turn" —
- * a "stop_sequence" finish means the marker fired and was stripped.
+ * Detection relies on the raw provider stop reason: a proper Anthropic finish
+ * hits the [END_OF_ANSWER] stop sequence (raw "stop_sequence") while a stall
+ * ends with raw "end_turn". OpenAI-compatible providers report a plain "stop"
+ * either way, so their stalls are not detectable this way and are left alone.
  */
-export function needsContinuation(
-  steps: StepResult<ToolSet>[],
-  markerInText: boolean
-): boolean {
+export function needsContinuation(steps: StepResult<ToolSet>[]): boolean {
   const last = steps[steps.length - 1];
   if (!last) return false;
   // stopWhen (e.g. maxTurns) ended the loop mid-work; not a model stall
@@ -97,11 +89,7 @@ export function needsContinuation(
     }
   }
   if (last.rawFinishReason === "stop_sequence") return false; // hit [END_OF_ANSWER]
-  if (last.rawFinishReason === "end_turn" || last.finishReason === "length") {
-    return true;
-  }
-  // Marker mode: no marker anywhere + no tool calls + a plain stop = stall
-  return markerInText && last.finishReason === "stop";
+  return last.rawFinishReason === "end_turn" || last.finishReason === "length";
 }
 
 export function createHasAskQuestionsCondition<
@@ -259,7 +247,7 @@ export function extractFinalAnswer(
     }
   }
 
-  // Collect all text, and separately the text AFTER the last tool call.
+  // Look for text with [END_OF_ANSWER] sequence (search all text)
   let allText = "";
   for (const step of steps) {
     for (const item of step.content) {
@@ -269,6 +257,18 @@ export function extractFinalAnswer(
     }
   }
 
+  const endMarkerIndex = allText.indexOf("[END_OF_ANSWER]");
+  if (endMarkerIndex !== -1) {
+    const answer = allText.substring(0, endMarkerIndex).trim();
+    if (answer) {
+      return {
+        answer,
+        tool_use: "text_with_end_marker",
+      };
+    }
+  }
+
+  // Fallback: collect all text after the last tool call
   let lastToolStepIndex = -1;
   let lastToolContentIndex = -1;
 
@@ -302,34 +302,6 @@ export function extractFinalAnswer(
       if (startCollecting && item.type === "text" && item.text) {
         textAfterLastTool += item.text;
       }
-    }
-  }
-
-  // Marker search. Prefer the text AFTER the last tool call — with providers
-  // that keep [END_OF_ANSWER] in the generated text, earlier inter-tool
-  // narration would otherwise ride along in the answer. Use the LAST
-  // occurrence in either case: an answer may legitimately QUOTE the marker
-  // mid-text (e.g. a report about this very codebase), while the protocol
-  // terminator is always at the end.
-  const markerIdxAfterTool = textAfterLastTool.lastIndexOf("[END_OF_ANSWER]");
-  if (markerIdxAfterTool !== -1) {
-    const answer = textAfterLastTool.substring(0, markerIdxAfterTool).trim();
-    if (answer) {
-      return {
-        answer,
-        tool_use: "text_with_end_marker",
-      };
-    }
-  }
-
-  const endMarkerIndex = allText.lastIndexOf("[END_OF_ANSWER]");
-  if (endMarkerIndex !== -1) {
-    const answer = allText.substring(0, endMarkerIndex).trim();
-    if (answer) {
-      return {
-        answer,
-        tool_use: "text_with_end_marker",
-      };
     }
   }
 

--- a/mcp/src/repo/utils.ts
+++ b/mcp/src/repo/utils.ts
@@ -39,7 +39,21 @@ function countTokens(text: string): number {
  * truncate a deep thinking pass mid-step and silently end the tool loop
  * with no answer.
  */
-export const MAX_OUTPUT_TOKENS = Number(process.env.MAX_OUTPUT_TOKENS) || 64000;
+/**
+ * Per-call output-token cap. An explicit MAX_OUTPUT_TOKENS env always wins.
+ * Otherwise the default is provider-aware: Anthropic runs at 128k because
+ * @ai-sdk/anthropic clamps known models down to their true per-model max
+ * (e.g. Opus 5 at 128k) instead of erroring, while OpenAI-compatible hosts
+ * (OpenRouter et al) reject max_tokens above the model limit rather than
+ * clamping, so they keep the conservative 64k default. Thinking tokens count
+ * against this same budget, so headroom matters more than the visible text
+ * length suggests.
+ */
+export function maxOutputTokensFor(provider?: string): number {
+  const env = Number(process.env.MAX_OUTPUT_TOKENS);
+  if (env > 0) return env;
+  return provider === "anthropic" ? 128_000 : 64_000;
+}
 
 export function createHasEndMarkerCondition<
   T extends ToolSet

--- a/mcp/src/repo/utils.ts
+++ b/mcp/src/repo/utils.ts
@@ -107,6 +107,44 @@ export function needsContinuation(steps: StepResult<ToolSet>[]): boolean {
 }
 
 /**
+ * Time-budget status nudges, injected between steps as a run approaches the
+ * busy-timeout hard kill (which aborts the stream and discards all work).
+ * Thresholds are fractions of the total budget so they track
+ * BUSY_TIMEOUT_MINUTES overrides: at 120 minutes they fall at 60 / 90 / ~110.
+ * Returns the message for the highest threshold that elapsed time has
+ * crossed and that hasn't fired yet, or null. Crossing a threshold also
+ * marks all lower ones fired, so a single slow step can't queue up stale
+ * lower-urgency nudges behind the current one. The final warning fires with
+ * ~8% of budget left (about 10 minutes at 120) so at least one more step
+ * boundary should occur before the kill.
+ */
+export function timeBudgetNudge(
+  elapsedMs: number,
+  totalMinutes: number,
+  fired: Set<number>,
+  askQuestionsEnabled: boolean
+): string | null {
+  const elapsedMin = Math.floor(elapsedMs / 60_000);
+  const fractions = [0.92, 0.75, 0.5];
+  for (const f of fractions) {
+    if (fired.has(f) || elapsedMin < totalMinutes * f) continue;
+    for (const g of fractions) if (g <= f) fired.add(g);
+    if (f === 0.5) {
+      return `Time status: ${elapsedMin} of ${totalMinutes} minutes elapsed. Pace yourself accordingly.`;
+    }
+    if (f === 0.75) {
+      return `Time status: ${elapsedMin} of ${totalMinutes} minutes elapsed. Start converging: prioritize the essential remaining work and begin producing your deliverables.`;
+    }
+    const remaining = Math.max(totalMinutes - elapsedMin, 1);
+    const askPath = askQuestionsEnabled
+      ? " If you are blocked on information only the user can provide, call ask_clarifying_questions immediately instead."
+      : "";
+    return `Time status: only ~${remaining} minutes remain before this run is forcibly terminated and unfinished work is lost. Stop exploring NOW and write your final answer with what you already have, ending with [END_OF_ANSWER].${askPath}`;
+  }
+  return null;
+}
+
+/**
  * True for the synthetic "continue" user messages injected after a stall
  * (see continuationNudge in agent.ts). They are persisted to the session for
  * transparent replay but are not real user turns: transcript rendering and

--- a/mcp/src/repo/utils.ts
+++ b/mcp/src/repo/utils.ts
@@ -46,6 +46,9 @@ export function createHasEndMarkerCondition<
 >(): StopCondition<T> {
   return ({ steps }) => {
     for (const step of steps) {
+      // A step that also makes tool calls isn't done — marker text there is a
+      // quotation (e.g. an answer describing this codebase), not a terminator.
+      if (step.content.some((item) => item.type === "tool-call")) continue;
       for (const item of step.content) {
         if (item.type === "text" && item.text?.includes("[END_OF_ANSWER]")) {
           return true;
@@ -54,6 +57,51 @@ export function createHasEndMarkerCondition<
     }
     return false;
   };
+}
+
+/**
+ * True when a run ended without a proper termination and should be nudged to
+ * continue. Proper terminations are: an ask_clarifying_questions call, or the
+ * [END_OF_ANSWER] marker — present in text, or matched as a stop sequence
+ * (surfaced as rawFinishReason "stop_sequence"). A run whose last step has no
+ * tool calls and none of those is either a voluntary early stop (raw
+ * "end_turn" — the model narrated a plan or emitted only reasoning and quit)
+ * or a truncation ("length"); both are recoverable by asking it to continue.
+ *
+ * OpenAI-compatible providers report raw "stop" for a stop-sequence match and
+ * a natural stop alike, so for them stopSequences is disabled and the marker
+ * is expected in the generated text (`markerInText`). In that mode a plain
+ * "stop" with no marker and no tool calls IS a stall. Without that mode
+ * (Anthropic), "stop" is only a stall when the raw reason is "end_turn" —
+ * a "stop_sequence" finish means the marker fired and was stripped.
+ */
+export function needsContinuation(
+  steps: StepResult<ToolSet>[],
+  markerInText: boolean
+): boolean {
+  const last = steps[steps.length - 1];
+  if (!last) return false;
+  // stopWhen (e.g. maxTurns) ended the loop mid-work; not a model stall
+  if ((last.toolCalls?.length ?? 0) > 0) return false;
+  for (const step of steps) {
+    for (const item of step.content) {
+      if (
+        item.type === "tool-result" &&
+        item.toolName === "ask_clarifying_questions"
+      ) {
+        return false;
+      }
+      if (item.type === "text" && item.text?.includes("[END_OF_ANSWER]")) {
+        return false;
+      }
+    }
+  }
+  if (last.rawFinishReason === "stop_sequence") return false; // hit [END_OF_ANSWER]
+  if (last.rawFinishReason === "end_turn" || last.finishReason === "length") {
+    return true;
+  }
+  // Marker mode: no marker anywhere + no tool calls + a plain stop = stall
+  return markerInText && last.finishReason === "stop";
 }
 
 export function createHasAskQuestionsCondition<
@@ -211,7 +259,7 @@ export function extractFinalAnswer(
     }
   }
 
-  // Look for text with [END_OF_ANSWER] sequence (search all text)
+  // Collect all text, and separately the text AFTER the last tool call.
   let allText = "";
   for (const step of steps) {
     for (const item of step.content) {
@@ -221,18 +269,6 @@ export function extractFinalAnswer(
     }
   }
 
-  const endMarkerIndex = allText.indexOf("[END_OF_ANSWER]");
-  if (endMarkerIndex !== -1) {
-    const answer = allText.substring(0, endMarkerIndex).trim();
-    if (answer) {
-      return {
-        answer,
-        tool_use: "text_with_end_marker",
-      };
-    }
-  }
-
-  // Fallback: collect all text after the last tool call
   let lastToolStepIndex = -1;
   let lastToolContentIndex = -1;
 
@@ -266,6 +302,34 @@ export function extractFinalAnswer(
       if (startCollecting && item.type === "text" && item.text) {
         textAfterLastTool += item.text;
       }
+    }
+  }
+
+  // Marker search. Prefer the text AFTER the last tool call — with providers
+  // that keep [END_OF_ANSWER] in the generated text, earlier inter-tool
+  // narration would otherwise ride along in the answer. Use the LAST
+  // occurrence in either case: an answer may legitimately QUOTE the marker
+  // mid-text (e.g. a report about this very codebase), while the protocol
+  // terminator is always at the end.
+  const markerIdxAfterTool = textAfterLastTool.lastIndexOf("[END_OF_ANSWER]");
+  if (markerIdxAfterTool !== -1) {
+    const answer = textAfterLastTool.substring(0, markerIdxAfterTool).trim();
+    if (answer) {
+      return {
+        answer,
+        tool_use: "text_with_end_marker",
+      };
+    }
+  }
+
+  const endMarkerIndex = allText.lastIndexOf("[END_OF_ANSWER]");
+  if (endMarkerIndex !== -1) {
+    const answer = allText.substring(0, endMarkerIndex).trim();
+    if (answer) {
+      return {
+        answer,
+        tool_use: "text_with_end_marker",
+      };
     }
   }
 

--- a/mcp/src/repo/utils.ts
+++ b/mcp/src/repo/utils.ts
@@ -92,6 +92,19 @@ export function needsContinuation(steps: StepResult<ToolSet>[]): boolean {
   return last.rawFinishReason === "end_turn" || last.finishReason === "length";
 }
 
+/**
+ * True for the synthetic "continue" user messages injected after a stall
+ * (see continuationNudge in agent.ts). They are persisted to the session for
+ * transparent replay but are not real user turns: transcript rendering and
+ * turn counting should skip them.
+ */
+export function isContinuationNudge(m: ModelMessage): boolean {
+  return (
+    (m.providerOptions as Record<string, any> | undefined)?.stakgraph
+      ?.continuationNudge === true
+  );
+}
+
 export function createHasAskQuestionsCondition<
   T extends ToolSet
 >(): StopCondition<T> {

--- a/mcp/src/repo/utils.ts
+++ b/mcp/src/repo/utils.ts
@@ -103,7 +103,17 @@ export function needsContinuation(steps: StepResult<ToolSet>[]): boolean {
     }
   }
   if (last.rawFinishReason === "stop_sequence") return false; // hit [END_OF_ANSWER]
-  return last.rawFinishReason === "end_turn" || last.finishReason === "length";
+  return (
+    last.rawFinishReason === "end_turn" ||
+    last.finishReason === "length" ||
+    // A mid-step stream error (observed with Kimi via OpenRouter: the stream
+    // dies right after a reasoning block, before tool calls) is surfaced by
+    // the SDK as a final step with finishReason "error" instead of a thrown
+    // exception — the loop exits and the run would report success with a
+    // garbage answer. The conversation up to the error is intact, so it is
+    // the most recoverable stall of all.
+    last.finishReason === "error"
+  );
 }
 
 /**

--- a/mcp/yarn.lock
+++ b/mcp/yarn.lock
@@ -167,15 +167,6 @@
     "@standard-schema/spec" "^1.0.0"
     eventsource-parser "^3.0.6"
 
-"@ai-sdk/provider-utils@^4.0.0":
-  version "4.0.35"
-  resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.35.tgz"
-  integrity sha512-bjYld/2KGPLt78kpqbya+fD4LYS7BqVQJyUjE3qAHrYB0FR2Q90BaWEVIBZaguTWXf/A8L6uG1zO1v9TxVlGWg==
-  dependencies:
-    "@ai-sdk/provider" "3.0.13"
-    "@standard-schema/spec" "^1.1.0"
-    eventsource-parser "^3.0.8"
-
 "@ai-sdk/provider@2.0.1":
   version "2.0.1"
   resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.1.tgz"
@@ -187,13 +178,6 @@
   version "3.0.10"
   resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz"
   integrity sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==
-  dependencies:
-    json-schema "^0.4.0"
-
-"@ai-sdk/provider@3.0.13", "@ai-sdk/provider@^3.0.0":
-  version "3.0.13"
-  resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.13.tgz"
-  integrity sha512-ZPtVYt5QIJzOta1kdUiDuCx4HhFkvNPv/rvmZ2b1iXwybYjJsCnNYR4PAw4kW7rgVfDARvHXcU64efWuqNp6bw==
   dependencies:
     json-schema "^0.4.0"
 
@@ -1645,21 +1629,10 @@
   dependencies:
     "@octokit/openapi-types" "^27.0.0"
 
-"@openrouter/ai-sdk-provider@6.0.0-alpha.1":
-  version "6.0.0-alpha.1"
-  resolved "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-6.0.0-alpha.1.tgz"
-  integrity sha512-N91glWtq6XFl8Kvgft14BiDeCLABHatylAVKHOWMRJHnBl6iKblI4iZgcipnF9Pj8ZRUO752qpPoZVC+L2C6tA==
-  dependencies:
-    "@ai-sdk/provider" "^3.0.0"
-    "@ai-sdk/provider-utils" "^4.0.0"
-    "@openrouter/sdk" "^0.3.11"
-
-"@openrouter/sdk@^0.3.11":
-  version "0.3.16"
-  resolved "https://registry.npmjs.org/@openrouter/sdk/-/sdk-0.3.16.tgz"
-  integrity sha512-WEBlrXdc5R8I7o2temkMV65tIRGkzg9ct4DMNZ/FHS/hiRscLRS5EpcuORnAgjzZAh9X2dSsBpgygM8T7KiNAw==
-  dependencies:
-    zod "^3.25.0 || ^4.0.0"
+"@openrouter/ai-sdk-provider@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.yarnpkg.com/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.10.0.tgz#83aa7b285a1f07500d85a23bfe909546e6916077"
+  integrity sha512-FMsAEjLUt5pWuRE2LDC/LCvVrFjLlrEzUITH5+5SZtfq7KZ2wrOHjQVxzz92sju8S9ltpzW87CLW8/b0oBXVCw==
 
 "@opentelemetry/api@1.9.0":
   version "1.9.0"
@@ -6353,7 +6326,7 @@ zod@4.1.12, zod@^4.1.8:
   resolved "https://registry.npmjs.org/zod/-/zod-4.1.12.tgz"
   integrity sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==
 
-zod@4.3.6, "zod@^3.25 || ^4.0", "zod@^3.25.0 || ^4.0.0":
+zod@4.3.6, "zod@^3.25 || ^4.0":
   version "4.3.6"
   resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
   integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
## Problem

Long agentic runs (especially Opus and Kimi K3) intermittently "just stop" without delivering what they promised — sometimes the last thing in the transcript is a reasoning block, sometimes a tool call, and the run still reports success with a garbage answer scraped from leftover narration.

Investigation on this branch identified **three distinct stall mechanisms**, all now handled:

1. **Voluntary stall** (`end_turn`): the model narrates a plan ("Let me now…") or emits only reasoning and ends its turn without tool calls or `[END_OF_ANSWER]`.
2. **Output-token truncation** (`length`): a step hits the per-call output cap mid-answer or mid-thinking (thinking tokens count against the same budget).
3. **Mid-stream connection error** (`error`): a transient network failure to the provider (reproduced live: `read ETIMEDOUT` to OpenRouter/Moonshot) kills the stream right after a reasoning block; the AI SDK surfaces it as a final step with `finishReason: "error"` instead of throwing, so the loop exits "successfully". This is the "reasoning block is the last thing I see" symptom.

## Fix: continuation machinery

When a run ends without a proper termination (no `[END_OF_ANSWER]`, no `ask_clarifying_questions`, no pending tool calls), the full conversation plus a synthetic user nudge is re-sent, resuming from the exact point of interruption (prompt caching makes this cheap):

- **Per-kind nudge wording** — stalls are told to execute their plan now (with an explicit escape hatch to ask the user a question instead of fabricating an answer); truncations are told to continue from the exact cutoff without repeating (and the nudge states the actual token limit); connection errors are told the interruption was transient and to re-issue the unexecuted tool call.
- **Per-kind budgets** — voluntary stalls get 2 nudges; involuntary interruptions (truncation/error) share a progress-gated allowance of 5, so a large text deliverable can span up to 6 stitched segments (~6× the per-call cap). A continuation that produces zero output tokens stops the loop.
- Nudges are persisted tagged (`providerOptions.stakgraph.continuationNudge`) so transcript consumers and turn counting can distinguish them from real user turns.
- Detection uses the raw provider stop reason (recorded per step as `rawFinishReason` for observability): Anthropic's `stop_sequence` vs `end_turn` distinguishes a proper finish from a stall. OpenAI-compatible providers report `stop` either way, so their voluntary stalls are conservatively left alone (no false positives); their truncations and connection errors are still caught.

## Supporting fixes

- **One-shot 400 retry** resuming from the in-flight step (the SDK only auto-retries 408/409/429/5xx), plus API error response bodies folded into error messages.
- **Provider-aware output cap**: default 128k for Anthropic (provider clamps known models to their true max), 64k for OpenAI-compatible hosts; `MAX_OUTPUT_TOKENS` env still overrides.
- **Time-budget nudges** at 50% / 75% / 92% of `BUSY_TIMEOUT_MINUTES` (default 120), injected between steps, so runs land before the hard-kill abort discards their work.
- **Kimi context limits corrected**: K3 is 1M (was falling back to 128k and truncating tool results at ~115k); K2.x are 262k, not 128k. Verified against the OpenRouter catalog.
- **Kimi routing pinned to Moonshot** via OpenRouter provider preferences (only Moonshot's endpoint has prompt caching and reliable tool-call parsing), with cached-token counts folded from provider metadata into step usage.
- **`generate_docx` accepts `markdownPath`**: large documents can be built incrementally with bash appends and then converted — a large inline `markdown` argument must fit one output-capped message and reliably failed on Kimi. The tool description steers large documents to this flow.

## Validation (live runs against harvey-labs prod task)

| Scenario | Result |
|---|---|
| Opus, clean run | 55k-token answer, `stop_sequence` finish, zero false nudges |
| Opus, forced 8k cap (text answer) | 5 resume continuations, mid-word stitching, zero duplication |
| Opus, forced 8k cap (file deliverables) | 1 truncation → nudge → model switched to chunked writes → both .docx produced |
| Kimi K3, wifi drop mid-run | Reproduced the silent-failure mechanism that motivated the `error` continuation |
| Kimi K3, prod config | Both deliverables via `markdownPath`, 36 steps, zero nudges needed, 1.2M cached tokens |

Unit tests cover `needsContinuation` (all three kinds plus proper terminations), nudge tagging, time-budget thresholds, and `markdownPath` (58 docgen + 54 utils tests passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)