### PR TITLE
Record Concept reads in graph_sub_agent sessions

### DIFF
--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -18,8 +18,14 @@ import {
   appendMessages,
   appendStepMeta,
   appendSessionEnd,
+  mergeReflection,
   type StepMeta,
 } from "./session.js";
+import {
+  withConceptCollection,
+  normalizeConceptReads,
+  type ConceptCollector,
+} from "./concepts.js";
 import {
   addUsage,
   normalizeUsage,
@@ -450,6 +456,12 @@ function registerGraphSubAgentTool(
         defaultDomains,
       });
 
+      // Record every Concept whose body a child tool hands back, exactly like
+      // the top-level run in agent.ts. Reads persist deterministically in
+      // endSession; sub-agents never get a reflect/ranking pass.
+      const conceptCollector: ConceptCollector = { reads: [] };
+      const runTools = withConceptCollection(childTools, conceptCollector);
+
       if (childSessionId) {
         createSession(
           childSessionId,
@@ -473,6 +485,29 @@ function registerGraphSubAgentTool(
         errorMessage?: string,
       ) => {
         if (!childSessionId) return;
+        // Best-effort, like reflectOnConcepts' read-only path: a failure here
+        // must never eat the child's answer or its session-end record.
+        if (conceptCollector.reads.length > 0) {
+          try {
+            const concepts = await normalizeConceptReads(
+              conceptCollector.reads,
+              sub.repo,
+            );
+            if (concepts.length > 0) {
+              mergeReflection(childSessionId, {
+                concepts: concepts.map((c) => ({
+                  id: c.id,
+                  ref_id: c.ref_id,
+                  repo: c.repo,
+                  name: c.name,
+                  rank: null,
+                })),
+              });
+            }
+          } catch (e) {
+            console.error("[concepts] could not record sub-agent concept reads:", e);
+          }
+        }
         appendStepMeta(childSessionId, stepMetas);
         await appendSessionEnd(childSessionId, {
           end_time: new Date().toISOString(),
@@ -499,11 +534,11 @@ function registerGraphSubAgentTool(
         provider = details.provider;
         modelId = details.modelId;
         const maxSteps = sub.maxSteps ?? DEFAULT_SUBAGENT_MAX_STEPS;
-        const hasEndMarker = createHasEndMarkerCondition<typeof childTools>();
+        const hasEndMarker = createHasEndMarkerCondition<typeof runTools>();
         const agent = new ToolLoopAgent({
           model,
           instructions: GRAPH_SUBAGENT_SYSTEM,
-          tools: childTools,
+          tools: runTools,
           providerOptions: getProviderOptions(details.provider, undefined, modelId) as any,
           stopWhen: maxSteps > 0 ? [hasEndMarker, stepCountIs(maxSteps)] : hasEndMarker,
           stopSequences: ["[END_OF_ANSWER]"],


### PR DESCRIPTION
## What

Extends the concept-read collection from #1543 to `graph_sub_agent` child sessions. Their reads are now recorded live, deterministically, exactly like the top-level run — no reflect/ranking pass.

## Why

#1543 wired `withConceptCollection` into `runAgent`, but `graph_sub_agent` doesn't recurse through `runAgent` — it spins up its own in-process `ToolLoopAgent` in `toolsJarvis.ts` with an unwrapped tool set. So a Concept read by a sub-agent was invisible to the live path and only recovered by the startup backfill: next boot, `graph_get` inputs only, intersected against the catalog (undercounts deleted concepts), with no repo scoping since child sessions have no stored config.

## How

All inside `registerGraphSubAgentTool`:

- The child tool set is wrapped with `withConceptCollection` right after `registerJarvisTools` builds it, and the `ToolLoopAgent` runs on the wrapped set.
- `endSession` mirrors agent.ts's read-only path: `normalizeConceptReads(reads, sub.repo)` then `mergeReflection(childSessionId, ...)` with `rank: null` entries — `mergeReflection` assigns `read_order` itself. Best-effort in a try/catch: a failure can never eat the child's answer or its session-end record.

## Reviewer notes

- `endSession` fires on both success and error, so a child that read concepts and then died still gets its record.
- The sidecar lands under the child's own session id (`<parent>-sub-<xxxx>`), served by GET /repo/agent/session, with `parent_session_id` linking back to the top-level run.
- The startup backfill never touches a session that already has a sidecar, so live data can't be clobbered; these sessions now just skip backfill.
- Grandchildren recurse through the same registration and get their own collector/sidecar.
- A parent running with `reflect: true` still only ranks the concepts the parent itself read; child reads stay unranked in the child's sidecar, by design.

Typecheck clean; full `yarn test:node` suite passes (474 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)