### PR TITLE
fix: convert Neo4j Integer/BigInt date props in gitree storage

### DIFF
--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -1751,12 +1751,12 @@ export class GraphStorage extends Storage {
       description: props.description,
       prNumbers: props.prNumbers || [],
       commitShas: props.commitShas || [],
-      createdAt: new Date(props.date * 1000),
-      lastUpdated: new Date(props.date * 1000),
+      createdAt: new Date(numberOrUndefined(props.date)! * 1000),
+      lastUpdated: new Date(numberOrUndefined(props.date)! * 1000),
       documentation: props.docs || undefined,
-      cluesCount: props.cluesCount || undefined,
+      cluesCount: numberOrUndefined(props.cluesCount),
       cluesLastAnalyzedAt: props.cluesLastAnalyzedAt
-        ? new Date(props.cluesLastAnalyzedAt * 1000)
+        ? new Date(numberOrUndefined(props.cluesLastAnalyzedAt)! * 1000)
         : undefined,
       usage: usageFromProps(props),
       embedding: props.embeddings || undefined,
@@ -1772,7 +1772,7 @@ export class GraphStorage extends Storage {
       repo: props.repo || undefined,
       title: props.title,
       summary: props.summary,
-      mergedAt: new Date(props.date * 1000),
+      mergedAt: new Date(numberOrUndefined(props.date)! * 1000),
       url: props.url,
       files: props.files || [],
       newDeclarations: props.newDeclarations
@@ -1791,7 +1791,7 @@ export class GraphStorage extends Storage {
       message: props.message,
       summary: props.summary,
       author: props.author,
-      committedAt: new Date(props.date * 1000),
+      committedAt: new Date(numberOrUndefined(props.date)! * 1000),
       url: props.url,
       files: props.files || [],
       newDeclarations: props.newDeclarations
@@ -1819,8 +1819,8 @@ export class GraphStorage extends Storage {
       relatedConcepts: props.relatedConcepts || [],
       relatedClues: props.relatedClues || [],
       dependsOn: props.dependsOn || [],
-      createdAt: new Date(props.createdAt * 1000),
-      updatedAt: new Date(props.updatedAt * 1000),
+      createdAt: new Date(numberOrUndefined(props.createdAt)! * 1000),
+      updatedAt: new Date(numberOrUndefined(props.updatedAt)! * 1000),
     };
   }
 


### PR DESCRIPTION
## Summary
- `nodeToConcept`, `nodeToPR`, `nodeToCommit`, and `nodeToClue` in `mcp/src/gitree/store/graphStorage.ts` multiplied Neo4j date properties directly (e.g. `props.date * 1000`) instead of using the existing `numberOrUndefined()` helper that converts Neo4j `Integer`/`BigInt` values via `.toNumber()`.
- When the driver returns those fields as native `BigInt`, this throws `TypeError: Cannot mix BigInt and other types, use explicit conversions`, breaking `getAllConcepts` (seen via `/gitree/relevant-features`) and other lookups that go through these converters.
- Routed all affected date-field reads through `numberOrUndefined()`, and also fixed `cluesCount` in `nodeToConcept` which had the same unguarded-read pattern.

## Test plan
- [x] `npx tsc --noEmit` passes in `mcp/`
- [ ] Verify `/gitree/relevant-features` no longer throws once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)