### PR TITLE
Flag restart-orphaned runs as retryable; stop concurrent runs on one session

### DIFF
--- a/mcp/src/graph/reqs.ts
+++ b/mcp/src/graph/reqs.ts
@@ -29,6 +29,11 @@ interface Request {
   result?: any;
   error?: any;
   progress?: any;
+  // Whether re-submitting the same request is expected to help. True only for
+  // infrastructure failures (a restart orphaning an in-flight run), never for
+  // agent errors or user aborts. Callers key their retry policy off this
+  // instead of string-matching the error text.
+  retryable?: boolean;
   // Caller's terminal callback, persisted so the startup sweep can still
   // notify the receiver about runs orphaned by a process restart.
   webhookUrl?: string;
@@ -95,6 +100,9 @@ export function startReq(webhookUrl?: string): string {
 export interface OrphanedReq {
   request_id: string;
   error: string;
+  /** Always true — a restart-orphaned run lost no durable state, so a
+   * re-submit of the same request picks up from the last completed turn. */
+  retryable: true;
   webhookUrl?: string;
 }
 
@@ -140,10 +148,11 @@ export function sweepOrphanedReqs(): OrphanedReq[] {
     if (!data) continue;
 
     if (data.status === "pending") {
-      failReq(id, RESTART_ORPHAN_ERROR);
+      failReq(id, RESTART_ORPHAN_ERROR, true);
       orphaned.push({
         request_id: id,
         error: RESTART_ORPHAN_ERROR,
+        retryable: true,
         ...(data.webhookUrl && { webhookUrl: data.webhookUrl }),
       });
     }
@@ -178,14 +187,16 @@ export function finishReq(id: string, result: any) {
   writeToDisk(id, { status: "completed", result });
 }
 
-export function failReq(id: string, error: any) {
+export function failReq(id: string, error: any, retryable = false) {
   if (META[id]) META[id].status = "failed";
   // Serialize error safely — Error objects don't JSON.stringify well
   const serializedError =
     error instanceof Error
       ? { message: error.message, stack: error.stack }
       : error;
-  writeToDisk(id, { status: "failed", error: serializedError });
+  // Always written (not just when true) so a caller reading /progress never
+  // has to distinguish "not retryable" from "this build predates the field".
+  writeToDisk(id, { status: "failed", error: serializedError, retryable });
 }
 
 export function updateReq(id: string, progress: any) {

--- a/mcp/src/graph_agent/index.ts
+++ b/mcp/src/graph_agent/index.ts
@@ -185,7 +185,7 @@ export async function graph_agent(req: Request, res: Response) {
           await finalizeSession();
           unregisterAbortController(request_id);
           if (body.sessionId !== request_id) {
-            unregisterAbortController(body.sessionId);
+            unregisterAbortController(body.sessionId, abortController);
           }
           endTracking(opId);
         });
@@ -195,7 +195,7 @@ export async function graph_agent(req: Request, res: Response) {
       console.error("[graph_agent] Stream setup error:", error);
       unregisterAbortController(request_id);
       if (body.sessionId !== request_id) {
-        unregisterAbortController(body.sessionId);
+        unregisterAbortController(body.sessionId, abortController);
       }
       endTracking(opId);
       if (!res.headersSent) {
@@ -283,7 +283,7 @@ export async function graph_agent(req: Request, res: Response) {
       .finally(() => {
         unregisterAbortController(request_id);
         if (body.sessionId && body.sessionId !== request_id) {
-          unregisterAbortController(body.sessionId);
+          unregisterAbortController(body.sessionId, abortController);
         }
         endTracking(opId);
       });
@@ -299,7 +299,7 @@ export async function graph_agent(req: Request, res: Response) {
     asyncReqs.failReq(request_id, error);
     unregisterAbortController(request_id);
     if (body.sessionId && body.sessionId !== request_id) {
-      unregisterAbortController(body.sessionId);
+      unregisterAbortController(body.sessionId, abortController);
     }
     res.status(500).json({ error: "Internal server error" });
     endTracking(opId);

--- a/mcp/src/log/index.ts
+++ b/mcp/src/log/index.ts
@@ -222,7 +222,7 @@ export async function logs_agent(req: Request, res: Response) {
       .finally(() => {
         unregisterAbortController(request_id);
         if (sessionId && sessionId !== request_id) {
-          unregisterAbortController(sessionId);
+          unregisterAbortController(sessionId, abortController);
         }
         endTracking(opId);
         // Clean up logs directory for non-session runs
@@ -237,7 +237,7 @@ export async function logs_agent(req: Request, res: Response) {
     asyncReqs.failReq(request_id, error);
     unregisterAbortController(request_id);
     if (sessionId && sessionId !== request_id) {
-      unregisterAbortController(sessionId);
+      unregisterAbortController(sessionId, abortController);
     }
     res.status(500).json({ error: "Internal server error" });
     endTracking(opId);

--- a/mcp/src/repo/events.ts
+++ b/mcp/src/repo/events.ts
@@ -150,15 +150,18 @@ export function registerAbortController(
   key: string,
   controller?: AbortController,
 ): AbortController {
-  // If a stale controller exists for this key, abort it first (only when
-  // we're creating a fresh one — aliasing should not abort an existing run).
-  if (!controller) {
-    const existing = abortControllers.get(key);
-    if (existing && !existing.signal.aborted) {
-      try { existing.abort(); } catch (_) {}
-    }
-  }
   const ctl = controller ?? new AbortController();
+  // Abort whatever else held this key. The guard is controller *identity*, not
+  // "were we passed one": re-registering the same controller (the sessionId
+  // alias of a run already keyed by request_id) must not abort the run it
+  // belongs to, but a genuinely different run on the same sessionId must be
+  // stopped. Without this, a caller retrying a session while the original was
+  // still alive left both runs appending to the same transcript.
+  const existing = abortControllers.get(key);
+  if (existing && existing !== ctl && !existing.signal.aborted) {
+    console.log(`[events] Aborting superseded run for key ${key}`);
+    try { existing.abort(); } catch (_) {}
+  }
   abortControllers.set(key, ctl);
   return ctl;
 }
@@ -167,7 +170,17 @@ export function getAbortController(key: string): AbortController | undefined {
   return abortControllers.get(key);
 }
 
-export function unregisterAbortController(key: string): void {
+/**
+ * Remove a key from the registry. Pass the controller you registered so a
+ * superseded run's cleanup can't evict the entry belonging to the run that
+ * replaced it — that would silently make /repo/agent/abort a no-op for the
+ * live run. Omitting it deletes unconditionally (legacy behavior).
+ */
+export function unregisterAbortController(
+  key: string,
+  controller?: AbortController,
+): void {
+  if (controller && abortControllers.get(key) !== controller) return;
   abortControllers.delete(key);
 }
 

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -244,7 +244,11 @@ function normalizeHeaders(input: unknown): Record<string, string> | undefined {
  */
 type TerminalWebhookPayload =
   | { request_id: string; status: "completed"; result: unknown }
-  | { request_id: string; status: "failed"; error: unknown };
+  // `retryable` is required on the failed variant so every caller gets an
+  // explicit signal: true only for infrastructure failures (a restart
+  // orphaning an in-flight run), where re-submitting the same request resumes
+  // from the last completed turn. Agent errors and aborts are false.
+  | { request_id: string; status: "failed"; error: unknown; retryable: boolean };
 
 const WEBHOOK_RETRY_DELAYS_MS = [0, 5_000, 30_000];
 const WEBHOOK_TIMEOUT_MS = 15_000;
@@ -305,6 +309,7 @@ export function sweepOrphanedRuns(): void {
         request_id: orphan.request_id,
         status: "failed",
         error: orphan.error,
+        retryable: orphan.retryable,
       });
     }
   }
@@ -466,14 +471,14 @@ export async function repo_agent(req: Request, res: Response) {
         .finally(async () => {
           res.off("close", onClientClose);
           await finalizeSession();
-          unregisterAbortController(body.sessionId);
+          unregisterAbortController(body.sessionId, abortController);
           endTracking(opId);
         });
 
       return;
     } catch (error: any) {
       console.error("[repo_agent] Stream setup error:", error);
-      unregisterAbortController(body.sessionId);
+      unregisterAbortController(body.sessionId, abortController);
       endTracking(opId);
       if (!res.headersSent) {
         res.status(500).json({ error: error.message || "Internal server error" });
@@ -604,13 +609,14 @@ export async function repo_agent(req: Request, res: Response) {
             request_id,
             status: "failed",
             error: errorMessage,
+            retryable: false,
           });
         }
       })
       .finally(() => {
         unregisterAbortController(request_id);
         if (body.sessionId && body.sessionId !== request_id) {
-          unregisterAbortController(body.sessionId);
+          unregisterAbortController(body.sessionId, abortController);
         }
         endTracking(opId);
       });
@@ -621,7 +627,7 @@ export async function repo_agent(req: Request, res: Response) {
     console.error("Error in repo_agent", error);
     unregisterAbortController(request_id);
     if (body.sessionId && body.sessionId !== request_id) {
-      unregisterAbortController(body.sessionId);
+      unregisterAbortController(body.sessionId, abortController);
     }
     res.status(500).json({ error: "Internal server error" });
     endTracking(opId);


### PR DESCRIPTION
## Why

When the server crashes mid-run, recovery is the caller's job: re-POST the same prompt with the same `sessionId`. That already works today — `appendMessages` fires once at the end of a turn, so the transcript is atomically all-or-nothing per turn. A crash leaves the session `.jsonl` at the last completed turn with no dangling tool calls and no half-written prompt to clean up.

Two things made that awkward to actually rely on.

## 1. `retryable` on failures

Callers had to string-match `"server restarted while request was in-flight"` to distinguish a retryable infrastructure failure from an agent error they shouldn't retry.

`failReq` now records a `retryable` flag, surfaced on both `/progress` (free — `checkReq` only strips `webhookUrl`) and the terminal webhook.

**It is set in exactly one place:** `sweepOrphanedReqs`, the startup sweep, for records still `pending` on disk. So `retryable: true` means precisely "the process died mid-run and the new process noticed on boot". Agent errors, model API failures, aborts and timeouts are all `false`.

Two deliberate choices:
- Written on **every** failure, not only when true, so a caller can't confuse "not retryable" with "this build predates the field".
- **Required** on the `failed` variant of `TerminalWebhookPayload`, so the type forces current and future failure sites to state an answer.

## 2. Concurrent runs on one sessionId

`registerAbortController` skipped its abort-stale branch whenever a controller was passed — which is exactly what the non-streaming path does when it aliases a run under its `sessionId`. A retry landing while the original was still alive left both runs appending to the same transcript. (The streaming path calls it without a controller, so it was already guarded.)

The guard is now controller **identity**: re-registering a run's own controller is still safe, but a genuinely different run on the same session supersedes it.

### Latent bug this made reachable

Every run's `finally` unregistered its `sessionId` key unconditionally. Once run B supersedes run A, A's cleanup would delete **B's** registry entry — silently turning `/repo/agent/abort` into a no-op for the live run. This was already reachable in the streaming path before this change.

`unregisterAbortController` now takes an optional controller and no-ops unless the stored entry matches. Passed at the `sessionId` call sites across `repo`, `graph_agent` and `log`; `request_id` keys are fresh UUIDs and can't collide, so those are left alone.

## Notes for reviewers

- **Scope is intentionally small.** Checkpointing partial turns (so a retry doesn't redo 20 minutes of tool calls) is a real follow-up, but it's an optimization — correctness doesn't depend on it.
- **Streaming runs get no `retryable` signal, ever.** The `body.stream` branch returns before `startReq` is called, so those runs have no `.reqs` record for the sweep to find. Streaming callers need their own idle timeout. Not a regression; worth knowing when writing the caller-side policy.
- A superseded run records as `failed` with error `"aborted"` and `retryable: false`, so a retry that races the original won't send the caller into a retry loop.
- Callers should cap retries at one — if the run is what killed the server, a second attempt reproduces the crash.

## Testing

- `tsc --noEmit` clean.
- `npm run test:node`: 438/439. The single failure (`toolsJarvis.test.ts` → "output ordering matches input ordering") is pre-existing on `main`, confirmed by re-running it against a stashed tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)