### PR TITLE
Backfill READ_CONCEPT edges for pre-existing reflection sidecars

### DIFF
--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -124,6 +124,11 @@ export class GraphStorage extends Storage {
         await session.run(
           "CREATE INDEX concept_id_index IF NOT EXISTS FOR (f:Concept) ON (f.id)"
         );
+        // READ_CONCEPT edge syncing resolves concepts by ref_id (the
+        // Data_Bank ref_id index doesn't apply to a :Concept-label match)
+        await session.run(
+          "CREATE INDEX concept_ref_id_index IF NOT EXISTS FOR (f:Concept) ON (f.ref_id)"
+        );
         await session.run(
           "CREATE INDEX pr_number_index IF NOT EXISTS FOR (p:PullRequest) ON (p.number)"
         );

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -42,7 +42,7 @@ import { mcp_routes } from "./handler/index.js";
 import { logs_agent } from "./log/index.js";
 import * as ga from "./graph_agent/index.js";
 import { pruneExpiredSessions } from "./repo/session.js";
-import { backfillConceptReads } from "./repo/conceptBackfill.js";
+import { backfillConceptReads, backfillConceptEdges } from "./repo/conceptBackfill.js";
 import { pruneExpiredArtifacts } from "./repo/artifacts.js";
 import {
   getBus,
@@ -370,9 +370,13 @@ app.listen(port, host, () => {
   // collection. Marker-guarded, so this is a single small file read once the
   // sweep has completed. Never awaited — a backfill must not delay boot, and
   // it needs Neo4j, which may not be up yet (it retries on the next boot).
-  void backfillConceptReads().catch((e) =>
-    console.error("[concept-backfill] failed:", e),
-  );
+  void backfillConceptReads()
+    .catch((e) => console.error("[concept-backfill] failed:", e))
+    // After the sidecar sweep: index pre-existing reflections as READ_CONCEPT
+    // edges. Sessions the sweep above just wrote synced their own edges via
+    // mergeReflection; this catches sidecars that predate edge syncing.
+    .then(() => backfillConceptEdges())
+    .catch((e) => console.error("[concept-edge-backfill] failed:", e));
 });
 
 //

--- a/mcp/src/repo/conceptBackfill.ts
+++ b/mcp/src/repo/conceptBackfill.ts
@@ -1,5 +1,6 @@
 import { ModelMessage } from "ai";
 import { existsSync, readFileSync, writeFileSync } from "fs";
+import { db } from "../graph/neo4j.js";
 import { listConcepts } from "../gitree/service.js";
 import {
   listSessionFiles,
@@ -202,4 +203,73 @@ export async function backfillConceptReads(
     `[concept-backfill] wrote ${written} sidecar(s) covering ${conceptCount} concept read(s)`,
   );
   return { scanned: sessions.length, written, concepts: conceptCount };
+}
+
+const EDGE_MARKER = ".concept-edge-backfill.json";
+
+/**
+ * One-off mirror of existing reflection sidecars into READ_CONCEPT edges.
+ *
+ * Edge syncing shipped after reflection collection had already been running,
+ * so sessions that reflected before it never got edges: the live sync fires
+ * only from mergeReflection and appendSessionEnd, and backfillConceptReads
+ * skips any session that already has a sidecar. This sweep reads each
+ * existing sidecar and issues the same idempotent MERGEs the live path does —
+ * no deletions, no model calls, and no data-quality downgrade (unlike
+ * regenerating sidecars, which would lose the ranked half forever).
+ *
+ * Sequential on purpose, one query per session, so boot doesn't flood the
+ * driver pool. A sweep with any db failure leaves the marker unwritten and
+ * retries next boot; sessions whose AgentSession node is missing simply link
+ * nothing (the Cypher MATCHes the session node) and are not failures.
+ */
+export async function backfillConceptEdges(): Promise<{
+  scanned: number;
+  synced: number;
+  failed: number;
+}> {
+  if (!db || existsSync(sessionsDirFile(EDGE_MARKER))) {
+    return { scanned: 0, synced: 0, failed: 0 };
+  }
+
+  const sessions = listSessionFiles();
+  let synced = 0;
+  let failed = 0;
+  for (const session of sessions) {
+    const reflection = loadReflection(session.sessionId);
+    if (!reflection) continue;
+    const linkable = reflection.concepts.filter((c) => c.ref_id || c.id);
+    if (linkable.length === 0) continue;
+    try {
+      await db.upsert_session_concept_edges(session.sessionId, linkable);
+      synced++;
+    } catch (e) {
+      failed++;
+      console.error(
+        `[concept-edge-backfill] session ${session.sessionId} failed:`,
+        e,
+      );
+    }
+  }
+
+  if (failed === 0) {
+    try {
+      writeFileSync(
+        sessionsDirFile(EDGE_MARKER),
+        JSON.stringify(
+          { completed_at: new Date().toISOString(), synced },
+          null,
+          2,
+        ),
+      );
+    } catch (e) {
+      console.error("[concept-edge-backfill] could not write marker:", e);
+    }
+  }
+  if (synced > 0 || failed > 0) {
+    console.log(
+      `[concept-edge-backfill] synced ${synced} session(s), ${failed} failure(s)`,
+    );
+  }
+  return { scanned: sessions.length, synced, failed };
 }


### PR DESCRIPTION
## What

Follow-up to #1549. A one-off, marker-guarded startup sweep (`backfillConceptEdges`) that mirrors every **existing** reflection sidecar into `READ_CONCEPT` edges, plus an index on `Concept.ref_id`.

## Why

#1549 syncs edges from `mergeReflection` and `appendSessionEnd` — the live paths. But reflections collected *before* that PR deployed never pass through either again: `backfillConceptReads` deliberately skips sessions that already have a sidecar, so those reflections would only become edges if the session happened to run another turn. On any instance that's been collecting reflections for a while, that's most of them.

The alternative — deleting sidecars so the read backfill regenerates them — was considered and rejected: it permanently loses the ranked half (`rank`/`evidence`/`contradicts`/`gap`, which the read-only backfill deliberately never reconstructs), loses everything for sessions older than the 7-day backfill window, and replaces accurate live-collected read sets with undercounting transcript reconstruction. The sweep reads what's on disk and issues the same idempotent MERGEs the live path does — no deletions, no model calls, no quality downgrade.

## How

- `backfillConceptEdges()` in conceptBackfill.ts: walks `listSessionFiles()`, syncs each session that has a sidecar with linkable concepts (ref_id or gitree id — name-only entries are skipped, matching the live filter). Own marker file (`.concept-edge-backfill.json`), written only after a sweep with zero db failures, so a Neo4j blip retries on the next boot — idempotence makes the retry free. Sessions whose AgentSession node doesn't exist link nothing (the Cypher `MATCH`es, never creates) and are not failures.
- Chained unawaited after `backfillConceptReads()` in index.ts — never delays boot; sidecars the read backfill writes in the same boot sync their own edges via `mergeReflection`, so ordering is a tidiness choice, not a correctness one.
- `concept_ref_id_index` in gitree graphStorage: edge syncing resolves concepts by `ref_id`, and the existing `Data_Bank.ref_id` index doesn't apply to a `:Concept`-label match. Closes the only unindexed lookup in the edge query (it was a label scan over a small label — cheap, but free is better).

## Perf notes

Sequential on purpose — one query per session, awaited, so boot doesn't flood the driver pool. Each query is an indexed session-node lookup plus (now-indexed) concept lookups over a handful of UNWIND rows. After the first completed sweep, the marker reduces this to a single `existsSync` per boot.

## Verification

- `tsc` clean, full `test:node` suite passing (479).
- End-to-end smoke test against a throwaway Neo4j 5 container with an isolated `SESSIONS_DIR`: linkable sidecar → 1 edge with correct properties; name-only sidecar → skipped without error; no-sidecar session → ignored; marker written with correct count; second run is a no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)