### PR TITLE
Record which Concepts a session read, and optionally rank them by usefulness

### DIFF
--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -42,6 +42,7 @@ import { mcp_routes } from "./handler/index.js";
 import { logs_agent } from "./log/index.js";
 import * as ga from "./graph_agent/index.js";
 import { pruneExpiredSessions } from "./repo/session.js";
+import { backfillConceptReads } from "./repo/conceptBackfill.js";
 import { pruneExpiredArtifacts } from "./repo/artifacts.js";
 import {
   getBus,
@@ -364,6 +365,14 @@ app.listen(port, host, () => {
 
   // Mark requests orphaned by the restart as failed and fire their webhooks
   rr.sweepOrphanedRuns();
+
+  // Recover which Concepts recent sessions read, for runs that predate
+  // collection. Marker-guarded, so this is a single small file read once the
+  // sweep has completed. Never awaited — a backfill must not delay boot, and
+  // it needs Neo4j, which may not be up yet (it retries on the next boot).
+  void backfillConceptReads().catch((e) =>
+    console.error("[concept-backfill] failed:", e),
+  );
 });
 
 //

--- a/mcp/src/repo/__tests__/concept-backfill.test.ts
+++ b/mcp/src/repo/__tests__/concept-backfill.test.ts
@@ -1,0 +1,154 @@
+/**
+ * Recovering concept reads from stored transcripts.
+ *
+ * The backfill reads tool-call INPUTS rather than results, which makes it
+ * robust to `truncateToolResults` but means it can't tell a Concept ref_id
+ * from any other node's. Catalog membership is the only thing standing between
+ * "recovered the read log" and "invented one", so that's what these cover.
+ */
+
+import { test, expect } from "../../testkit.js";
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import type { ModelMessage } from "ai";
+
+const tmpSessionsDir = path.join(os.tmpdir(), `test-backfill-${randomUUID()}`);
+fs.mkdirSync(tmpSessionsDir, { recursive: true });
+process.env.SESSIONS_DIR = tmpSessionsDir;
+process.env.NO_DB = "true";
+
+// Must come after the env override — session.ts captures SESSIONS_DIR at
+// module load, and this module reaches it. A static import here would point
+// the sweep at the real .sessions directory, where it would write sidecars
+// and a marker into live data.
+const { conceptReadsFromTranscript, confirmConceptReads } = await import(
+  "../conceptBackfill.js"
+);
+
+/** An assistant turn carrying tool calls, as stored in the session JSONL. */
+function assistantCalls(
+  calls: { toolName: string; input: Record<string, unknown> }[],
+): ModelMessage {
+  return {
+    role: "assistant",
+    content: calls.map((c, i) => ({
+      type: "tool-call",
+      toolCallId: `toolu_${i}`,
+      toolName: c.toolName,
+      input: c.input,
+    })),
+  } as ModelMessage;
+}
+
+const catalog = [
+  { id: "c_4f2a", ref_id: "ref-abc", name: "auth-session-lifecycle", repo: "stakwork/hive" },
+  { id: "c_91bd", ref_id: "ref-def", name: "stakwork-workflow-runs", repo: "stakwork/hive" },
+];
+
+test.describe("reading concept reads out of a transcript", () => {
+  test("picks up both tool paths, in call order", () => {
+    const reads = conceptReadsFromTranscript([
+      { role: "user", content: "how does auth work?" },
+      assistantCalls([
+        { toolName: "graph_get", input: { ref_id: "ref-def" } },
+        { toolName: "learn_concept", input: { concept_id: "c_4f2a" } },
+      ]),
+    ]);
+    expect(reads).toHaveLength(2);
+    expect(reads[0].ref_id).toBe("ref-def");
+    expect(reads[0].via).toBe("graph_get");
+    expect(reads[1].id).toBe("c_4f2a");
+  });
+
+  test("ignores tools that don't return a concept body", () => {
+    const reads = conceptReadsFromTranscript([
+      assistantCalls([
+        { toolName: "graph_search", input: { q: "auth" } },
+        { toolName: "list_concepts", input: {} },
+        { toolName: "stakgraph_code", input: { ref_id: "ref-abc" } },
+      ]),
+    ]);
+    expect(reads).toHaveLength(0);
+  });
+
+  test("survives a transcript with no tool calls at all", () => {
+    expect(
+      conceptReadsFromTranscript([
+        { role: "user", content: "hi" },
+        { role: "assistant", content: "hello" },
+      ]),
+    ).toHaveLength(0);
+  });
+});
+
+test.describe("confirming reads against the catalog", () => {
+  test("drops a graph_get on a node that isn't a Concept", () => {
+    // The input alone looks identical to a concept read — only the catalog
+    // says otherwise. Recording this would invent a read that never happened.
+    const confirmed = confirmConceptReads(
+      [
+        { ref_id: "ref-abc", via: "graph_get" },
+        { ref_id: "ref-some-function", via: "graph_get" },
+      ],
+      catalog,
+    );
+    expect(confirmed).toHaveLength(1);
+    expect(confirmed[0].ref_id).toBe("ref-abc");
+  });
+
+  test("fills in the identifiers and name the transcript didn't carry", () => {
+    const confirmed = confirmConceptReads([{ ref_id: "ref-def", via: "graph_get" }], catalog);
+    expect(confirmed[0].id).toBe("c_91bd");
+    expect(confirmed[0].name).toBe("stakwork-workflow-runs");
+    expect(confirmed[0].repo).toBe("stakwork/hive");
+  });
+
+  test("the same concept read both ways collapses, as it does live", () => {
+    const confirmed = confirmConceptReads(
+      [
+        { id: "c_4f2a", via: "learn_concept" },
+        { ref_id: "ref-abc", via: "graph_get" },
+      ],
+      catalog,
+    );
+    expect(confirmed).toHaveLength(1);
+  });
+
+  test("an empty catalog recovers nothing rather than everything", () => {
+    // A failed or empty lookup must not be read as "none of these are known,
+    // so record them all" — that's the failure mode that would fabricate data.
+    expect(confirmConceptReads([{ ref_id: "ref-abc", via: "graph_get" }], [])).toHaveLength(0);
+  });
+});
+
+test.describe("the backfill sweep", () => {
+  test("does nothing when there are no sessions", async () => {
+    const { backfillConceptReads } = await import("../conceptBackfill.js");
+    const result = await backfillConceptReads();
+    expect(result).toEqual({ scanned: 0, written: 0, concepts: 0 });
+  });
+
+  test("leaves a session that already has a sidecar alone", async () => {
+    const { mergeReflection, loadReflection } = await import("../session.js");
+    const { backfillConceptReads } = await import("../conceptBackfill.js");
+    const sessionId = `sess-${randomUUID()}`;
+
+    // A live-collected sidecar, with a ranking worth protecting.
+    mergeReflection(sessionId, {
+      concepts: [{ ref_id: "ref-abc", name: "auth", rank: 1, evidence: "decisive" }],
+    });
+    fs.writeFileSync(
+      path.join(tmpSessionsDir, `${sessionId}.jsonl`),
+      JSON.stringify(assistantCalls([{ toolName: "graph_get", input: { ref_id: "ref-def" } }])) + "\n",
+    );
+
+    await backfillConceptReads();
+
+    const saved = loadReflection(sessionId);
+    expect(saved?.concepts).toHaveLength(1);
+    expect(saved?.concepts[0].rank).toBe(1);
+    expect(saved?.concepts[0].evidence).toBe("decisive");
+  });
+});

--- a/mcp/src/repo/__tests__/concepts.test.ts
+++ b/mcp/src/repo/__tests__/concepts.test.ts
@@ -1,0 +1,323 @@
+/**
+ * Concept collection + reflection.
+ *
+ * The invariants worth pinning down are the ones where a plausible-looking
+ * implementation still loses data:
+ *
+ *   1. A Concept reached through `graph_get` is recorded, not just one reached
+ *      through `learn_concept`. The two tools key on different identifiers, so
+ *      the same concept read both ways must collapse to one entry.
+ *   2. The deterministic read list survives a model turn that returns garbage,
+ *      and a failed reflect never clobbers a ranking an earlier turn produced.
+ */
+
+import { test, expect } from "../../testkit.js";
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+import {
+  conceptReadFrom,
+  withConceptCollection,
+  mergeConceptReads,
+  conceptKey,
+  parseReflection,
+  buildReflectTurn,
+  reflectEnabled,
+  reflectPromptOverride,
+  type ConceptCollector,
+} from "../concepts.js";
+
+// session.ts reads SESSIONS_DIR once at module load, so it must be set before
+// the dynamic import below and stay fixed for the lifetime of the process.
+const tmpSessionsDir = path.join(os.tmpdir(), `test-concepts-${randomUUID()}`);
+fs.mkdirSync(tmpSessionsDir, { recursive: true });
+process.env.SESSIONS_DIR = tmpSessionsDir;
+process.env.NO_DB = "true";
+
+/** A graph_get result for a Concept node, as the tool actually returns it. */
+function graphGetConcept(overrides: Record<string, any> = {}) {
+  return JSON.stringify({
+    ref_id: "ref-abc",
+    node_type: "Concept",
+    name: "auth-session-lifecycle",
+    properties: { id: "c_4f2a", repo: "stakwork/hive" },
+    edges: { PARENT_OF: 2 },
+    ...overrides,
+  });
+}
+
+test.describe("recording concept reads", () => {
+  test("records a Concept resolved through graph_get", () => {
+    const read = conceptReadFrom("graph_get", { ref_id: "ref-abc" }, graphGetConcept());
+    expect(read?.ref_id).toBe("ref-abc");
+    expect(read?.id).toBe("c_4f2a");
+    expect(read?.name).toBe("auth-session-lifecycle");
+    expect(read?.via).toBe("graph_get");
+  });
+
+  test("ignores graph_get results for other node types", () => {
+    const other = JSON.stringify({
+      ref_id: "ref-xyz",
+      node_type: "Function",
+      name: "handleAuth",
+      properties: {},
+    });
+    expect(conceptReadFrom("graph_get", { ref_id: "ref-xyz" }, other)).toBeNull();
+  });
+
+  test("records a concept read through learn_concept", () => {
+    const doc = {
+      id: "c_91bd",
+      name: "stakwork-workflow-runs",
+      description: "how runs are stored",
+      documentation: "# Runs\n...",
+    };
+    const read = conceptReadFrom("learn_concept", { concept_id: "c_91bd" }, doc);
+    expect(read?.id).toBe("c_91bd");
+    expect(read?.via).toBe("learn_concept");
+  });
+
+  test("a concept miss is not a read", () => {
+    const miss = { error: "Concept not found" };
+    expect(conceptReadFrom("learn_concept", { concept_id: "nope" }, miss)).toBeNull();
+  });
+
+  test("wrapping collects reads and passes results through untouched", async () => {
+    const collector: ConceptCollector = { reads: [] };
+    const raw = graphGetConcept();
+    const tools: Record<string, any> = {
+      graph_get: { description: "resolve a node", execute: async () => raw },
+      learn_concept: {
+        description: "read a concept",
+        execute: async () => ({ id: "c_91bd", name: "runs", documentation: "x" }),
+      },
+      graph_search: { description: "search", execute: async () => "[]" },
+    };
+
+    const wrapped = withConceptCollection(tools, collector);
+    const passthrough = await wrapped.graph_get.execute({ ref_id: "ref-abc" }, {});
+    await wrapped.learn_concept.execute({ concept_id: "c_91bd" }, {});
+    await wrapped.graph_search.execute({ q: "auth" }, {});
+
+    expect(passthrough).toBe(raw);
+    expect(collector.reads).toHaveLength(2);
+    expect(wrapped.graph_get.description).toBe("resolve a node");
+    // graph_search surfaces concepts without their body — not a read.
+    expect(collector.reads.map((r) => r.via)).toEqual(["graph_get", "learn_concept"]);
+  });
+});
+
+test.describe("normalizing across the two id spaces", () => {
+  const catalog = [
+    { id: "c_4f2a", ref_id: "ref-abc", name: "auth-session-lifecycle", repo: "stakwork/hive" },
+    { id: "c_91bd", ref_id: "ref-def", name: "stakwork-workflow-runs", repo: "stakwork/hive" },
+  ];
+
+  test("the same concept read both ways collapses to one entry", () => {
+    const merged = mergeConceptReads(
+      [
+        { id: "c_4f2a", name: "auth-session-lifecycle", via: "learn_concept" },
+        { ref_id: "ref-abc", name: "auth-session-lifecycle", via: "graph_get" },
+      ],
+      catalog,
+    );
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBe("c_4f2a");
+    expect(merged[0].ref_id).toBe("ref-abc");
+    // Both paths are retained — how a concept gets reached is worth knowing.
+    expect(merged[0].via).toBe("learn_concept,graph_get");
+  });
+
+  test("fills in the identifier the read path didn't carry", () => {
+    const merged = mergeConceptReads([{ ref_id: "ref-def", via: "graph_get" }], catalog);
+    expect(merged[0].id).toBe("c_91bd");
+    expect(merged[0].name).toBe("stakwork-workflow-runs");
+    expect(merged[0].repo).toBe("stakwork/hive");
+  });
+
+  test("keeps reads the catalog can't resolve", () => {
+    const merged = mergeConceptReads([{ ref_id: "ref-gone", via: "graph_get" }], []);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].ref_id).toBe("ref-gone");
+  });
+
+  test("a concept with no gitree id is still recorded", () => {
+    // Concepts created directly in the graph never enter gitree's id space.
+    const merged = mergeConceptReads([{ ref_id: "ref-only", via: "graph_get" }], [
+      { ref_id: "ref-only", name: "graph-native-concept" },
+    ]);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].id).toBeUndefined();
+    expect(conceptKey(merged[0])).toBe("ref-only");
+  });
+
+  test("ref_id keys ahead of id, so a partial record merges with a full one", () => {
+    // Turn 1's catalog lookup failed, leaving ref_id only; turn 2's succeeded.
+    // Keying on id first would file these as two separate concepts.
+    const partial = mergeConceptReads([{ ref_id: "ref-abc", via: "graph_get" }], []);
+    const full = mergeConceptReads([{ id: "c_4f2a", via: "learn_concept" }], catalog);
+    expect(conceptKey(partial[0])).toBe(conceptKey(full[0]));
+  });
+
+  test("distinct concepts stay distinct", () => {
+    const merged = mergeConceptReads(
+      [
+        { id: "c_4f2a", via: "learn_concept" },
+        { ref_id: "ref-def", via: "graph_get" },
+      ],
+      catalog,
+    );
+    expect(merged).toHaveLength(2);
+  });
+});
+
+test.describe("parsing the reflect turn", () => {
+  const concepts = [
+    { id: "c_4f2a", ref_id: "ref-abc", name: "auth", via: "learn_concept" },
+    { id: "c_91bd", ref_id: "ref-def", name: "runs", via: "graph_get" },
+  ];
+
+  test("overlays rank, evidence and contradictions onto the read list", () => {
+    const out = parseReflection(
+      JSON.stringify({
+        ranking: [
+          { id: "c_4f2a", rank: 1, evidence: "used for the sidecar answer" },
+          { id: "c_91bd", rank: 2, evidence: "opened on a wrong guess", contradicts: "says X; source says Y" },
+        ],
+        gap: "provenance sidecar format",
+      }),
+      concepts,
+    );
+    expect(out.concepts[0].rank).toBe(1);
+    expect(out.concepts[1].contradicts).toBe("says X; source says Y");
+    expect(out.gap).toBe("provenance sidecar format");
+  });
+
+  test("a concept the model skipped stays unranked rather than disappearing", () => {
+    const out = parseReflection(
+      JSON.stringify({ ranking: [{ id: "c_4f2a", rank: 1 }], gap: null }),
+      concepts,
+    );
+    expect(out.concepts).toHaveLength(2);
+    expect(out.concepts[1].rank).toBeNull();
+    expect(out.gap).toBeNull();
+  });
+
+  test("ids the model invented are dropped", () => {
+    const out = parseReflection(
+      JSON.stringify({ ranking: [{ id: "c_does_not_exist", rank: 1 }] }),
+      concepts,
+    );
+    expect(out.concepts).toHaveLength(2);
+    expect(out.concepts.every((c) => c.rank === null)).toBe(true);
+  });
+
+  test("non-JSON output is kept as raw, with the read list intact", () => {
+    const out = parseReflection("The first concept was the useful one.", concepts);
+    expect(out.concepts).toHaveLength(2);
+    expect(out.raw).toBe("The first concept was the useful one.");
+  });
+});
+
+test.describe("the reflect turn itself", () => {
+  test("lists the concepts read, ids and names only", () => {
+    const turn = buildReflectTurn([
+      { id: "c_4f2a", ref_id: "ref-abc", name: "auth-session-lifecycle", via: "learn_concept" },
+    ]);
+    expect(turn.role).toBe("user");
+    expect(turn.content).toContain("c_4f2a");
+    expect(turn.content).toContain("auth-session-lifecycle");
+  });
+
+  test("a caller prompt replaces the instructions but keeps the concept list", () => {
+    const turn = buildReflectTurn(
+      [{ id: "c_4f2a", name: "auth", via: "learn_concept" }],
+      "Which of these would you keep?",
+    );
+    expect(turn.content).toContain("Which of these would you keep?");
+    expect(turn.content).toContain("c_4f2a");
+    expect(turn.content).not.toContain("REFLECTION");
+  });
+
+  test("reflect config accepts true or an object", () => {
+    expect(reflectEnabled(true)).toBe(true);
+    expect(reflectEnabled({ prompt: "hi" })).toBe(true);
+    expect(reflectEnabled(false)).toBe(false);
+    expect(reflectEnabled(undefined)).toBe(false);
+    expect(reflectPromptOverride({ prompt: "  hi  " })).toBe("hi");
+    expect(reflectPromptOverride(true)).toBeUndefined();
+    expect(reflectPromptOverride({ prompt: "   " })).toBeUndefined();
+  });
+});
+
+test.describe("the reflection sidecar", () => {
+  test("merges turns and never lets a failed reflect clobber a ranking", async () => {
+    const { mergeReflection, loadReflection } = await import("../session.js");
+    const sessionId = `sess-${randomUUID()}`;
+
+    mergeReflection(sessionId, {
+      concepts: [
+        { id: "c_4f2a", name: "auth", rank: 1, evidence: "load-bearing" },
+        { id: "c_91bd", name: "runs", rank: 2 },
+      ],
+      gap: "sidecar format",
+    });
+
+    // A later turn reads a third concept, but its reflect call fails — the
+    // reads still land, carrying no ranks of their own.
+    mergeReflection(sessionId, {
+      concepts: [
+        { id: "c_91bd", name: "runs", rank: null },
+        { id: "c_02e1", name: "ontology", rank: null },
+      ],
+    });
+
+    const saved = loadReflection(sessionId);
+    expect(saved?.concepts).toHaveLength(3);
+    const byId = Object.fromEntries((saved?.concepts ?? []).map((c) => [c.id, c]));
+    expect(byId["c_4f2a"].rank).toBe(1);
+    expect(byId["c_4f2a"].evidence).toBe("load-bearing");
+    expect(byId["c_91bd"].rank).toBe(2);
+    expect(byId["c_02e1"].rank).toBeNull();
+    // Unranked concepts sort after ranked ones.
+    expect(saved?.concepts[2].id).toBe("c_02e1");
+    expect(saved?.gap).toBe("sidecar format");
+  });
+
+  test("a ref_id-only record and a fuller one are the same concept", async () => {
+    const { mergeReflection, loadReflection } = await import("../session.js");
+    const sessionId = `sess-${randomUUID()}`;
+
+    mergeReflection(sessionId, {
+      concepts: [{ ref_id: "ref-abc", name: "auth", rank: 1, evidence: "used it" }],
+    });
+    mergeReflection(sessionId, {
+      concepts: [{ id: "c_4f2a", ref_id: "ref-abc", name: "auth", rank: null }],
+    });
+
+    const saved = loadReflection(sessionId);
+    expect(saved?.concepts).toHaveLength(1);
+    expect(saved?.concepts[0].id).toBe("c_4f2a");
+    expect(saved?.concepts[0].rank).toBe(1);
+    expect(saved?.concepts[0].evidence).toBe("used it");
+  });
+
+  test("a later ranking supersedes an earlier one", async () => {
+    const { mergeReflection, loadReflection } = await import("../session.js");
+    const sessionId = `sess-${randomUUID()}`;
+
+    mergeReflection(sessionId, { concepts: [{ id: "c_4f2a", rank: 1, evidence: "first pass" }] });
+    mergeReflection(sessionId, { concepts: [{ id: "c_4f2a", rank: 3, evidence: "second pass" }] });
+
+    const saved = loadReflection(sessionId);
+    expect(saved?.concepts[0].rank).toBe(3);
+    expect(saved?.concepts[0].evidence).toBe("second pass");
+  });
+
+  test("no sidecar for a session that read nothing", async () => {
+    const { loadReflection } = await import("../session.js");
+    expect(loadReflection(`sess-${randomUUID()}`)).toBeNull();
+  });
+});

--- a/mcp/src/repo/__tests__/concepts.test.ts
+++ b/mcp/src/repo/__tests__/concepts.test.ts
@@ -316,6 +316,20 @@ test.describe("the reflection sidecar", () => {
     expect(saved?.concepts[0].evidence).toBe("second pass");
   });
 
+  test("returns what it wrote, so the run result can carry it", async () => {
+    // ContextResult.reflection (and the /progress terminal payload) is this
+    // return value — a void merge would silently ship `undefined` to callers.
+    const { mergeReflection } = await import("../session.js");
+    const sessionId = `sess-${randomUUID()}`;
+    const returned = mergeReflection(sessionId, {
+      concepts: [{ ref_id: "ref-abc", name: "auth", rank: 1 }],
+      gap: null,
+    });
+    expect(returned.session_id).toBe(sessionId);
+    expect(returned.concepts).toHaveLength(1);
+    expect(returned.concepts[0].rank).toBe(1);
+  });
+
   test("no sidecar for a session that read nothing", async () => {
     const { loadReflection } = await import("../session.js");
     expect(loadReflection(`sess-${randomUUID()}`)).toBeNull();

--- a/mcp/src/repo/__tests__/concepts.test.ts
+++ b/mcp/src/repo/__tests__/concepts.test.ts
@@ -17,7 +17,21 @@ import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
 
-import {
+import type { ConceptCollector } from "../concepts.js";
+
+// session.ts reads SESSIONS_DIR once at module load, so it must be set before
+// anything that reaches session.ts is imported, and stay fixed for the
+// lifetime of the process.
+const tmpSessionsDir = path.join(os.tmpdir(), `test-concepts-${randomUUID()}`);
+fs.mkdirSync(tmpSessionsDir, { recursive: true });
+process.env.SESSIONS_DIR = tmpSessionsDir;
+process.env.NO_DB = "true";
+
+// Imported here, not at the top: concepts.ts reaches session.ts through
+// utils.ts, so a static import would bind SESSIONS_DIR to the real .sessions
+// directory before the override above ran — and these tests would write their
+// fixtures into it. (Type-only imports are erased, so they're safe up top.)
+const {
   conceptReadFrom,
   withConceptCollection,
   mergeConceptReads,
@@ -26,15 +40,7 @@ import {
   buildReflectTurn,
   reflectEnabled,
   reflectPromptOverride,
-  type ConceptCollector,
-} from "../concepts.js";
-
-// session.ts reads SESSIONS_DIR once at module load, so it must be set before
-// the dynamic import below and stay fixed for the lifetime of the process.
-const tmpSessionsDir = path.join(os.tmpdir(), `test-concepts-${randomUUID()}`);
-fs.mkdirSync(tmpSessionsDir, { recursive: true });
-process.env.SESSIONS_DIR = tmpSessionsDir;
-process.env.NO_DB = "true";
+} = await import("../concepts.js");
 
 /** A graph_get result for a Concept node, as the tool actually returns it. */
 function graphGetConcept(overrides: Record<string, any> = {}) {

--- a/mcp/src/repo/__tests__/concepts.test.ts
+++ b/mcp/src/repo/__tests__/concepts.test.ts
@@ -316,6 +316,61 @@ test.describe("the reflection sidecar", () => {
     expect(saved?.concepts[0].evidence).toBe("second pass");
   });
 
+  test("read order is assigned with no model involved", async () => {
+    const { mergeReflection, loadReflection } = await import("../session.js");
+    const sessionId = `sess-${randomUUID()}`;
+
+    // What a run without `reflect` produces: reads, no ranks.
+    mergeReflection(sessionId, {
+      concepts: [
+        { ref_id: "ref-a", name: "first", rank: null },
+        { ref_id: "ref-b", name: "second", rank: null },
+      ],
+    });
+
+    const saved = loadReflection(sessionId);
+    expect(saved?.concepts.map((c) => c.read_order)).toEqual([1, 2]);
+    expect(saved?.concepts.every((c) => c.rank === null)).toBe(true);
+  });
+
+  test("later turns append without renumbering earlier reads", async () => {
+    const { mergeReflection, loadReflection } = await import("../session.js");
+    const sessionId = `sess-${randomUUID()}`;
+
+    mergeReflection(sessionId, { concepts: [{ ref_id: "ref-a", rank: null }] });
+    mergeReflection(sessionId, {
+      concepts: [
+        { ref_id: "ref-a", rank: null }, // re-read: keeps its position
+        { ref_id: "ref-b", rank: null },
+      ],
+    });
+
+    const saved = loadReflection(sessionId);
+    const byRef = Object.fromEntries((saved?.concepts ?? []).map((c) => [c.ref_id, c]));
+    expect(byRef["ref-a"].read_order).toBe(1);
+    expect(byRef["ref-b"].read_order).toBe(2);
+  });
+
+  test("a reflect-off turn doesn't disturb ranks an earlier reflect produced", async () => {
+    const { mergeReflection, loadReflection } = await import("../session.js");
+    const sessionId = `sess-${randomUUID()}`;
+
+    mergeReflection(sessionId, {
+      concepts: [
+        { ref_id: "ref-a", rank: 2, evidence: "some help" },
+        { ref_id: "ref-b", rank: 1, evidence: "decisive" },
+      ],
+    });
+    mergeReflection(sessionId, { concepts: [{ ref_id: "ref-c", rank: null }] });
+
+    const saved = loadReflection(sessionId);
+    // Judged concepts stay ordered by rank; the new read falls in behind them.
+    expect(saved?.concepts.map((c) => c.ref_id)).toEqual(["ref-b", "ref-a", "ref-c"]);
+    expect(saved?.concepts[0].rank).toBe(1);
+    expect(saved?.concepts[2].rank).toBeNull();
+    expect(saved?.concepts[2].read_order).toBe(3);
+  });
+
   test("returns what it wrote, so the run result can carry it", async () => {
     // ContextResult.reflection (and the /progress terminal payload) is this
     // return value — a void merge would silently ship `undefined` to callers.

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -19,6 +19,15 @@ import {
   withProviderCacheUsage,
 } from "../aieo/src/index.js";
 import { get_tools, ToolsConfig, SkillsConfig, GgnnConfig, MessagesRef, ProvenanceCollector, toolConfigEnabled, redactToolsConfig } from "./tools.js";
+import {
+  withConceptCollection,
+  normalizeConceptReads,
+  runReflection,
+  reflectEnabled,
+  reflectPromptOverride,
+  type ConceptCollector,
+  type ReflectConfig,
+} from "./concepts.js";
 import { SKILLS, enabledEntries, renderSkillIndex } from "./skills.js";
 import { type SubAgent, subAgentRepoNames } from "./subagent.js";
 import { ContextResult } from "../tools/types.js";
@@ -53,6 +62,7 @@ import {
   sessionExists,
   saveSessionConfig,
   saveSessionMetadata,
+  mergeReflection,
   SessionConfig,
   StepMeta,
 } from "./session.js";
@@ -469,6 +479,12 @@ export interface GetContextOptions {
   commitList?: string[];
   // Skip prepending repo info to the first prompt (handler-level; recorded in config)
   ignoreRepoInfo?: boolean;
+  // Concept reflection. Concepts a run READ are always recorded to the
+  // session's reflection sidecar; this opt-in additionally asks the agent,
+  // once the run is over, to rank them by how load-bearing they were.
+  // `{ prompt }` overrides the instruction text — the list of concepts read
+  // is appended by us either way, since a caller can't know what was read.
+  reflect?: ReflectConfig;
   // Replay mode: `prompt` is a full ModelMessage[] (including the system turn)
   // that is run verbatim. No system prompt is generated, no enrichment blocks
   // are appended, no session history is loaded, no attachments are resolved,
@@ -497,8 +513,13 @@ interface PreparedAgent {
   // the escape hatch offered in the continuation nudge.
   askQuestionsEnabled: boolean;
   provenanceCollector: ProvenanceCollector;
+  conceptCollector: ConceptCollector;
   abortSignal: AbortSignal | undefined;
   mcpClients: McpToolsResult["clients"];
+  // The run's system prompt and tool set, kept so the reflect pass can re-send
+  // them byte-identical and hit the provider's prompt cache.
+  instructions: string | undefined;
+  tools: ToolSet;
 }
 
 /**
@@ -596,6 +617,13 @@ async function prepareAgent(
     // Detect any "*_org_agent" tools (e.g. stakwork_org_agent, evanfeenstra_org_agent)
     orgAgentToolNames = Object.keys(mcpResult.tools).filter(name => /_org_agent$/i.test(name));
   }
+
+  // Record every gitree Concept whose body a tool hands back. Wrapping the
+  // assembled tool set here (rather than threading a collector through
+  // get_tools' argument list) keeps the concern in one place; the wrapper
+  // preserves each tool's description, which the session config reads below.
+  const conceptCollector: ConceptCollector = { reads: [] };
+  tools = withConceptCollection(tools, conceptCollector) as typeof tools;
 
   let instructions = systemOverride
     ? `${systemOverride}\n\n${SYSTEM_PROMPT_END(false)}`
@@ -752,6 +780,7 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
         ontologyDomains: opts.ontologyDomains,
         commitList: opts.commitList,
         ignoreRepoInfo: opts.ignoreRepoInfo,
+        reflect: opts.reflect,
       });
       hasSystemTurn = true;
     }
@@ -910,9 +939,92 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
     messagesRef,
     askQuestionsEnabled,
     provenanceCollector,
+    conceptCollector,
     abortSignal: opts.abortSignal,
     mcpClients,
+    instructions: transparent ? undefined : instructions,
+    tools,
   };
+}
+
+/**
+ * Record which gitree Concepts this run read, and — when `reflect` is on —
+ * ask the agent to rank them.
+ *
+ * Called after the session has been persisted, so it is the last thing a run
+ * does. Two properties it must keep:
+ *
+ *  - The deterministic half survives the model half. The read list is written
+ *    whether or not `reflect` is set and whether or not the reflect call
+ *    succeeds; a failed call leaves any ranking from a previous turn intact.
+ *  - It never fails the run. The answer has already been produced (and in the
+ *    streaming path, already delivered), so every error here is logged and
+ *    swallowed.
+ *
+ * `messages` must be the MODEL-facing transcript, not the stored one: with
+ * `truncateToolResults` on, the persisted copy is lossy, and any divergence
+ * from what was actually sent costs the prompt-cache hit that makes replaying
+ * the transcript affordable.
+ */
+async function reflectOnConcepts(
+  prepared: PreparedAgent,
+  opts: GetContextOptions,
+  messages: ModelMessage[],
+): Promise<void> {
+  const { sessionId, conceptCollector } = prepared;
+  if (!sessionId || conceptCollector.reads.length === 0) return;
+
+  // A single repo scopes the id lookup; with several in play, resolve against
+  // every concept the graph holds.
+  const repo = opts.repos?.length === 1 ? opts.repos[0] : undefined;
+  let concepts: Awaited<ReturnType<typeof normalizeConceptReads>>;
+  try {
+    concepts = await normalizeConceptReads(conceptCollector.reads, repo);
+  } catch (e) {
+    console.error("[concepts] could not normalize concept reads:", e);
+    return;
+  }
+  if (concepts.length === 0) return;
+
+  const unranked = concepts.map((c) => ({
+    id: c.id,
+    ref_id: c.ref_id,
+    repo: c.repo,
+    name: c.name,
+    rank: null,
+  }));
+
+  if (!reflectEnabled(opts.reflect)) {
+    try {
+      mergeReflection(sessionId, { concepts: unranked });
+    } catch (e) {
+      console.error("[concepts] could not record concept reads:", e);
+    }
+    return;
+  }
+
+  try {
+    console.log(`===> reflecting on ${concepts.length} concept(s) for session ${sessionId}`);
+    const result = await runReflection({
+      model: prepared.model,
+      modelId: prepared.modelId,
+      provider: prepared.provider,
+      system: prepared.instructions,
+      tools: prepared.tools as Record<string, any>,
+      messages,
+      concepts,
+      promptOverride: reflectPromptOverride(opts.reflect),
+    });
+    mergeReflection(sessionId, result);
+  } catch (e) {
+    console.error("[concepts] reflection failed:", e);
+    // The ranking is the optional half — keep the read record regardless.
+    try {
+      mergeReflection(sessionId, { concepts: unranked });
+    } catch (inner) {
+      console.error("[concepts] could not record concept reads:", inner);
+    }
+  }
 }
 
 /**
@@ -1025,6 +1137,8 @@ export async function get_context(
 
   let steps: Awaited<ReturnType<typeof agent.generate>>["steps"] = [];
   let streamTotalUsage: LanguageModelUsage | undefined;
+  // The exact conversation the model last saw, for the post-run reflect pass.
+  let modelFacingMessages: ModelMessage[] = [];
   // Each segment pairs the user-facing message that started it (the real user
   // message, then continuation nudges) with the steps it produced, so session
   // persistence can interleave them faithfully. priorMessages holds messages
@@ -1166,6 +1280,12 @@ export async function get_context(
     }
 
     steps = segments.flatMap((s) => s.steps);
+    // The final call's own messages plus what it generated — byte-identical to
+    // what the provider cached, unlike the (possibly truncated) stored copy.
+    modelFacingMessages = [
+      ...sent,
+      ...(((await run.streamResult.response)?.messages ?? []) as ModelMessage[]),
+    ];
   } catch (err) {
     const aborted = isAbortError(err);
     // Surface the API's error detail: some failures (e.g. 400s) carry only a
@@ -1227,6 +1347,7 @@ export async function get_context(
       status: "success",
       token_usage: usage,
     });
+    await reflectOnConcepts(prepared, opts, modelFacingMessages);
   }
 
   const final = extractFinalAnswer(steps);
@@ -1322,6 +1443,20 @@ export async function stream_context(
           status: "success",
           token_usage: stepUsage,
         });
+        // The stream is already consumed and the answer already delivered, so
+        // the reflect call costs the caller no latency — and the provider's
+        // cache of this transcript is still warm. Kept in its own try so a
+        // failure here is never reported as a session-persistence failure.
+        try {
+          const responseMessages =
+            ((await (streamResult as any).response)?.messages ?? []) as ModelMessage[];
+          await reflectOnConcepts(prepared, opts, [
+            ...initialModelMessages(prepared),
+            ...responseMessages,
+          ]);
+        } catch (e) {
+          console.error("[concepts] could not assemble transcript for reflection:", e);
+        }
       } catch (e) {
         const aborted = isAbortError(e);
         enrichErrorMessage(e);

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -65,6 +65,7 @@ import {
   mergeReflection,
   SessionConfig,
   StepMeta,
+  type SessionReflection,
 } from "./session.js";
 import { McpServer, getMcpTools, McpToolsResult } from "./mcpServers.js";
 import type { GoogleSheetsToolsOptions } from "./toolsGoogleSheets.js";
@@ -970,9 +971,9 @@ async function reflectOnConcepts(
   prepared: PreparedAgent,
   opts: GetContextOptions,
   messages: ModelMessage[],
-): Promise<void> {
+): Promise<SessionReflection | undefined> {
   const { sessionId, conceptCollector } = prepared;
-  if (!sessionId || conceptCollector.reads.length === 0) return;
+  if (!sessionId || conceptCollector.reads.length === 0) return undefined;
 
   // A single repo scopes the id lookup; with several in play, resolve against
   // every concept the graph holds.
@@ -982,9 +983,9 @@ async function reflectOnConcepts(
     concepts = await normalizeConceptReads(conceptCollector.reads, repo);
   } catch (e) {
     console.error("[concepts] could not normalize concept reads:", e);
-    return;
+    return undefined;
   }
-  if (concepts.length === 0) return;
+  if (concepts.length === 0) return undefined;
 
   const unranked = concepts.map((c) => ({
     id: c.id,
@@ -993,15 +994,16 @@ async function reflectOnConcepts(
     name: c.name,
     rank: null,
   }));
-
-  if (!reflectEnabled(opts.reflect)) {
+  const recordReadsOnly = (): SessionReflection | undefined => {
     try {
-      mergeReflection(sessionId, { concepts: unranked });
+      return mergeReflection(sessionId, { concepts: unranked });
     } catch (e) {
       console.error("[concepts] could not record concept reads:", e);
+      return undefined;
     }
-    return;
-  }
+  };
+
+  if (!reflectEnabled(opts.reflect)) return recordReadsOnly();
 
   try {
     console.log(`===> reflecting on ${concepts.length} concept(s) for session ${sessionId}`);
@@ -1015,15 +1017,11 @@ async function reflectOnConcepts(
       concepts,
       promptOverride: reflectPromptOverride(opts.reflect),
     });
-    mergeReflection(sessionId, result);
+    return mergeReflection(sessionId, result);
   } catch (e) {
     console.error("[concepts] reflection failed:", e);
     // The ranking is the optional half — keep the read record regardless.
-    try {
-      mergeReflection(sessionId, { concepts: unranked });
-    } catch (inner) {
-      console.error("[concepts] could not record concept reads:", inner);
-    }
+    return recordReadsOnly();
   }
 }
 
@@ -1139,6 +1137,7 @@ export async function get_context(
   let streamTotalUsage: LanguageModelUsage | undefined;
   // The exact conversation the model last saw, for the post-run reflect pass.
   let modelFacingMessages: ModelMessage[] = [];
+  let reflection: SessionReflection | undefined;
   // Each segment pairs the user-facing message that started it (the real user
   // message, then continuation nudges) with the steps it produced, so session
   // persistence can interleave them faithfully. priorMessages holds messages
@@ -1347,7 +1346,7 @@ export async function get_context(
       status: "success",
       token_usage: usage,
     });
-    await reflectOnConcepts(prepared, opts, modelFacingMessages);
+    reflection = await reflectOnConcepts(prepared, opts, modelFacingMessages);
   }
 
   const final = extractFinalAnswer(steps);
@@ -1380,6 +1379,7 @@ export async function get_context(
     },
     logs: opts.logs ? JSON.stringify(steps, null, 2) : undefined,
     sessionId,
+    reflection,
   };
 }
 

--- a/mcp/src/repo/conceptBackfill.ts
+++ b/mcp/src/repo/conceptBackfill.ts
@@ -1,0 +1,205 @@
+import { ModelMessage } from "ai";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { listConcepts } from "../gitree/service.js";
+import {
+  listSessionFiles,
+  loadSession,
+  loadSessionConfig,
+  loadReflection,
+  mergeReflection,
+  sessionsDirFile,
+} from "./session.js";
+import { mergeConceptReads, type ConceptIdentity, type ConceptRead } from "./concepts.js";
+
+/**
+ * One-off backfill of the observed half of the concept record.
+ *
+ * Which Concepts a session read is recoverable from its stored transcript, so
+ * sessions that ran before collection existed can be filled in after the fact.
+ * Only the observed half — read set and read order. Ranking is deliberately
+ * not backfilled: those transcripts are long cold, so a reflect pass would pay
+ * full input price for a judgement made days after the fact.
+ *
+ * Runs from the startup task block. Safe to call on every boot: a marker file
+ * records how far it got, and sessions that already have a reflection sidecar
+ * are never touched, so live-collected data can't be overwritten.
+ */
+
+const MARKER = ".concept-backfill.json";
+/** How far back to look. Sessions older than this are left alone. */
+const DEFAULT_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+interface Marker {
+  completed_at: string;
+  /** Sessions last written at or before this are done; newer ones aren't. */
+  through_mtime: number;
+}
+
+function readMarker(): Marker | null {
+  try {
+    const filePath = sessionsDirFile(MARKER);
+    if (!existsSync(filePath)) return null;
+    return JSON.parse(readFileSync(filePath, "utf-8")) as Marker;
+  } catch {
+    return null;
+  }
+}
+
+function writeMarker(through_mtime: number): void {
+  try {
+    const marker: Marker = {
+      completed_at: new Date().toISOString(),
+      through_mtime,
+    };
+    writeFileSync(sessionsDirFile(MARKER), JSON.stringify(marker, null, 2));
+  } catch (e) {
+    console.error("[concept-backfill] could not write marker:", e);
+  }
+}
+
+/** Tool calls whose INPUT names a concept the agent went on to read. */
+const READ_TOOL_INPUTS: Record<string, "id" | "ref_id"> = {
+  learn_concept: "id",
+  graph_get: "ref_id",
+};
+
+/**
+ * Pull concept reads out of a stored transcript, in call order.
+ *
+ * Reads the tool-call INPUTS rather than the results, because a session that
+ * ran with `truncateToolResults` has a clipped `graph_get` body that may not
+ * parse — inputs are never truncated. The cost is that the input alone can't
+ * say whether a ref_id belongs to a Concept or a Function, so the caller must
+ * intersect these against the catalog before recording any of them.
+ */
+export function conceptReadsFromTranscript(messages: ModelMessage[]): ConceptRead[] {
+  const reads: ConceptRead[] = [];
+  for (const message of messages) {
+    if (message.role !== "assistant" || !Array.isArray(message.content)) continue;
+    for (const part of message.content as any[]) {
+      if (part?.type !== "tool-call") continue;
+      const field = READ_TOOL_INPUTS[part.toolName];
+      if (!field) continue;
+      const value = part.input?.[field === "id" ? "concept_id" : "ref_id"];
+      if (typeof value !== "string" || !value) continue;
+      reads.push({ [field]: value, via: part.toolName } as ConceptRead);
+    }
+  }
+  return reads;
+}
+
+/**
+ * Keep only the reads the catalog confirms are Concepts, then normalize them.
+ *
+ * This is where backfill differs from live collection, and it's the step that
+ * keeps it honest: a `graph_get` input alone can't say whether a ref_id names
+ * a Concept or a Function, so anything the catalog doesn't know is dropped
+ * rather than recorded. The live path has the node type in the tool result and
+ * needs no catalog to be sure.
+ *
+ * The trade is that a concept deleted since the run is unrecoverable, so a
+ * backfilled session can undercount. It never over-counts.
+ */
+export function confirmConceptReads(
+  candidates: ConceptRead[],
+  catalog: ConceptIdentity[],
+): ConceptRead[] {
+  const known = new Set<string>();
+  for (const c of catalog) {
+    if (c.id) known.add(c.id);
+    if (c.ref_id) known.add(c.ref_id);
+  }
+  const confirmed = candidates.filter(
+    (r) => (r.id && known.has(r.id)) || (r.ref_id && known.has(r.ref_id)),
+  );
+  return confirmed.length > 0 ? mergeConceptReads(confirmed, catalog) : [];
+}
+
+/** Catalog lookups are per-repo and reused across every session in the sweep. */
+async function catalogFor(
+  repo: string | undefined,
+  cache: Map<string, ConceptIdentity[]>,
+): Promise<ConceptIdentity[]> {
+  const key = repo ?? "*";
+  const cached = cache.get(key);
+  if (cached) return cached;
+  const { concepts } = await listConcepts(repo);
+  cache.set(key, concepts);
+  return concepts;
+}
+
+export async function backfillConceptReads(
+  windowMs: number = DEFAULT_WINDOW_MS,
+): Promise<{ scanned: number; written: number; concepts: number }> {
+  const marker = readMarker();
+  const floor = Math.max(marker?.through_mtime ?? 0, Date.now() - windowMs);
+  // Oldest first, so the high-water mark can stop at the first session that
+  // failed and everything after it is retried on the next boot.
+  const sessions = listSessionFiles()
+    .filter((s) => s.mtimeMs > floor)
+    .sort((a, b) => a.mtimeMs - b.mtimeMs);
+  if (sessions.length === 0) {
+    return { scanned: 0, written: 0, concepts: 0 };
+  }
+
+  console.log(`[concept-backfill] scanning ${sessions.length} session(s)`);
+  const catalogCache = new Map<string, ConceptIdentity[]>();
+  let written = 0;
+  let conceptCount = 0;
+  let highWater = floor;
+  let stalled = false;
+  const advance = (mtimeMs: number) => {
+    if (!stalled) highWater = mtimeMs;
+  };
+
+  for (const session of sessions) {
+    try {
+      // Never overwrite a sidecar the live path already produced.
+      if (loadReflection(session.sessionId)) {
+        advance(session.mtimeMs);
+        continue;
+      }
+      const candidates = conceptReadsFromTranscript(loadSession(session.sessionId));
+      if (candidates.length === 0) {
+        advance(session.mtimeMs);
+        continue;
+      }
+
+      const config = loadSessionConfig(session.sessionId);
+      const repo = config?.repos?.length === 1 ? config.repos[0] : undefined;
+      const catalog = await catalogFor(repo, catalogCache);
+
+      const concepts = confirmConceptReads(candidates, catalog);
+      if (concepts.length === 0) {
+        advance(session.mtimeMs);
+        continue;
+      }
+
+      mergeReflection(session.sessionId, {
+        concepts: concepts.map((c) => ({
+          id: c.id,
+          ref_id: c.ref_id,
+          repo: c.repo,
+          name: c.name,
+          rank: null,
+        })),
+      });
+      written++;
+      conceptCount += concepts.length;
+      advance(session.mtimeMs);
+    } catch (e) {
+      // One bad session must not sink the sweep, but the marker must not move
+      // past it either — a Neo4j blip mid-sweep would otherwise mark every
+      // remaining session done without ever having read it. Keep going to
+      // salvage what we can; leave the mark where it was.
+      stalled = true;
+      console.error(`[concept-backfill] session ${session.sessionId} failed:`, e);
+    }
+  }
+
+  writeMarker(highWater);
+  console.log(
+    `[concept-backfill] wrote ${written} sidecar(s) covering ${conceptCount} concept read(s)`,
+  );
+  return { scanned: sessions.length, written, concepts: conceptCount };
+}

--- a/mcp/src/repo/concepts.ts
+++ b/mcp/src/repo/concepts.ts
@@ -1,0 +1,365 @@
+import { generateText, ModelMessage, LanguageModel, type Tool } from "ai";
+import { listConcepts } from "../gitree/service.js";
+import { getProviderOptions } from "../aieo/src/index.js";
+import { extractLeadingJsonObject, maxOutputTokensFor } from "./utils.js";
+import type { ReflectedConcept } from "./session.js";
+
+/**
+ * Concept reflection.
+ *
+ * Two halves, deliberately kept separate so a bad model turn never costs us
+ * the hard data:
+ *
+ *  1. Collection (deterministic) — which gitree Concepts the agent actually
+ *     READ during a run. Recorded from tool results, not from the model.
+ *  2. Reflection (opt-in, `reflect`) — one extra call appended to the finished
+ *     transcript asking the agent to rank those concepts by how load-bearing
+ *     they were. Runs immediately after the run ends, while the provider's
+ *     prompt cache is still warm, so the transcript re-read is ~0.1x input
+ *     price.
+ */
+
+/** Caller config for the `reflect` request field: `true` or an object. */
+export type ReflectConfig = boolean | { prompt?: string };
+
+export function reflectEnabled(reflect?: ReflectConfig): boolean {
+  if (reflect === true) return true;
+  if (reflect && typeof reflect === "object") return true;
+  return false;
+}
+
+export function reflectPromptOverride(reflect?: ReflectConfig): string | undefined {
+  if (reflect && typeof reflect === "object" && typeof reflect.prompt === "string") {
+    const trimmed = reflect.prompt.trim();
+    if (trimmed) return trimmed;
+  }
+  return undefined;
+}
+
+/** One read of a Concept's body during a run. */
+export interface ConceptRead {
+  /** gitree concept id (what `learn_concept` takes). */
+  id?: string;
+  /** Graph ref_id (what `graph_get` takes). */
+  ref_id?: string;
+  name?: string;
+  repo?: string;
+  /** Raw tool name the read came through, e.g. "learn_concept" | "graph_get". */
+  via: string;
+}
+
+export interface ConceptCollector {
+  reads: ConceptRead[];
+}
+
+/**
+ * Tools that return a Concept's BODY. Deliberately excludes `graph_search` /
+ * `graph_neighbors` / `list_concepts`: those surface a name and description
+ * without the documentation, and `list_concepts` returns the whole catalog, so
+ * appearing in one says nothing about what the agent chose to read.
+ */
+const CONCEPT_READ_TOOLS = ["learn_concept", "graph_get"];
+
+function parseMaybeJson(result: unknown): any {
+  if (typeof result === "string") {
+    try {
+      return JSON.parse(result);
+    } catch {
+      return null;
+    }
+  }
+  return result;
+}
+
+/**
+ * Pull a Concept read out of one tool result, or null if it wasn't one.
+ *
+ * Keyed off the RESULT rather than the tool name wherever possible: the graph
+ * tools stamp `node_type` on what they return, so a new tool that resolves
+ * nodes is picked up by adding its name to CONCEPT_READ_TOOLS, with no new
+ * shape-specific parsing.
+ */
+export function conceptReadFrom(
+  toolName: string,
+  input: any,
+  result: unknown,
+): ConceptRead | null {
+  const parsed = parseMaybeJson(result);
+  if (!parsed || typeof parsed !== "object") return null;
+  if (parsed.error) return null;
+
+  if (parsed.node_type === "Concept") {
+    if (!parsed.ref_id) return null;
+    return {
+      ref_id: parsed.ref_id,
+      id: parsed.properties?.id,
+      name: parsed.name ?? parsed.properties?.name,
+      repo: parsed.properties?.repo,
+      via: toolName,
+    };
+  }
+
+  // learn_concept resolves through gitree rather than the graph, so it returns
+  // documentation with no node_type. Its input carries the id.
+  if (toolName === "learn_concept") {
+    const id = parsed.id ?? input?.concept_id;
+    if (!id) return null;
+    if (!parsed.documentation && !parsed.description) return null;
+    return { id, name: parsed.name, via: toolName };
+  }
+
+  return null;
+}
+
+/**
+ * Wrap the concept-reading tools so every read is recorded as it happens.
+ *
+ * Returns a new tool map — the originals are not mutated. Collection is
+ * best-effort: a throw inside the recorder must never fail the tool call the
+ * agent is actually making.
+ */
+export function withConceptCollection(
+  tools: Record<string, Tool<any, any>>,
+  collector: ConceptCollector,
+): Record<string, Tool<any, any>> {
+  const wrapped: Record<string, Tool<any, any>> = { ...tools };
+  for (const name of CONCEPT_READ_TOOLS) {
+    const original = tools[name];
+    if (!original || typeof (original as any).execute !== "function") continue;
+    const execute = (original as any).execute.bind(original);
+    wrapped[name] = {
+      ...original,
+      execute: async (input: any, options: any) => {
+        const result = await execute(input, options);
+        try {
+          const read = conceptReadFrom(name, input, result);
+          if (read) collector.reads.push(read);
+        } catch (e) {
+          console.error(`[concepts] failed to record ${name} read:`, e);
+        }
+        return result;
+      },
+    } as Tool<any, any>;
+  }
+  return wrapped;
+}
+
+/**
+ * Identity for merging, both within a run and across the turns of a session.
+ *
+ * `ref_id` leads because it is the identifier the node itself always carries:
+ * a Concept created directly in the graph has no gitree `id` at all, and a
+ * `learn_concept` read only gains a ref_id once the catalog resolves it. Under
+ * an id-first key, a concept recorded as ref_id-only on one turn (catalog
+ * lookup failed) and as id+ref_id on the next would land in the sidecar twice.
+ */
+export function conceptKey(c: { id?: string; ref_id?: string; name?: string }): string {
+  return c.ref_id ?? c.id ?? c.name ?? "";
+}
+
+/** One concept as the catalog knows it, carrying both identifiers. */
+export interface ConceptIdentity {
+  id?: string;
+  ref_id?: string;
+  name?: string;
+  repo?: string;
+}
+
+/**
+ * Collapse raw reads into one entry per concept, resolving both identifiers
+ * against a catalog.
+ *
+ * The two read paths key on different things — `learn_concept` on gitree's
+ * `id`, `graph_get` on the graph `ref_id` — so the same concept reached both
+ * ways arrives as two entries with no overlapping key. The catalog is what
+ * lets them collapse; without it the ranking list shows the same concept
+ * twice and every downstream count is inflated.
+ *
+ * Pure, so the merge is testable without a graph. `normalizeConceptReads`
+ * supplies the real catalog.
+ */
+export function mergeConceptReads(
+  reads: ConceptRead[],
+  catalog: ConceptIdentity[],
+): ConceptRead[] {
+  const byId = new Map<string, ConceptIdentity>();
+  const byRefId = new Map<string, ConceptIdentity>();
+  for (const c of catalog) {
+    if (c.id) byId.set(c.id, c);
+    if (c.ref_id) byRefId.set(c.ref_id, c);
+  }
+
+  const merged = new Map<string, ConceptRead>();
+  for (const read of reads) {
+    const known =
+      (read.id ? byId.get(read.id) : undefined) ??
+      (read.ref_id ? byRefId.get(read.ref_id) : undefined);
+    const resolved: ConceptRead = {
+      id: known?.id ?? read.id,
+      ref_id: known?.ref_id ?? read.ref_id,
+      name: known?.name ?? read.name,
+      repo: known?.repo ?? read.repo,
+      via: read.via,
+    };
+    const key = conceptKey(resolved);
+    if (!key) continue;
+    const prev = merged.get(key);
+    if (prev) {
+      if (prev.via !== resolved.via) prev.via = `${prev.via},${resolved.via}`;
+      continue;
+    }
+    merged.set(key, resolved);
+  }
+  return [...merged.values()];
+}
+
+/**
+ * Resolve reads against the live concept catalog.
+ *
+ * Best-effort: if the catalog lookup fails, reads are still returned, deduped
+ * on whichever key each one already has. A run's concept record is worth
+ * keeping even when it can't be fully cross-referenced.
+ */
+export async function normalizeConceptReads(
+  reads: ConceptRead[],
+  repo?: string,
+): Promise<ConceptRead[]> {
+  if (reads.length === 0) return [];
+  let catalog: ConceptIdentity[] = [];
+  try {
+    catalog = (await listConcepts(repo)).concepts;
+  } catch (e) {
+    console.error("[concepts] could not load concept list for normalization:", e);
+  }
+  return mergeConceptReads(reads, catalog);
+}
+
+const DEFAULT_REFLECT_PROMPT = `REFLECTION — a review turn on the work you just finished. Do not call any tools. Answer with JSON only.
+
+1. Rank the concepts listed below from most to least load-bearing for the answer you gave, and for each give one line of evidence: where you used it and what it changed. A concept you read and never ended up using is a useful answer, not a failure — say so plainly.
+2. Did anything you read in those concepts contradict what you found in the source? If so, quote both sides in \`contradicts\`. Omit the field when nothing did.
+3. Was there anything you had to work out from the source that one of these concepts should have covered? Put it in \`gap\` as one sentence, or null.
+
+Respond with JSON and nothing else:
+{"ranking":[{"id":"<id>","rank":1,"evidence":"...","contradicts":"..."}],"gap":"..." or null}`;
+
+/**
+ * The identifier to show the model for one concept.
+ *
+ * Deliberately not the storage key: this is the id the agent actually passed
+ * or saw during the run — `learn_concept` takes gitree's id, the graph tools
+ * take ref_id — so the entry is recognizable to it. `parseReflection` accepts
+ * either identifier back, so a mismatch costs nothing.
+ */
+function displayId(c: ConceptRead): string {
+  if (c.via.includes("learn_concept")) return c.id ?? c.ref_id ?? "";
+  return c.ref_id ?? c.id ?? "";
+}
+
+/**
+ * Build the single user turn appended to the finished transcript.
+ *
+ * The concept list is always appended by us, including under a caller-supplied
+ * prompt: the caller has no way of knowing which concepts a run read, so it
+ * can't supply this part itself.
+ */
+export function buildReflectTurn(
+  concepts: ConceptRead[],
+  promptOverride?: string,
+): ModelMessage {
+  const list = concepts.map((c) => `  ${displayId(c)}  ${c.name ?? "(unnamed)"}`).join("\n");
+  return {
+    role: "user",
+    content: `${promptOverride ?? DEFAULT_REFLECT_PROMPT}\n\nConcepts you read this session:\n${list}`,
+  };
+}
+
+/**
+ * Parse the reflect turn's output onto the concepts we know were read.
+ *
+ * Lenient by design. The ranking is only ever an overlay on the deterministic
+ * read list: ids the model invented are dropped, ids it omitted stay with
+ * `rank: null`, and text that isn't JSON at all (likely under a custom prompt)
+ * is preserved as `raw` instead of being thrown away.
+ */
+export function parseReflection(
+  text: string,
+  concepts: ConceptRead[],
+): { concepts: ReflectedConcept[]; gap: string | null; raw?: string } {
+  const base: ReflectedConcept[] = concepts.map((c) => ({
+    id: c.id,
+    ref_id: c.ref_id,
+    repo: c.repo,
+    name: c.name,
+    rank: null,
+  }));
+
+  const parsed = extractLeadingJsonObject(text);
+  const ranking = Array.isArray(parsed?.ranking) ? parsed.ranking : null;
+  if (!ranking) {
+    return { concepts: base, gap: null, raw: text.trim() || undefined };
+  }
+
+  const byKey = new Map<string, ReflectedConcept>();
+  for (const c of base) {
+    if (c.id) byKey.set(c.id, c);
+    if (c.ref_id) byKey.set(c.ref_id, c);
+  }
+  for (const entry of ranking) {
+    const target = byKey.get(entry?.id) ?? byKey.get(entry?.ref_id);
+    if (!target) continue;
+    const rank = Number(entry?.rank);
+    if (Number.isFinite(rank)) target.rank = rank;
+    if (typeof entry?.evidence === "string") target.evidence = entry.evidence;
+    if (typeof entry?.contradicts === "string" && entry.contradicts.trim()) {
+      target.contradicts = entry.contradicts;
+    }
+  }
+
+  const gap = typeof parsed?.gap === "string" && parsed.gap.trim() ? parsed.gap : null;
+  return { concepts: base, gap };
+}
+
+export interface ReflectRunArgs {
+  model: LanguageModel;
+  modelId: string;
+  provider: string;
+  /** The run's system prompt, byte-identical. */
+  system: string | undefined;
+  /** The run's tool set, byte-identical. */
+  tools: Record<string, Tool<any, any>>;
+  /** The full model-facing transcript of the finished run. */
+  messages: ModelMessage[];
+  concepts: ConceptRead[];
+  promptOverride?: string;
+}
+
+/**
+ * Run the reflect call against the finished transcript.
+ *
+ * Everything before the appended turn is sent byte-identical to what the run
+ * itself sent — same tools, same system prompt, same provider options — so the
+ * provider serves it from cache. That is what makes replaying a long transcript
+ * affordable, and it is fragile in a specific way: changing the tool set
+ * invalidates the whole prefix, and changing `tool_choice` or the thinking
+ * setting invalidates the messages half of it (which is nearly all of a long
+ * agentic run). So the model is told not to call tools rather than being
+ * prevented from doing so.
+ */
+export async function runReflection(args: ReflectRunArgs): Promise<{
+  concepts: ReflectedConcept[];
+  gap: string | null;
+  raw?: string;
+}> {
+  const { model, modelId, provider, system, tools, messages, concepts } = args;
+  const providerOptions = getProviderOptions(provider as any, undefined, modelId);
+  const result = await generateText({
+    model,
+    ...(system ? { system } : {}),
+    messages: [...messages, buildReflectTurn(concepts, args.promptOverride)],
+    tools,
+    providerOptions: providerOptions as any,
+    maxOutputTokens: maxOutputTokensFor(provider),
+  });
+  return parseReflection(result.text ?? "", concepts);
+}

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -12,7 +12,7 @@ import { startTracking, endTracking } from "../busy.js";
 import { services_agent } from "./services.js";
 import { mocks_agent } from "./mocks.js";
 import { ModelName } from "../aieo/src/index.js";
-import { SessionConfig, loadSession, loadSessionConfig, loadSessionMetadata, sessionExists } from "./session.js";
+import { SessionConfig, loadSession, loadSessionConfig, loadSessionMetadata, loadReflection, sessionExists } from "./session.js";
 import { McpServer } from "./mcpServers.js";
 import { existsSync } from "fs";
 import path from "path";
@@ -196,6 +196,7 @@ function parseAgentBody(req: Request) {
       )
     : undefined;
   const _metadata = req.body._metadata as unknown;
+  const reflect = normalizeReflect(req.body.reflect);
   // Optional terminal-result callback (non-streaming path only). When set,
   // the run's terminal payload — the same shape GET /progress serves, plus
   // request_id — is POSTed to this URL on completion/failure, so callers
@@ -214,10 +215,25 @@ function parseAgentBody(req: Request) {
     repoUrl, username, pat, commitList, prompt, messages, toolsConfig, schema,
     modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, mcpServers,
     systemOverride, mode, skills, ontologyDomains, subAgents, ggnn, stream, repoList, maxTurns, headers,
-    ignoreRepoInfo, attachments, _metadata, webhookUrl,
+    ignoreRepoInfo, attachments, _metadata, webhookUrl, reflect,
     stakwork: stakworkApiKey ? { apiKey: stakworkApiKey, baseUrl: stakworkBaseUrl } : undefined,
     googleSheets,
   };
+}
+
+/**
+ * Coerce a request-body `reflect` value. Accepts `true` or `{ prompt }`;
+ * anything else (including `false`) turns reflection off. The prompt override
+ * replaces the instruction text only — the list of concepts the run read is
+ * appended by the server either way.
+ */
+function normalizeReflect(input: unknown): boolean | { prompt?: string } | undefined {
+  if (input === true) return true;
+  if (input && typeof input === "object" && !Array.isArray(input)) {
+    const prompt = (input as { prompt?: unknown }).prompt;
+    return typeof prompt === "string" && prompt.trim() ? { prompt: prompt.trim() } : true;
+  }
+  return undefined;
 }
 
 /**
@@ -421,6 +437,7 @@ export async function repo_agent(req: Request, res: Response) {
           _metadata: body._metadata,
           commitList: body.commitList,
           ignoreRepoInfo: body.ignoreRepoInfo,
+          reflect: body.reflect,
         },
       );
 
@@ -547,6 +564,7 @@ export async function repo_agent(req: Request, res: Response) {
           _metadata: body._metadata,
           commitList: body.commitList,
           ignoreRepoInfo: body.ignoreRepoInfo,
+          reflect: body.reflect,
           onStepEvent: (content) => {
             const events = filterStepContent(content);
             for (const ev of events) bus.emit(ev);
@@ -692,7 +710,10 @@ export async function get_agent_session(req: Request, res: Response) {
     const messages = loadSession(sessionId);
     const config = loadSessionConfig(sessionId);
     const _metadata = loadSessionMetadata(sessionId);
-    res.json({ sessionId, messages, config, _metadata });
+    // Null when the session read no concepts (or predates the sidecar);
+    // `config.reflect` says whether a ranking was ever asked for.
+    const reflection = loadReflection(sessionId);
+    res.json({ sessionId, messages, config, _metadata, reflection });
   } catch (e) {
     console.error("Error in get_agent_session", e);
     res.status(500).json({ error: "Internal server error" });

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -580,6 +580,10 @@ export async function repo_agent(req: Request, res: Response) {
           usage: result.usage,
           logs: result.logs,
           sessionId: result.sessionId,
+          // Present when the run read any Concepts. The run is held open for
+          // the reflect call, so deliver its result here rather than making
+          // the caller follow up with GET /repo/agent/session for it.
+          reflection: result.reflection,
         };
         asyncReqs.finishReq(request_id, terminalResult);
         // Post-completion side effects are isolated: if one throws it must

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -419,17 +419,34 @@ export function loadSearchProvenance(
 }
 
 // ── Concept reflection ───────────────────────────────────────────────
-// Which gitree Concepts a session actually read, and (when `reflect` is on)
-// the agent's own ranking of how load-bearing each one was. Cumulative over
-// the whole session rather than per-run: the reflect call sees the entire
-// transcript, so its latest ranking supersedes the previous one.
+// Which gitree Concepts a session actually read, in the order it read them.
+// That much is recorded for every session with no model involved and no flag
+// to set. `reflect` adds a second layer on top: the agent's own ranking of
+// how load-bearing each one turned out to be.
+//
+// Cumulative over the whole session rather than per-run — the reflect call
+// sees the entire transcript, so its latest ranking supersedes the previous
+// one, while read order is assigned once and left alone.
 
 export interface ReflectedConcept {
   id?: string;
   ref_id?: string;
   repo?: string;
   name?: string;
-  /** 1 = most load-bearing. null when this concept was read but not ranked. */
+  /**
+   * 1-based order this concept was first read in the session. Always set, with
+   * no model involved — reading a concept is enough to earn an entry.
+   * Assigned once and never revised, so it stays stable as later turns append.
+   */
+  read_order?: number;
+  /**
+   * How load-bearing the concept was, 1 = most. Only ever set by the `reflect`
+   * pass; null means nothing has judged it, not that it was useless.
+   *
+   * Deliberately distinct from `read_order`: one field carrying "read first"
+   * on some sessions and "mattered most" on others can't be aggregated, since
+   * a consumer can't tell which meaning it has.
+   */
   rank: number | null;
   /** One line on which turn used it and what it changed. */
   evidence?: string;
@@ -477,8 +494,10 @@ export function loadReflection(sessionId: string): SessionReflection | null {
  *
  * Union by identity (`ref_id`, falling back to `id`). An incoming entry only
  * overwrites `rank`/`evidence`/`contradicts` when it actually carries them, so
- * a failed reflect call adds its newly-read concepts without clobbering the
- * ranking from a previous turn that succeeded.
+ * a failed reflect call — or a turn that ran without `reflect` at all — adds
+ * its newly-read concepts without clobbering the ranking from a previous turn
+ * that succeeded. New concepts get the next `read_order`; existing ones keep
+ * the one they already have.
  */
 export function mergeReflection(
   sessionId: string,
@@ -506,17 +525,32 @@ export function mergeReflection(
     byKey.set(key, {
       ...prev,
       ...c,
+      // First read wins: a concept re-read on a later turn keeps its position.
+      read_order: prev.read_order ?? c.read_order,
       rank: c.rank ?? prev.rank,
       evidence: c.evidence ?? prev.evidence,
       contradicts: c.contradicts ?? prev.contradicts,
     });
   }
 
+  // Stamp read order on anything that doesn't have it yet, continuing from the
+  // highest already assigned. Map iteration is existing-then-incoming, so a
+  // concept keeps the position it first got no matter how many turns follow.
+  let nextOrder = 1;
+  for (const c of byKey.values()) {
+    if (typeof c.read_order === "number") nextOrder = Math.max(nextOrder, c.read_order + 1);
+  }
+  for (const c of byKey.values()) {
+    if (typeof c.read_order !== "number") c.read_order = nextOrder++;
+  }
+
+  // Judged concepts first, most load-bearing at the top; everything else falls
+  // back to the order it was read in.
   const concepts = [...byKey.values()].sort((a, b) => {
-    if (a.rank === b.rank) return (a.name ?? "").localeCompare(b.name ?? "");
-    if (a.rank === null) return 1;
-    if (b.rank === null) return -1;
-    return a.rank - b.rank;
+    if (a.rank !== null && b.rank !== null) return a.rank - b.rank;
+    if (a.rank === null && b.rank !== null) return 1;
+    if (a.rank !== null && b.rank === null) return -1;
+    return (a.read_order ?? 0) - (b.read_order ?? 0);
   });
 
   const reflection: SessionReflection = {

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -58,6 +58,12 @@ export interface SessionInitConfig {
   ontologyDomains?: string;
   commitList?: string[];
   ignoreRepoInfo?: boolean;
+  /**
+   * Whether the post-run concept reflection was requested, and any prompt
+   * override. Recorded so an absent reflection sidecar can be read correctly:
+   * with `reflect` on, no file means the run read no concepts.
+   */
+  reflect?: boolean | { prompt?: string };
 }
 
 export interface StepMeta {
@@ -251,6 +257,10 @@ export function deleteSession(sessionId: string): void {
   if (existsSync(metadataPath)) {
     unlinkSync(metadataPath);
   }
+  const reflectionPath = getReflectionFile(sessionId);
+  if (existsSync(reflectionPath)) {
+    unlinkSync(reflectionPath);
+  }
   deleteAttachments(sessionId);
 }
 
@@ -406,6 +416,119 @@ export function loadSearchProvenance(
   } catch {
     return [];
   }
+}
+
+// ── Concept reflection ───────────────────────────────────────────────
+// Which gitree Concepts a session actually read, and (when `reflect` is on)
+// the agent's own ranking of how load-bearing each one was. Cumulative over
+// the whole session rather than per-run: the reflect call sees the entire
+// transcript, so its latest ranking supersedes the previous one.
+
+export interface ReflectedConcept {
+  id?: string;
+  ref_id?: string;
+  repo?: string;
+  name?: string;
+  /** 1 = most load-bearing. null when this concept was read but not ranked. */
+  rank: number | null;
+  /** One line on which turn used it and what it changed. */
+  evidence?: string;
+  /**
+   * What this concept claims vs. what the agent found in the source, when the
+   * two disagreed. A review flag, not grounds for automatic invalidation —
+   * the agent may have misread, or the concept may be accurate about an older
+   * state of the repo.
+   */
+  contradicts?: string;
+}
+
+export interface SessionReflection {
+  session_id: string;
+  updated_at: string;
+  concepts: ReflectedConcept[];
+  /** Something the agent had to work out from source that no concept covered. */
+  gap?: string | null;
+  /** Raw model output, kept only when it didn't parse into the shape above. */
+  raw?: string;
+}
+
+function getReflectionFile(sessionId: string): string {
+  const sessionDir = path.isAbsolute(SESSIONS_DIR)
+    ? SESSIONS_DIR
+    : path.join(process.cwd(), SESSIONS_DIR);
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true });
+  }
+  return path.join(sessionDir, `${sessionId}.reflection.json`);
+}
+
+export function loadReflection(sessionId: string): SessionReflection | null {
+  const filePath = getReflectionFile(sessionId);
+  if (!existsSync(filePath)) return null;
+  try {
+    return JSON.parse(readFileSync(filePath, "utf-8")) as SessionReflection;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Merge this run's concepts into the session's reflection sidecar.
+ *
+ * Union by identity (`ref_id`, falling back to `id`). An incoming entry only
+ * overwrites `rank`/`evidence`/`contradicts` when it actually carries them, so
+ * a failed reflect call adds its newly-read concepts without clobbering the
+ * ranking from a previous turn that succeeded.
+ */
+export function mergeReflection(
+  sessionId: string,
+  incoming: {
+    concepts: ReflectedConcept[];
+    gap?: string | null;
+    raw?: string;
+  },
+): SessionReflection {
+  const existing = loadReflection(sessionId);
+  const byKey = new Map<string, ReflectedConcept>();
+  // ref_id leads: it is the only identifier every Concept node carries (see
+  // conceptKey in concepts.ts). An id-first key double-counts a concept that
+  // was recorded ref_id-only on one turn and id+ref_id on another.
+  const keyOf = (c: ReflectedConcept) => c.ref_id ?? c.id ?? c.name ?? "";
+
+  for (const c of existing?.concepts ?? []) byKey.set(keyOf(c), c);
+  for (const c of incoming.concepts) {
+    const key = keyOf(c);
+    const prev = byKey.get(key);
+    if (!prev) {
+      byKey.set(key, c);
+      continue;
+    }
+    byKey.set(key, {
+      ...prev,
+      ...c,
+      rank: c.rank ?? prev.rank,
+      evidence: c.evidence ?? prev.evidence,
+      contradicts: c.contradicts ?? prev.contradicts,
+    });
+  }
+
+  const concepts = [...byKey.values()].sort((a, b) => {
+    if (a.rank === b.rank) return (a.name ?? "").localeCompare(b.name ?? "");
+    if (a.rank === null) return 1;
+    if (b.rank === null) return -1;
+    return a.rank - b.rank;
+  });
+
+  const reflection: SessionReflection = {
+    session_id: sessionId,
+    updated_at: new Date().toISOString(),
+    concepts,
+    gap: incoming.gap ?? existing?.gap ?? null,
+  };
+  if (incoming.raw) reflection.raw = incoming.raw;
+
+  writeFileSync(getReflectionFile(sessionId), JSON.stringify(reflection, null, 2));
+  return reflection;
 }
 
 export type AnnotationMarker =
@@ -566,6 +689,8 @@ export function pruneExpiredSessions(): number {
         if (existsSync(annPath)) unlinkSync(annPath);
         const configPath = filePath.replace(/\.jsonl$/, ".config.json");
         if (existsSync(configPath)) unlinkSync(configPath);
+        const reflectionPath = filePath.replace(/\.jsonl$/, ".reflection.json");
+        if (existsSync(reflectionPath)) unlinkSync(reflectionPath);
         deleteAttachments(sessionId);
         pruned++;
       }

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -739,6 +739,58 @@ export function pruneExpiredSessions(): number {
 }
 
 /**
+ * Every primary conversation file on disk, with its id and last-write time.
+ *
+ * Shares the sidecar exclusion list with pruneExpiredSessions — `.jsonl` alone
+ * doesn't identify a conversation, since the meta/provenance/annotation/
+ * attachment sidecars use the same extension.
+ */
+export function listSessionFiles(): {
+  sessionId: string;
+  filePath: string;
+  mtimeMs: number;
+}[] {
+  const sessionDir = path.isAbsolute(SESSIONS_DIR)
+    ? SESSIONS_DIR
+    : path.join(process.cwd(), SESSIONS_DIR);
+  if (!existsSync(sessionDir)) return [];
+
+  const out: { sessionId: string; filePath: string; mtimeMs: number }[] = [];
+  for (const file of readdirSync(sessionDir)) {
+    if (
+      !file.endsWith(".jsonl") ||
+      file.endsWith(".meta.jsonl") ||
+      file.endsWith(".provenance.jsonl") ||
+      file.endsWith(".annotations.jsonl") ||
+      file.endsWith(".attachments.jsonl")
+    )
+      continue;
+    const filePath = path.join(sessionDir, file);
+    try {
+      out.push({
+        sessionId: file.replace(/\.jsonl$/, ""),
+        filePath,
+        mtimeMs: statSync(filePath).mtimeMs,
+      });
+    } catch {
+      // ignore files that vanish or can't be stat'd mid-scan
+    }
+  }
+  return out;
+}
+
+/** Path to a marker file in the sessions dir, used by one-off backfills. */
+export function sessionsDirFile(name: string): string {
+  const sessionDir = path.isAbsolute(SESSIONS_DIR)
+    ? SESSIONS_DIR
+    : path.join(process.cwd(), SESSIONS_DIR);
+  if (!existsSync(sessionDir)) {
+    mkdirSync(sessionDir, { recursive: true });
+  }
+  return path.join(sessionDir, name);
+}
+
+/**
  * Truncate a tool result for storage efficiency.
  * The model already processed this data, so we can store references instead of full content.
  */

--- a/mcp/src/tools/types.ts
+++ b/mcp/src/tools/types.ts
@@ -1,4 +1,5 @@
 import { AiUsageWithLegacy } from "../aieo/src/usage.js";
+import type { SessionReflection } from "../repo/session.js";
 
 export type Json = Record<string, unknown> | undefined;
 
@@ -18,4 +19,9 @@ export interface ContextResult {
   content: any;
   logs?: string;
   sessionId?: string; // Return session ID for multi-turn conversations
+  // Concepts this session read, with the agent's ranking when `reflect` was
+  // set. Cumulative over the session, and identical to what the reflection
+  // sidecar holds — returned here so a caller that waited for the reflect
+  // call doesn't need a second round-trip to GET /repo/agent/session.
+  reflection?: SessionReflection;
 }


### PR DESCRIPTION
## Why

There's currently no way to find out, after a run, which gitree Concepts actually carried the answer. The catalog grows, but nothing feeds back which entries earn their place — a concept nobody ever opens and one every run depends on look identical from the outside.

## What

Two halves, kept separate so a bad model turn never costs the hard data.

**Collection — always on.** Every Concept whose *body* a tool returns is recorded to a cumulative `<sessionId>.reflection.json` sidecar. Both read paths are covered: `learn_concept` and `graph_get`. `graph_search` / `graph_neighbors` / `list_concepts` deliberately don't count — they surface a name and description without the body, and `list_concepts` returns the whole catalog, so appearing in one says nothing about what the agent chose to read.

**Reflection — opt-in via `reflect`.** Appends one turn to the finished transcript asking the agent to rank those concepts by how load-bearing they were, with evidence per concept, plus anything it read that contradicted the source and anything it had to work out that no concept covered.

```json
{ "prompt": "...", "reflect": true }
```

`reflect` also accepts `{ "prompt": "..." }` to override the instruction text. The list of concepts read is appended by the server either way — a caller has no way of knowing what a run read.

The result is delivered three ways: on the terminal payload that `GET /progress` serves, on the webhook POST, and on `GET /repo/agent/session`. All three carry the same cumulative object.

```json
{
  "session_id": "b3f1...",
  "updated_at": "2026-08-07T18:22:04.113Z",
  "concepts": [
    { "id": "c_4f2a", "ref_id": "9d1c8e...", "repo": "stakwork/hive",
      "name": "auth-session-lifecycle", "rank": 1,
      "evidence": "gave the session-file layout; the sidecar answer came straight from it" }
  ],
  "gap": "provenance sidecar format — had to read session.ts directly"
}
```

## For reviewers

**The prompt cache is the entire cost argument, and it's fragile in a specific way.** Replaying a long transcript is only affordable because the provider serves the prefix from cache at ~0.1x input. That requires the reflect call to re-send the run's tools and system prompt *byte-identical* — changing the tool set invalidates the whole prefix, and changing `tool_choice` or the thinking setting invalidates the messages half, which is nearly all of a long agentic run. So the model is **told** not to call tools rather than being prevented from doing so, and provider options are reused verbatim. Same reason the messages come from the model-facing transcript rather than the stored one, which is lossy under `truncateToolResults`.

Worth checking on the first real run: that `cache_read_input_tokens` on the reflect call is actually large. That premise has not been verified against a live provider — see limitations.

**Keying is `ref_id` first, `id` second.** A Concept created directly in the graph has no gitree `id` at all, and a `learn_concept` read only gains a `ref_id` once the catalog resolves it. Under an id-first key, a concept recorded ref_id-only on one turn (catalog lookup hiccuped) and id+ref_id on the next lands in the sidecar twice. Both merge points — within a run and across turns — use the same precedence, and there's a test for exactly this case.

**The ranking is an overlay, never a replacement.** Invented ids are dropped, omitted ones stay `rank: null`, output that isn't JSON at all (likely under a custom prompt) is preserved as `raw`, and a failed reflect merges its new reads without clobbering a ranking an earlier turn produced. The deterministic read list is written whether or not `reflect` is set and whether or not the call succeeds.

**`contradicts` is a review flag, not an action.** The agent may have misread, or the concept may be accurate about an older state of the repo — `stale` and `wrong` look identical from inside a single run and are fixed differently. Nothing consumes this field automatically, and nothing should without a human reading the two quoted sides.

**Where reflect runs, and what waits on it.** Both paths run it from the same place — after the session is persisted, while the provider's cache of the transcript is still warm. Neither blocks an HTTP response: the streaming path runs it in `finalizeSession` once the stream is consumed, and the non-streaming path already returns `{request_id, status: "pending"}` up front. What it does delay in the non-streaming path is the *terminal payload* — `finishReq`, the `done` bus event, and the webhook — by one model call. That's deliberate: running it before the run is marked complete keeps the call inside the window where the process is guaranteed alive, and the payload it delays is also the one that now carries it.

**No graph writes.** Sessions are file-backed, so there's no session node to hang an edge off, and introducing one is a much larger commitment than this warrants. Cross-session aggregates (`read_count`, `decisive_count` on Concept nodes) would be a later batch job over the sidecars, if reading them directly turns out not to be enough.

## Testing

23 new tests in `mcp/src/repo/__tests__/concepts.test.ts` covering collection through both tool paths, the id-space merge, ranking overlay and its failure modes, and sidecar merge semantics. Full `npm run test:node` suite: 460/461. The one failure (`toolsJarvis.test.ts` "output ordering matches input ordering") fails identically on `main` and is unrelated.

## Limitations

- **The reflect call itself has never run against a live provider.** Prompt construction, parsing, merging, and collection are all covered by tests; `generateText` against a real transcript and a real graph is not. First real run is the test.
- **`graph_get` concept ids are a soft assumption.** `properties.id` is read off the Jarvis node for the gitree id. If Jarvis doesn't carry it, the read is still recorded by `ref_id` and the catalog lookup fills the id in — the tested fallback — but worth confirming against a live graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)