### PR TITLE
Recover full log lines truncated by CloudWatch Logs Insights (@ptr + GetLogRecord)

### DIFF
--- a/mcp/src/log/__tests__/cloudwatch-insights.test.ts
+++ b/mcp/src/log/__tests__/cloudwatch-insights.test.ts
@@ -7,6 +7,7 @@ import { fileURLToPath } from "url";
 import {
   buildInsightsQuery,
   fetchCloudwatchLogsInsights,
+  HYDRATE_MIN_MSG_LEN,
   type FetchCloudwatchParams,
 } from "../cloudwatch.js";
 
@@ -26,6 +27,7 @@ type SendResult = Record<string, unknown>;
 function makeMockClient(handlers: {
   StartQueryCommand?: (input: Record<string, unknown>) => SendResult;
   GetQueryResultsCommand?: (input: Record<string, unknown>) => SendResult;
+  GetLogRecordCommand?: (input: Record<string, unknown>) => SendResult;
 }) {
   return {
     send: async (command: { constructor: { name: string }; input: Record<string, unknown> }) => {
@@ -260,4 +262,89 @@ test("fetchCloudwatchLogsInsights: Timeout status with no results returns lineCo
 
   expect(resultB.truncated).toBe(true);
   expect(resultB.lineCount).toBe(0);
+});
+
+// ---------------------------------------------------------------------------
+// Hydration of truncated messages via @ptr → GetLogRecord
+// ---------------------------------------------------------------------------
+test("fetchCloudwatchLogsInsights: hydrates long messages to full length via GetLogRecord", async () => {
+  const logsDir = makeTmpDir();
+
+  const truncatedMsg = "x".repeat(HYDRATE_MIN_MSG_LEN + 50);
+  const fullMsg = truncatedMsg + "y".repeat(3000);
+  const shortMsg = "short line";
+  let getLogRecordCalls: string[] = [];
+
+  const mockClient = makeMockClient({
+    StartQueryCommand: () => ({ queryId: "qid-hydrate-test" }),
+    GetQueryResultsCommand: () => ({
+      status: "Complete",
+      results: [
+        [
+          { field: "@timestamp", value: "2024-01-01T00:00:00.000Z" },
+          { field: "@logStream", value: "stream1" },
+          { field: "@message", value: truncatedMsg },
+          { field: "@ptr", value: "ptr-long" },
+        ],
+        [
+          { field: "@timestamp", value: "2024-01-01T00:00:01.000Z" },
+          { field: "@logStream", value: "stream1" },
+          { field: "@message", value: shortMsg },
+          { field: "@ptr", value: "ptr-short" },
+        ],
+      ],
+    }),
+    GetLogRecordCommand: (input) => {
+      getLogRecordCalls.push(input.logRecordPointer as string);
+      return { logRecord: { "@message": fullMsg } };
+    },
+  });
+
+  const result = await fetchCloudwatchLogsInsights(
+    { logGroupName: "/test/group", minutes: 30, logsDir },
+    mockClient
+  );
+
+  expect(result.lineCount).toBe(2);
+  expect(result.hydratedLines).toBe(1);
+  // Only the suspect (long) line should be hydrated, not the short one
+  expect(getLogRecordCalls).toEqual(["ptr-long"]);
+
+  const content = fs.readFileSync(path.join(logsDir, result.file), "utf-8");
+  expect(content).toContain(fullMsg);
+  expect(content).toContain(shortMsg);
+});
+
+test("fetchCloudwatchLogsInsights: keeps truncated message when GetLogRecord fails", async () => {
+  const logsDir = makeTmpDir();
+
+  const truncatedMsg = "z".repeat(HYDRATE_MIN_MSG_LEN + 10);
+
+  const mockClient = makeMockClient({
+    StartQueryCommand: () => ({ queryId: "qid-hydrate-fail-test" }),
+    GetQueryResultsCommand: () => ({
+      status: "Complete",
+      results: [
+        [
+          { field: "@timestamp", value: "2024-01-01T00:00:00.000Z" },
+          { field: "@logStream", value: "stream1" },
+          { field: "@message", value: truncatedMsg },
+          { field: "@ptr", value: "ptr-fail" },
+        ],
+      ],
+    }),
+    GetLogRecordCommand: () => {
+      throw new Error("ThrottlingException");
+    },
+  });
+
+  const result = await fetchCloudwatchLogsInsights(
+    { logGroupName: "/test/group", minutes: 30, logsDir },
+    mockClient
+  );
+
+  expect(result.lineCount).toBe(1);
+  expect(result.hydratedLines).toBe(0);
+  const content = fs.readFileSync(path.join(logsDir, result.file), "utf-8");
+  expect(content).toContain(truncatedMsg);
 });

--- a/mcp/src/log/cloudwatch.ts
+++ b/mcp/src/log/cloudwatch.ts
@@ -6,6 +6,7 @@ import {
   DescribeLogStreamsCommand,
   StartQueryCommand,
   GetQueryResultsCommand,
+  GetLogRecordCommand,
 } from "@aws-sdk/client-cloudwatch-logs";
 import { fromIni } from "@aws-sdk/credential-providers";
 import * as fs from "fs";
@@ -33,6 +34,16 @@ function getClient(): CloudWatchLogsClient {
 const MAX_FETCH_PAGES = 200;
 const MAX_FETCH_WALL_MS = 60_000;
 
+// GetQueryResults truncates long field values (~1000 chars for @message).
+// Each result row carries a @ptr whose GetLogRecord response contains the
+// complete event, so any message at/over this length is suspect and gets
+// re-fetched ("hydrated") individually.
+export const HYDRATE_MIN_MSG_LEN = 950;
+const MAX_HYDRATE_RECORDS = 500;
+const HYDRATE_BATCH_SIZE = 5;
+const HYDRATE_BATCH_INTERVAL_MS = 500; // 5 calls / 500ms keeps GetLogRecord under ~10 TPS
+const MAX_HYDRATE_WALL_MS = 30_000;
+
 /** Sanitize a log group name into a safe filename */
 function safeFilename(logGroup: string): string {
   return logGroup.replace(/^\/+/, "").replace(/\//g, "-");
@@ -54,6 +65,8 @@ export interface FetchCloudwatchResult {
   logGroup: string;
   timeRange: { startTime: string; endTime: string };
   truncated: boolean;
+  /** Lines whose full text was recovered via GetLogRecord (Insights path only). */
+  hydratedLines?: number;
 }
 
 /**
@@ -281,19 +294,26 @@ export async function fetchCloudwatchLogsInsights(
     await sleep(1000);
   }
 
-  // Map result rows → `[ISO_TIMESTAMP] [logStream] message`
-  const lines = results.map((row) => {
+  // Map result rows, keeping each row's @ptr so truncated messages can be
+  // hydrated to their full text below.
+  const rows = results.map((row) => {
     let timestamp = "";
     let logStream = "";
     let message = "";
+    let ptr = "";
     for (const field of row) {
       if (field.field === "@timestamp") timestamp = field.value ?? "";
       else if (field.field === "@logStream") logStream = field.value ?? "";
       else if (field.field === "@message") message = (field.value ?? "").trimEnd();
+      else if (field.field === "@ptr") ptr = field.value ?? "";
     }
     const isoTime = timestamp ? new Date(timestamp).toISOString() : "unknown";
-    return `[${isoTime}] [${logStream}] ${message}`;
+    return { isoTime, logStream, message, ptr };
   });
+
+  const hydratedLines = await hydrateTruncatedMessages(rows, client, abortSignal);
+
+  const lines = rows.map((r) => `[${r.isoTime}] [${r.logStream}] ${r.message}`);
 
   // Write to file — same naming convention as fetchCloudwatchLogs
   const ts = new Date().toISOString().replace(/[:.]/g, "-");
@@ -310,7 +330,77 @@ export async function fetchCloudwatchLogsInsights(
       endTime: new Date(endTimeMs).toISOString(),
     },
     truncated,
+    hydratedLines,
   };
+}
+
+/**
+ * Re-fetch suspected-truncated messages via GetLogRecord (the row's @ptr).
+ * Mutates `rows` in place; returns how many messages were replaced with a
+ * longer full-text version. Failures leave the truncated message untouched.
+ */
+async function hydrateTruncatedMessages(
+  rows: { message: string; ptr: string }[],
+  client: CloudWatchLogsClient,
+  abortSignal?: AbortSignal
+): Promise<number> {
+  const suspects = rows.filter(
+    (r) => r.ptr && r.message.length >= HYDRATE_MIN_MSG_LEN
+  );
+  if (suspects.length === 0) return 0;
+
+  const toHydrate = suspects.slice(0, MAX_HYDRATE_RECORDS);
+  if (suspects.length > toHydrate.length) {
+    console.warn(
+      `[cloudwatch] ${suspects.length} suspected-truncated lines; hydrating only the first ${MAX_HYDRATE_RECORDS}`
+    );
+  }
+
+  const deadline = Date.now() + MAX_HYDRATE_WALL_MS;
+  let hydrated = 0;
+  let failed = 0;
+
+  for (let i = 0; i < toHydrate.length; i += HYDRATE_BATCH_SIZE) {
+    if (abortSignal?.aborted || Date.now() > deadline) break;
+    const batch = toHydrate.slice(i, i + HYDRATE_BATCH_SIZE);
+    await Promise.all(
+      batch.map(async (row) => {
+        try {
+          const resp = await client.send(
+            new GetLogRecordCommand({ logRecordPointer: row.ptr }),
+            { abortSignal: abortSignal as any }
+          );
+          const full = (resp.logRecord?.["@message"] ?? "").trimEnd();
+          if (full.length > row.message.length) {
+            row.message = full;
+            hydrated++;
+          }
+        } catch {
+          failed++;
+        }
+      })
+    );
+    if (i + HYDRATE_BATCH_SIZE < toHydrate.length) {
+      await new Promise<void>((resolve) => {
+        const t = setTimeout(resolve, HYDRATE_BATCH_INTERVAL_MS);
+        abortSignal?.addEventListener(
+          "abort",
+          () => {
+            clearTimeout(t);
+            resolve();
+          },
+          { once: true }
+        );
+      });
+    }
+  }
+
+  if (failed > 0) {
+    console.warn(
+      `[cloudwatch] failed to hydrate ${failed} truncated line(s) via GetLogRecord`
+    );
+  }
+  return hydrated;
 }
 
 export interface ListLogGroupsResult {

--- a/mcp/src/log/tools.ts
+++ b/mcp/src/log/tools.ts
@@ -96,7 +96,10 @@ export function get_log_tools(
           const truncNote = result.truncated
             ? " NOTE: results may be incomplete (fetch hit the wall-clock cap or the query timed out on AWS) — narrow the filter_pattern, log_stream_names, or minutes to get complete results."
             : "";
-          return `Fetched ${result.lineCount} log lines from ${result.logGroup} (${result.timeRange.startTime} to ${result.timeRange.endTime}). Saved to file: ${result.file}. Use bash to search through it (e.g. rg, grep, head, tail, awk).${truncNote}`;
+          const hydrateNote = result.hydratedLines
+            ? ` ${result.hydratedLines} long line(s) were recovered to full length via GetLogRecord (Logs Insights truncates long messages in query results).`
+            : "";
+          return `Fetched ${result.lineCount} log lines from ${result.logGroup} (${result.timeRange.startTime} to ${result.timeRange.endTime}). Saved to file: ${result.file}. Use bash to search through it (e.g. rg, grep, head, tail, awk).${hydrateNote}${truncNote}`;
         } catch (e: any) {
           return `Failed to fetch CloudWatch logs: ${e.message}`;
         }


### PR DESCRIPTION
## What changed

The logs agent's `fetch_cloudwatch` tool uses CloudWatch Logs Insights, whose `GetQueryResults` API truncates long field values — `@message` gets uniformly cut at ~1,000 chars, which recently blocked recovering a full 60-criterion rubric from a task run's logs.

This PR recovers the full text using AWS's documented mechanism: every Insights result row automatically includes a `@ptr` field, and [`GetLogRecord`](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetLogRecord.html) with that pointer returns "the full unparsed log event ... within `@message`".

- `mcp/src/log/cloudwatch.ts`: capture `@ptr` in the Insights row mapping; new `hydrateTruncatedMessages` helper re-fetches any message ≥ 950 chars (the suspect zone) and replaces it with the full text
- `mcp/src/log/tools.ts`: the tool result tells the agent when lines were recovered, so it knows the saved file contains full text
- `mcp/src/log/__tests__/cloudwatch-insights.test.ts`: tests for the hydration path and the failure fallback

## Guardrails

AWS publishes no TPS quota for `GetLogRecord` (neighboring read APIs are 10–25 TPS) and a full event can be up to 1MB, so hydration is bounded: batches of 5 with a 500ms gap (~10 TPS max), capped at 500 records and 30s wall-clock, abort-signal aware. A failed hydration keeps the truncated line instead of failing the fetch.

## Reviewer notes

- **IAM**: the role the MCP server runs under needs `logs:GetLogRecord`. Without it, hydration silently falls back to truncated lines (with a console warning).
- No query change was needed — `@ptr` is returned on every non-`stats` Insights query per the [GetQueryResults docs](https://docs.aws.amazon.com/AmazonCloudWatchLogs/latest/APIReference/API_GetQueryResults.html).
- All 12 tests in `cloudwatch-insights.test.ts` pass (10 existing + 2 new); `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)