### PR TITLE
Fix zero token_usage on sessions with numeric ids

### DIFF
--- a/mcp/scripts/backfill-agent-session-node-key.cypher
+++ b/mcp/scripts/backfill-agent-session-node-key.cypher
@@ -1,0 +1,77 @@
+// Backfill: normalize AgentSession.node_key to STRING.
+//
+// External clients supply their own session ids. When one sent a numeric id as
+// a JSON number (e.g. {"sessionId": 151395375}), the value reached Cypher
+// untouched and MERGE stored `node_key` as a Float (1.51395375E8) rather than
+// the string "151395375".
+//
+// Cypher equality is type-strict, so GET_AGENT_SESSION_QUERY
+// (`MATCH (n:AgentSession {node_key: $session_id})`, called with a string id
+// from the URL path) never matched these nodes. LIST_AGENT_SESSIONS_QUERY
+// matches on label only and stringifies afterwards, so it kept working — which
+// is why affected sessions showed correct token usage in /api/sessions and
+// all-zeros in /api/sessions/:id.
+//
+// The code fix (String() coercion at the route boundary, mcp/src/repo/index.ts)
+// stops new nodes from being written this way. This script repairs the ones
+// already in the graph.
+//
+// The type test is `NOT toString(n.node_key) = n.node_key` rather than
+// valueType(): it needs no version floor, and cross-type `=` yields false in
+// Cypher rather than erroring. String keys compare equal to their own
+// toString() and are skipped; numeric keys don't and are selected.
+//
+// Run against prod with cypher-shell:
+//   cypher-shell -a "$NEO4J_URI" -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" \
+//     -f mcp/scripts/backfill-agent-session-node-key.cypher
+
+// ---------------------------------------------------------------------------
+// STEP 1 — dry run. Count and preview affected nodes. Writes nothing.
+// ---------------------------------------------------------------------------
+MATCH (n:AgentSession)
+WHERE n.node_key IS NOT NULL AND NOT toString(n.node_key) = n.node_key
+RETURN count(n) AS affected;
+
+MATCH (n:AgentSession)
+WHERE n.node_key IS NOT NULL AND NOT toString(n.node_key) = n.node_key
+RETURN n.node_key                        AS current_key,
+       toString(toInteger(n.node_key))   AS will_become,
+       n.total_tokens                    AS total_tokens,
+       n.model                           AS model
+ORDER BY n.start_time DESC
+LIMIT 20;
+
+// Collision check — MUST return 0 rows before running STEP 2. A row means a
+// string-keyed node already occupies the id a numeric node would rename onto;
+// merge or delete those by hand first, or the graph gains duplicate keys.
+MATCH (n:AgentSession)
+WHERE n.node_key IS NOT NULL AND NOT toString(n.node_key) = n.node_key
+WITH DISTINCT toString(toInteger(n.node_key)) AS target
+MATCH (s:AgentSession)
+WHERE s.node_key = target
+RETURN target, count(s) AS existing_string_nodes;
+
+// ---------------------------------------------------------------------------
+// STEP 2 — the write. Run only after STEP 1 looks right.
+//
+// toInteger() before toString() matters: these are stored as Floats, so a bare
+// toString() yields "1.51395375E8" instead of "151395375". `n.name` is updated
+// too because buildRunFromNode() falls back to it when node_key is absent.
+// ---------------------------------------------------------------------------
+MATCH (n:AgentSession)
+WHERE n.node_key IS NOT NULL AND NOT toString(n.node_key) = n.node_key
+WITH n, toString(toInteger(n.node_key)) AS fixed
+SET n.node_key = fixed, n.name = fixed
+RETURN count(n) AS rewritten;
+
+// ---------------------------------------------------------------------------
+// STEP 3 — verify. Both counts must be 0.
+// ---------------------------------------------------------------------------
+MATCH (n:AgentSession)
+WHERE n.node_key IS NOT NULL AND NOT toString(n.node_key) = n.node_key
+RETURN count(n) AS remaining_non_string;
+
+// Catches a toString()-without-toInteger() mistake ("1.51395375E8").
+MATCH (n:AgentSession)
+WHERE n.node_key CONTAINS 'E'
+RETURN count(n) AS scientific_notation_leaked;

--- a/mcp/src/benchmark/sessions.ts
+++ b/mcp/src/benchmark/sessions.ts
@@ -19,22 +19,38 @@ import { addUsage, emptyUsage, normalizeUsage } from "../aieo/src/usage.js";
 
 const SESSIONS_DIR = process.env.SESSIONS_DIR || ".sessions";
 
+/**
+ * Usage/timing recovered from the `.meta.jsonl` sidecar, for sessions with no
+ * readable Neo4j node. The sidecar holds provider-reported per-step usage, so
+ * this is real data — not an estimate. Shared by the list and detail endpoints
+ * so the two can't drift (they did: the detail endpoint used to hardcode zeros
+ * here, silently zeroing every session whose node lookup missed).
+ */
+function deriveFromStepMeta(id: string, mtime: Date) {
+  const steps = loadStepMeta(id);
+  if (steps.length === 0) {
+    return {
+      usage: emptyUsage(),
+      duration_ms: 0,
+      timestamp: mtime.toISOString(),
+    };
+  }
+  return {
+    usage: addUsage(...steps.map((step) => normalizeUsage(step.usage))),
+    duration_ms:
+      new Date(steps[steps.length - 1].timestamp).getTime() -
+      new Date(steps[0].timestamp).getTime(),
+    timestamp: steps[0].timestamp,
+  };
+}
+
 function buildOrphanRun(dir: string, file: string) {
   const id = file.replace(/\.jsonl$/, "");
   const fullPath = path.join(dir, file);
   const stat = statSync(fullPath);
   const { userPromptPreview, answerPreview, toolSequence, toolCallCount, messageCount } =
     parseSessionMessages(fullPath);
-  const steps = loadStepMeta(id);
-  let usage = emptyUsage();
-  let duration_ms = 0;
-  if (steps.length > 0) {
-    usage = addUsage(...steps.map((step) => normalizeUsage(step.usage)));
-    const first = steps[0];
-    const last = steps[steps.length - 1];
-    duration_ms =
-      new Date(last.timestamp).getTime() - new Date(first.timestamp).getTime();
-  }
+  const { usage, duration_ms, timestamp } = deriveFromStepMeta(id, stat.mtime);
   return {
     id,
     // Sub-agent sessions are named `<parent>-sub-<hex>`; recover the link
@@ -44,7 +60,7 @@ function buildOrphanRun(dir: string, file: string) {
     provider: "",
     model: "",
     repo: "",
-    timestamp: steps.length > 0 ? steps[0].timestamp : stat.mtime.toISOString(),
+    timestamp,
     duration_ms,
     token_usage: {
       input: usage.input,
@@ -413,6 +429,10 @@ async function buildFullSession(
   if (!hasFile) return null;
 
   const stat = statSync(filePath);
+  // No Neo4j node — recover usage/timing from the step-meta sidecar rather
+  // than reporting zeros. cost_usd stays 0: pricing needs the model/provider,
+  // which only the node carries.
+  const { usage, duration_ms, timestamp } = deriveFromStepMeta(id, stat.mtime);
   return {
     id,
     parent_session_id: id.match(/^(.+)-sub-[0-9a-f]{8}$/)?.[1] ?? "",
@@ -420,14 +440,14 @@ async function buildFullSession(
     repo: "",
     provider: "",
     model: "",
-    timestamp: stat.mtime.toISOString(),
-    duration_ms: 0,
+    timestamp,
+    duration_ms,
     token_usage: {
-      input: 0,
-      cache_read: 0,
-      cache_write: 0,
-      output: 0,
-      total: 0,
+      input: usage.input,
+      cache_read: usage.cache_read,
+      cache_write: usage.cache_write,
+      output: usage.output,
+      total: usage.total,
     },
     cost_usd: 0,
     status: "success",

--- a/mcp/src/repo/__tests__/session-id-coercion.test.ts
+++ b/mcp/src/repo/__tests__/session-id-coercion.test.ts
@@ -1,0 +1,208 @@
+/**
+ * Regression tests for numeric session ids reporting zero token usage.
+ *
+ * External clients supply their own session ids. When a client sent one as a
+ * JSON number ({"sessionId": 151395375}), the `as string` cast in
+ * repo/index.ts was compile-time only, so a JS number flowed all the way into
+ * `MERGE (n:AgentSession {node_key: $session_id})` and Neo4j stored node_key
+ * as a Float. Cypher equality is type-strict, so the detail endpoint's lookup
+ * with the string id from the URL path never matched. `buildFullSession` then
+ * fell through to its file-only branch, which hardcoded token_usage to zeros —
+ * while the list endpoint (which matches on label, not key) kept reporting the
+ * real numbers. Every session with a numeric id showed 0 tokens on
+ * GET /api/sessions/:id.
+ *
+ * Two invariants are covered here:
+ *   1. Session ids are coerced to strings before they reach the Neo4j key, so
+ *      no new node can be written with a non-string node_key.
+ *   2. When the node lookup misses for any reason, the detail endpoint recovers
+ *      usage from the `.meta.jsonl` sidecar instead of reporting zeros.
+ *
+ * These run with NO_DB=true, so `db` is undefined and the detail endpoint takes
+ * exactly the file-only branch that used to zero everything out.
+ */
+
+import { test, expect } from "../../testkit.js";
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// session.ts reads SESSIONS_DIR once at module load, so it must be set before
+// the dynamic import below and stay fixed for the lifetime of the process.
+const tmpSessionsDir = path.join(
+  os.tmpdir(),
+  `test-session-id-coercion-${randomUUID()}`,
+);
+fs.mkdirSync(tmpSessionsDir, { recursive: true });
+process.env.SESSIONS_DIR = tmpSessionsDir;
+process.env.NO_DB = "true";
+
+const NUMERIC_ID = 151395375;
+
+/** Minimal express Response double capturing the JSON body and status. */
+function mockRes() {
+  const captured: { status: number; body: any } = { status: 200, body: null };
+  const res: any = {
+    status(code: number) {
+      captured.status = code;
+      return res;
+    },
+    json(body: any) {
+      captured.body = body;
+      return res;
+    },
+  };
+  return { res, captured };
+}
+
+test.describe("numeric session ids", () => {
+  test("createSession coerces a numeric id to a string", async () => {
+    const { createSession, sessionExists } = await import("../session.js");
+
+    // Cast mirrors reality: the type says string, the JSON body carried a number.
+    const returned = createSession(NUMERIC_ID as unknown as string);
+
+    expect(typeof returned).toBe("string");
+    expect(returned).toBe("151395375");
+    // The string id — the one the URL path will carry — must resolve.
+    expect(sessionExists("151395375")).toBe(true);
+  });
+
+  test("appendSessionEnd accepts a numeric id without losing the session", async () => {
+    const { createSession, appendSessionEnd } = await import("../session.js");
+
+    const id = 151395376;
+    createSession(id as unknown as string);
+
+    // sessionMeta is keyed by the coerced string. If appendSessionEnd skipped
+    // the same coercion, this lookup would miss and it would bail out with
+    // "was never registered via createSession()" — writing no node at all.
+    const errors: string[] = [];
+    const originalError = console.error;
+    console.error = (...args: unknown[]) => errors.push(args.join(" "));
+    try {
+      await appendSessionEnd(id as unknown as string, {
+        end_time: new Date().toISOString(),
+        model: "claude-sonnet-5",
+        provider: "anthropic",
+        duration_ms: 1234,
+        status: "success",
+        token_usage: {
+          input: 10,
+          cache_read: 20,
+          cache_write: 30,
+          output: 40,
+          total: 100,
+        } as any,
+      });
+    } finally {
+      console.error = originalError;
+    }
+
+    expect(errors.join("\n")).not.toContain("never registered");
+  });
+
+  test("detail endpoint recovers usage from step meta when the node is missing", async () => {
+    const { createSession, appendMessages, appendStepMeta } = await import(
+      "../session.js"
+    );
+    const { get_session } = await import("../../benchmark/sessions.js");
+
+    const id = createSession(151395377 as unknown as string);
+    appendMessages(id, [{ role: "user", content: "hi" }] as any);
+
+    // Two steps of provider-reported usage in the sidecar. Under NO_DB there is
+    // no AgentSession node, so this is the only surviving record of the spend.
+    appendStepMeta(id, [
+      {
+        step: 0,
+        turn: 2,
+        usage: {
+          input: 2,
+          cache_read: 0,
+          cache_write: 33886,
+          output: 161,
+          total: 34049,
+        },
+        cumulativeInput: 33888,
+        cumulativeOutput: 161,
+        toolCalls: ["bash"],
+        timestamp: "2026-08-07T15:24:49.432Z",
+      },
+      {
+        step: 1,
+        turn: 2,
+        usage: {
+          input: 3,
+          cache_read: 1000,
+          cache_write: 500,
+          output: 200,
+          total: 1703,
+        },
+        cumulativeInput: 35391,
+        cumulativeOutput: 361,
+        toolCalls: [],
+        timestamp: "2026-08-07T15:25:49.432Z",
+      },
+    ] as any);
+
+    const { res, captured } = mockRes();
+    await get_session({ params: { id }, query: {} } as any, res);
+
+    expect(captured.status).toBe(200);
+    const usage = captured.body.token_usage;
+
+    // The regression: this whole object used to be hardcoded zeros.
+    expect(usage.total).toBe(34049 + 1703);
+    expect(usage.input).toBe(5);
+    expect(usage.cache_read).toBe(1000);
+    expect(usage.cache_write).toBe(34386);
+    expect(usage.output).toBe(361);
+
+    // Duration is derived from the step timestamps (60s apart), not left at 0.
+    expect(captured.body.duration_ms).toBe(60000);
+  });
+
+  test("detail and list endpoints agree on usage for the same session", async () => {
+    const { createSession, appendMessages, appendStepMeta } = await import(
+      "../session.js"
+    );
+    const { get_session, list_sessions } = await import(
+      "../../benchmark/sessions.js"
+    );
+
+    const id = createSession(151395378 as unknown as string);
+    appendMessages(id, [{ role: "user", content: "hi" }] as any);
+    appendStepMeta(id, [
+      {
+        step: 0,
+        turn: 2,
+        usage: {
+          input: 7,
+          cache_read: 900,
+          cache_write: 80,
+          output: 13,
+          total: 1000,
+        },
+        cumulativeInput: 987,
+        cumulativeOutput: 13,
+        toolCalls: [],
+        timestamp: "2026-08-07T15:24:49.432Z",
+      },
+    ] as any);
+
+    const detail = mockRes();
+    await get_session({ params: { id }, query: {} } as any, detail.res);
+
+    const list = mockRes();
+    await list_sessions({} as any, list.res);
+    const row = (list.captured.body as any[]).find((r) => r.id === id);
+
+    // The original bug was precisely this disagreement: list reported the real
+    // spend while detail reported zeros for the very same session.
+    expect(row).toBeTruthy();
+    expect(detail.captured.body.token_usage).toEqual(row.token_usage);
+    expect(detail.captured.body.token_usage.total).toBe(1000);
+  });
+});

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -139,7 +139,11 @@ function parseAgentBody(req: Request) {
   const apiKey = req.body.apiKey as string | undefined;
   const baseUrl = req.body.baseUrl as string | undefined;
   const logs = req.body.logs as boolean | undefined;
-  const sessionId = (req.body.sessionId as string | undefined) || randomUUID();
+  // Coerce, don't cast: external clients send numeric ids as JSON numbers
+  // (e.g. {"sessionId": 151395375}). A bare `as string` is compile-time only,
+  // so the number reached Neo4j and MERGE stored node_key as a Float — which
+  // then never matched the string id used on lookup.
+  const sessionId = String(req.body.sessionId ?? "") || randomUUID();
   const sessionConfig = req.body.sessionConfig as SessionConfig | undefined;
   const mcpServers = (req.body.mcpServers as McpServer[] | undefined)?.map((s) => ({
     ...s,

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -105,7 +105,9 @@ export function createSession(
   repo?: string,
   parentSessionId?: string,
 ): string {
-  const sessionId = id || randomUUID();
+  // Defense in depth against non-string ids from callers that skipped the
+  // route-level coercion — a numeric id poisons the Neo4j node_key type.
+  const sessionId = String(id ?? "") || randomUUID();
   sessionMeta.set(sessionId, {
     source: source || "unknown",
     start_time: new Date().toISOString(),
@@ -126,7 +128,7 @@ export function createSession(
  * Append end-of-session metadata (timing, model, token usage).
  */
 export async function appendSessionEnd(
-  sessionId: string,
+  rawSessionId: string,
   opts: {
     end_time: string;
     model?: string;
@@ -137,6 +139,9 @@ export async function appendSessionEnd(
     error_message?: string;
   },
 ): Promise<void> {
+  // Must match the coercion in createSession(): the sessionMeta key and the
+  // Neo4j node_key are both string-typed, and Cypher equality is type-strict.
+  const sessionId = String(rawSessionId ?? "");
   console.log(`[session] end session_id=${sessionId} model=${opts.model ?? ""} status=${opts.status ?? "success"} tokens=${opts.token_usage?.total ?? 0} duration_ms=${opts.duration_ms ?? 0}`);
 
   const stored = sessionMeta.get(sessionId);


### PR DESCRIPTION
## The bug

`GET /api/sessions/:id` returned all-zero `token_usage` for every session whose id came from an external client as a JSON number. `GET /api/sessions` reported the correct numbers for those same sessions.

Verified against prod (`swarmSx67vR`), **1,686 sessions affected**:

| session id | list | detail |
|---|---|---|
| `151395375` | 3,455,186 · sonnet-5 · 556s | **0** · model `""` · dur 0 |
| `151405698` | 4,268,426 · sonnet-5 | **0** · model `""` · dur 0 |
| `151404637` | 5,411,166 · sonnet-5 | **0** · model `""` · dur 0 |
| `4d1aaf1b-…` (UUID) | 8,436,050 | 8,436,050 ✅ |

No data was lost — the node had it, and `step_meta` on the zeroed response summed to exactly the total the list reported.

## Root cause

A client sends `{"sessionId": 151395375}` as a JSON **number**. In `repo/index.ts`:

```ts
const sessionId = (req.body.sessionId as string | undefined) || randomUUID();
```

`as string` is a compile-time assertion with no runtime coercion, so the number flowed unconverted into `MERGE (n:AgentSession {node_key: $session_id})`. The driver maps a JS number to a Cypher **Float**, so `node_key` was stored as `1.51395375E8`, not `"151395375"`.

The leak was visible in the prod payload — `step_meta[].sessionId` is a raw JSON number, written from that same variable:

```json
"sessionId": 151395375,
```

The two read paths then diverge:

- **List** matches on label + `n.file`, never on the key, then stringifies via `String(s.node_key)`. Works.
- **Detail** matches `{node_key: $session_id}` against `String(req.params.id)`. Cypher equality is type-strict: Float ≠ String → no match.

`get_agent_session` returns null, so `buildFullSession` drops to its file-only branch — which hardcoded zeros.

## Changes

**1. Coerce at the boundary** — `String(req.body.sessionId ?? "") || randomUUID()`, plus `createSession`/`appendSessionEnd` as defense in depth. Both sides must coerce identically: `sessionMeta` is keyed by the coerced string, so a one-sided fix would make `appendSessionEnd` miss the map and bail with *"was never registered via createSession()"*, writing no node at all. There's a test pinning that.

**2. Fallback recovers real usage** — extracted `deriveFromStepMeta()` and pointed both `buildOrphanRun` and the `buildFullSession` fallback at it. The duplicated-then-drifted derivation is what let this hide. A missing node now degrades to real usage and duration instead of silent zeros. `cost_usd` stays 0 there — pricing needs model/provider, which only the node carries.

**3. Backfill** — `mcp/scripts/backfill-agent-session-node-key.cypher`, **not run automatically**.

## Deploying

The code fix stops new bad nodes but does not repair the 1,686 existing ones. Run the backfill separately:

```bash
cypher-shell -a "$NEO4J_URI" -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" -f mcp/scripts/backfill-agent-session-node-key.cypher
```

Two notes on it:

- The type test is `NOT toString(n.node_key) = n.node_key`, not `valueType()`. The Neo4j image is `sphinxlightning/sphinx-neo4j:latest` with no pinned version; `valueType()` needs 5.13+ and scoped `CALL (n) {...}` needs 5.23+. This form has no version floor. `IN TRANSACTIONS` is also omitted — ~1,686 nodes is one trivial transaction, and it avoids needing `:auto` in cypher-shell.
- It uses `toString(toInteger(...))`, not `toString(...)`. These landed as Floats, so a bare `toString` writes `"1.51395375E8"`. STEP 3 checks for exactly that mistake.

**Run STEP 1 first** — the collision check must return zero rows. A row means a string-keyed node already occupies an id a numeric node would rename onto, which would produce duplicate keys.

## Tests

`mcp/src/repo/__tests__/session-id-coercion.test.ts` — 4 tests, placed under `src/repo/__tests__/` so the existing `test:node` glob picks them up without touching `package.json`.

Verified they catch the regression: 3 of 4 fail with the source changes stashed, including the one asserting list and detail agree on the same session — the exact disagreement seen in prod. The fourth (`appendSessionEnd` with a numeric id) passes either way; it doesn't reproduce the original bug, it guards the asymmetric-coercion hazard this PR introduces.

Full suite: 438/439 pass. The one failure (`toolsJarvis` "output ordering matches input ordering") is pre-existing and unrelated — it fails identically on a clean tree.

## Not covered

The coercion is on `/repo/agent`'s `req.body.sessionId`. I did not audit every other entry point that can seed a session id. `mcp/src/repo/agent.ts:720` has a resume path that assigns `sessionId = inputSessionId` directly, bypassing `createSession`. It's harmless now because `appendSessionEnd` coerces before Neo4j, but an uncoerced value still circulates in-process — which is why `step_meta[].sessionId` was a raw number in prod. Worth a follow-up sweep to make the type honest end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)