### PR TITLE
Lead the session-signal row with the concepts pill, closed by default

### DIFF
--- a/mcp/benchmark/src/components/sessions/SessionConcepts.tsx
+++ b/mcp/benchmark/src/components/sessions/SessionConcepts.tsx
@@ -22,6 +22,11 @@ function conceptKey(c: ReflectedConcept, i: number): string {
   return c.ref_id ?? c.id ?? c.name ?? String(i);
 }
 
+/**
+ * Sits first in the session-signal row, alongside `flagged` / `oversized` /
+ * `repeats`. Those are inert text, so this one has to carry enough weight —
+ * filled violet, a caret, a hover state — to read as the button it is.
+ */
 export function ConceptsPill({
   count,
   open,
@@ -34,35 +39,27 @@ export function ConceptsPill({
   return (
     <button
       onClick={onToggle}
-      title={open ? "Hide concepts" : "Show concepts read"}
+      className="concepts-pill"
+      title={open ? "Hide concepts read" : "Show the concepts this session read"}
       style={{
         display: "inline-flex",
         alignItems: "center",
         gap: "6px",
         fontSize: "11px",
-        padding: "4px 10px",
-        borderRadius: "9999px",
-        border: `1px solid ${open ? "#4c1d95" : "#27272a"}`,
-        backgroundColor: open ? "rgba(76,29,149,0.18)" : "#18181b",
-        color: "#ededed",
+        fontWeight: 600,
+        padding: "3px 10px",
+        borderRadius: "6px",
+        border: `1px solid ${open ? "#a78bfa" : "#6d28d9"}`,
+        backgroundColor: open ? "rgba(109,40,217,0.4)" : "rgba(109,40,217,0.28)",
+        color: "#ddd6fe",
         cursor: "pointer",
         fontFamily: "inherit",
       }}
     >
-      <span
-        style={{
-          color: "#71717a",
-          textTransform: "uppercase",
-          letterSpacing: "0.08em",
-          fontSize: "10px",
-        }}
-      >
-        concepts
+      <span>
+        {count} concept{count === 1 ? "" : "s"}
       </span>
-      <span>{count}</span>
-      <span style={{ fontSize: "9px", color: "#71717a" }}>
-        {open ? "▴" : "▾"}
-      </span>
+      <span style={{ fontSize: "9px" }}>{open ? "▴" : "▾"}</span>
     </button>
   );
 }

--- a/mcp/benchmark/src/components/sessions/SessionDetail.tsx
+++ b/mcp/benchmark/src/components/sessions/SessionDetail.tsx
@@ -117,10 +117,10 @@ export function SessionDetail({
   showSessionAnnotationForm,
   setShowSessionAnnotationForm,
 }: SessionDetailProps) {
-  // Open by default so the concept list is scannable the moment a session
-  // loads; the pill collapses it. Re-opens when you switch sessions.
-  const [conceptsOpen, setConceptsOpen] = useState(true);
-  useEffect(() => setConceptsOpen(true), [selected?.id]);
+  // Closed by default — the pill is the resting state, the list is opt-in.
+  // Collapses again when you switch sessions.
+  const [conceptsOpen, setConceptsOpen] = useState(false);
+  useEffect(() => setConceptsOpen(false), [selected?.id]);
   const concepts = selected?.reflection?.concepts ?? [];
 
   return (
@@ -199,13 +199,6 @@ export function SessionDetail({
                     label="calls"
                     value={String(selected.tool_call_count)}
                   />
-                  {concepts.length > 0 && (
-                    <ConceptsPill
-                      count={concepts.length}
-                      open={conceptsOpen}
-                      onToggle={() => setConceptsOpen((v) => !v)}
-                    />
-                  )}
                 </div>
               </div>
               <div
@@ -247,18 +240,27 @@ export function SessionDetail({
                 )}
               </div>
             </div>
-            {(diagnostics.counts.oversized > 0 ||
+            {(concepts.length > 0 ||
+              diagnostics.counts.oversized > 0 ||
               diagnostics.counts.fallback > 0 ||
               diagnostics.counts.repeat > 0 ||
               diagnostics.counts.empty > 0) && (
               <div
                 style={{
                   display: "flex",
+                  alignItems: "center",
                   gap: "8px",
                   flexWrap: "wrap",
                   marginTop: "8px",
                 }}
               >
+                {concepts.length > 0 && (
+                  <ConceptsPill
+                    count={concepts.length}
+                    open={conceptsOpen}
+                    onToggle={() => setConceptsOpen((v) => !v)}
+                  />
+                )}
                 {(
                   [
                     {

--- a/mcp/benchmark/src/index.css
+++ b/mcp/benchmark/src/index.css
@@ -39,6 +39,17 @@ body {
   opacity: 1;
 }
 
+/* The one interactive chip in the session-signal row — it has to read as a
+   button next to neighbours that are inert text. */
+.concepts-pill {
+  transition: background-color 0.12s, border-color 0.12s;
+}
+
+.concepts-pill:hover {
+  background-color: rgba(109, 40, 217, 0.4) !important;
+  border-color: #a78bfa !important;
+}
+
 .markdown-block > :first-child {
   margin-top: 0;
 }


### PR DESCRIPTION
Follow-up to #1544, from looking at it on real sessions.

## What was wrong

In the meta row the pill was lost. Next to `model` / `duration` / `turns` / `calls` it read as another inert fact, and on real sessions it wrapped to a second line — easy to miss entirely.

## Changes

**Moved to the front of the `flagged` / `oversized` / `repeats` row.** That's where the eye already goes for what a session *did*, and the pill leads it.

**Styled as a control.** Everything else in that row is inert text, so the pill needs weight to read as clickable: filled violet instead of the neutral chip, a caret, and a hover state. The violet also keeps it clearly apart from the warning colors it now sits beside — concepts read is not a problem, and it shouldn't inherit the red/orange/yellow vocabulary of its neighbours.

**Hidden by default.** The pill is the resting state and the list is opt-in; it re-collapses when you switch sessions.

## Verification

`tsc --noEmit` and `vite build` clean.

Driven in a browser against a stub with a session carrying both concepts and diagnostics: pill renders first in the row ahead of `5 flagged / 4 oversized / 3 repeats`, list is hidden on load, click expands it and flips the caret, and switching sessions collapses it again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)