### PR TITLE
feat: make busy operation timeout configurable, default 2 hours

### DIFF
--- a/mcp/src/busy.ts
+++ b/mcp/src/busy.ts
@@ -8,7 +8,8 @@ interface TrackedOperation {
   externalAbortController?: AbortController;
 }
 
-const TIMEOUT_MS = 60 * 60 * 1000;
+const TIMEOUT_MINUTES = parseInt(process.env.BUSY_TIMEOUT_MINUTES || "", 10) || 120;
+const TIMEOUT_MS = TIMEOUT_MINUTES * 60 * 1000;
 const activeOperations = new Map<string, TrackedOperation>();
 let operationCounter = 0;
 
@@ -35,7 +36,7 @@ export function startTracking(
   const operationId = generateOperationId(routeName);
   const timeout = setTimeout(() => {
     console.warn(
-      `[busy] TIMEOUT: Operation ${operationId} (${routeName}) exceeded 60 minutes, forcing cleanup`
+      `[busy] TIMEOUT: Operation ${operationId} (${routeName}) exceeded ${TIMEOUT_MINUTES} minutes, forcing cleanup`
     );
     const op = activeOperations.get(operationId);
     if (op?.externalAbortController && !op.externalAbortController.signal.aborted) {


### PR DESCRIPTION
## What changed

- The forced-cleanup timeout for tracked operations in `mcp/src/busy.ts` now defaults to **2 hours** (was 1 hour).
- It can be overridden with the `BUSY_TIMEOUT_MINUTES` env var (e.g. `BUSY_TIMEOUT_MINUTES=30`). Unset or invalid values fall back to 120.
- The timeout warning log now reports the actual configured minutes instead of a hardcoded "60 minutes".

## Why

Long-running operations were being safety-aborted at the fixed 60-minute limit with no way to adjust it per deployment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)