### PR TITLE
Persist graph_sub_agent runs as first-class sessions in /sessions

### DIFF
--- a/mcp/src/benchmark/sessions.ts
+++ b/mcp/src/benchmark/sessions.ts
@@ -37,6 +37,9 @@ function buildOrphanRun(dir: string, file: string) {
   }
   return {
     id,
+    // Sub-agent sessions are named `<parent>-sub-<hex>`; recover the link
+    // even when the Neo4j node is missing.
+    parent_session_id: id.match(/^(.+)-sub-[0-9a-f]{8}$/)?.[1] ?? "",
     source: "unknown",
     provider: "",
     model: "",
@@ -209,6 +212,7 @@ export async function list_sessions(_req: Request, res: Response) {
         const mod = String(s.model ?? "");
         return {
           id,
+          parent_session_id: String(s.parent_session_id ?? ""),
           source: String(s.source ?? "unknown"),
           repo: String(s.repo ?? ""),
           provider: prov,
@@ -328,6 +332,7 @@ export async function get_session(req: Request, res: Response) {
         const mod = String(s.model ?? "");
         res.json({
           id,
+          parent_session_id: String(s.parent_session_id ?? ""),
           source: String(s.source ?? "unknown"),
             repo: String(s.repo ?? ""),
           provider: prov,
@@ -359,6 +364,7 @@ export async function get_session(req: Request, res: Response) {
   const stat = statSync(filePath);
   res.json({
     id,
+    parent_session_id: id.match(/^(.+)-sub-[0-9a-f]{8}$/)?.[1] ?? "",
     source: "unknown",
       repo: "",
     provider: "",

--- a/mcp/src/gitsee/agent/tools.ts
+++ b/mcp/src/gitsee/agent/tools.ts
@@ -54,19 +54,18 @@ function execCommand(
     process.stdout.on("data", (data) => {
       stdout += data.toString();
 
-      // Safety check: if output gets too large, kill process and resolve
-      if (stdout.length > 10000) {
-        process.kill("SIGKILL");
-        if (!resolved) {
-          resolved = true;
-          clearTimeout(timeout);
-          const truncated =
-            stdout.substring(0, 10000) +
-            "\n\n[... output truncated due to size limit ...]";
-          resolve(truncated);
-        }
-        return;
-      }
+      // if (stdout.length > 10000) {
+      //   process.kill("SIGKILL");
+      //   if (!resolved) {
+      //     resolved = true;
+      //     clearTimeout(timeout);
+      //     const truncated =
+      //       stdout.substring(0, 10000) +
+      //       "\n\n[... output truncated due to size limit ...]";
+      //     resolve(truncated);
+      //   }
+      //   return;
+      // }
     });
 
     process.stderr.on("data", (data) => {
@@ -79,14 +78,14 @@ function execCommand(
         clearTimeout(timeout);
 
         if (code === 0) {
-          if (stdout.length > 10000) {
-            const truncated =
-              stdout.substring(0, 10000) +
-              "\n\n[... output truncated to 10,000 characters ...]";
-            resolve(truncated);
-          } else {
-            resolve(stdout);
-          }
+          // if (stdout.length > 10000) {
+          //   const truncated =
+          //     stdout.substring(0, 10000) +
+          //     "\n\n[... output truncated to 10,000 characters ...]";
+          //   resolve(truncated);
+          // } else {
+          resolve(stdout);
+          // }
         } else if (code === 1) {
           // ripgrep returns exit code 1 when no matches found
           resolve("No matches found");
@@ -205,13 +204,12 @@ export async function fulltextSearch(
       .map(([file, lines]) => `${lines.length}\t${file} (lines: ${lines.join(', ')})`)
       .join('\n');
     
-    // Limit the result to 10,000 characters to prevent overwhelming output
-    if (output.length > 10000) {
-      return (
-        output.substring(0, 10000) +
-        "\n\n[... output truncated to 10,000 characters ...]"
-      );
-    }
+    // if (output.length > 10000) {
+    //   return (
+    //     output.substring(0, 10000) +
+    //     "\n\n[... output truncated to 10,000 characters ...]"
+    //   );
+    // }
 
     return output;
   } catch (error: any) {

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1638,6 +1638,7 @@ class Db {
 
   async upsert_agent_session(params: {
     session_id: string;
+    parent_session_id: string;
     source: string;
     repo: string;
     model: string;

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -319,7 +319,8 @@ ON CREATE SET n.ref_id = randomUUID(), n.date_added_to_graph = $ts, n.namespace 
   n.input_tokens = 0, n.cache_read_tokens = 0, n.cache_write_tokens = 0,
   n.output_tokens = 0, n.total_tokens = 0, n.duration_ms = 0,
   n.status = 'success', n.error_message = ''
-SET n.end_time = toInteger($end_time),
+SET n.parent_session_id = CASE WHEN $parent_session_id = '' THEN coalesce(n.parent_session_id, '') ELSE $parent_session_id END,
+    n.end_time = toInteger($end_time),
     n.repo = $repo,
     n.input_tokens = coalesce(n.input_tokens, 0) + toInteger($input_tokens),
     n.cache_read_tokens = coalesce(n.cache_read_tokens, 0) + toInteger($cache_read_tokens),

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -574,6 +574,10 @@ async function prepareAgent(
     opts.stakwork,
     opts.googleSheets,
     skills,
+    // Parent session id for graph_sub_agent child-session linkage. The
+    // resolved sessionId (set below) is always inputSessionId when defined,
+    // so passing it here is safe even though tools are built first.
+    transparent ? undefined : inputSessionId,
   );
 
   // Load and merge MCP server tools if configured.

--- a/mcp/src/repo/bash.ts
+++ b/mcp/src/repo/bash.ts
@@ -53,14 +53,14 @@ function execRipgrepCommandDirect(
         clearTimeout(timeout);
 
         if (code === 0) {
-          if (stdout.length > 10000) {
-            const truncated =
-              stdout.substring(0, 10000) +
-              "\n\n[... output truncated to 10,000 characters ...]";
-            resolve(truncated);
-          } else {
-            resolve(stdout);
-          }
+          // if (stdout.length > 10000) {
+          //   const truncated =
+          //     stdout.substring(0, 10000) +
+          //     "\n\n[... output truncated to 10,000 characters ...]";
+          //   resolve(truncated);
+          // } else {
+          resolve(stdout);
+          // }
         } else if (code === 1) {
           resolve("No matches found");
         } else {
@@ -132,13 +132,12 @@ function execShellCommand(
         resolved = true;
         clearTimeout(timeout);
 
-        // Truncate if needed
         let output = stdout;
-        if (output.length > 10000) {
-          output =
-            output.substring(0, 10000) +
-            "\n\n[... output truncated to 10,000 characters ...]";
-        }
+        // if (output.length > 10000) {
+        //   output =
+        //     output.substring(0, 10000) +
+        //     "\n\n[... output truncated to 10,000 characters ...]";
+        // }
 
         if (code === 0) {
           resolve(output);
@@ -313,13 +312,12 @@ export async function fulltextSearch(
       )
       .join("\n");
 
-    // Limit the result to 10,000 characters to prevent overwhelming output
-    if (output.length > 10000) {
-      return (
-        output.substring(0, 10000) +
-        "\n\n[... output truncated to 10,000 characters ...]"
-      );
-    }
+    // if (output.length > 10000) {
+    //   return (
+    //     output.substring(0, 10000) +
+    //     "\n\n[... output truncated to 10,000 characters ...]"
+    //   );
+    // }
 
     return output || `No matches found for "${query}"`;
   } catch (error: any) {

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -18,7 +18,10 @@ import { AiUsage, AiUsageWithLegacy } from "../aieo/src/usage.js";
 
 const SESSIONS_DIR = process.env.SESSIONS_DIR || ".sessions";
 
-const sessionMeta = new Map<string, { source: string; start_time: string; repo?: string }>();
+const sessionMeta = new Map<
+  string,
+  { source: string; start_time: string; repo?: string; parent_session_id?: string }
+>();
 
 export interface Session {
   id: string;
@@ -98,12 +101,14 @@ export function createSession(
   system?: string,
   source?: string,
   repo?: string,
+  parentSessionId?: string,
 ): string {
   const sessionId = id || randomUUID();
   sessionMeta.set(sessionId, {
     source: source || "unknown",
     start_time: new Date().toISOString(),
     repo,
+    parent_session_id: parentSessionId,
   });
   const filePath = getSessionFile(sessionId);
   if (system) {
@@ -143,6 +148,7 @@ export async function appendSessionEnd(
   await db
     ?.upsert_agent_session({
       session_id: sessionId,
+      parent_session_id: stored.parent_session_id || "",
       source: stored.source,
       repo: stored.repo || "",
       model: opts.model || "",

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -407,6 +407,7 @@ export async function get_tools(
   stakwork?: StakworkToolsOptions,
   googleSheets?: GoogleSheetsToolsOptions,
   skills?: SkillsConfig,
+  sessionId?: string,
 ) {
   const repoArr = repoPath.split("/");
   const isMultiRepo = repoPath === "/tmp";
@@ -925,6 +926,13 @@ export async function get_tools(
             : undefined,
           modelName,
           apiKey,
+          // Links each sub-agent run back to the owning session so it appears
+          // as its own inspectable session in /sessions.
+          parentSessionId: sessionId,
+          repo:
+            repos && repos.length > 0
+              ? repos.join(", ")
+              : repoPath.replace(/\/+$/, "").split("/").slice(-2).join("/"),
         }
       : undefined,
     // Opt-in ontology write tools (create/update/delete node & edge types).

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -1,6 +1,7 @@
 import { tool, Tool, ToolLoopAgent, stepCountIs } from "ai";
 import { z } from "zod";
 import axios from "axios";
+import { randomUUID } from "crypto";
 import {
   getModelDetails,
   getProviderOptions,
@@ -9,7 +10,21 @@ import {
 import {
   extractFinalAnswer,
   createHasEndMarkerCondition,
+  extractMessagesFromSteps,
+  logStep,
 } from "./utils.js";
+import {
+  createSession,
+  appendMessages,
+  appendStepMeta,
+  appendSessionEnd,
+  type StepMeta,
+} from "./session.js";
+import {
+  addUsage,
+  normalizeUsage,
+  withProviderCacheUsage,
+} from "../aieo/src/usage.js";
 
 function appendNamespace(params: URLSearchParams, namespace?: string): void {
   if (namespace && namespace.length > 0) {
@@ -277,6 +292,16 @@ export interface JarvisSubAgentConfig {
   baseUrl?: string;
   headers?: Record<string, string>;
   /**
+   * Session id of the agent that owns this tool. When set, each sub-agent run
+   * is persisted as a first-class session (`<parentSessionId>-sub-<rand>`)
+   * with a `parent_session_id` link, so it shows up in /sessions like any
+   * other run. When unset (parent runs without session persistence),
+   * sub-agent runs are not persisted either.
+   */
+  parentSessionId?: string;
+  /** Repo label stamped on persisted sub-agent sessions. */
+  repo?: string;
+  /**
    * Current recursion depth. Internal — callers should leave this unset (0);
    * it is incremented automatically as sub-agents spawn sub-agents.
    */
@@ -361,35 +386,118 @@ function registerGraphSubAgentTool(
     }),
     execute: async ({ prompt }: { prompt: string }) => {
       const childTools: Record<string, Tool<any, any>> = {};
+      // Persist the child run as its own session (linked to the parent) only
+      // when the parent itself is session-backed. Grandchildren link to the
+      // child, giving a full chain back to the top-level session.
+      const childSessionId = sub.parentSessionId
+        ? `${sub.parentSessionId}-sub-${randomUUID().slice(0, 8)}`
+        : undefined;
       // Recurse with depth+1 so nested sub-agents stop at maxDepth.
       registerJarvisTools(childTools, {
-        subAgent: { ...sub, depth: depth + 1 },
+        subAgent: { ...sub, depth: depth + 1, parentSessionId: childSessionId },
       });
 
+      if (childSessionId) {
+        createSession(
+          childSessionId,
+          GRAPH_SUBAGENT_SYSTEM,
+          "graph_sub_agent",
+          sub.repo,
+          sub.parentSessionId,
+        );
+      }
+
+      const startTime = Date.now();
+      let lastStepTime = startTime;
+      const stepMetas: StepMeta[] = [];
+      let cumInput = 0;
+      let cumOutput = 0;
+      let modelId = "";
+      let provider: string | undefined;
+
+      const endSession = async (
+        status: "success" | "error",
+        errorMessage?: string,
+      ) => {
+        if (!childSessionId) return;
+        appendStepMeta(childSessionId, stepMetas);
+        await appendSessionEnd(childSessionId, {
+          end_time: new Date().toISOString(),
+          model: modelId,
+          provider,
+          duration_ms: Date.now() - startTime,
+          status,
+          error_message: errorMessage,
+          token_usage:
+            stepMetas.length > 0
+              ? normalizeUsage(addUsage(...stepMetas.map((s) => s.usage)))
+              : undefined,
+        });
+      };
+
       try {
-        const { model, provider, modelId } = getModelDetails(
+        const details = getModelDetails(
           sub.modelName,
           sub.apiKey,
           sub.baseUrl,
           sub.headers,
         );
+        const model = details.model;
+        provider = details.provider;
+        modelId = details.modelId;
         const maxSteps = sub.maxSteps ?? DEFAULT_SUBAGENT_MAX_STEPS;
         const hasEndMarker = createHasEndMarkerCondition<typeof childTools>();
         const agent = new ToolLoopAgent({
           model,
           instructions: GRAPH_SUBAGENT_SYSTEM,
           tools: childTools,
-          providerOptions: getProviderOptions(provider, undefined, modelId) as any,
+          providerOptions: getProviderOptions(details.provider, undefined, modelId) as any,
           stopWhen: maxSteps > 0 ? [hasEndMarker, stepCountIs(maxSteps)] : hasEndMarker,
           stopSequences: ["[END_OF_ANSWER]"],
+          onStepFinish: (sf) => {
+            if (!childSessionId) return;
+            const now = Date.now();
+            const elapsedMs = now - lastStepTime;
+            lastStepTime = now;
+            logStep(sf.content, childSessionId, elapsedMs);
+            const u = withProviderCacheUsage(
+              normalizeUsage(sf.usage),
+              sf.providerMetadata as Record<string, any> | undefined,
+            );
+            cumInput += u.inputTokens ?? 0;
+            cumOutput += u.outputTokens ?? 0;
+            stepMetas.push({
+              step: stepMetas.length,
+              turn: 1,
+              finishReason: sf.finishReason,
+              rawFinishReason: sf.rawFinishReason,
+              usage: u,
+              cumulativeInput: cumInput,
+              cumulativeOutput: cumOutput,
+              toolCalls: (sf.toolCalls ?? []).map(
+                (tc: { toolName: string }) => tc.toolName,
+              ),
+              timestamp: new Date().toISOString(),
+              sessionId: childSessionId,
+              elapsedMs,
+            });
+          },
         });
         console.log(
-          `[graph_sub_agent] depth=${depth + 1} spawning child: ${prompt.slice(0, 200)}`,
+          `[graph_sub_agent] depth=${depth + 1}${childSessionId ? ` session=${childSessionId}` : ""} spawning child: ${prompt.slice(0, 200)}`,
         );
         const result = await agent.generate({ prompt });
+        if (childSessionId) {
+          appendMessages(
+            childSessionId,
+            extractMessagesFromSteps({ role: "user", content: prompt }, result.steps),
+          );
+        }
+        await endSession("success");
         const final = extractFinalAnswer(result.steps);
         return final.answer || "Sub-agent returned no findings.";
       } catch (err: any) {
+        await endSession("error", err?.message ?? String(err));
         return `graph_sub_agent failed: ${err?.message ?? String(err)}`;
       }
     },


### PR DESCRIPTION
## What

`graph_sub_agent` child runs now show up in `/sessions` as their own inspectable sessions, linked to the run that spawned them via a new `parent_session_id` field.

## Why

The sub-agent tool ran a bare in-process `ToolLoopAgent` with no session persistence — you could see the parent making `graph_sub_agent` tool calls, but the child's transcript, tool calls, and token usage were discarded entirely (and its token spend never counted in session stats).

## How

- **`toolsJarvis.ts`** — when the parent run is session-backed, each invocation mints a child id `<parentSessionId>-sub-<8 hex>`, calls `createSession` (source `graph_sub_agent`, same repo label as the parent), logs every step (`appendMessages` transcript, `appendStepMeta` usage, `logStep` console lines), and closes with `appendSessionEnd` carrying token usage, duration, model/provider, and success/error status. Grandchildren link to their immediate parent, so the chain goes all the way up.
- **`queries.ts` / `neo4j.ts` / `session.ts`** — `parent_session_id` is stored on the `AgentSession` node. The Cypher only overwrites it when non-empty, so a later parent-session upsert can't clobber a child's link.
- **`tools.ts` / `agent.ts`** — `get_tools` takes an optional `sessionId`, passed from `prepareAgent` (the resolved session id is always `inputSessionId` when defined, so passing it before session creation is safe; `undefined` in transparent mode).
- **`benchmark/sessions.ts`** — `/api/sessions` and `/api/sessions/:id` return `parent_session_id` on every row; for orphan JSONL files without a Neo4j node it's recovered from the `-sub-` naming pattern.

## Notes for reviewers

- Parents without a session (e.g. transparent replay, no `sessionId` supplied) keep the old unpersisted behavior — children are not persisted either.
- Sub-agent spend now appears in `/api/sessions/stats`, which it previously silently didn't — totals will go up accordingly. Filterable via `source=graph_sub_agent`.
- The benchmark UI doesn't yet render the parent/child relationship (nesting or a "spawned by" link); the data is in the API response for a follow-up.
- Tests: `npm run test:node` passes 434/435; the one failure (`create_batch_triplet` output ordering in `toolsJarvis.test.ts`) is pre-existing on `main` and unrelated. `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Also in this PR

- **Removed 10k-char tool output truncation** (`repo/bash.ts`, `gitsee/agent/tools.ts`): the `[... output truncated to 10,000 characters ...]` caps are commented out so bash/grep/fulltext tool results return in full — including the gitsee mid-stream check that killed the process once stdout passed 10k chars.
