### PR TITLE
Index session concept reflections as READ_CONCEPT graph edges

### DIFF
--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1665,6 +1665,44 @@ class Db {
     }
   }
 
+  /**
+   * Mirror a session's reflection sidecar into the graph as
+   * (AgentSession)-[:READ_CONCEPT]->(Concept) edges. Idempotent, and a no-op
+   * for sessions whose AgentSession node doesn't exist yet — so it is safe to
+   * call from either side of the session-node upsert. Returns how many
+   * concepts were linked (unmatched ones are skipped, not errors).
+   */
+  async upsert_session_concept_edges(
+    session_id: string,
+    concepts: Array<{
+      id?: string;
+      ref_id?: string;
+      read_order?: number;
+      rank?: number | null;
+      evidence?: string;
+      contradicts?: string;
+    }>,
+  ): Promise<number> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(Q.UPSERT_SESSION_CONCEPT_EDGES_QUERY, {
+        session_id,
+        concepts: concepts.map((c) => ({
+          id: c.id ?? null,
+          ref_id: c.ref_id ?? null,
+          read_order: c.read_order ?? null,
+          rank: c.rank ?? null,
+          evidence: c.evidence ?? null,
+          contradicts: c.contradicts ?? null,
+        })),
+      });
+      const linked = result.records[0]?.get("linked");
+      return linked?.toNumber?.() ?? Number(linked) ?? 0;
+    } finally {
+      await session.close();
+    }
+  }
+
   async list_agent_sessions(opts: {
     limit?: number;
     offset?: number;

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -382,6 +382,32 @@ WHERE n.file = 'session://generated'
 RETURN n
 `;
 
+// Index a session's concept reflection as edges. The reflection sidecar file
+// is the source of truth; these edges mirror its fully-merged state on every
+// sync, so plain SET (not coalesce) is correct here — a null rank clears the
+// edge property exactly as the sidecar says. Matching prefers the graph ref_id
+// and falls back to the gitree id; a concept regenerated under a new ref_id
+// simply stops matching (the sidecar still holds the record), and the MATCH on
+// the session node (never MERGE — see the guard in appendSessionEnd) makes the
+// whole write a no-op until the AgentSession node exists.
+export const UPSERT_SESSION_CONCEPT_EDGES_QUERY = `
+MATCH (s:AgentSession {node_key: $session_id})
+UNWIND $concepts AS con
+OPTIONAL MATCH (c:Concept)
+WHERE (con.ref_id IS NOT NULL AND c.ref_id = con.ref_id)
+   OR (con.id IS NOT NULL AND c.id = con.id)
+WITH s, con, collect(c) AS matches
+WITH s, con,
+     head([m IN matches WHERE con.ref_id IS NOT NULL AND m.ref_id = con.ref_id] + matches) AS c
+WHERE c IS NOT NULL
+MERGE (s)-[r:READ_CONCEPT]->(c)
+SET r.read_order = toInteger(con.read_order),
+    r.rank = toInteger(con.rank),
+    r.evidence = con.evidence,
+    r.contradicts = con.contradicts
+RETURN count(r) AS linked
+`;
+
 export const CREATE_SIBLING_EDGE_QUERY = `
 MATCH (a:Hint {ref_id: $source_ref_id})
 MATCH (b:Hint {ref_id: $target_ref_id})

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -178,6 +178,11 @@ export async function appendSessionEnd(
       error_message: opts.error_message || "",
     })
     .catch((e) => console.error("[sessions] Neo4j upsert failed:", e));
+  // Now that the AgentSession node exists, index any reflection that was
+  // merged before it did (sub-agent runs reflect before appendSessionEnd —
+  // see toolsJarvis — and earlier turns' syncs no-oped without the node).
+  const reflection = loadReflection(sessionId);
+  if (reflection) syncReflectionEdges(sessionId, reflection.concepts);
 }
 
 /**
@@ -562,7 +567,30 @@ export function mergeReflection(
   if (incoming.raw) reflection.raw = incoming.raw;
 
   writeFileSync(getReflectionFile(sessionId), JSON.stringify(reflection, null, 2));
+  syncReflectionEdges(sessionId, reflection.concepts);
   return reflection;
+}
+
+/**
+ * Fire-and-forget mirror of a session's reflection into the graph as
+ * (AgentSession)-[:READ_CONCEPT]->(Concept) edges, so concept usage is
+ * queryable (and outlives the 30-day sidecar pruning, which the node does).
+ * The sidecar file remains the source of truth: edges are an index over it,
+ * and every failure mode — db down, AgentSession node not created yet,
+ * concept regenerated under a new ref_id, concept recorded name-only — is
+ * silently absorbed rather than propagated. Runs from mergeReflection (node
+ * already exists on the main agent path) and again from appendSessionEnd
+ * (catches reflections merged before the node existed).
+ */
+export function syncReflectionEdges(
+  sessionId: string,
+  concepts: ReflectedConcept[],
+): void {
+  const linkable = concepts.filter((c) => c.ref_id || c.id);
+  if (linkable.length === 0) return;
+  db
+    ?.upsert_session_concept_edges(sessionId, linkable)
+    .catch((e) => console.error("[concepts] READ_CONCEPT edge sync failed:", e));
 }
 
 export type AnnotationMarker =


### PR DESCRIPTION
## What

When a session's concept reflection is merged into its `.reflection.json` sidecar, the merged state is now also mirrored into the graph as `(AgentSession)-[:READ_CONCEPT]->(Concept)` edges, with `read_order`, `rank`, `evidence`, and `contradicts` as edge properties.

## Why

The reflection sidecar is an opaque local file — invisible to Cypher, to Hive, and deleted by the 30-day session pruning even though AgentSession nodes (and Concept nodes) live on. With edges, concept usage becomes one-hop queryable: most load-bearing concepts across sessions, concepts never read by any session (prune candidates), concepts with `contradicts` flags needing review, and which sessions relied on a concept before regenerating it.

## How

- `UPSERT_SESSION_CONCEPT_EDGES_QUERY` (queries.ts) resolves each concept by graph `ref_id`, falling back to gitree `id`; when both would match different nodes, `ref_id` wins. Unmatched or name-only entries are skipped, never errors. The session node is `MATCH`ed, never `MERGE`d — preserving the existing guard against creating nodes for unregistered sessions.
- `Db.upsert_session_concept_edges()` (neo4j.ts), same shape as the other AgentSession methods.
- `syncReflectionEdges()` (session.ts) fires-and-forgets the upsert from **two** places, because reflection ordering differs by path: `mergeReflection` (main agent paths reflect after `appendSessionEnd`, so the node exists — this also covers the Jarvis sub-agent path and the concept backfill, which links historical sessions for free) and `appendSessionEnd` (catches reflections merged *before* the node existed, e.g. Jarvis children). Both are idempotent MERGEs, so double-syncing is harmless.

The sidecar file remains the source of truth; edges are a best-effort index over it. Plain `SET` (not coalesce) is correct in the Cypher because the sync always writes the fully-merged sidecar state — a null rank clears the edge property exactly as the file says. Reflection stays never-fail: db down, missing node, or a concept regenerated under a new ref_id are all logged and swallowed.

## Reviewer notes

- Edges dangle silently if a concept is regenerated under a new `ref_id` — intentional; treat edge presence as an index, not ground truth (comment in queries.ts says so).
- `pruneExpiredSessions` deliberately does not delete edges: nodes already outlive their jsonl, and the long-horizon usage signal is the point.
- Verified with `tsc`, the full `test:node` suite (474 passing), and a live smoke test against a throwaway Neo4j 5 container covering ref_id match, id fallback, unmatched skip, missing-session no-op, idempotent re-run with rank clearing, and ref_id-over-id precedence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)