### PR TITLE
Steer logs agent to /stakwork/production for full untruncated workflow log lines

### DIFF
--- a/mcp/src/log/index.ts
+++ b/mcp/src/log/index.ts
@@ -109,6 +109,7 @@ export async function logs_agent(req: Request, res: Response) {
       `\nRecent Stakwork workflow runs (use projectId with fetch_workflow_run to get logs):`,
       runsJson,
       `\nPick the most relevant run based on the user's question, if its about a recent workflow (like a feature architecture, hive task, etc.) Use the projectId to fetch logs. If a run has agentLogs, you can use fetch_agent_log to read the full log content for a specific agent.`,
+      `\nIMPORTANT: fetch_workflow_run messages are truncated to 1000 characters per line (truncated lines end with "... (continued)"). The full untruncated lines for a run are in the CloudWatch log group "/stakwork/production" — if you hit a truncated line you need in full, use fetch_cloudwatch with log_group "/stakwork/production", filter_pattern "project_id_<projectId>", and minutes covering the run's createdAt time.`,
     ].join("\n");
     finalPrompt = runsContext + `\n\n${finalPrompt}`;
   }

--- a/mcp/src/log/tools.ts
+++ b/mcp/src/log/tools.ts
@@ -262,7 +262,7 @@ export function get_log_tools(
 
     tools.fetch_workflow_run = tool({
       description:
-        "Fetch logs for a Stakwork workflow run. Pick the projectId from the list of recent runs provided in the prompt. Returns logs in reverse chronological order. Supports filtering by step name, status, and pagination.",
+        'Fetch logs for a Stakwork workflow run. Pick the projectId from the list of recent runs provided in the prompt. Returns logs in reverse chronological order. Supports filtering by step name, status, and pagination. NOTE: messages are truncated to 1000 chars per line (ending in "... (continued)") — the full untruncated lines live in the CloudWatch log group "/stakwork/production", searchable with fetch_cloudwatch using filter_pattern "project_id_<projectId>".',
       inputSchema: z.object({
         project_id: z
           .string()


### PR DESCRIPTION
## What changed

Follow-up to #1529, which fixed the wrong layer: the truncated `score_rubric` lines were never coming from CloudWatch. `fetch_workflow_run` serves `project_logs` DB rows, and senza-lnd's `ProjectLog` truncates those to **1,000 chars at write time** (`TRUNCATE_LIMIT = 1_000`, omission `'... (continued)'`) — so a 60-criterion rubric payload dies at criterion 2, and no retrieval-side fix can recover text that was never stored.

The full text does exist: `ProjectLog.log_message` calls `log_to_lograge` with the **untruncated** message before truncating, and lograge writes to the Rails app's stdout → the CloudWatch log group `/stakwork/production`, tagged `project_id_<id>`.

Two one-line changes teach the logs agent this:

- `mcp/src/log/index.ts`: the `stakworkRuns` prompt context now says workflow-run lines are truncated at 1,000 chars and full lines are in `/stakwork/production` via `fetch_cloudwatch` with `filter_pattern "project_id_<projectId>"` and a `minutes` window covering the run's `createdAt`
- `mcp/src/log/tools.ts`: same note on the `fetch_workflow_run` tool description, so the agent learns it when it hits a `(continued)` line mid-investigation

## Verified against the real run

Queried `/stakwork/production` (account 745666712914, us-east-1) for run 151266402's window:

- `Step attributes`: 25,599 chars — full criteria array, C-003/C-051/C-058/C-060 all present
- `Got data`: 43,783 chars — full `criteria_results`, all present
- `Agent skill completed with result`: 43,814 chars — all present
- Lines arrive intact (no 16KB stdout splitting), and Logs Insights returned the 43K-char values **untruncated** — the "~1000-char Insights cap" was a misdiagnosis; it was always the DB truncation

## Reviewer notes

- Verified with an admin profile — the repo2graph container's own IAM role must be able to read `/stakwork/production` (it reads `/swarms/*` today). If it's denied, the agent gets a clean error and falls back to the truncated lines.
- The durable fix for payload-heavy skills is still an `agentLogs` artifact on the senza-lnd side; this PR just makes the existing data reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)