### PR TITLE
Agent tools: propose_concept_change and list_concept_proposals

### DIFF
--- a/mcp/src/gitree/PROPOSALS_API.md
+++ b/mcp/src/gitree/PROPOSALS_API.md
@@ -75,6 +75,10 @@ Body: `{ decidedBy?: string, reason?: string }`. No graph side effects. Same 404
 
 Decided proposals are kept in the graph (audit trail) — the list endpoint with `status=accepted|rejected` is a per-concept change history via their `conceptId`/`createdConceptId`.
 
+## Agent tools (producer side)
+
+Swarm agents can file and inspect proposals without HTTP: `propose_concept_change` and `list_concept_proposals` in `repo/tools.ts` (opt-in via tools config, like `create_triplet`). They call the same `createProposal`/`listProposals` service functions as the endpoints, with `source: "agent"`. Agents never get accept/reject — deciding is human-only.
+
 ## Hive integration notes
 
 - Follow the existing thin-proxy pattern of `src/app/api/learnings/concepts/*` (swarm URL + `x-api-token` via `getSwarmConfig`, `requireReadAccess` for GET, `requireMemberAccess` for accept/reject).

--- a/mcp/src/gitree/__tests__/concept-proposals.test.ts
+++ b/mcp/src/gitree/__tests__/concept-proposals.test.ts
@@ -16,7 +16,7 @@
  */
 import { test, expect } from "../../testkit.js";
 import { applyProposal } from "../proposals.js";
-import { HttpError } from "../service.js";
+import { createProposal, HttpError } from "../service.js";
 import type { Concept, ConceptProposal } from "../types.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -54,11 +54,16 @@ function makeStorage(seed: Concept[] = []) {
   for (const concept of seed) store[concept.id] = concept;
   const savedDocs: Array<{ conceptId: string; documentation: string }> = [];
   const savedConcepts: Concept[] = [];
+  const savedProposals: ConceptProposal[] = [];
 
   const storage: any = {
     _store: store,
     _savedDocs: savedDocs,
     _savedConcepts: savedConcepts,
+    _savedProposals: savedProposals,
+    saveProposal: async (proposal: ConceptProposal) => {
+      savedProposals.push(proposal);
+    },
     initialize: async () => {},
     getConcept: async (id: string, repo?: string) => {
       const fullId = repo && !id.includes("/") ? `${repo}/${id}` : id;
@@ -94,6 +99,128 @@ async function expectHttpError(
   }
   throw new Error(`Expected HttpError ${statusCode}, but nothing was thrown`);
 }
+
+// ─── createProposal (propose-time validation + snapshots) ───────────────────
+
+test.describe("createProposal", () => {
+  test("update: snapshots the target's current docs as baseDocs", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        documentation: "current docs",
+      }),
+    ]);
+
+    const proposal = await createProposal(storage, {
+      action: "update",
+      conceptId: "owner/repo/auth",
+      documentation: "proposed docs",
+      rationale: "docs are stale",
+    });
+
+    expect(proposal.status).toBe("pending");
+    expect(proposal.baseDocs).toBe("current docs");
+    expect(proposal.repo).toBe("owner/repo");
+    expect(storage._savedProposals.length).toBe(1);
+    // nothing written to the concept itself
+    expect(storage._store["owner/repo/auth"].documentation).toBe(
+      "current docs"
+    );
+  });
+
+  test("merge: snapshots both the surviving and absorbed docs", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+        documentation: "auth docs",
+      }),
+      makeConcept({
+        id: "owner/repo/login",
+        name: "Login",
+        repo: "owner/repo",
+        documentation: "login docs",
+      }),
+    ]);
+
+    const proposal = await createProposal(storage, {
+      action: "merge",
+      conceptId: "owner/repo/login",
+      mergeIntoConceptId: "owner/repo/auth",
+      documentation: "merged docs",
+    });
+
+    expect(proposal.baseDocs).toBe("auth docs");
+    expect(proposal.absorbedDocs).toBe("login docs");
+  });
+
+  test("rejects an invalid action with 400", async () => {
+    const storage = makeStorage([]);
+    await expectHttpError(
+      () => createProposal(storage, { action: "rename" as any }),
+      400
+    );
+    expect(storage._savedProposals.length).toBe(0);
+  });
+
+  test("update against a missing concept 404s without saving", async () => {
+    const storage = makeStorage([]);
+    await expectHttpError(
+      () =>
+        createProposal(storage, {
+          action: "update",
+          conceptId: "owner/repo/nope",
+          documentation: "docs",
+        }),
+      404
+    );
+    expect(storage._savedProposals.length).toBe(0);
+  });
+
+  test("create 409s early when the concept already exists", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+      }),
+    ]);
+    await expectHttpError(
+      () =>
+        createProposal(storage, {
+          action: "create",
+          repo: "owner/repo",
+          name: "Auth",
+          documentation: "docs",
+        }),
+      409
+    );
+    expect(storage._savedProposals.length).toBe(0);
+  });
+
+  test("merge into itself is rejected", async () => {
+    const storage = makeStorage([
+      makeConcept({
+        id: "owner/repo/auth",
+        name: "Auth",
+        repo: "owner/repo",
+      }),
+    ]);
+    await expectHttpError(
+      () =>
+        createProposal(storage, {
+          action: "merge",
+          conceptId: "owner/repo/auth",
+          mergeIntoConceptId: "owner/repo/auth",
+          documentation: "docs",
+        }),
+      400
+    );
+  });
+});
 
 // ─── update ─────────────────────────────────────────────────────────────────
 

--- a/mcp/src/gitree/proposals.ts
+++ b/mcp/src/gitree/proposals.ts
@@ -1,22 +1,13 @@
 import { Request, Response } from "express";
-import { randomUUID } from "crypto";
 import { GraphStorage } from "./store/index.js";
+import { Concept, ConceptProposal, ConceptProposalStatus } from "./types.js";
 import {
-  Concept,
-  ConceptProposal,
-  ConceptProposalAction,
-  ConceptProposalStatus,
-} from "./types.js";
-import { generateSlug, makeRepoId } from "./store/utils.js";
-import { createConceptDirect, HttpError } from "./service.js";
+  createConceptDirect,
+  createProposal,
+  requireConcept,
+  HttpError,
+} from "./service.js";
 import { parseRepoParam } from "./routes.js";
-
-const VALID_ACTIONS: ConceptProposalAction[] = [
-  "create",
-  "update",
-  "delete",
-  "merge",
-];
 
 const VALID_STATUSES: ConceptProposalStatus[] = [
   "pending",
@@ -37,18 +28,6 @@ function sendError(res: Response, error: any, fallback: string) {
 
 function optionalString(value: any): string | undefined {
   return typeof value === "string" && value.trim() ? value.trim() : undefined;
-}
-
-async function requireConcept(
-  storage: GraphStorage,
-  conceptId: string,
-  repo?: string
-): Promise<Concept> {
-  const concept = await storage.getConcept(conceptId, repo);
-  if (!concept) {
-    throw new HttpError(404, `Concept ${conceptId} not found`);
-  }
-  return concept;
 }
 
 // A pending proposal's target may drift while it sits in the queue (another
@@ -82,134 +61,14 @@ function unionArray<T>(a: T[], b: T[]): T[] {
 export async function gitree_create_proposal(req: Request, res: Response) {
   console.log("===> gitree_create_proposal", req.path, req.method);
   try {
-    const body = req.body || {};
-    const action = body.action as ConceptProposalAction;
-    if (!VALID_ACTIONS.includes(action)) {
-      res.status(400).json({
-        error: `action must be one of: ${VALID_ACTIONS.join(", ")}`,
-      });
-      return;
-    }
-
     const storage = new GraphStorage();
     await storage.initialize();
 
-    const proposal: ConceptProposal = {
-      id: randomUUID(),
-      action,
-      status: "pending",
-      repo: optionalString(body.repo),
-      rationale: optionalString(body.rationale),
-      source: optionalString(body.source),
-      prNumbers: Array.isArray(body.prNumbers)
-        ? body.prNumbers.filter((n: any) => Number.isFinite(n)).map(Number)
-        : undefined,
-      sessionIds: Array.isArray(body.sessionIds)
-        ? body.sessionIds.filter((s: any) => typeof s === "string")
-        : undefined,
-      createdAt: new Date(),
-    };
+    const proposal = await createProposal(storage, req.body || {});
 
-    if (action === "create") {
-      const name = optionalString(body.name);
-      if (!name) {
-        throw new HttpError(400, "name is required for a create proposal");
-      }
-      if (typeof body.documentation !== "string") {
-        throw new HttpError(
-          400,
-          "documentation is required and must be a string"
-        );
-      }
-      const slug = generateSlug(name);
-      if (!slug) {
-        throw new HttpError(400, "name must contain alphanumeric characters");
-      }
-      // Early feedback only — existence is re-checked authoritatively at
-      // accept time, since concepts can appear while the proposal is pending.
-      const targetId = proposal.repo ? makeRepoId(proposal.repo, slug) : slug;
-      const existing = await storage.getConcept(targetId, proposal.repo);
-      if (existing) {
-        throw new HttpError(409, `Concept ${targetId} already exists`, {
-          conceptId: targetId,
-        });
-      }
-      const parent = optionalString(body.parent);
-      if (parent) {
-        const parentConcept = await storage.getConcept(parent, proposal.repo);
-        if (!parentConcept) {
-          throw new HttpError(400, `Parent concept ${parent} not found`);
-        }
-        proposal.parent = parentConcept.id;
-      }
-      proposal.name = name;
-      proposal.description = optionalString(body.description);
-      proposal.documentation = body.documentation;
-    } else if (action === "update") {
-      const conceptId = optionalString(body.conceptId);
-      if (!conceptId) {
-        throw new HttpError(
-          400,
-          "conceptId is required for an update proposal"
-        );
-      }
-      if (typeof body.documentation !== "string") {
-        throw new HttpError(
-          400,
-          "documentation is required and must be a string"
-        );
-      }
-      const concept = await requireConcept(storage, conceptId, proposal.repo);
-      proposal.conceptId = concept.id;
-      proposal.repo = proposal.repo || concept.repo;
-      proposal.baseDocs = concept.documentation ?? "";
-      proposal.documentation = body.documentation;
-      proposal.description = optionalString(body.description);
-    } else if (action === "delete") {
-      const conceptId = optionalString(body.conceptId);
-      if (!conceptId) {
-        throw new HttpError(400, "conceptId is required for a delete proposal");
-      }
-      const concept = await requireConcept(storage, conceptId, proposal.repo);
-      proposal.conceptId = concept.id;
-      proposal.repo = proposal.repo || concept.repo;
-      proposal.baseDocs = concept.documentation ?? "";
-    } else {
-      // merge: conceptId is absorbed into mergeIntoConceptId
-      const conceptId = optionalString(body.conceptId);
-      const mergeIntoConceptId = optionalString(body.mergeIntoConceptId);
-      if (!conceptId || !mergeIntoConceptId) {
-        throw new HttpError(
-          400,
-          "conceptId (absorbed) and mergeIntoConceptId (surviving) are required for a merge proposal"
-        );
-      }
-      if (typeof body.documentation !== "string") {
-        throw new HttpError(
-          400,
-          "documentation (the merged docs for the surviving concept) is required and must be a string"
-        );
-      }
-      const absorbed = await requireConcept(storage, conceptId, proposal.repo);
-      const into = await requireConcept(
-        storage,
-        mergeIntoConceptId,
-        proposal.repo
-      );
-      if (absorbed.id === into.id) {
-        throw new HttpError(400, "A concept cannot be merged into itself");
-      }
-      proposal.conceptId = absorbed.id;
-      proposal.mergeIntoConceptId = into.id;
-      proposal.repo = proposal.repo || into.repo;
-      proposal.baseDocs = into.documentation ?? "";
-      proposal.absorbedDocs = absorbed.documentation ?? "";
-      proposal.documentation = body.documentation;
-      proposal.description = optionalString(body.description);
-    }
-
-    await storage.saveProposal(proposal);
-    console.log(`✅ Concept proposal created: ${proposal.id} (${action})`);
+    console.log(
+      `✅ Concept proposal created: ${proposal.id} (${proposal.action})`
+    );
     res.json({ status: "success", proposal });
   } catch (error: any) {
     sendError(res, error, "Failed to create proposal");

--- a/mcp/src/gitree/service.ts
+++ b/mcp/src/gitree/service.ts
@@ -1,5 +1,11 @@
+import { randomUUID } from "crypto";
 import { GraphStorage } from "./store/index.js";
-import { Concept } from "./types.js";
+import {
+  Concept,
+  ConceptProposal,
+  ConceptProposalAction,
+  ConceptProposalStatus,
+} from "./types.js";
 import { generateSlug, makeRepoId } from "./store/utils.js";
 
 /**
@@ -116,6 +122,187 @@ export async function createConceptDirect(
   }
 
   return { concept, parentId: parentConcept?.id };
+}
+
+// ─── Concept Proposals ───────────────────────────────────────────────────────
+
+export const VALID_PROPOSAL_ACTIONS: ConceptProposalAction[] = [
+  "create",
+  "update",
+  "delete",
+  "merge",
+];
+
+export interface CreateProposalInput {
+  action: ConceptProposalAction;
+  repo?: string;
+  conceptId?: string;
+  mergeIntoConceptId?: string;
+  name?: string;
+  description?: string;
+  documentation?: string;
+  parent?: string;
+  rationale?: string;
+  source?: string;
+  prNumbers?: number[];
+  sessionIds?: string[];
+}
+
+function optionalString(value: any): string | undefined {
+  return typeof value === "string" && value.trim() ? value.trim() : undefined;
+}
+
+export async function requireConcept(
+  storage: GraphStorage,
+  conceptId: string,
+  repo?: string
+): Promise<Concept> {
+  const concept = await storage.getConcept(conceptId, repo);
+  if (!concept) {
+    throw new HttpError(404, `Concept ${conceptId} not found`);
+  }
+  return concept;
+}
+
+/**
+ * Validate and persist a ConceptProposal. Shared by POST /gitree/proposals
+ * and the propose_concept_change agent tool. Snapshots the target's current
+ * docs (baseDocs/absorbedDocs) server-side so accept can detect drift.
+ */
+export async function createProposal(
+  storage: GraphStorage,
+  input: CreateProposalInput
+): Promise<ConceptProposal> {
+  const action = input.action;
+  if (!VALID_PROPOSAL_ACTIONS.includes(action)) {
+    throw new HttpError(
+      400,
+      `action must be one of: ${VALID_PROPOSAL_ACTIONS.join(", ")}`
+    );
+  }
+
+  const proposal: ConceptProposal = {
+    id: randomUUID(),
+    action,
+    status: "pending",
+    repo: optionalString(input.repo),
+    rationale: optionalString(input.rationale),
+    source: optionalString(input.source),
+    prNumbers: Array.isArray(input.prNumbers)
+      ? input.prNumbers.filter((n: any) => Number.isFinite(n)).map(Number)
+      : undefined,
+    sessionIds: Array.isArray(input.sessionIds)
+      ? input.sessionIds.filter((s: any) => typeof s === "string")
+      : undefined,
+    createdAt: new Date(),
+  };
+
+  if (action === "create") {
+    const name = optionalString(input.name);
+    if (!name) {
+      throw new HttpError(400, "name is required for a create proposal");
+    }
+    if (typeof input.documentation !== "string") {
+      throw new HttpError(
+        400,
+        "documentation is required and must be a string"
+      );
+    }
+    const slug = generateSlug(name);
+    if (!slug) {
+      throw new HttpError(400, "name must contain alphanumeric characters");
+    }
+    // Early feedback only — existence is re-checked authoritatively at
+    // accept time, since concepts can appear while the proposal is pending.
+    const targetId = proposal.repo ? makeRepoId(proposal.repo, slug) : slug;
+    const existing = await storage.getConcept(targetId, proposal.repo);
+    if (existing) {
+      throw new HttpError(409, `Concept ${targetId} already exists`, {
+        conceptId: targetId,
+      });
+    }
+    const parent = optionalString(input.parent);
+    if (parent) {
+      const parentConcept = await storage.getConcept(parent, proposal.repo);
+      if (!parentConcept) {
+        throw new HttpError(400, `Parent concept ${parent} not found`);
+      }
+      proposal.parent = parentConcept.id;
+    }
+    proposal.name = name;
+    proposal.description = optionalString(input.description);
+    proposal.documentation = input.documentation;
+  } else if (action === "update") {
+    const conceptId = optionalString(input.conceptId);
+    if (!conceptId) {
+      throw new HttpError(400, "conceptId is required for an update proposal");
+    }
+    if (typeof input.documentation !== "string") {
+      throw new HttpError(
+        400,
+        "documentation is required and must be a string"
+      );
+    }
+    const concept = await requireConcept(storage, conceptId, proposal.repo);
+    proposal.conceptId = concept.id;
+    proposal.repo = proposal.repo || concept.repo;
+    proposal.baseDocs = concept.documentation ?? "";
+    proposal.documentation = input.documentation;
+    proposal.description = optionalString(input.description);
+  } else if (action === "delete") {
+    const conceptId = optionalString(input.conceptId);
+    if (!conceptId) {
+      throw new HttpError(400, "conceptId is required for a delete proposal");
+    }
+    const concept = await requireConcept(storage, conceptId, proposal.repo);
+    proposal.conceptId = concept.id;
+    proposal.repo = proposal.repo || concept.repo;
+    proposal.baseDocs = concept.documentation ?? "";
+  } else {
+    // merge: conceptId is absorbed into mergeIntoConceptId
+    const conceptId = optionalString(input.conceptId);
+    const mergeIntoConceptId = optionalString(input.mergeIntoConceptId);
+    if (!conceptId || !mergeIntoConceptId) {
+      throw new HttpError(
+        400,
+        "conceptId (absorbed) and mergeIntoConceptId (surviving) are required for a merge proposal"
+      );
+    }
+    if (typeof input.documentation !== "string") {
+      throw new HttpError(
+        400,
+        "documentation (the merged docs for the surviving concept) is required and must be a string"
+      );
+    }
+    const absorbed = await requireConcept(storage, conceptId, proposal.repo);
+    const into = await requireConcept(
+      storage,
+      mergeIntoConceptId,
+      proposal.repo
+    );
+    if (absorbed.id === into.id) {
+      throw new HttpError(400, "A concept cannot be merged into itself");
+    }
+    proposal.conceptId = absorbed.id;
+    proposal.mergeIntoConceptId = into.id;
+    proposal.repo = proposal.repo || into.repo;
+    proposal.baseDocs = into.documentation ?? "";
+    proposal.absorbedDocs = absorbed.documentation ?? "";
+    proposal.documentation = input.documentation;
+    proposal.description = optionalString(input.description);
+  }
+
+  await storage.saveProposal(proposal);
+  return proposal;
+}
+
+export async function listProposals(
+  repo?: string,
+  status?: ConceptProposalStatus
+): Promise<ConceptProposal[]> {
+  const storage = new GraphStorage();
+  await storage.initialize();
+  return storage.getAllProposals(repo, status);
 }
 
 export interface ConceptSummary {

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -17,7 +17,14 @@ import { getProviderTool, Provider, ModelName, getGatewayBaseURL } from "../aieo
 import { log_agent_context } from "../log/agent.js";
 import { createRunLogsDir, cleanupRunLogsDir } from "../log/utils.js";
 import { RepoAnalyzer } from "gitsee/server";
-import { listConcepts, getConceptDocumentation } from "../gitree/service.js";
+import {
+  listConcepts,
+  getConceptDocumentation,
+  createProposal,
+  listProposals,
+  HttpError,
+} from "../gitree/service.js";
+import { GraphStorage as GitreeGraphStorage } from "../gitree/store/index.js";
 import { scanSkills, listPack, loadSkill, type IndexEntry } from "./skills.js";
 import { db } from "../graph/neo4j.js";
 import { callRemoteAgent, subAgentRepoNames, type SubAgent } from "./subagent.js";
@@ -87,6 +94,8 @@ type ToolName =
   | "list_concepts"
   | "learn_concept"
   | "learn_concepts"
+  | "propose_concept_change"
+  | "list_concept_proposals"
   | "list_skills"
   | "load_skill"
   | "list_workflows"
@@ -223,7 +232,8 @@ const TOOL_NAMES: Set<string> = new Set<string>([
   "repo_overview", "file_summary", "recent_commits", "recent_contributions",
   "fulltext_search", "web_search", "bash", "final_answer",
   "ask_clarifying_questions", "list_concepts", "learn_concept",
-  "learn_concepts", "list_skills", "load_skill",
+  "learn_concepts", "propose_concept_change", "list_concept_proposals",
+  "list_skills", "load_skill",
   "list_workflows", "learn_workflow", "read_workflow_json",
   "vector_search", "stakgraph_search", "stakgraph_map", "stakgraph_code",
   "graph_sub_agent", "ontology_edit", "create_triplet",
@@ -326,6 +336,10 @@ Rules:
   learn_concept:
     "Get detailed information about a specific concept (feature) including its full documentation, associated PRs with summaries, and commits. Use this when you need deep understanding of how a particular feature was implemented and evolved over time.",
   learn_concepts: '', // this is just for naming, to enable the above 2.
+  propose_concept_change:
+    "Propose a change to the Concept knowledge base: create a new concept, update or delete an existing one, or merge two duplicate concepts. The change is NOT applied — it goes into a review queue where a human accepts or rejects it, with a diff of the documentation. For update/merge, first read the current docs with learn_concept and submit the FULL revised documentation (it replaces the whole body). Always give a rationale — the reviewer sees it. Check list_concept_proposals first so you don't file a duplicate of a proposal that is already pending.",
+  list_concept_proposals:
+    "List proposed changes to the Concept knowledge base (pending review by default). Use this before propose_concept_change to avoid filing a duplicate of a proposal that is already awaiting review.",
   list_skills:
     "List available skills. Called with no argument, returns every skill and skill pack installed — including packs not listed in your system prompt. Pass `pack` to expand one pack into its individual skills with their descriptions. This returns names and descriptions only; use load_skill to read a skill's actual instructions.",
   load_skill:
@@ -1418,6 +1432,123 @@ export async function get_tools(
           } catch (e) {
             console.error("Error getting concept:", e);
             return "Could not retrieve concept";
+          }
+        },
+      });
+    }
+    // concept proposals (human-reviewed writes; propose tool is opt-in)
+    if (
+      toolConfigEnabled(toolsConfig.propose_concept_change) ||
+      toolConfigEnabled(toolsConfig.list_concept_proposals)
+    ) {
+      allTools.list_concept_proposals = tool({
+        description: defaultDescriptions.list_concept_proposals,
+        inputSchema: z.object({
+          status: z
+            .enum(["pending", "accepted", "rejected"])
+            .optional()
+            .default("pending")
+            .describe("Filter by proposal status (default: pending)"),
+        }),
+        execute: async ({ status }) => {
+          try {
+            const repo = isMultiRepo ? undefined : `${repoOwner}/${repoName}`;
+            const proposals = await listProposals(repo, status);
+            return {
+              proposals: proposals.map((p) => ({
+                id: p.id,
+                action: p.action,
+                status: p.status,
+                conceptId: p.conceptId,
+                mergeIntoConceptId: p.mergeIntoConceptId,
+                name: p.name,
+                rationale: p.rationale,
+                source: p.source,
+                createdAt: p.createdAt,
+              })),
+              count: proposals.length,
+              repo,
+            };
+          } catch (e) {
+            console.error("Error listing concept proposals:", e);
+            return "Could not retrieve concept proposals";
+          }
+        },
+      });
+    }
+    if (toolConfigEnabled(toolsConfig.propose_concept_change)) {
+      allTools.propose_concept_change = tool({
+        description: defaultDescriptions.propose_concept_change,
+        inputSchema: z.object({
+          action: z
+            .enum(["create", "update", "delete", "merge"])
+            .describe(
+              "create a new concept, update or delete an existing one, or merge concept_id into merge_into_concept_id"
+            ),
+          concept_id: z
+            .string()
+            .optional()
+            .describe(
+              "Target concept id (required for update/delete; for merge, the concept that will be absorbed and deleted). Use ids from list_concepts — never fabricate."
+            ),
+          merge_into_concept_id: z
+            .string()
+            .optional()
+            .describe("merge only: the surviving concept's id"),
+          name: z
+            .string()
+            .optional()
+            .describe("create only: human-readable name for the new concept"),
+          description: z
+            .string()
+            .optional()
+            .describe("Optional one-line description (new or replacement)"),
+          documentation: z
+            .string()
+            .optional()
+            .describe(
+              "Full markdown documentation (required for create/update/merge). Replaces the entire body — for updates, start from learn_concept's current docs."
+            ),
+          rationale: z
+            .string()
+            .describe(
+              "Why this change should be made — shown to the human reviewer"
+            ),
+          pr_numbers: z
+            .array(z.number())
+            .optional()
+            .describe("PR numbers that motivated this proposal (evidence)"),
+        }),
+        execute: async (input) => {
+          try {
+            const repo = isMultiRepo ? undefined : `${repoOwner}/${repoName}`;
+            const storage = new GitreeGraphStorage();
+            await storage.initialize();
+            const proposal = await createProposal(storage, {
+              action: input.action,
+              repo,
+              conceptId: input.concept_id,
+              mergeIntoConceptId: input.merge_into_concept_id,
+              name: input.name,
+              description: input.description,
+              documentation: input.documentation,
+              rationale: input.rationale,
+              source: "agent",
+              prNumbers: input.pr_numbers,
+            });
+            return {
+              status: "pending_review",
+              proposalId: proposal.id,
+              action: proposal.action,
+              message:
+                "Proposal filed. It will only take effect if a human reviewer accepts it.",
+            };
+          } catch (e: any) {
+            if (e instanceof HttpError) {
+              return { error: e.message, ...(e.extra || {}) };
+            }
+            console.error("Error proposing concept change:", e);
+            return { error: e?.message || "Could not create proposal" };
           }
         },
       });


### PR DESCRIPTION
## What

Follow-up to #1561 (Concept Proposals). Adds two opt-in agent tools in `repo/tools.ts` so swarm agents can participate in concept maintenance through the human review queue:

- **`propose_concept_change`** — file a create/update/delete/merge proposal. The change is not applied; it lands in the review queue with `source: "agent"`. The tool schema requires a `rationale` (shown to the reviewer) and returns validation errors as tool results the model can self-correct from.
- **`list_concept_proposals`** — list proposals (pending by default), so recurring workflows can dedup against the queue instead of filing the same proposal every run.

Both are gated behind tools-config flags (same pattern as `create_triplet`) — only explicitly-configured agent runs get them. Agents never get accept/reject; deciding stays human-only via the review endpoints.

## Refactor

Proposal creation/validation (including server-side `baseDocs`/`absorbedDocs` snapshotting) moved from the `POST /gitree/proposals` route handler into shared `createProposal()` / `listProposals()` in `gitree/service.ts`. The endpoint and the tools call the same functions in-process — no HTTP self-call. (`service.ts` rather than `proposals.ts` because `repo/tools.ts` importing `proposals.ts` would create an import cycle via `routes.ts` → `repo/agent.ts`; `tools.ts` already imports `listConcepts` from `service.ts`.)

## Testing

- 6 new unit tests over `createProposal`: snapshot capture (update + merge), early 409 on existing concept, 404 on missing target, invalid action, self-merge guard.
- `npx tsc --noEmit` clean; full `npm run test:node` passes on top of main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)