### PR TITLE
Concept Proposals: human-reviewed create/update/delete/merge for Concepts

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -30,7 +30,7 @@
     "stage-vein": "rm -rf .vein && rsync -a --exclude node_modules --exclude web/node_modules --exclude build --exclude web/dist --exclude .git --exclude .env --exclude workspace ../vein/ .vein/",
     "sphinx-git": "tsx src/sphinx-git/bin.ts",
     "test": "playwright test",
-    "test:node": "NO_DB=true tsx --test --test-timeout=30000 --test-force-exit \"src/repo/**/*.test.ts\" \"src/log/**/*.test.ts\" \"src/graph_agent/**/*.test.ts\" \"src/graph/**/*.test.ts\" \"src/__tests__/tools.test.ts\" \"src/__tests__/skills.test.ts\"",
+    "test:node": "NO_DB=true tsx --test --test-timeout=30000 --test-force-exit \"src/repo/**/*.test.ts\" \"src/log/**/*.test.ts\" \"src/graph_agent/**/*.test.ts\" \"src/graph/**/*.test.ts\" \"src/gitree/**/*.test.ts\" \"src/__tests__/tools.test.ts\" \"src/__tests__/skills.test.ts\"",
     "test:ui": "playwright test --ui",
     "test:debug": "playwright test --debug",
     "gen-redoc": "tsc --noEmit && tsx docs/gen-redoc.ts",

--- a/mcp/src/gitree/PROPOSALS_API.md
+++ b/mcp/src/gitree/PROPOSALS_API.md
@@ -1,0 +1,83 @@
+# Concept Proposals API
+
+Pending create/update/delete/merge changes to Concepts, stored in the swarm graph and reviewed by a human before they land. Base URL is the swarm (port 3355), same auth as other `/gitree/*` endpoints (`x-api-token` header).
+
+## Proposal shape
+
+```jsonc
+{
+  "id": "uuid",
+  "action": "create | update | delete | merge",
+  "status": "pending | accepted | rejected",
+  "repo": "owner/repo",
+
+  // targets (update/delete/merge). For merge: conceptId is absorbed into mergeIntoConceptId.
+  "conceptId": "owner/repo/auth-system",
+  "mergeIntoConceptId": "owner/repo/authentication",
+
+  // proposed content
+  "name": "…",              // create only
+  "description": "…",       // optional description change
+  "documentation": "…",     // full proposed markdown docs
+  "parent": "…",            // create only, optional parent concept id
+
+  // snapshots captured server-side at propose time — use for diff rendering
+  "baseDocs": "…",          // docs of the edited concept when the proposal was made
+  "absorbedDocs": "…",      // merge only: docs of the concept that will be deleted
+
+  // review metadata
+  "rationale": "…",         // why — show this to the reviewer
+  "source": "…",            // producer, e.g. "pr-merge", "dedup-workflow", "agent"
+  "prNumbers": [123],
+  "sessionIds": ["…"],
+
+  // decision (set once decided)
+  "decidedBy": "…",
+  "decisionReason": "…",
+  "decidedAt": "ISO date",
+  "createdConceptId": "…",  // accepted create: the minted concept id (deep-link target)
+
+  "createdAt": "ISO date"
+}
+```
+
+**Diff rendering:** for `update`/`merge`, diff `baseDocs` → `documentation`. For `create`, there is no before. For `delete`, show `baseDocs` as removed. For `merge`, also show `absorbedDocs` (the concept being folded in and deleted).
+
+## Endpoints
+
+### `GET /gitree/proposals?repo=owner/repo&status=pending`
+Both params optional. → `{ proposals: Proposal[], count, repo }`, newest first. Use `status=pending` for the review queue / badge count.
+
+### `GET /gitree/proposals/:id`
+→ `{ proposal }` or 404.
+
+### `POST /gitree/proposals`
+Create a proposal (for producers; the UI likely doesn't call this). Body: `action` plus the relevant fields above (`baseDocs`/`absorbedDocs` are captured server-side — do not send). Validates targets exist (404) and, for create, that the name doesn't collide (409). → `{ status: "success", proposal }`.
+
+### `POST /gitree/proposals/:id/accept`
+Body: `{ decidedBy?: string, force?: boolean }`.
+Applies the change to the Concept graph, then stamps the proposal accepted. → `{ status: "success", proposal }`.
+
+Errors:
+- `404` — proposal (or its target concept) no longer exists
+- `409 { status }` — already accepted/rejected (idempotency guard)
+- `409 { code: "stale_base", conceptId }` — the concept's docs changed since the proposal was made. Surface this in the UI ("concept has changed since this was proposed — re-review") and offer a re-fetch + explicit force retry (`force: true` overrides).
+
+### `POST /gitree/proposals/:id/reject`
+Body: `{ decidedBy?: string, reason?: string }`. No graph side effects. Same 404/409-already-decided errors. → `{ status: "success", proposal }`.
+
+## Accept semantics (what the UI can promise the user)
+
+- **create** → new Concept minted exactly like `POST /gitree/create-concept-direct` (id = `owner/repo/<slug-of-name>`, in `createdConceptId`).
+- **update** → target's documentation (and description, if proposed) replaced.
+- **delete** → target Concept deleted.
+- **merge** → surviving concept gets the merged docs + unioned PR/commit provenance; absorbed concept is deleted.
+
+Decided proposals are kept in the graph (audit trail) — the list endpoint with `status=accepted|rejected` is a per-concept change history via their `conceptId`/`createdConceptId`.
+
+## Hive integration notes
+
+- Follow the existing thin-proxy pattern of `src/app/api/learnings/concepts/*` (swarm URL + `x-api-token` via `getSwarmConfig`, `requireReadAccess` for GET, `requireMemberAccess` for accept/reject).
+- Pass the Hive user's identifier as `decidedBy` on accept/reject.
+- Diff UI: reuse `computeUnifiedDiff` (`src/lib/diff/unifiedLineDiff.ts`) and the `UnifiedDiffView` rendering from `ProposalCard.tsx` — same contract as the chat proposal cards (`oldStr` = `baseDocs`, `newStr` = `documentation`).
+- After an accepted create, deep-link to `/w/{slug}/learn?concept={createdConceptId}`.

--- a/mcp/src/gitree/__tests__/concept-proposals.test.ts
+++ b/mcp/src/gitree/__tests__/concept-proposals.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Unit tests for applying ConceptProposals (accept-time semantics).
+ *
+ * Strategy: mock GraphStorage so no real Neo4j connection is needed, and call
+ * the real applyProposal used by POST /gitree/proposals/:id/accept. Covers:
+ *   - update: docs applied through saveDocumentation
+ *   - update with description: goes through saveConcept (embedding refresh)
+ *   - update stale base → 409 with code "stale_base", nothing written
+ *   - update stale base + force → applied
+ *   - delete: concept removed, stale base honored
+ *   - merge: provenance unioned, surviving concept updated, absorbed deleted
+ *   - merge stale base on the surviving concept → 409
+ *   - create: delegates to createConceptDirect, returns createdConceptId
+ *   - create when concept appeared while pending → 409
+ *   - update when target vanished while pending → 404
+ */
+import { test, expect } from "../../testkit.js";
+import { applyProposal } from "../proposals.js";
+import { HttpError } from "../service.js";
+import type { Concept, ConceptProposal } from "../types.js";
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeConcept(
+  overrides: Partial<Concept> & { id: string; name: string }
+): Concept {
+  const now = new Date();
+  return {
+    repo: undefined,
+    description: "",
+    prNumbers: [],
+    commitShas: [],
+    createdAt: now,
+    lastUpdated: now,
+    documentation: "",
+    ...overrides,
+  };
+}
+
+function makeProposal(
+  overrides: Partial<ConceptProposal> & { action: ConceptProposal["action"] }
+): ConceptProposal {
+  return {
+    id: "test-proposal-id",
+    status: "pending",
+    createdAt: new Date(),
+    ...overrides,
+  };
+}
+
+/** In-memory mock of the GraphStorage surface applyProposal touches. */
+function makeStorage(seed: Concept[] = []) {
+  const store: Record<string, Concept> = {};
+  for (const concept of seed) store[concept.id] = concept;
+  const savedDocs: Array<{ conceptId: string; documentation: string }> = [];
+  const savedConcepts: Concept[] = [];
+
+  const storage: any = {
+    _store: store,
+    _savedDocs: savedDocs,
+    _savedConcepts: savedConcepts,
+    initialize: async () => {},
+    getConcept: async (id: string, repo?: string) => {
+      const fullId = repo && !id.includes("/") ? `${repo}/${id}` : id;
+      return store[fullId] ?? null;
+    },
+    saveConcept: async (concept: Concept) => {
+      store[concept.id] = concept;
+      savedConcepts.push(concept);
+    },
+    saveDocumentation: async (conceptId: string, documentation: string) => {
+      savedDocs.push({ conceptId, documentation });
+      if (store[conceptId]) store[conceptId].documentation = documentation;
+    },
+    deleteConcept: async (id: string, repo?: string) => {
+      const fullId = repo && !id.includes("/") ? `${repo}/${id}` : id;
+      delete store[fullId];
+    },
+    linkConceptParent: async () => {},
+  };
+  return storage;
+}
+
+async function expectHttpError(
+  fn: () => Promise<any>,
+  statusCode: number
+): Promise<HttpError> {
+  try {
+    await fn();
+  } catch (err: any) {
+    expect(err instanceof HttpError).toBe(true);
+    expect(err.statusCode).toBe(statusCode);
+    return err;
+  }
+  throw new Error(`Expected HttpError ${statusCode}, but nothing was thrown`);
+}
+
+// ─── update ─────────────────────────────────────────────────────────────────
+
+test.describe("applyProposal — update", () => {
+  test("applies documentation through saveDocumentation when base matches", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        documentation: "old docs",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "update",
+      conceptId: "owner/repo/auth",
+      repo: "owner/repo",
+      baseDocs: "old docs",
+      documentation: "new docs",
+    });
+
+    const result = await applyProposal(storage, proposal, false);
+
+    expect(result.createdConceptId).toBe(undefined);
+    expect(storage._savedDocs).toEqual([
+      { conceptId: "owner/repo/auth", documentation: "new docs" },
+    ]);
+    expect(storage._savedConcepts.length).toBe(0);
+    expect(storage._store["owner/repo/auth"].documentation).toBe("new docs");
+  });
+
+  test("goes through saveConcept when the description also changes", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        description: "old description",
+        documentation: "old docs",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "update",
+      conceptId: "owner/repo/auth",
+      repo: "owner/repo",
+      baseDocs: "old docs",
+      documentation: "new docs",
+      description: "new description",
+    });
+
+    await applyProposal(storage, proposal, false);
+
+    expect(storage._savedConcepts.length).toBe(1);
+    expect(storage._savedConcepts[0].description).toBe("new description");
+    expect(storage._savedConcepts[0].documentation).toBe("new docs");
+    expect(storage._savedDocs.length).toBe(0);
+  });
+
+  test("rejects a stale base with 409 stale_base and writes nothing", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        documentation: "docs changed by someone else",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "update",
+      conceptId: "owner/repo/auth",
+      repo: "owner/repo",
+      baseDocs: "old docs",
+      documentation: "new docs",
+    });
+
+    const err = await expectHttpError(
+      () => applyProposal(storage, proposal, false),
+      409
+    );
+    expect(err.extra?.code).toBe("stale_base");
+    expect(storage._savedDocs.length).toBe(0);
+    expect(storage._store["owner/repo/auth"].documentation).toBe(
+      "docs changed by someone else"
+    );
+  });
+
+  test("force overrides a stale base", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        documentation: "docs changed by someone else",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "update",
+      conceptId: "owner/repo/auth",
+      repo: "owner/repo",
+      baseDocs: "old docs",
+      documentation: "new docs",
+    });
+
+    await applyProposal(storage, proposal, true);
+
+    expect(storage._store["owner/repo/auth"].documentation).toBe("new docs");
+  });
+
+  test("404s when the target vanished while the proposal was pending", async () => {
+    const storage = makeStorage([]);
+    const proposal = makeProposal({
+      action: "update",
+      conceptId: "owner/repo/gone",
+      repo: "owner/repo",
+      baseDocs: "old docs",
+      documentation: "new docs",
+    });
+
+    await expectHttpError(() => applyProposal(storage, proposal, false), 404);
+  });
+});
+
+// ─── delete ─────────────────────────────────────────────────────────────────
+
+test.describe("applyProposal — delete", () => {
+  test("deletes the concept when base matches", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/dead",
+        name: "Dead",
+        repo: "owner/repo",
+        documentation: "docs",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "delete",
+      conceptId: "owner/repo/dead",
+      repo: "owner/repo",
+      baseDocs: "docs",
+    });
+
+    await applyProposal(storage, proposal, false);
+
+    expect(storage._store["owner/repo/dead"]).toBe(undefined);
+  });
+
+  test("refuses to delete when docs drifted since propose time", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/dead",
+        name: "Dead",
+        repo: "owner/repo",
+        documentation: "docs got rewritten",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "delete",
+      conceptId: "owner/repo/dead",
+      repo: "owner/repo",
+      baseDocs: "docs",
+    });
+
+    await expectHttpError(() => applyProposal(storage, proposal, false), 409);
+    expect(storage._store["owner/repo/dead"]).toBeDefined();
+  });
+});
+
+// ─── merge ──────────────────────────────────────────────────────────────────
+
+test.describe("applyProposal — merge", () => {
+  test("unions provenance into the survivor and deletes the absorbed concept", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        description: "surviving",
+        documentation: "auth docs",
+        prNumbers: [1, 2],
+        commitShas: ["aaa"],
+      }),
+      makeConcept({
+        id: "owner/repo/login",
+        name: "Login",
+        repo: "owner/repo",
+        documentation: "login docs",
+        prNumbers: [2, 3],
+        commitShas: ["bbb"],
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "merge",
+      conceptId: "owner/repo/login",
+      mergeIntoConceptId: "owner/repo/auth",
+      repo: "owner/repo",
+      baseDocs: "auth docs",
+      absorbedDocs: "login docs",
+      documentation: "merged docs",
+    });
+
+    await applyProposal(storage, proposal, false);
+
+    const survivor = storage._store["owner/repo/auth"];
+    expect(survivor.documentation).toBe("merged docs");
+    expect(survivor.prNumbers).toEqual([1, 2, 3]);
+    expect(survivor.commitShas).toEqual(["aaa", "bbb"]);
+    expect(survivor.description).toBe("surviving");
+    expect(storage._store["owner/repo/login"]).toBe(undefined);
+  });
+
+  test("409s when the surviving concept's docs drifted", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        documentation: "auth docs drifted",
+      }),
+      makeConcept({
+        id: "owner/repo/login",
+        name: "Login",
+        repo: "owner/repo",
+        documentation: "login docs",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "merge",
+      conceptId: "owner/repo/login",
+      mergeIntoConceptId: "owner/repo/auth",
+      repo: "owner/repo",
+      baseDocs: "auth docs",
+      documentation: "merged docs",
+    });
+
+    await expectHttpError(() => applyProposal(storage, proposal, false), 409);
+    expect(storage._store["owner/repo/login"]).toBeDefined();
+    expect(storage._store["owner/repo/auth"].documentation).toBe(
+      "auth docs drifted"
+    );
+  });
+});
+
+// ─── create ─────────────────────────────────────────────────────────────────
+
+test.describe("applyProposal — create", () => {
+  test("creates the concept and reports its minted id", async () => {
+    const storage = makeStorage([]);
+    const proposal = makeProposal({
+      action: "create",
+      repo: "owner/repo",
+      name: "Rate Limiting",
+      description: "How rate limits work",
+      documentation: "rate limit docs",
+    });
+
+    const result = await applyProposal(storage, proposal, false);
+
+    expect(result.createdConceptId).toBe("owner/repo/rate-limiting");
+    const created = storage._store["owner/repo/rate-limiting"];
+    expect(created).toBeDefined();
+    expect(created.name).toBe("Rate Limiting");
+    expect(created.description).toBe("How rate limits work");
+    expect(created.documentation).toBe("rate limit docs");
+  });
+
+  test("409s when the concept appeared while the proposal was pending", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/rate-limiting",
+        name: "Rate Limiting",
+        repo: "owner/repo",
+      }),
+    ]);
+    const proposal = makeProposal({
+      action: "create",
+      repo: "owner/repo",
+      name: "Rate Limiting",
+      documentation: "rate limit docs",
+    });
+
+    const err = await expectHttpError(
+      () => applyProposal(storage, proposal, false),
+      409
+    );
+    expect(err.extra?.conceptId).toBe("owner/repo/rate-limiting");
+  });
+});

--- a/mcp/src/gitree/__tests__/create-concept-direct-parent.test.ts
+++ b/mcp/src/gitree/__tests__/create-concept-direct-parent.test.ts
@@ -99,130 +99,50 @@ function makeRes() {
   return res;
 }
 
-/**
- * Monkey-patch GraphStorage constructor so the handler picks up our mock.
- * Routes.ts does `new GraphStorage()` directly; we intercept via module-level
- * dynamic import swapping isn't available in node:test without an ESM mocking
- * library — so we use the established pattern of injecting via the module's
- * imported symbol by temporarily replacing it in the module cache.
- *
- * Since tsx/ESM doesn't allow reassigning named exports directly, we instead
- * test through the handler function but pass a mockStorage instance by
- * re-exporting a thin adapter that accepts an injected storage.
- *
- * Simpler approach: extract handler logic into a helper that accepts storage.
- * Since we can't do that without changing prod code, we test via a local
- * re-implementation that calls the same logic path but with injectable storage.
- * This keeps tests honest without requiring prod refactors.
- *
- * Concretely: we call the handler directly after temporarily replacing
- * `GraphStorage` in the routes module's closure by patching global module state.
- * This is idiomatic in ESM test environments where esmock isn't used.
- *
- * For test isolation we instead use a lightweight approach: create a thin
- * wrapper that exercises the same code paths but via the exported handler
- * with a mock backing. We accomplish this via a local testable reimplementation
- * of the handler logic that reads from the same code but accepts injectable
- * storage — which keeps test coverage meaningful without E2E infra.
- */
+// ─── Handler adapter ─────────────────────────────────────────────────────────
+// Calls the real shared service logic (also used by the route handler and by
+// accepted "create" concept-proposals) with an injected mock storage, mapping
+// the result/HttpError to the same {status, body} shape the route produces.
 
-// ─── Handler logic reimplementation (mirrors routes.ts exactly) ─────────────
-
-import { generateSlug, makeRepoId } from "../store/utils.js";
+import { createConceptDirect, HttpError } from "../service.js";
 
 async function callHandlerWithStorage(
   storage: any,
   body: Record<string, any>
 ): Promise<{ status: number; body: any }> {
-  const { name, documentation, description, repo, parent } = body;
-
-  if (!name || typeof name !== "string" || !name.trim()) {
-    return { status: 400, body: { error: "name is required" } };
-  }
-  if (typeof documentation !== "string") {
-    return { status: 400, body: { error: "documentation is required and must be a string" } };
-  }
-
-  const slug = generateSlug(name);
-  if (!slug) {
-    return { status: 400, body: { error: "name must contain alphanumeric characters" } };
-  }
-
-  const repoId = typeof repo === "string" && repo.trim() ? repo.trim() : undefined;
-  const conceptId = repoId ? makeRepoId(repoId, slug) : slug;
-  const parentId =
-    typeof parent === "string" && parent.trim() ? parent.trim() : undefined;
-
   await storage.initialize();
-
-  const existing = await storage.getConcept(conceptId, repoId);
-  if (existing) {
+  try {
+    const { concept, parentId } = await createConceptDirect(storage, {
+      name: body.name,
+      documentation: body.documentation,
+      description: body.description,
+      repo: body.repo,
+      parent: body.parent,
+    });
     return {
-      status: 409,
-      body: { error: `Concept ${conceptId} already exists`, conceptId },
-    };
-  }
-
-  let parentConcept: Concept | null = null;
-  if (parentId) {
-    parentConcept = await storage.getConcept(parentId, repoId);
-    if (!parentConcept) {
-      return { status: 400, body: { error: `Parent concept ${parentId} not found` } };
-    }
-    if (parentConcept.id === conceptId) {
-      return { status: 400, body: { error: "A concept cannot be its own parent" } };
-    }
-  }
-
-  const now = new Date();
-  const concept: Concept = {
-    id: conceptId,
-    repo: repoId,
-    name: name.trim(),
-    description: typeof description === "string" ? description : "",
-    prNumbers: [],
-    commitShas: [],
-    createdAt: now,
-    lastUpdated: now,
-    documentation,
-  };
-
-  await storage.saveConcept(concept);
-  await storage.saveDocumentation(conceptId, documentation);
-
-  if (parentId && parentConcept) {
-    try {
-      await storage.linkConceptParent(parentConcept.id, conceptId);
-    } catch (linkErr: any) {
-      try {
-        await storage.deleteConcept(conceptId, repoId);
-      } catch (rollbackErr: any) {
-        // log but don't mask original error
-      }
-      return {
-        status: 500,
-        body: {
-          error: `Concept created but parent link failed; rolled back: ${linkErr.message}`,
+      status: 200,
+      body: {
+        status: "success",
+        message: `Created concept ${concept.id}`,
+        concept: {
+          id: concept.id,
+          repo: concept.repo,
+          name: concept.name,
+          description: concept.description,
+          documentation: concept.documentation,
+          ...(parentId ? { parent: parentId } : {}),
         },
+      },
+    };
+  } catch (error: any) {
+    if (error instanceof HttpError) {
+      return {
+        status: error.statusCode,
+        body: { error: error.message, ...(error.extra || {}) },
       };
     }
+    throw error;
   }
-
-  return {
-    status: 200,
-    body: {
-      status: "success",
-      message: `Created concept ${conceptId}`,
-      concept: {
-        id: concept.id,
-        repo: concept.repo,
-        name: concept.name,
-        description: concept.description,
-        documentation: concept.documentation,
-        ...(parentConcept ? { parent: parentConcept.id } : {}),
-      },
-    },
-  };
 }
 
 // ─── Tests ───────────────────────────────────────────────────────────────────

--- a/mcp/src/gitree/proposals.ts
+++ b/mcp/src/gitree/proposals.ts
@@ -1,0 +1,457 @@
+import { Request, Response } from "express";
+import { randomUUID } from "crypto";
+import { GraphStorage } from "./store/index.js";
+import {
+  Concept,
+  ConceptProposal,
+  ConceptProposalAction,
+  ConceptProposalStatus,
+} from "./types.js";
+import { generateSlug, makeRepoId } from "./store/utils.js";
+import { createConceptDirect, HttpError } from "./service.js";
+import { parseRepoParam } from "./routes.js";
+
+const VALID_ACTIONS: ConceptProposalAction[] = [
+  "create",
+  "update",
+  "delete",
+  "merge",
+];
+
+const VALID_STATUSES: ConceptProposalStatus[] = [
+  "pending",
+  "accepted",
+  "rejected",
+];
+
+function sendError(res: Response, error: any, fallback: string) {
+  if (error instanceof HttpError) {
+    res
+      .status(error.statusCode)
+      .json({ error: error.message, ...(error.extra || {}) });
+    return;
+  }
+  console.error(fallback, error);
+  res.status(500).json({ error: error.message || fallback });
+}
+
+function optionalString(value: any): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+async function requireConcept(
+  storage: GraphStorage,
+  conceptId: string,
+  repo?: string
+): Promise<Concept> {
+  const concept = await storage.getConcept(conceptId, repo);
+  if (!concept) {
+    throw new HttpError(404, `Concept ${conceptId} not found`);
+  }
+  return concept;
+}
+
+// A pending proposal's target may drift while it sits in the queue (another
+// proposal accepted first, or a manual edit). Refuse to clobber the newer
+// docs unless the reviewer explicitly forces it.
+function checkStaleBase(
+  proposal: ConceptProposal,
+  concept: Concept,
+  force: boolean
+) {
+  if (force) return;
+  if ((proposal.baseDocs ?? "") !== (concept.documentation ?? "")) {
+    throw new HttpError(
+      409,
+      `Documentation of concept ${concept.id} has changed since this proposal was created; re-review or pass force=true`,
+      { code: "stale_base", conceptId: concept.id }
+    );
+  }
+}
+
+function unionArray<T>(a: T[], b: T[]): T[] {
+  return Array.from(new Set([...a, ...b]));
+}
+
+/**
+ * Create a concept proposal
+ * POST /gitree/proposals
+ * Body: { action, repo?, conceptId?, mergeIntoConceptId?, name?, description?,
+ *         documentation?, parent?, rationale?, source?, prNumbers?, sessionIds? }
+ */
+export async function gitree_create_proposal(req: Request, res: Response) {
+  console.log("===> gitree_create_proposal", req.path, req.method);
+  try {
+    const body = req.body || {};
+    const action = body.action as ConceptProposalAction;
+    if (!VALID_ACTIONS.includes(action)) {
+      res.status(400).json({
+        error: `action must be one of: ${VALID_ACTIONS.join(", ")}`,
+      });
+      return;
+    }
+
+    const storage = new GraphStorage();
+    await storage.initialize();
+
+    const proposal: ConceptProposal = {
+      id: randomUUID(),
+      action,
+      status: "pending",
+      repo: optionalString(body.repo),
+      rationale: optionalString(body.rationale),
+      source: optionalString(body.source),
+      prNumbers: Array.isArray(body.prNumbers)
+        ? body.prNumbers.filter((n: any) => Number.isFinite(n)).map(Number)
+        : undefined,
+      sessionIds: Array.isArray(body.sessionIds)
+        ? body.sessionIds.filter((s: any) => typeof s === "string")
+        : undefined,
+      createdAt: new Date(),
+    };
+
+    if (action === "create") {
+      const name = optionalString(body.name);
+      if (!name) {
+        throw new HttpError(400, "name is required for a create proposal");
+      }
+      if (typeof body.documentation !== "string") {
+        throw new HttpError(
+          400,
+          "documentation is required and must be a string"
+        );
+      }
+      const slug = generateSlug(name);
+      if (!slug) {
+        throw new HttpError(400, "name must contain alphanumeric characters");
+      }
+      // Early feedback only — existence is re-checked authoritatively at
+      // accept time, since concepts can appear while the proposal is pending.
+      const targetId = proposal.repo ? makeRepoId(proposal.repo, slug) : slug;
+      const existing = await storage.getConcept(targetId, proposal.repo);
+      if (existing) {
+        throw new HttpError(409, `Concept ${targetId} already exists`, {
+          conceptId: targetId,
+        });
+      }
+      const parent = optionalString(body.parent);
+      if (parent) {
+        const parentConcept = await storage.getConcept(parent, proposal.repo);
+        if (!parentConcept) {
+          throw new HttpError(400, `Parent concept ${parent} not found`);
+        }
+        proposal.parent = parentConcept.id;
+      }
+      proposal.name = name;
+      proposal.description = optionalString(body.description);
+      proposal.documentation = body.documentation;
+    } else if (action === "update") {
+      const conceptId = optionalString(body.conceptId);
+      if (!conceptId) {
+        throw new HttpError(
+          400,
+          "conceptId is required for an update proposal"
+        );
+      }
+      if (typeof body.documentation !== "string") {
+        throw new HttpError(
+          400,
+          "documentation is required and must be a string"
+        );
+      }
+      const concept = await requireConcept(storage, conceptId, proposal.repo);
+      proposal.conceptId = concept.id;
+      proposal.repo = proposal.repo || concept.repo;
+      proposal.baseDocs = concept.documentation ?? "";
+      proposal.documentation = body.documentation;
+      proposal.description = optionalString(body.description);
+    } else if (action === "delete") {
+      const conceptId = optionalString(body.conceptId);
+      if (!conceptId) {
+        throw new HttpError(400, "conceptId is required for a delete proposal");
+      }
+      const concept = await requireConcept(storage, conceptId, proposal.repo);
+      proposal.conceptId = concept.id;
+      proposal.repo = proposal.repo || concept.repo;
+      proposal.baseDocs = concept.documentation ?? "";
+    } else {
+      // merge: conceptId is absorbed into mergeIntoConceptId
+      const conceptId = optionalString(body.conceptId);
+      const mergeIntoConceptId = optionalString(body.mergeIntoConceptId);
+      if (!conceptId || !mergeIntoConceptId) {
+        throw new HttpError(
+          400,
+          "conceptId (absorbed) and mergeIntoConceptId (surviving) are required for a merge proposal"
+        );
+      }
+      if (typeof body.documentation !== "string") {
+        throw new HttpError(
+          400,
+          "documentation (the merged docs for the surviving concept) is required and must be a string"
+        );
+      }
+      const absorbed = await requireConcept(storage, conceptId, proposal.repo);
+      const into = await requireConcept(
+        storage,
+        mergeIntoConceptId,
+        proposal.repo
+      );
+      if (absorbed.id === into.id) {
+        throw new HttpError(400, "A concept cannot be merged into itself");
+      }
+      proposal.conceptId = absorbed.id;
+      proposal.mergeIntoConceptId = into.id;
+      proposal.repo = proposal.repo || into.repo;
+      proposal.baseDocs = into.documentation ?? "";
+      proposal.absorbedDocs = absorbed.documentation ?? "";
+      proposal.documentation = body.documentation;
+      proposal.description = optionalString(body.description);
+    }
+
+    await storage.saveProposal(proposal);
+    console.log(`✅ Concept proposal created: ${proposal.id} (${action})`);
+    res.json({ status: "success", proposal });
+  } catch (error: any) {
+    sendError(res, error, "Failed to create proposal");
+  }
+}
+
+/**
+ * List proposals
+ * GET /gitree/proposals?repo=owner/repo&status=pending (both optional)
+ */
+export async function gitree_list_proposals(req: Request, res: Response) {
+  try {
+    const repo = parseRepoParam(req);
+    const statusParam = req.query.status as string | undefined;
+    if (
+      statusParam &&
+      !VALID_STATUSES.includes(statusParam as ConceptProposalStatus)
+    ) {
+      res.status(400).json({
+        error: `status must be one of: ${VALID_STATUSES.join(", ")}`,
+      });
+      return;
+    }
+
+    const storage = new GraphStorage();
+    await storage.initialize();
+    const proposals = await storage.getAllProposals(
+      repo,
+      statusParam as ConceptProposalStatus | undefined
+    );
+
+    res.json({ proposals, count: proposals.length, repo: repo || "all" });
+  } catch (error: any) {
+    sendError(res, error, "Failed to list proposals");
+  }
+}
+
+/**
+ * Get a specific proposal
+ * GET /gitree/proposals/:id
+ */
+export async function gitree_get_proposal(req: Request, res: Response) {
+  try {
+    const storage = new GraphStorage();
+    await storage.initialize();
+    const proposal = await storage.getProposal(req.params.id as string);
+    if (!proposal) {
+      res.status(404).json({ error: "Proposal not found" });
+      return;
+    }
+    res.json({ proposal });
+  } catch (error: any) {
+    sendError(res, error, "Failed to get proposal");
+  }
+}
+
+/**
+ * Accept a proposal — applies the change to the Concept graph through the
+ * same write paths direct edits use, then stamps the proposal accepted.
+ * POST /gitree/proposals/:id/accept
+ * Body: { decidedBy?, force? } — force overrides the stale-base check
+ */
+export async function gitree_accept_proposal(req: Request, res: Response) {
+  console.log("===> gitree_accept_proposal", req.path, req.method);
+  try {
+    const body = req.body || {};
+    const decidedBy = optionalString(body.decidedBy);
+    const force = body.force === true || body.force === "true";
+
+    const storage = new GraphStorage();
+    await storage.initialize();
+
+    const proposal = await storage.getProposal(req.params.id as string);
+    if (!proposal) {
+      res.status(404).json({ error: "Proposal not found" });
+      return;
+    }
+    if (proposal.status !== "pending") {
+      throw new HttpError(
+        409,
+        `Proposal ${proposal.id} was already ${proposal.status}`,
+        { status: proposal.status }
+      );
+    }
+
+    // Claim before applying so a concurrent accept can never apply twice;
+    // rolled back to pending if applying fails.
+    const claimed = await storage.claimProposal(
+      proposal.id,
+      "accepted",
+      decidedBy
+    );
+    if (!claimed) {
+      throw new HttpError(
+        409,
+        `Proposal ${proposal.id} was already decided by another request`
+      );
+    }
+
+    try {
+      const { createdConceptId } = await applyProposal(
+        storage,
+        proposal,
+        force
+      );
+      if (createdConceptId) {
+        await storage.setProposalCreatedConcept(proposal.id, createdConceptId);
+      }
+      const updated = await storage.getProposal(proposal.id);
+      console.log(
+        `✅ Concept proposal accepted: ${proposal.id} (${proposal.action})`
+      );
+      res.json({ status: "success", proposal: updated });
+    } catch (applyError: any) {
+      await storage.releaseProposalClaim(proposal.id).catch((releaseError) => {
+        console.error(
+          `Failed to release claim on proposal ${proposal.id}:`,
+          releaseError
+        );
+      });
+      throw applyError;
+    }
+  } catch (error: any) {
+    sendError(res, error, "Failed to accept proposal");
+  }
+}
+
+/**
+ * Reject a proposal — stamps the decision, touches no Concept.
+ * POST /gitree/proposals/:id/reject
+ * Body: { decidedBy?, reason? }
+ */
+export async function gitree_reject_proposal(req: Request, res: Response) {
+  console.log("===> gitree_reject_proposal", req.path, req.method);
+  try {
+    const body = req.body || {};
+    const storage = new GraphStorage();
+    await storage.initialize();
+
+    const proposal = await storage.getProposal(req.params.id as string);
+    if (!proposal) {
+      res.status(404).json({ error: "Proposal not found" });
+      return;
+    }
+    const claimed = await storage.claimProposal(
+      proposal.id,
+      "rejected",
+      optionalString(body.decidedBy),
+      optionalString(body.reason)
+    );
+    if (!claimed) {
+      throw new HttpError(
+        409,
+        `Proposal ${proposal.id} was already ${proposal.status}`,
+        { status: proposal.status }
+      );
+    }
+    const updated = await storage.getProposal(proposal.id);
+    res.json({ status: "success", proposal: updated });
+  } catch (error: any) {
+    sendError(res, error, "Failed to reject proposal");
+  }
+}
+
+export async function applyProposal(
+  storage: GraphStorage,
+  proposal: ConceptProposal,
+  force: boolean
+): Promise<{ createdConceptId?: string }> {
+  switch (proposal.action) {
+    case "create": {
+      const { concept } = await createConceptDirect(storage, {
+        name: proposal.name || "",
+        documentation: proposal.documentation ?? "",
+        description: proposal.description,
+        repo: proposal.repo,
+        parent: proposal.parent,
+      });
+      return { createdConceptId: concept.id };
+    }
+
+    case "update": {
+      const concept = await requireConcept(
+        storage,
+        proposal.conceptId!,
+        proposal.repo
+      );
+      checkStaleBase(proposal, concept, force);
+      if (proposal.description !== undefined) {
+        // saveConcept refreshes the embedding from name + description
+        await storage.saveConcept({
+          ...concept,
+          description: proposal.description,
+          documentation: proposal.documentation ?? "",
+          lastUpdated: new Date(),
+        });
+      } else {
+        await storage.saveDocumentation(
+          concept.id,
+          proposal.documentation ?? ""
+        );
+      }
+      return {};
+    }
+
+    case "delete": {
+      const concept = await requireConcept(
+        storage,
+        proposal.conceptId!,
+        proposal.repo
+      );
+      checkStaleBase(proposal, concept, force);
+      await storage.deleteConcept(concept.id, proposal.repo);
+      return {};
+    }
+
+    case "merge": {
+      const absorbed = await requireConcept(
+        storage,
+        proposal.conceptId!,
+        proposal.repo
+      );
+      const into = await requireConcept(
+        storage,
+        proposal.mergeIntoConceptId!,
+        proposal.repo
+      );
+      checkStaleBase(proposal, into, force);
+      // saveConcept also re-creates TOUCHES edges for the unioned provenance
+      await storage.saveConcept({
+        ...into,
+        description: proposal.description ?? into.description,
+        documentation: proposal.documentation ?? into.documentation,
+        prNumbers: unionArray(into.prNumbers, absorbed.prNumbers),
+        commitShas: unionArray(
+          into.commitShas || [],
+          absorbed.commitShas || []
+        ),
+        lastUpdated: new Date(),
+      });
+      await storage.deleteConcept(absorbed.id, proposal.repo);
+      return {};
+    }
+  }
+}

--- a/mcp/src/gitree/routes.ts
+++ b/mcp/src/gitree/routes.ts
@@ -16,7 +16,7 @@ import {
 } from "../aieo/src/provider.js";
 import { generateObject, jsonSchema } from "ai";
 import { formatConceptWithDetails } from "./utils.js";
-import { listConcepts } from "./service.js";
+import { listConcepts, createConceptDirect, HttpError } from "./service.js";
 import {
   toReturnNode,
   toReturnNodeNoBody,
@@ -92,7 +92,7 @@ function parseGitRepoUrl(url: string): { owner: string; repo: string } | null {
  * Accepts: owner/repo, https://github.com/owner/repo, etc.
  * Returns normalized "owner/repo" format or undefined
  */
-function parseRepoParam(req: Request): string | undefined {
+export function parseRepoParam(req: Request): string | undefined {
   const repoParam = req.query.repo as string | undefined;
   if (!repoParam) return undefined;
   
@@ -1147,112 +1147,38 @@ export async function gitree_create_concept_direct(
   try {
     const { name, documentation, description, repo, parent } = req.body;
 
-    if (!name || typeof name !== "string" || !name.trim()) {
-      res.status(400).json({ error: "name is required" });
-      return;
-    }
-    if (typeof documentation !== "string") {
-      res
-        .status(400)
-        .json({ error: "documentation is required and must be a string" });
-      return;
-    }
-
-    const slug = generateSlug(name);
-    if (!slug) {
-      res
-        .status(400)
-        .json({ error: "name must contain alphanumeric characters" });
-      return;
-    }
-    const repoId =
-      typeof repo === "string" && repo.trim() ? repo.trim() : undefined;
-    const conceptId = repoId ? makeRepoId(repoId, slug) : slug;
-    const parentId =
-      typeof parent === "string" && parent.trim() ? parent.trim() : undefined;
-
     const storage = new GraphStorage();
     await storage.initialize();
 
-    const existing = await storage.getConcept(conceptId, repoId);
-    if (existing) {
-      res.status(409).json({
-        error: `Concept ${conceptId} already exists`,
-        conceptId,
-      });
-      return;
-    }
-
-    // Validate parent before any persistence — a bad parent must never leave
-    // a partially-created concept behind.
-    let parentConcept = null;
-    if (parentId) {
-      parentConcept = await storage.getConcept(parentId, repoId);
-      if (!parentConcept) {
-        res
-          .status(400)
-          .json({ error: `Parent concept ${parentId} not found` });
-        return;
-      }
-      if (parentConcept.id === conceptId) {
-        res.status(400).json({ error: "A concept cannot be its own parent" });
-        return;
-      }
-    }
-
-    const now = new Date();
-    const concept: Concept = {
-      id: conceptId,
-      repo: repoId,
-      name: name.trim(),
-      description: typeof description === "string" ? description : "",
-      prNumbers: [],
-      commitShas: [],
-      createdAt: now,
-      lastUpdated: now,
+    const { concept, parentId } = await createConceptDirect(storage, {
+      name,
       documentation,
-    };
+      description,
+      repo,
+      parent,
+    });
 
-    await storage.saveConcept(concept);
-    await storage.saveDocumentation(conceptId, documentation);
-
-    // Link to parent if provided — compensating rollback on failure.
-    if (parentId && parentConcept) {
-      try {
-        await storage.linkConceptParent(parentConcept.id, conceptId);
-        console.log(
-          `🔗 Linked concept ${conceptId} under parent ${parentConcept.id}`
-        );
-      } catch (linkErr: any) {
-        try {
-          await storage.deleteConcept(conceptId, repoId);
-        } catch (rollbackErr: any) {
-          console.error(
-            `Rollback failed for orphaned concept ${conceptId}:`,
-            rollbackErr
-          );
-        }
-        return res.status(500).json({
-          error: `Concept created but parent link failed; rolled back: ${linkErr.message}`,
-        });
-      }
-    }
-
-    console.log(`✅ Concept created (direct): ${conceptId}`);
+    console.log(`✅ Concept created (direct): ${concept.id}`);
 
     res.json({
       status: "success",
-      message: `Created concept ${conceptId}`,
+      message: `Created concept ${concept.id}`,
       concept: {
         id: concept.id,
         repo: concept.repo,
         name: concept.name,
         description: concept.description,
         documentation: concept.documentation,
-        ...(parentConcept ? { parent: parentConcept.id } : {}),
+        ...(parentId ? { parent: parentId } : {}),
       },
     });
   } catch (error: any) {
+    if (error instanceof HttpError) {
+      res
+        .status(error.statusCode)
+        .json({ error: error.message, ...(error.extra || {}) });
+      return;
+    }
     console.error("Error creating concept (direct):", error);
     res
       .status(500)

--- a/mcp/src/gitree/service.ts
+++ b/mcp/src/gitree/service.ts
@@ -1,4 +1,122 @@
 import { GraphStorage } from "./store/index.js";
+import { Concept } from "./types.js";
+import { generateSlug, makeRepoId } from "./store/utils.js";
+
+/**
+ * Error carrying an HTTP status (and optional extra response fields) so
+ * service-layer logic can be shared across route handlers without each one
+ * re-implementing the status mapping.
+ */
+export class HttpError extends Error {
+  constructor(
+    public statusCode: number,
+    message: string,
+    public extra?: Record<string, unknown>
+  ) {
+    super(message);
+  }
+}
+
+export interface CreateConceptDirectInput {
+  name: string;
+  documentation: string;
+  description?: string;
+  repo?: string;
+  parent?: string;
+}
+
+/**
+ * Create a concept from caller-supplied content (no repo analysis). Shared by
+ * POST /gitree/create-concept-direct and accepted "create" proposals so both
+ * paths mint ids, validate parents, and roll back identically.
+ */
+export async function createConceptDirect(
+  storage: GraphStorage,
+  input: CreateConceptDirectInput
+): Promise<{ concept: Concept; parentId?: string }> {
+  const name = typeof input.name === "string" ? input.name.trim() : "";
+  if (!name) {
+    throw new HttpError(400, "name is required");
+  }
+  if (typeof input.documentation !== "string") {
+    throw new HttpError(400, "documentation is required and must be a string");
+  }
+
+  const slug = generateSlug(name);
+  if (!slug) {
+    throw new HttpError(400, "name must contain alphanumeric characters");
+  }
+  const repoId =
+    typeof input.repo === "string" && input.repo.trim()
+      ? input.repo.trim()
+      : undefined;
+  const conceptId = repoId ? makeRepoId(repoId, slug) : slug;
+  const parentId =
+    typeof input.parent === "string" && input.parent.trim()
+      ? input.parent.trim()
+      : undefined;
+
+  const existing = await storage.getConcept(conceptId, repoId);
+  if (existing) {
+    throw new HttpError(409, `Concept ${conceptId} already exists`, {
+      conceptId,
+    });
+  }
+
+  // Validate parent before any persistence — a bad parent must never leave
+  // a partially-created concept behind.
+  let parentConcept = null;
+  if (parentId) {
+    parentConcept = await storage.getConcept(parentId, repoId);
+    if (!parentConcept) {
+      throw new HttpError(400, `Parent concept ${parentId} not found`);
+    }
+    if (parentConcept.id === conceptId) {
+      throw new HttpError(400, "A concept cannot be its own parent");
+    }
+  }
+
+  const now = new Date();
+  const concept: Concept = {
+    id: conceptId,
+    repo: repoId,
+    name,
+    description: typeof input.description === "string" ? input.description : "",
+    prNumbers: [],
+    commitShas: [],
+    createdAt: now,
+    lastUpdated: now,
+    documentation: input.documentation,
+  };
+
+  await storage.saveConcept(concept);
+  await storage.saveDocumentation(conceptId, input.documentation);
+
+  // Link to parent if provided — compensating rollback on failure.
+  if (parentId && parentConcept) {
+    try {
+      await storage.linkConceptParent(parentConcept.id, conceptId);
+      console.log(
+        `🔗 Linked concept ${conceptId} under parent ${parentConcept.id}`
+      );
+    } catch (linkErr: any) {
+      try {
+        await storage.deleteConcept(conceptId, repoId);
+      } catch (rollbackErr: any) {
+        console.error(
+          `Rollback failed for orphaned concept ${conceptId}:`,
+          rollbackErr
+        );
+      }
+      throw new HttpError(
+        500,
+        `Concept created but parent link failed; rolled back: ${linkErr.message}`
+      );
+    }
+  }
+
+  return { concept, parentId: parentConcept?.id };
+}
 
 export interface ConceptSummary {
   id: string;

--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -4,6 +4,8 @@ import { v4 as uuidv4 } from "uuid";
 import { Storage } from "./storage.js";
 import {
   Concept,
+  ConceptProposal,
+  ConceptProposalStatus,
   PRRecord,
   CommitRecord,
   Clue,
@@ -172,6 +174,15 @@ export class GraphStorage extends Storage {
         );
         await session.run(
           "CREATE INDEX pr_id_index IF NOT EXISTS FOR (p:PullRequest) ON (p.id)"
+        );
+        await session.run(
+          "CREATE INDEX concept_proposal_id_index IF NOT EXISTS FOR (p:ConceptProposal) ON (p.id)"
+        );
+        await session.run(
+          "CREATE INDEX concept_proposal_repo_index IF NOT EXISTS FOR (p:ConceptProposal) ON (p.repo)"
+        );
+        await session.run(
+          "CREATE INDEX concept_proposal_status_index IF NOT EXISTS FOR (p:ConceptProposal) ON (p.status)"
         );
         await session.run(
           "CREATE INDEX commit_id_index IF NOT EXISTS FOR (c:Commit) ON (c.id)"
@@ -2587,5 +2598,277 @@ export class GraphStorage extends Storage {
     } finally {
       await session.close();
     }
+  }
+
+  // Concept Proposals
+
+  async saveProposal(proposal: ConceptProposal): Promise<void> {
+    const session = this.resilientSession();
+    try {
+      const now = Math.floor(Date.now() / 1000);
+      await session.run(
+        `
+        MERGE (p:${Data_Bank}:ConceptProposal {id: $id})
+        SET p.action = $action,
+            p.status = $status,
+            p.repo = $repo,
+            p.conceptId = $conceptId,
+            p.mergeIntoConceptId = $mergeIntoConceptId,
+            p.name = $name,
+            p.description = $description,
+            p.documentation = $documentation,
+            p.parent = $parent,
+            p.baseDocs = $baseDocs,
+            p.absorbedDocs = $absorbedDocs,
+            p.rationale = $rationale,
+            p.source = $source,
+            p.prNumbers = $prNumbers,
+            p.sessionIds = $sessionIds,
+            p.namespace = $namespace,
+            p.Data_Bank = $dataBankName,
+            p.ref_id = COALESCE(p.ref_id, $refId),
+            p.createdAt = COALESCE(p.createdAt, $createdAt),
+            p.date_added_to_graph = COALESCE(p.date_added_to_graph, $now)
+        RETURN p
+        `,
+        {
+          id: proposal.id,
+          action: proposal.action,
+          status: proposal.status,
+          repo: proposal.repo || null,
+          conceptId: proposal.conceptId || null,
+          mergeIntoConceptId: proposal.mergeIntoConceptId || null,
+          name: proposal.name || null,
+          description: proposal.description ?? null,
+          documentation: proposal.documentation ?? null,
+          parent: proposal.parent || null,
+          baseDocs: proposal.baseDocs ?? null,
+          absorbedDocs: proposal.absorbedDocs ?? null,
+          rationale: proposal.rationale || null,
+          source: proposal.source || null,
+          prNumbers: proposal.prNumbers || [],
+          sessionIds: proposal.sessionIds || [],
+          namespace: "default",
+          dataBankName: proposal.id,
+          refId: uuidv4(),
+          createdAt: Math.floor(proposal.createdAt.getTime() / 1000),
+          now,
+        }
+      );
+
+      // TARGETS edges to the concept(s) this proposal wants to change. For
+      // merge, both targets get an edge with a role so the UI can tell which
+      // concept survives.
+      const targets: Array<{ conceptId: string; role: string | null }> = [];
+      if (proposal.conceptId) {
+        targets.push({
+          conceptId: proposal.conceptId,
+          role: proposal.action === "merge" ? "absorb" : null,
+        });
+      }
+      if (proposal.mergeIntoConceptId) {
+        targets.push({ conceptId: proposal.mergeIntoConceptId, role: "into" });
+      }
+      for (const target of targets) {
+        await session.run(
+          `
+          MATCH (p:ConceptProposal {id: $id})
+          MATCH (c:Concept {id: $conceptId})
+          MERGE (p)-[r:TARGETS]->(c)
+          ON CREATE SET r.ref_id = randomUUID()
+          SET r.role = $role
+          `,
+          { id: proposal.id, conceptId: target.conceptId, role: target.role }
+        );
+      }
+
+      // EVIDENCE edges to the PRs that motivated this proposal (same matching
+      // pattern as the TOUCHES edges in saveConcept).
+      if (proposal.prNumbers && proposal.prNumbers.length > 0 && proposal.repo) {
+        await session.run(
+          `
+          MATCH (p:ConceptProposal {id: $id})
+          UNWIND $prNumbers as prNumber
+          MATCH (pr:PullRequest)
+          WHERE (pr.repo = $repo AND pr.number = prNumber) OR pr.id = $repo + '/pr-' + toString(prNumber)
+          MERGE (p)-[r:EVIDENCE]->(pr)
+          ON CREATE SET r.ref_id = randomUUID()
+          `,
+          {
+            id: proposal.id,
+            prNumbers: proposal.prNumbers,
+            repo: proposal.repo,
+          }
+        );
+      }
+    } finally {
+      await session.close();
+    }
+  }
+
+  async getProposal(id: string): Promise<ConceptProposal | null> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(
+        `
+        MATCH (p:ConceptProposal)
+        WHERE p.id = $id OR p.ref_id = $id
+        RETURN p
+        LIMIT 1
+        `,
+        { id }
+      );
+      if (result.records.length === 0) return null;
+      return this.nodeToProposal(result.records[0].get("p"));
+    } finally {
+      await session.close();
+    }
+  }
+
+  async getAllProposals(
+    repo?: string,
+    status?: ConceptProposalStatus
+  ): Promise<ConceptProposal[]> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(
+        `
+        MATCH (p:ConceptProposal)
+        WHERE ($repo IS NULL OR p.repo = $repo)
+          AND ($status IS NULL OR p.status = $status)
+        RETURN p
+        ORDER BY p.createdAt DESC
+        `,
+        { repo: repo || null, status: status || null }
+      );
+      return result.records.flatMap((record) => {
+        const node = record.get("p");
+        try {
+          return [this.nodeToProposal(node)];
+        } catch (error) {
+          console.warn(
+            `Skipping malformed ConceptProposal node ${node?.properties?.id}:`,
+            error
+          );
+          return [];
+        }
+      });
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Atomically move a pending proposal to a decided status. Returns false if
+   * the proposal was not in "pending" (already decided by a concurrent
+   * request) — callers use this as a claim so a proposal can never be
+   * applied twice.
+   */
+  async claimProposal(
+    id: string,
+    status: "accepted" | "rejected",
+    decidedBy?: string,
+    decisionReason?: string
+  ): Promise<boolean> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(
+        `
+        MATCH (p:ConceptProposal {id: $id, status: 'pending'})
+        SET p.status = $status,
+            p.decidedBy = $decidedBy,
+            p.decisionReason = $decisionReason,
+            p.decidedAt = $decidedAt
+        RETURN p
+        `,
+        {
+          id,
+          status,
+          decidedBy: decidedBy || null,
+          decisionReason: decisionReason || null,
+          decidedAt: Math.floor(Date.now() / 1000),
+        }
+      );
+      return result.records.length > 0;
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Roll a claimed proposal back to pending — used when applying an accepted
+   * proposal fails (stale base, target vanished) so the reviewer can retry.
+   */
+  async releaseProposalClaim(id: string): Promise<void> {
+    const session = this.resilientSession();
+    try {
+      await session.run(
+        `
+        MATCH (p:ConceptProposal {id: $id})
+        SET p.status = 'pending',
+            p.decidedBy = null,
+            p.decisionReason = null,
+            p.decidedAt = null
+        `,
+        { id }
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Record the concept minted by an accepted "create" proposal, and link the
+   * proposal to it so the decided proposal doubles as change history.
+   */
+  async setProposalCreatedConcept(
+    id: string,
+    conceptId: string
+  ): Promise<void> {
+    const session = this.resilientSession();
+    try {
+      await session.run(
+        `
+        MATCH (p:ConceptProposal {id: $id})
+        SET p.createdConceptId = $conceptId
+        WITH p
+        MATCH (c:Concept {id: $conceptId})
+        MERGE (p)-[r:TARGETS]->(c)
+        ON CREATE SET r.ref_id = randomUUID()
+        `,
+        { id, conceptId }
+      );
+    } finally {
+      await session.close();
+    }
+  }
+
+  private nodeToProposal(node: any): ConceptProposal {
+    const props = node.properties;
+    return {
+      id: props.id,
+      action: props.action,
+      status: props.status,
+      repo: props.repo || undefined,
+      conceptId: props.conceptId || undefined,
+      mergeIntoConceptId: props.mergeIntoConceptId || undefined,
+      name: props.name || undefined,
+      description: props.description ?? undefined,
+      documentation: props.documentation ?? undefined,
+      parent: props.parent || undefined,
+      baseDocs: props.baseDocs ?? undefined,
+      absorbedDocs: props.absorbedDocs ?? undefined,
+      rationale: props.rationale || undefined,
+      source: props.source || undefined,
+      prNumbers: (props.prNumbers || []).map((n: any) =>
+        n?.toNumber ? n.toNumber() : n
+      ),
+      sessionIds: props.sessionIds || [],
+      decidedBy: props.decidedBy || undefined,
+      decisionReason: props.decisionReason || undefined,
+      decidedAt: props.decidedAt != null ? safeDate(props.decidedAt) : undefined,
+      createdConceptId: props.createdConceptId || undefined,
+      createdAt: safeDate(props.createdAt),
+    };
   }
 }

--- a/mcp/src/gitree/types.ts
+++ b/mcp/src/gitree/types.ts
@@ -201,6 +201,51 @@ export interface Clue {
 }
 
 /**
+ * ConceptProposal - a pending create/update/delete/merge of a Concept,
+ * awaiting human review. Decided proposals are kept in the graph as an
+ * audit trail of Concept changes.
+ */
+export type ConceptProposalAction = "create" | "update" | "delete" | "merge";
+
+export type ConceptProposalStatus = "pending" | "accepted" | "rejected";
+
+export interface ConceptProposal {
+  id: string; // uuid — proposals are not repo-slug addressed (many can target one concept)
+  action: ConceptProposalAction;
+  status: ConceptProposalStatus;
+  repo?: string; // Repository identifier "owner/repo"
+
+  // Targets (update/delete/merge). For merge, conceptId is absorbed into mergeIntoConceptId.
+  conceptId?: string;
+  mergeIntoConceptId?: string;
+
+  // Proposed content
+  name?: string; // create only
+  description?: string; // create/update/merge — optional description change
+  documentation?: string; // create/update/merge — full proposed documentation
+  parent?: string; // create only — optional parent concept id
+
+  // Snapshots captured at propose time, for diff rendering and staleness
+  // detection at accept time (target may have drifted while pending).
+  baseDocs?: string; // docs of the edited concept (update/delete: target; merge: the surviving concept)
+  absorbedDocs?: string; // merge only — docs of the concept that will be deleted
+
+  // Review metadata
+  rationale?: string; // why this change is proposed (shown to the reviewer)
+  source?: string; // producer identifier (e.g. workflow name, "pr-merge", "agent")
+  prNumbers?: number[]; // evidence: PRs that motivated this proposal
+  sessionIds?: string[]; // evidence: agent sessions that motivated this proposal
+
+  // Decision
+  decidedBy?: string;
+  decisionReason?: string;
+  decidedAt?: Date;
+  createdConceptId?: string; // set when an accepted "create" lands, for deep-linking
+
+  createdAt: Date;
+}
+
+/**
  * Result from clue analysis
  */
 export interface ClueAnalysisResult {

--- a/mcp/src/index.ts
+++ b/mcp/src/index.ts
@@ -23,6 +23,7 @@ import * as r from "./graph/routes.js";
 import * as l from "./graph/learnings.js";
 import * as uploads from "./graph/uploads.js";
 import * as gitree from "./gitree/routes.js";
+import * as gitreeProposals from "./gitree/proposals.js";
 import { mountLab } from "./lab/mount.js";
 import { loadModelPricing } from "./aieo/src/index.js";
 import path from "path";
@@ -301,6 +302,20 @@ app.delete("/gitree/clues/:id", gitree.gitree_delete_clue);
 app.post("/gitree/search-clues", gitree.gitree_search_clues);
 app.post("/gitree/search-concepts", gitree.gitree_search_concepts);
 app.post("/gitree/provenance", gitree.gitree_provenance);
+
+// Concept proposals — pending create/update/delete/merge changes to Concepts,
+// reviewed by a human before they land
+app.post("/gitree/proposals", gitreeProposals.gitree_create_proposal);
+app.get("/gitree/proposals", gitreeProposals.gitree_list_proposals);
+app.get("/gitree/proposals/:id", gitreeProposals.gitree_get_proposal);
+app.post(
+  "/gitree/proposals/:id/accept",
+  gitreeProposals.gitree_accept_proposal,
+);
+app.post(
+  "/gitree/proposals/:id/reject",
+  gitreeProposals.gitree_reject_proposal,
+);
 
 // Legacy `/gitree/features*` aliases (deprecated) — kept so existing API
 // consumers keep working after the Feature->Concept rename. Remove once all


### PR DESCRIPTION
## What

Adds **ConceptProposal** nodes to gitree: pending create/update/delete/merge changes to Concepts that sit in the graph until a human accepts or rejects them. This is the stakgraph half of the automated concept-maintenance ("dream") flow — long-running workflows can now propose changes instead of writing directly, and Hive's Learn UI will render the review queue with diffs.

## Endpoints

| Route | Purpose |
|---|---|
| `POST /gitree/proposals` | create a proposal (validates targets; snapshots `baseDocs` server-side) |
| `GET /gitree/proposals?repo=&status=` | list (review queue via `status=pending`) |
| `GET /gitree/proposals/:id` | fetch one |
| `POST /gitree/proposals/:id/accept` | apply the change through the existing Concept write paths, stamp accepted |
| `POST /gitree/proposals/:id/reject` | stamp rejected, no graph side effects |

## Design notes

- **Node**: `:Data_Bank:Concept_Proposal`-style conventions — `:Data_Bank:ConceptProposal` with uuid `id`, `ref_id`, namespace, epoch-seconds dates; indexes on id/repo/status. `TARGETS` edges to the concept(s) (role `absorb`/`into` for merges) and `EVIDENCE` edges to motivating PRs.
- **Staleness**: `baseDocs` is snapshotted at propose time; accept returns `409 {code: "stale_base"}` if the target's docs drifted while pending, overridable with `force: true`.
- **Concurrency**: accept atomically claims the proposal (`pending -> accepted` conditional SET) before applying, so concurrent accepts can never double-apply; the claim is rolled back to pending if applying fails.
- **Accept semantics**: create mints via the same path as `create-concept-direct`; update writes docs (and description, refreshing the embedding); merge unions PR/commit provenance into the surviving concept and deletes the absorbed one; decided proposals are kept as an audit trail.
- **Refactor**: `createConceptDirect` extracted into `service.ts`, shared by the existing route and accepted create proposals. The pre-existing `create-concept-direct-parent` test contained a full local reimplementation of the handler (storage wasn't injectable before) — it now tests the real helper.
- **CI**: `src/gitree/**/*.test.ts` added to the `test:node` glob — the existing gitree test wasn't running in CI.

`PROPOSALS_API.md` documents the surface for the Hive UI work.

## Testing

- 11 new unit tests over the real `applyProposal` (stale-base 409s, force override, merge union + absorbed deletion, create collision, vanished target).
- `npx tsc --noEmit` clean; full `npm run test:node` passes (519 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Update: agent tools — moved to #1562 (this section described a commit pushed after the merge)

Adds two opt-in agent tools in `repo/tools.ts` (gated via tools config, like `create_triplet`):
- `propose_concept_change` — file a create/update/delete/merge proposal into the review queue (`source: "agent"`)
- `list_concept_proposals` — see what's already pending, to avoid duplicate filings

Proposal creation/validation moved from the route handler into shared `createProposal`/`listProposals` in `gitree/service.ts` — the endpoint and the tools call the same functions in-process (no HTTP hop). Agents never get accept/reject; deciding stays human-only. +6 unit tests over `createProposal` (snapshot capture, early 409/404s, self-merge guard); 525 tests passing.

