### PR TITLE
Show the Concepts a session read in the sessions UI

### DIFF
--- a/mcp/benchmark/src/api.ts
+++ b/mcp/benchmark/src/api.ts
@@ -1,4 +1,9 @@
-import type { ProductionRun, Annotation, AnnotationMarker } from "./types";
+import type {
+  ProductionRun,
+  Annotation,
+  AnnotationMarker,
+  ConceptDetail,
+} from "./types";
 
 const BASE = "/api";
 
@@ -6,6 +11,31 @@ async function req<T>(path: string, init?: RequestInit): Promise<T> {
   const res = await fetch(`${BASE}${path}`, {
     headers: { "Content-Type": "application/json" },
     ...init,
+  });
+  if (!res.ok) {
+    const err = (await res.json().catch(() => ({}))) as { error?: string };
+    throw new Error(err.error || `HTTP ${res.status}`);
+  }
+  return res.json() as Promise<T>;
+}
+
+/**
+ * Call an endpoint outside the (pre-auth, public) `/api` router.
+ *
+ * Concept documentation lives behind `authMiddleware`, and deliberately stays
+ * there — it describes private repo internals, so it must not be proxied
+ * through the sessions router. `window.__AUTH_TOKEN__` is injected into
+ * index.html server-side for exactly this; it's empty in dev, where auth is
+ * off anyway.
+ */
+async function authedReq<T>(path: string): Promise<T> {
+  const token = (window as unknown as { __AUTH_TOKEN__?: string })
+    .__AUTH_TOKEN__;
+  const res = await fetch(path, {
+    headers: {
+      "Content-Type": "application/json",
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
   });
   if (!res.ok) {
     const err = (await res.json().catch(() => ({}))) as { error?: string };
@@ -26,5 +56,13 @@ export const api = {
         method: "POST",
         body: JSON.stringify(body),
       }),
+  },
+  concepts: {
+    get: (id: string, repo?: string) =>
+      authedReq<ConceptDetail>(
+        `/gitree/concepts/${encodeURIComponent(id)}${
+          repo ? `?repo=${encodeURIComponent(repo)}` : ""
+        }`,
+      ),
   },
 };

--- a/mcp/benchmark/src/components/sessions/SessionConcepts.tsx
+++ b/mcp/benchmark/src/components/sessions/SessionConcepts.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useState } from "react";
+import { CopyableBlock } from "../ui";
+import { muted } from "./styles";
+import { api } from "../../api";
+import type { ReflectedConcept, SessionReflection } from "../../types";
+
+/**
+ * The gitree Concepts a session read.
+ *
+ * Three depths, so the common case costs nothing: a count pill in the header,
+ * the names one click in, and a concept's full documentation one click past
+ * that. The names list is what you scan — it renders open by default so
+ * landing on a session shows what it leaned on without any interaction.
+ */
+
+/** Read order is the scan order, and the only field every entry carries. */
+function byReadOrder(a: ReflectedConcept, b: ReflectedConcept): number {
+  return (a.read_order ?? 0) - (b.read_order ?? 0);
+}
+
+function conceptKey(c: ReflectedConcept, i: number): string {
+  return c.ref_id ?? c.id ?? c.name ?? String(i);
+}
+
+export function ConceptsPill({
+  count,
+  open,
+  onToggle,
+}: {
+  count: number;
+  open: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      onClick={onToggle}
+      title={open ? "Hide concepts" : "Show concepts read"}
+      style={{
+        display: "inline-flex",
+        alignItems: "center",
+        gap: "6px",
+        fontSize: "11px",
+        padding: "4px 10px",
+        borderRadius: "9999px",
+        border: `1px solid ${open ? "#4c1d95" : "#27272a"}`,
+        backgroundColor: open ? "rgba(76,29,149,0.18)" : "#18181b",
+        color: "#ededed",
+        cursor: "pointer",
+        fontFamily: "inherit",
+      }}
+    >
+      <span
+        style={{
+          color: "#71717a",
+          textTransform: "uppercase",
+          letterSpacing: "0.08em",
+          fontSize: "10px",
+        }}
+      >
+        concepts
+      </span>
+      <span>{count}</span>
+      <span style={{ fontSize: "9px", color: "#71717a" }}>
+        {open ? "▴" : "▾"}
+      </span>
+    </button>
+  );
+}
+
+/** Full documentation for one concept, fetched on first expand. */
+function ConceptBody({ concept }: { concept: ReflectedConcept }) {
+  const [doc, setDoc] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    // Only gitree ids resolve; a Concept reached solely through the graph has
+    // a ref_id and no id, and there is nothing to fetch it with.
+    if (!concept.id) return;
+    let cancelled = false;
+    api.concepts
+      .get(concept.id, concept.repo)
+      .then((res) => {
+        if (cancelled) return;
+        setDoc(
+          res.concept.documentation ||
+            res.concept.description ||
+            "No documentation recorded for this concept.",
+        );
+      })
+      .catch((e: Error) => {
+        if (!cancelled) setError(e.message);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [concept.id, concept.repo]);
+
+  return (
+    <div style={{ padding: "4px 0 10px 0" }}>
+      {concept.evidence && (
+        <p style={{ ...muted, color: "#d4d4d8", padding: "0 14px 8px 14px" }}>
+          {concept.evidence}
+        </p>
+      )}
+      {concept.contradicts && (
+        <div style={{ padding: "0 14px 8px 14px" }}>
+          <p
+            style={{
+              margin: "0 0 4px 0",
+              fontSize: "10px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "#fdba74",
+            }}
+          >
+            Contradicts source
+          </p>
+          <p style={{ ...muted, color: "#d4d4d8", margin: 0 }}>
+            {concept.contradicts}
+          </p>
+        </div>
+      )}
+      {!concept.id ? (
+        <p style={{ ...muted, padding: "0 14px" }}>
+          Read through the graph only — no gitree id to load documentation with.
+        </p>
+      ) : error ? (
+        <p style={{ ...muted, padding: "0 14px", color: "#fca5a5" }}>
+          Could not load documentation: {error}
+        </p>
+      ) : doc === null ? (
+        <p style={{ ...muted, padding: "0 14px" }}>Loading documentation…</p>
+      ) : (
+        <CopyableBlock value={doc} maxHeight="24rem" />
+      )}
+    </div>
+  );
+}
+
+function ConceptRow({ concept, index }: { concept: ReflectedConcept; index: number }) {
+  return (
+    <details style={{ borderTop: "1px solid #1f1f22" }}>
+      <summary
+        style={{
+          listStyle: "none",
+          display: "flex",
+          alignItems: "center",
+          gap: "10px",
+          padding: "8px 14px",
+          cursor: "pointer",
+          userSelect: "none",
+        }}
+      >
+        <span
+          style={{
+            display: "inline-block",
+            width: "24px",
+            flexShrink: 0,
+            fontSize: "10px",
+            fontWeight: 700,
+            color: "#52525b",
+          }}
+        >
+          {concept.read_order ?? index + 1}
+        </span>
+        <span
+          style={{
+            fontSize: "12px",
+            fontWeight: 600,
+            color: "#ededed",
+            overflowWrap: "anywhere",
+          }}
+        >
+          {concept.name || concept.id || concept.ref_id || "(unnamed)"}
+        </span>
+        {concept.rank !== null && (
+          <span
+            title="Agent's ranking of how load-bearing this concept was"
+            style={{
+              fontSize: "10px",
+              fontWeight: 700,
+              backgroundColor: "#3f3f46",
+              borderRadius: "9999px",
+              padding: "1px 6px",
+              color: "#ededed",
+              flexShrink: 0,
+            }}
+          >
+            #{concept.rank}
+          </span>
+        )}
+        {concept.contradicts && (
+          <span
+            title="This concept disagreed with what the agent found in the source"
+            style={{
+              fontSize: "10px",
+              lineHeight: 1,
+              padding: "3px 6px",
+              borderRadius: "9999px",
+              border: "1px solid #7c2d12",
+              color: "#fdba74",
+              backgroundColor: "rgba(124,45,18,0.35)",
+              flexShrink: 0,
+            }}
+          >
+            contradicts
+          </span>
+        )}
+      </summary>
+      <ConceptBody concept={concept} />
+    </details>
+  );
+}
+
+/**
+ * The names list. Rendered next to the header card, below the meta pills, so
+ * it reads as part of the session summary rather than as another trace panel.
+ */
+export function ConceptsPanel({ reflection }: { reflection: SessionReflection }) {
+  // Stored rank-first (see mergeReflection); re-sort so the list always reads
+  // in the order the session actually visited them.
+  const concepts = [...reflection.concepts].sort(byReadOrder);
+  return (
+    <div
+      style={{
+        marginTop: "10px",
+        border: "1px solid #27272a",
+        borderRadius: "8px",
+        backgroundColor: "#0d0d0f",
+        overflow: "hidden",
+      }}
+    >
+      {concepts.map((c, i) => (
+        <ConceptRow key={conceptKey(c, i)} concept={c} index={i} />
+      ))}
+      {reflection.gap && (
+        <div
+          style={{
+            borderTop: "1px solid #1f1f22",
+            padding: "8px 14px 10px 14px",
+          }}
+        >
+          <p
+            style={{
+              margin: "0 0 4px 0",
+              fontSize: "10px",
+              textTransform: "uppercase",
+              letterSpacing: "0.1em",
+              color: "#71717a",
+            }}
+          >
+            Gap — worked out from source, covered by no concept
+          </p>
+          <p style={{ ...muted, color: "#d4d4d8", margin: 0 }}>
+            {reflection.gap}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/mcp/benchmark/src/components/sessions/SessionDetail.tsx
+++ b/mcp/benchmark/src/components/sessions/SessionDetail.tsx
@@ -1,5 +1,7 @@
+import { useEffect, useState } from "react";
 import { CopyableBlock, shortId } from "../ui";
 import { MetaPill, SourceBadge } from "./SessionBadges";
+import { ConceptsPill, ConceptsPanel } from "./SessionConcepts";
 import { TurnCard } from "./TurnCard";
 import { EntryRow } from "./EntryRow";
 import { AnnotationBadge, AnnotationForm } from "../Annotations";
@@ -115,6 +117,12 @@ export function SessionDetail({
   showSessionAnnotationForm,
   setShowSessionAnnotationForm,
 }: SessionDetailProps) {
+  // Open by default so the concept list is scannable the moment a session
+  // loads; the pill collapses it. Re-opens when you switch sessions.
+  const [conceptsOpen, setConceptsOpen] = useState(true);
+  useEffect(() => setConceptsOpen(true), [selected?.id]);
+  const concepts = selected?.reflection?.concepts ?? [];
+
   return (
     <div style={{ flex: 1, minWidth: 0, minHeight: 0, overflowY: "auto" }}>
       {selected ? (
@@ -191,6 +199,13 @@ export function SessionDetail({
                     label="calls"
                     value={String(selected.tool_call_count)}
                   />
+                  {concepts.length > 0 && (
+                    <ConceptsPill
+                      count={concepts.length}
+                      open={conceptsOpen}
+                      onToggle={() => setConceptsOpen((v) => !v)}
+                    />
+                  )}
                 </div>
               </div>
               <div
@@ -287,6 +302,9 @@ export function SessionDetail({
                     </span>
                   ))}
               </div>
+            )}
+            {conceptsOpen && selected.reflection && concepts.length > 0 && (
+              <ConceptsPanel reflection={selected.reflection} />
             )}
             <div
               style={{

--- a/mcp/benchmark/src/types.ts
+++ b/mcp/benchmark/src/types.ts
@@ -58,6 +58,40 @@ export interface SearchProvenanceEntry {
   };
 }
 
+/**
+ * One gitree Concept the session read. `read_order` is always present (it is
+ * recorded with no model involved); everything from `rank` down only appears
+ * when the run was started with `reflect`.
+ */
+export interface ReflectedConcept {
+  id?: string;
+  ref_id?: string;
+  repo?: string;
+  name?: string;
+  read_order?: number;
+  rank: number | null;
+  evidence?: string;
+  contradicts?: string;
+}
+
+export interface SessionReflection {
+  session_id: string;
+  updated_at: string;
+  concepts: ReflectedConcept[];
+  gap?: string | null;
+  raw?: string;
+}
+
+/** Full concept as `GET /gitree/concepts/:id` serves it. */
+export interface ConceptDetail {
+  concept: {
+    id: string;
+    name?: string;
+    description?: string;
+    documentation?: string;
+  };
+}
+
 export interface ProductionRun {
   id: string;
   source: string;
@@ -77,5 +111,6 @@ export interface ProductionRun {
   step_meta?: StepMeta[];
   search_provenance?: SearchProvenanceEntry[];
   annotations?: Annotation[];
+  reflection?: SessionReflection | null;
   trace?: unknown;
 }

--- a/mcp/benchmark/vite.config.ts
+++ b/mcp/benchmark/vite.config.ts
@@ -15,6 +15,9 @@ export default defineConfig({
     port: 3366,
     proxy: {
       "/api": "http://localhost:3355",
+      // Concept documentation lives behind auth on the main app, not on the
+      // (public) sessions router — see api.ts.
+      "/gitree": "http://localhost:3355",
     },
   },
 });

--- a/mcp/src/benchmark/sessions.ts
+++ b/mcp/src/benchmark/sessions.ts
@@ -6,6 +6,7 @@ import {
   loadStepMeta,
   loadSearchProvenance,
   loadAnnotations,
+  loadReflection,
   appendAnnotation,
   type Annotation,
   type AnnotationMarker,
@@ -383,6 +384,9 @@ async function buildFullSession(
   const step_meta = loadStepMeta(id);
   const search_provenance = loadSearchProvenance(id);
   const annotations = loadAnnotations(id);
+  // Which gitree Concepts this session read, in read order, plus the agent's
+  // ranking when the run asked for one. Null for sessions that read none.
+  const reflection = loadReflection(id);
 
   if (db) {
     try {
@@ -418,6 +422,7 @@ async function buildFullSession(
           step_meta,
           search_provenance,
           annotations,
+          reflection,
           trace,
         };
       }
@@ -459,6 +464,7 @@ async function buildFullSession(
     step_meta,
     search_provenance,
     annotations,
+    reflection,
     trace,
   };
 }


### PR DESCRIPTION
#1543 records which gitree Concepts every session reads — with no flag and no model call — but nothing surfaced it. `GET /api/sessions/:id` never returned the field, so the benchmark UI had nothing to draw. This serves it and renders it.

## Backend

`buildFullSession` now returns `reflection` alongside `step_meta` / `search_provenance` / `annotations`, from **both** return branches (the Neo4j one and the file-only fallback) — the two drifting is exactly the bug `deriveFromStepMeta` was extracted to prevent.

## UI

Three depths, so the common case costs nothing:

1. a `concepts N` pill in the header meta row, next to `turns` / `calls`
2. the concept names, one click in — rendered **open by default**, since scanning what a session leaned on is the reason to look
3. a concept's full documentation, one click past that

Each row carries what the sidecar knows: read order in the gutter, a `#N` badge when the run was started with `reflect`, an orange `contradicts` chip when the concept disagreed with what the agent found in the source, and the session-level `gap` once at the bottom.

The pill sits in the neutral meta row rather than the `flagged` / `oversized` / `repeats` row — everything in that row is a problem and is colored like one, and concepts read is a fact, not a warning.

## Two things worth reviewing

**Ordering.** Rows sort by `read_order`, not by the array as served. `mergeReflection` stores concepts rank-first, so the served order means "most load-bearing" on a reflect run and "read first" everywhere else. `read_order` is the one field every entry carries and always means the same thing.

**Auth.** Documentation comes from `/gitree/concepts/:id`, which is behind `authMiddleware` and stays there — concept bodies describe private repo internals, so they must not be proxied through the pre-auth, public sessions router. The SPA sends `window.__AUTH_TOKEN__`, already injected into `index.html` for exactly this purpose. Dev needed a `/gitree` vite proxy entry.

A Concept reached only through `graph_get` has a `ref_id` and no gitree `id`; those rows say so rather than firing a request that can't resolve.

## Verification

Server and frontend `tsc --noEmit` clean; `vite build` clean. Server suite 473/474 — the one failure is `toolsJarvis.test.ts` "output ordering matches input ordering", which fails identically on `main`.

Driven in a browser against a stub API: pill renders and toggles, names list in read order with rank badges and the contradicts chip, documentation fetches and renders as markdown on expand, `gap` renders once, and the ref_id-only row degrades to its explanatory message instead of erroring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)