### PR TITLE
Phase 6 write side: PostLLMHook cost accumulators + live pricing catalog

### DIFF
--- a/gateway/auth/go/types.go
+++ b/gateway/auth/go/types.go
@@ -200,6 +200,22 @@ type EffectiveCaveats struct {
 	Exp        string
 }
 
+// ChainLayer is one budgeted layer of the verified macaroon chain:
+// the invocation first, then each attenuation in order. Phase-6
+// enforcement walks this to accumulate per-run cost/steps
+// (PostLLMHook writes cost:run:<RunID> for every layer) and to cap
+// each layer's spend against its own MaxCostUSD (PreLLMHook cap
+// walk). Exp is the layer's own expiry, RFC 3339 — the TTL axis for
+// that layer's Redis keys.
+//
+// The last element's RunID always equals Claims.RunID (the leaf).
+type ChainLayer struct {
+	RunID      string
+	MaxCostUSD float64
+	MaxSteps   int
+	Exp        string
+}
+
 // Claims is the verified output of Verify. Adapters stamp this on
 // their plugin context for downstream hooks.
 //
@@ -209,7 +225,9 @@ type EffectiveCaveats struct {
 // attenuation processing. UABudget is nil when the UA carried no
 // budget — adapters MUST treat nil as "no UA-level cap" rather than
 // substituting defaults; absent budget is a design choice, not
-// missing data.
+// missing data. UAIAT/UAExp carry the UA's own validity window:
+// UAIAT is the comparison axis for revoke_user_before enforcement,
+// UAExp the TTL axis for the cost:ua accumulator.
 //
 // Phase 11:
 //   - Realm (the singular invocation realm) is gone.
@@ -226,9 +244,12 @@ type Claims struct {
 	AgentName        string // last element of the final agents list
 	RunID            string // innermost attenuation's run_id, or invocation's if none
 	EffectiveCaveats EffectiveCaveats
-	UANonce          string   // ua.nonce; key for cost:ua:<nonce>
-	UABudget         *Budget  // nil if UA carried no budget
-	PermittedRealms  []string // sorted keys of EffectiveCaveats.Budget.RealmBudgets, or nil
-	Nonces           []string // [ua.nonce, inv.nonce, atts[*].caveats.nonce]
-	IAT              string   // invocation.iat
+	UANonce          string       // ua.nonce; key for cost:ua:<nonce>
+	UABudget         *Budget      // nil if UA carried no budget
+	UAIAT            string       // ua.iat; revoke_user_before comparison axis
+	UAExp            string       // ua.exp; TTL axis for cost:ua:<nonce>
+	Chain            []ChainLayer // invocation first, then attenuations in order; last is the leaf
+	PermittedRealms  []string     // sorted keys of EffectiveCaveats.Budget.RealmBudgets, or nil
+	Nonces           []string     // [ua.nonce, inv.nonce, atts[*].caveats.nonce]
+	IAT              string       // invocation.iat
 }

--- a/gateway/auth/go/verify.go
+++ b/gateway/auth/go/verify.go
@@ -67,6 +67,25 @@ func VerifyJSON(raw []byte, policy Policy, now time.Time) (*Claims, error) {
 	nonces = append(nonces, m.UserAuthorization.Nonce, m.Invocation.Nonce)
 	nonces = append(nonces, attNonces...)
 
+	// Chain: every budgeted layer, outermost first. The enforcement
+	// adapter walks this for the per-run accumulators and the cap
+	// walk; the last element is always the leaf (== runID above).
+	chain := make([]ChainLayer, 0, 1+len(m.Attenuations))
+	chain = append(chain, ChainLayer{
+		RunID:      m.Invocation.RunID,
+		MaxCostUSD: m.Invocation.MaxCostUSD,
+		MaxSteps:   m.Invocation.MaxSteps,
+		Exp:        m.Invocation.Exp,
+	})
+	for _, att := range m.Attenuations {
+		chain = append(chain, ChainLayer{
+			RunID:      att.Caveats.RunID,
+			MaxCostUSD: att.Caveats.MaxCostUSD,
+			MaxSteps:   att.Caveats.MaxSteps,
+			Exp:        att.Caveats.Exp,
+		})
+	}
+
 	return &Claims{
 		OrgID:            m.OrgID,
 		UserID:           m.UserAuthorization.UserID,
@@ -75,6 +94,9 @@ func VerifyJSON(raw []byte, policy Policy, now time.Time) (*Claims, error) {
 		EffectiveCaveats: effective,
 		UANonce:          m.UserAuthorization.Nonce,
 		UABudget:         m.UserAuthorization.Budget,
+		UAIAT:            m.UserAuthorization.IAT,
+		UAExp:            m.UserAuthorization.Exp,
+		Chain:            chain,
 		PermittedRealms:  permittedRealms(&effective),
 		Nonces:           nonces,
 		IAT:              m.Invocation.IAT,

--- a/gateway/auth/ts/src/types.ts
+++ b/gateway/auth/ts/src/types.ts
@@ -206,6 +206,21 @@ export interface EffectiveCaveats {
   exp: string;
 }
 
+/**
+ * One budgeted layer of the verified chain: the invocation first,
+ * then each attenuation in order. Phase-6 enforcement walks this for
+ * the per-run accumulators (`cost:run:<run_id>` per layer) and the
+ * cap walk (each layer's spend vs its own `max_cost_usd`). The last
+ * element's `run_id` always equals `Claims.run_id` (the leaf).
+ */
+export interface ChainLayer {
+  run_id: string;
+  max_cost_usd: number;
+  max_steps: number;
+  /** The layer's own expiry (RFC 3339) — TTL axis for its Redis keys. */
+  exp: string;
+}
+
 export interface Claims {
   org_id: string;
   user_id: string;
@@ -228,6 +243,12 @@ export interface Claims {
    * is a design choice, not missing data.
    */
   ua_budget: Budget | null;
+  /** `user_authorization.iat` — the revoke_user_before comparison axis. */
+  ua_iat: string;
+  /** `user_authorization.exp` — TTL axis for the `cost:ua` accumulator. */
+  ua_exp: string;
+  /** Budgeted layers, outermost first: invocation, then attenuations. */
+  chain: ChainLayer[];
   /**
    * Sorted list of realm-ids the verified chain authorizes spend
    * on. Derived from `effective_caveats.budget.realm_budgets` —

--- a/gateway/auth/ts/src/verify.ts
+++ b/gateway/auth/ts/src/verify.ts
@@ -85,6 +85,23 @@ export function verify(
     now,
   );
 
+  // Chain: every budgeted layer, outermost first. Mirrors the Go
+  // verifier — the last element is always the leaf (run_id above).
+  const chain = [
+    {
+      run_id: m.invocation.run_id,
+      max_cost_usd: m.invocation.max_cost_usd,
+      max_steps: m.invocation.max_steps,
+      exp: m.invocation.exp,
+    },
+    ...m.attenuations.map((att) => ({
+      run_id: att.caveats.run_id,
+      max_cost_usd: att.caveats.max_cost_usd,
+      max_steps: att.caveats.max_steps,
+      exp: att.caveats.exp,
+    })),
+  ];
+
   return {
     org_id: m.org_id,
     user_id: m.user_authorization.user_id,
@@ -93,6 +110,9 @@ export function verify(
     effective_caveats: effective,
     ua_nonce: m.user_authorization.nonce,
     ua_budget: m.user_authorization.budget ?? null,
+    ua_iat: m.user_authorization.iat,
+    ua_exp: m.user_authorization.exp,
+    chain,
     permitted_realms: permittedRealms(effective),
     nonces: [m.user_authorization.nonce, m.invocation.nonce, ...nonces],
     iat: m.invocation.iat,

--- a/gateway/data/config.json
+++ b/gateway/data/config.json
@@ -69,6 +69,14 @@
           "canvas-agent": { "cap_usd": 10000, "window": "1d" },
           "logs-agent": { "cap_usd": 10000, "window": "1d" },
           "repo-agent": { "cap_usd": 10000, "window": "1d" }
+        },
+        "model_pricing": {
+          "claude-3-5-haiku-latest": { "input_per_mtok": 0.8, "output_per_mtok": 4.0 },
+          "claude-haiku-4-5": { "input_per_mtok": 1.0, "output_per_mtok": 5.0 },
+          "claude-sonnet-4-5": { "input_per_mtok": 3.0, "output_per_mtok": 15.0 },
+          "claude-opus-4-5": { "input_per_mtok": 5.0, "output_per_mtok": 25.0 },
+          "gpt-4o": { "input_per_mtok": 2.5, "output_per_mtok": 10.0 },
+          "gpt-4o-mini": { "input_per_mtok": 0.15, "output_per_mtok": 0.6 }
         }
       }
     }

--- a/gateway/go.sum
+++ b/gateway/go.sum
@@ -54,6 +54,8 @@ github.com/mark3labs/mcp-go v0.43.2 h1:21PUSlWWiSbUPQwXIJ5WKlETixpFpq+WBpbMGDSVy
 github.com/mark3labs/mcp-go v0.43.2/go.mod h1:YnJfOL382MIWDx1kMY+2zsRHU/q78dBg9aFb8W6Thdw=
 github.com/maximhq/bifrost/core v1.5.18 h1:f1lX3sPesKTScUJHv+K9tWpd1wLLjd7CAzJY0BpbAaE=
 github.com/maximhq/bifrost/core v1.5.18/go.mod h1:7vry9xB5kmjT3smAVVQ2+mtfTmmeSN+7N1b8r1buaTI=
+github.com/maximhq/bifrost/core v1.6.2 h1:dESW02/iyDznt/VnnjzYnevddUmplXw2YeaK/0dl3HA=
+github.com/maximhq/bifrost/core v1.6.2/go.mod h1:GuRwPmx0Kh7lhZ+SnbLjVAclDI360DyKrJtioc3t5jg=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=

--- a/gateway/internal/adminapi/budgets.go
+++ b/gateway/internal/adminapi/budgets.go
@@ -2,15 +2,14 @@ package adminapi
 
 import (
 	"context"
-	"fmt"
 	"net/http"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/redis/go-redis/v9"
 
 	"github.com/stakwork/stakgraph/gateway/internal/auth"
+	"github.com/stakwork/stakgraph/gateway/internal/duration"
 	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
 	"github.com/stakwork/stakgraph/gateway/internal/redisclient"
 )
@@ -225,61 +224,15 @@ func (h *budgetHandlers) readSpentFromLogs(
 }
 
 // bucketBounds derives (period_start, period_end, redis_bucket_key)
-// for a given window string, anchored to `now`. Mirrors the per-window
-// formats in phase-6 §"Bucket-key format by window suffix" — keep this
-// in lockstep with the plugin-side PostLLMHook (gateway/internal/auth/
-// ttl.go) so the same key written there is read here.
-//
-// Phase 8 only needs `1h`/`1d`/`1w`/`1M` for the dashboard. Other
-// suffixes return ok=false and the handler degrades gracefully. The
-// full grammar is phase-6's concern.
+// for a given window string, anchored to `now`. Thin adapter over
+// gateway/internal/duration — the same package the phase-6
+// PostLLMHook accumulator uses to compute the key it writes, so
+// reader and writer can't drift.
 func bucketBounds(window string, now time.Time) (start, end time.Time, key string, ok bool) {
-	switch window {
-	case "1h":
-		// Sub-day rolling: bucket starts on the hour boundary.
-		start = now.Truncate(time.Hour)
-		end = start.Add(time.Hour)
-		key = formatEpochBucket(start)
-	case "1d":
-		// Calendar day, UTC midnight.
-		start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
-		end = start.AddDate(0, 0, 1)
-		key = start.Format("2006-01-02")
-	case "1w":
-		// ISO week starting Monday.
-		// Go's Weekday: Sunday=0..Saturday=6; ISO wants Monday=1..Sunday=7.
-		wd := int(now.Weekday())
-		if wd == 0 {
-			wd = 7
-		}
-		start = time.Date(now.Year(), now.Month(), now.Day()-(wd-1), 0, 0, 0, 0, time.UTC)
-		end = start.AddDate(0, 0, 7)
-		y, w := start.ISOWeek()
-		key = formatISOWeek(y, w)
-	case "1M":
-		start = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
-		end = start.AddDate(0, 1, 0)
-		key = start.Format("2006-01")
-	case "1Y":
-		start = time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
-		end = start.AddDate(1, 0, 0)
-		key = start.Format("2006")
-	default:
+	w, err := duration.Parse(window)
+	if err != nil {
 		return time.Time{}, time.Time{}, "", false
 	}
-	return start, end, key, true
-}
-
-// formatEpochBucket returns the bucket-start unix-epoch as a
-// decimal string. Per phase-6 §"Bucket-key format by window suffix":
-// sub-day windows use the unix epoch of the window start (rounded
-// to the unit), not a human date.
-func formatEpochBucket(t time.Time) string {
-	return strconv.FormatInt(t.Unix(), 10)
-}
-
-// formatISOWeek returns "YYYY-Www" zero-padded — matches the bucket
-// key format spelled out in the phase-6 schema table.
-func formatISOWeek(year, week int) string {
-	return fmt.Sprintf("%04d-W%02d", year, week)
+	start, end = w.Bounds(now)
+	return start, end, w.BucketKey(now), true
 }

--- a/gateway/internal/auth/accumulator.go
+++ b/gateway/internal/auth/accumulator.go
@@ -1,0 +1,147 @@
+package auth
+
+import (
+	"context"
+	"time"
+
+	macaroon "github.com/stakwork/stakgraph/gateway/auth/go"
+	"github.com/stakwork/stakgraph/gateway/internal/duration"
+	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
+	"github.com/stakwork/stakgraph/gateway/internal/redisclient"
+)
+
+// Redis key sub-paths for the phase-6 accumulators (the bifrost:
+// prefix is added by redisclient.Key). Shapes per
+// gateway/plans/phases/phase-6-plugin-enforcement.md "Redis schema".
+const (
+	costRunPrefix   = "cost:run:"   // HASH { total: float }
+	stepsRunPrefix  = "steps:run:"  // HASH { total: int }
+	toolsRunPrefix  = "tools:run:"  // LIST, capped at toolHistoryLen
+	costUAPrefix    = "cost:ua:"    // HASH { total: float }
+	costAgentPrefix = "cost:agent:" // HASH { total: float }, key + ":" + bucket
+)
+
+// toolHistoryLen is the tool-loop detection window: tools:run keeps
+// the last N tool names (LPUSH + LTRIM 0 N-1).
+const toolHistoryLen = 10
+
+// ApplyToLLMPost is the canonical "call from PostLLMHook" entry
+// point for the phase-6 accumulator writes. It walks the verified
+// chain and issues one pipelined Redis round-trip:
+//
+//   - HINCRBYFLOAT cost:run:<r> / HINCRBY steps:run:<r> + EXPIRE,
+//     for every distinct run_id in the chain (leaf + ancestors) —
+//     killing or capping a parent must see descendant spend.
+//   - HINCRBYFLOAT cost:ua:<ua.nonce> + EXPIRE, only when the UA
+//     carried a cumulative budget (phase-4 "budget envelope").
+//   - HINCRBYFLOAT cost:agent:<agent>:<bucket> + EXPIRE, only when
+//     the leaf agent has a configured windowed budget.
+//   - LPUSH/LTRIM tools:run:<leaf> + EXPIRE when the response
+//     contained tool calls.
+//
+// Fire-and-forget per the phase-6 failure-mode contract: accounting
+// fails open. The pipeline runs on a goroutine with its own timeout;
+// errors log loudly and are never surfaced to the caller — a Redis
+// outage must not block or fail the response. The resulting drift is
+// bounded by outage duration × call rate and is reconciled against
+// logs.db (which Bifrost's own logging plugin writes after us).
+//
+// No-op when claims is nil (shadow mode without a verified macaroon)
+// or Redis is unconfigured (observability mode).
+func ApplyToLLMPost(claims *macaroon.Claims, costUSD float64, toolNames []string) {
+	if claims == nil || redisclient.Client() == nil {
+		return
+	}
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), pipelineTimeout)
+		defer cancel()
+		if err := accumulate(ctx, claims, costUSD, toolNames, time.Now().UTC()); err != nil {
+			pluginlog.Warnf(
+				"auth: accumulator pipeline failed (spend uncounted this call) run_id=%s agent=%s cost=%.4f: %v",
+				claims.RunID, claims.AgentName, costUSD, err,
+			)
+		}
+	}()
+}
+
+// accumulate is the synchronous pipeline body. Split from
+// ApplyToLLMPost so tests can run it deterministically against
+// miniredis without racing the goroutine.
+//
+// Every command is individually idempotent on its own value
+// (HINCRBYFLOAT is commutative, LPUSH+LTRIM is bounded, EXPIRE is
+// set-not-add), so the pipeline needs no transaction — out-of-order
+// or partially-applied writes converge to the same state. See
+// phase-6 "Pipelining and atomicity".
+func accumulate(
+	ctx context.Context,
+	claims *macaroon.Claims,
+	costUSD float64,
+	toolNames []string,
+	now time.Time,
+) error {
+	rdb := redisclient.Client()
+	if rdb == nil {
+		return nil
+	}
+	pipe := rdb.Pipeline()
+
+	// Per-run accumulators: every distinct run_id in the chain,
+	// outermost first. Each layer's keys get that layer's own TTL
+	// axis (clamp(layer.exp - now + 1h, 1h, 7d)) — an ancestor's
+	// accumulator must outlive the short-lived leaf that wrote it.
+	// TTL refreshes on every write, so an actively-spending run
+	// keeps its keys alive for its whole lifetime.
+	seen := make(map[string]bool, len(claims.Chain))
+	leafTTL := runKeyTTL(parseRFC3339(claims.EffectiveCaveats.Exp), now)
+	for _, layer := range claims.Chain {
+		if layer.RunID == "" || seen[layer.RunID] {
+			continue
+		}
+		seen[layer.RunID] = true
+		ttl := runKeyTTL(parseRFC3339(layer.Exp), now)
+		costKey := redisclient.Key(costRunPrefix + layer.RunID)
+		stepsKey := redisclient.Key(stepsRunPrefix + layer.RunID)
+		pipe.HIncrByFloat(ctx, costKey, "total", costUSD)
+		pipe.HIncrBy(ctx, stepsKey, "total", 1)
+		pipe.Expire(ctx, costKey, ttl)
+		pipe.Expire(ctx, stepsKey, ttl)
+	}
+
+	// UA cumulative envelope — only when the org actually set one.
+	// No bucket ⇒ no enforcement; per-invocation caps are checked at
+	// signature time and need no Redis state.
+	if claims.UABudget != nil && claims.UABudget.MaxTotalUSD > 0 && claims.UANonce != "" {
+		uaKey := redisclient.Key(costUAPrefix + claims.UANonce)
+		uaTTL := runKeyTTL(parseRFC3339(claims.UAExp), now)
+		pipe.HIncrByFloat(ctx, uaKey, "total", costUSD)
+		pipe.Expire(ctx, uaKey, uaTTL)
+	}
+
+	// Per-agent windowed bucket — only when the operator configured
+	// a budget for this agent. The bucket key is computed from THIS
+	// write's clock ("bucket by the time of the write" — see phase-6
+	// "Bucket boundary mid-call"), never carried over from PreHook.
+	if b, ok := GetConfig().AgentBudgets[claims.AgentName]; ok && b.CapUSD > 0 && b.Window != "" {
+		if w, err := duration.Parse(b.Window); err != nil {
+			pluginlog.Warnf("auth: accumulator agent=%s: unrecognized window %q", claims.AgentName, b.Window)
+		} else {
+			agentKey := redisclient.Key(costAgentPrefix + claims.AgentName + ":" + w.BucketKey(now))
+			pipe.HIncrByFloat(ctx, agentKey, "total", costUSD)
+			pipe.Expire(ctx, agentKey, w.TTL())
+		}
+	}
+
+	// Tool-loop history on the leaf run only.
+	if len(toolNames) > 0 && claims.RunID != "" {
+		toolsKey := redisclient.Key(toolsRunPrefix + claims.RunID)
+		for _, name := range toolNames {
+			pipe.LPush(ctx, toolsKey, name)
+		}
+		pipe.LTrim(ctx, toolsKey, 0, toolHistoryLen-1)
+		pipe.Expire(ctx, toolsKey, leafTTL)
+	}
+
+	_, err := pipe.Exec(ctx)
+	return err
+}

--- a/gateway/internal/auth/accumulator_test.go
+++ b/gateway/internal/auth/accumulator_test.go
@@ -1,0 +1,224 @@
+package auth
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	macaroon "github.com/stakwork/stakgraph/gateway/auth/go"
+)
+
+// chainClaims builds a verified-claims shape with an invocation layer
+// plus n attenuation layers, exps spaced so per-layer TTLs differ.
+func chainClaims(runIDs []string, exps []string) *macaroon.Claims {
+	chain := make([]macaroon.ChainLayer, len(runIDs))
+	for i := range runIDs {
+		chain[i] = macaroon.ChainLayer{
+			RunID:      runIDs[i],
+			MaxCostUSD: 5,
+			MaxSteps:   100,
+			Exp:        exps[i],
+		}
+	}
+	leaf := len(runIDs) - 1
+	return &macaroon.Claims{
+		OrgID:     "org_acme",
+		UserID:    testUserID,
+		AgentName: "coder",
+		RunID:     runIDs[leaf],
+		EffectiveCaveats: macaroon.EffectiveCaveats{
+			Agents:     []string{"coder"},
+			MaxCostUSD: 5,
+			MaxSteps:   100,
+			Exp:        exps[leaf],
+		},
+		UANonce: "aaaa000000000000000000000000aaaa",
+		UAIAT:   "2026-05-14T09:00:00Z",
+		UAExp:   "2026-06-14T09:00:00Z",
+		Chain:   chain,
+		Nonces:  []string{"aaaa000000000000000000000000aaaa", "bbbb000000000000000000000000bbbb"},
+		IAT:     "2026-05-14T10:00:00Z",
+	}
+}
+
+func testNow() time.Time {
+	return time.Date(2026, 5, 14, 10, 5, 0, 0, time.UTC)
+}
+
+func TestAccumulate_PerRunChainWalk(t *testing.T) {
+	mr := newMiniRedis(t)
+	claims := chainClaims(
+		[]string{"r_parent", "r_child"},
+		[]string{"2026-05-14T18:00:00Z", "2026-05-14T10:30:00Z"},
+	)
+
+	if err := accumulate(context.Background(), claims, 0.42, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range []string{"r_parent", "r_child"} {
+		if got := mr.HGet("bifrost:cost:run:"+r, "total"); got != "0.42" {
+			t.Errorf("cost:run:%s total = %q, want 0.42", r, got)
+		}
+		if got := mr.HGet("bifrost:steps:run:"+r, "total"); got != "1" {
+			t.Errorf("steps:run:%s total = %q, want 1", r, got)
+		}
+	}
+
+	// Second call accumulates.
+	if err := accumulate(context.Background(), claims, 0.08, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+	if got := mr.HGet("bifrost:cost:run:r_parent", "total"); got != "0.5" {
+		t.Errorf("after second call cost:run:r_parent = %q, want 0.5", got)
+	}
+	if got := mr.HGet("bifrost:steps:run:r_child", "total"); got != "2" {
+		t.Errorf("after second call steps:run:r_child = %q, want 2", got)
+	}
+}
+
+func TestAccumulate_PerLayerTTL(t *testing.T) {
+	mr := newMiniRedis(t)
+	// Parent exp 8h out, leaf exp 25m out. Parent keys must get the
+	// longer TTL (exp-now+1h), leaf keys the 1h floor + 25m.
+	claims := chainClaims(
+		[]string{"r_parent", "r_child"},
+		[]string{"2026-05-14T18:05:00Z", "2026-05-14T10:30:00Z"},
+	)
+	if err := accumulate(context.Background(), claims, 0.01, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+
+	parentTTL := mr.TTL("bifrost:cost:run:r_parent")
+	childTTL := mr.TTL("bifrost:cost:run:r_child")
+	if want := 9 * time.Hour; parentTTL != want { // 8h remaining + 1h grace
+		t.Errorf("parent TTL = %s, want %s", parentTTL, want)
+	}
+	if want := 85 * time.Minute; childTTL != want { // 25m remaining + 1h grace
+		t.Errorf("child TTL = %s, want %s", childTTL, want)
+	}
+}
+
+func TestAccumulate_DuplicateRunIDsWrittenOnce(t *testing.T) {
+	mr := newMiniRedis(t)
+	// An attenuation that narrows caps but keeps the parent's run_id
+	// must not double-count the call.
+	claims := chainClaims(
+		[]string{"r_same", "r_same"},
+		[]string{"2026-05-14T18:00:00Z", "2026-05-14T12:00:00Z"},
+	)
+	if err := accumulate(context.Background(), claims, 0.10, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+	if got := mr.HGet("bifrost:cost:run:r_same", "total"); got != "0.1" {
+		t.Errorf("cost:run:r_same = %q, want 0.1 (single write)", got)
+	}
+	if got := mr.HGet("bifrost:steps:run:r_same", "total"); got != "1" {
+		t.Errorf("steps:run:r_same = %q, want 1 (single write)", got)
+	}
+}
+
+func TestAccumulate_UAEnvelope_OnlyWhenBudgetSet(t *testing.T) {
+	mr := newMiniRedis(t)
+	claims := chainClaims([]string{"r_1"}, []string{"2026-05-14T11:00:00Z"})
+
+	// No UABudget → no cost:ua key.
+	if err := accumulate(context.Background(), claims, 0.25, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+	if mr.Exists("bifrost:cost:ua:" + claims.UANonce) {
+		t.Fatal("cost:ua written despite nil UABudget")
+	}
+
+	// With a budget → accumulate under the UA nonce, TTL from ua.exp
+	// (a month out → clamped to the 7d ceiling).
+	claims.UABudget = &macaroon.Budget{MaxTotalUSD: 200}
+	if err := accumulate(context.Background(), claims, 0.25, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+	if got := mr.HGet("bifrost:cost:ua:"+claims.UANonce, "total"); got != "0.25" {
+		t.Errorf("cost:ua total = %q, want 0.25", got)
+	}
+	if got, want := mr.TTL("bifrost:cost:ua:"+claims.UANonce), 7*24*time.Hour; got != want {
+		t.Errorf("cost:ua TTL = %s, want %s (7d ceiling)", got, want)
+	}
+}
+
+func TestAccumulate_AgentBucket_OnlyWhenConfigured(t *testing.T) {
+	mr := newMiniRedis(t)
+	claims := chainClaims([]string{"r_1"}, []string{"2026-05-14T11:00:00Z"})
+
+	// No configured budget for "coder" → no agent key.
+	SetConfigForTest(Config{})
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+	if err := accumulate(context.Background(), claims, 0.30, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+	if keys := mr.Keys(); len(keys) != 2 { // cost:run + steps:run only
+		t.Fatalf("unexpected keys without agent budget: %v", keys)
+	}
+
+	// Configured 1d budget → write to the UTC day bucket with 48h TTL.
+	SetConfigForTest(Config{AgentBudgets: map[string]AgentBudget{
+		"coder": {CapUSD: 500, Window: "1d"},
+	}})
+	if err := accumulate(context.Background(), claims, 0.30, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+	key := "bifrost:cost:agent:coder:2026-05-14"
+	if got := mr.HGet(key, "total"); got != "0.3" {
+		t.Errorf("%s total = %q, want 0.3", key, got)
+	}
+	if got, want := mr.TTL(key), 48*time.Hour; got != want {
+		t.Errorf("agent bucket TTL = %s, want %s", got, want)
+	}
+}
+
+func TestAccumulate_ToolHistory_CappedAtTen(t *testing.T) {
+	mr := newMiniRedis(t)
+	claims := chainClaims([]string{"r_1"}, []string{"2026-05-14T11:00:00Z"})
+
+	for i := 0; i < 6; i++ {
+		if err := accumulate(context.Background(), claims, 0, []string{"grep", "read"}, testNow()); err != nil {
+			t.Fatal(err)
+		}
+	}
+	list, err := mr.List("bifrost:tools:run:r_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(list) != toolHistoryLen {
+		t.Fatalf("tools list length = %d, want %d (LTRIM cap)", len(list), toolHistoryLen)
+	}
+	// Most recent push is at the head.
+	if list[0] != "read" {
+		t.Errorf("tools head = %q, want most-recent \"read\"", list[0])
+	}
+}
+
+func TestAccumulate_ZeroCostStillCountsStep(t *testing.T) {
+	mr := newMiniRedis(t)
+	claims := chainClaims([]string{"r_1"}, []string{"2026-05-14T11:00:00Z"})
+
+	// Errored call: cost 0, but the step must still increment (phase-6
+	// PostLLMHook step 1).
+	if err := accumulate(context.Background(), claims, 0, nil, testNow()); err != nil {
+		t.Fatal(err)
+	}
+	if got := mr.HGet("bifrost:steps:run:r_1", "total"); got != "1" {
+		t.Errorf("steps after zero-cost call = %q, want 1", got)
+	}
+	if got := mr.HGet("bifrost:cost:run:r_1", "total"); got != "0" {
+		t.Errorf("cost after zero-cost call = %q, want 0", got)
+	}
+}
+
+func TestApplyToLLMPost_NilClaimsOrNoRedis_NoOp(t *testing.T) {
+	// Nil claims: must not panic, must not write.
+	mr := newMiniRedis(t)
+	ApplyToLLMPost(nil, 1.0, nil)
+	time.Sleep(20 * time.Millisecond) // would-be goroutine window
+	if keys := mr.Keys(); len(keys) != 0 {
+		t.Fatalf("nil claims wrote keys: %v", keys)
+	}
+}

--- a/gateway/internal/auth/config.go
+++ b/gateway/internal/auth/config.go
@@ -39,6 +39,17 @@ type Config struct {
 	// budget column / progress bar. Empty map ⇒ no agent has a
 	// cap, every request passes the budget check.
 	AgentBudgets map[string]AgentBudget `json:"agent_budgets"`
+
+	// ModelPricing is the per-model token pricing the phase-6
+	// accumulator uses to turn usage into dollars when the provider
+	// response doesn't carry its own cost (Usage.Cost is populated
+	// by only a handful of providers — Anthropic and OpenAI chat
+	// responses don't have it in bifrost core v1.5.x). Keys are
+	// resolved model names as Bifrost reports them, with or without
+	// the "provider/" prefix. A model with no entry accumulates $0
+	// and logs loudly — undercounting is visible in the daily
+	// logs.db reconciliation rather than silently guessed at.
+	ModelPricing map[string]ModelPrice `json:"model_pricing"`
 }
 
 // AgentBudget is one row in `agent_budgets`. Window uses the Bifrost
@@ -51,6 +62,14 @@ type AgentBudget struct {
 	Window string  `json:"window"`
 }
 
+// ModelPrice is one row of `model_pricing`: dollars per million
+// tokens, the unit every provider publishes prices in. The phase-6
+// accumulator computes prompt*input/1e6 + completion*output/1e6.
+type ModelPrice struct {
+	InputPerMTok  float64 `json:"input_per_mtok"`
+	OutputPerMTok float64 `json:"output_per_mtok"`
+}
+
 // pluginConfigEnvelope mirrors the shape pluginlog.Init receives. We
 // don't import its internal type; this is a private decoder for the
 // subset of fields auth cares about. Bifrost passes the raw `config`
@@ -59,6 +78,7 @@ type AgentBudget struct {
 type pluginConfigEnvelope struct {
 	EnforceMacaroons bool                   `json:"enforce_macaroons"`
 	AgentBudgets     map[string]AgentBudget `json:"agent_budgets"`
+	ModelPricing     map[string]ModelPrice  `json:"model_pricing"`
 }
 
 var (
@@ -121,5 +141,6 @@ func parseConfig(raw any) (Config, error) {
 	return Config{
 		EnforceMacaroons: env.EnforceMacaroons,
 		AgentBudgets:     env.AgentBudgets,
+		ModelPricing:     env.ModelPricing,
 	}, nil
 }

--- a/gateway/internal/auth/doc.go
+++ b/gateway/internal/auth/doc.go
@@ -8,26 +8,31 @@
 //
 // What's in scope here
 // --------------------
-//   - config.go       enforce_macaroons flag (shadow → enforce rollout)
+//   - config.go       enforce_macaroons flag (shadow → enforce rollout),
+//     agent_budgets, model_pricing
 //   - verifier.go     Verify() — header extraction + trust lookup + pure verify
 //   - revocation.go   CheckRevocations() — bifrost:revoke:* / revoke_user_before:*
-//   - ttl.go          clamp(exp-now+1h, 1h, 7d) shared with phase-6 accumulators
+//   - ttl.go          clamp(exp-now+1h, 1h, 7d) shared by revocation + accumulators
 //   - enforcement.go  Evaluate() + ApplyToLLMPre() — hook glue
+//   - accumulator.go  ApplyToLLMPost() — phase-6 PostLLMHook pipeline:
+//     cost:run / steps:run per chain layer, cost:ua envelope,
+//     cost:agent windowed buckets, tools:run history
+//   - pricing.go      PriceCall() — model_pricing table → dollars
 //   - admin.go        admin endpoints (revoke management — minimal scope)
 //
-// What's out of scope (phase 6)
-// -----------------------------
-//   - Per-run cost cap walk (cost:run:<run_id> with ancestor walking)
-//   - Per-UA cumulative spend (cost:ua:<ua_nonce>)
-//   - Per-agent windowed budgets (cost:agent:<name>:<bucket_key>)
-//   - Step counters / tool-loop detection
-//   - Kill switches (kill:<run_id>, kill:agent:<name>)
-//   - PostLLMHook accumulator pipelines
+// What's still out of scope (phase 6 read side)
+// ---------------------------------------------
+//   - Per-run cost/step cap walk in PreLLMHook (reads the
+//     accumulators this package now writes)
+//   - ua_budget / realm_budget / agent budget 402 rejections
+//   - Tool-loop detection (reads tools:run)
+//   - Kill switches (kill:<run_id>, kill:agent:<name>) + admin routes
 //
-// All of the above land in a follow-up PR against this same package.
-// The Claims surfaced here already carry everything that work needs
-// (RunID, UANonce, UABudget, EffectiveCaveats); the missing piece is
-// just the Redis pipeline plumbing.
+// The write side landing first is deliberate: accumulators are
+// shadow-safe (they reject nothing), they light up the phase-8
+// budget endpoint that currently falls back to logs.db, and the cap
+// walk needs weeks of real accumulated state to validate against
+// before it starts rejecting.
 //
 // Operational posture
 // -------------------

--- a/gateway/internal/auth/pricing.go
+++ b/gateway/internal/auth/pricing.go
@@ -1,0 +1,57 @@
+package auth
+
+import (
+	"strings"
+
+	"github.com/stakwork/stakgraph/gateway/internal/pricing"
+)
+
+// PriceCall converts token usage into dollars. Returns (cost, true)
+// when a price source knows the model, (0, false) when none does —
+// the caller decides how loudly to complain about an unpriced model.
+//
+// Source precedence (the hook layer sits one level above this: a
+// provider-computed Usage.Cost.TotalCost wins over everything here):
+//
+//  1. The operator's model_pricing config block — the explicit
+//     override, and the only source in air-gapped deployments.
+//  2. The pricing catalog (internal/pricing) — bifrost's own
+//     datasheet, fetched at boot and refreshed daily. Same file
+//     bifrost prices logs.db rows from, so enforcement dollars and
+//     reported dollars agree.
+//
+// Model matching: exact key first, then the name with any
+// "provider/" prefix stripped, so "anthropic/claude-sonnet-5" and
+// "claude-sonnet-5" resolve to the same entry whichever form the
+// caller holds.
+func PriceCall(model string, promptTokens, completionTokens int) (float64, bool) {
+	if model == "" {
+		return 0, false
+	}
+	const mtok = 1_000_000
+	if entry, ok := configPrice(model); ok {
+		return float64(promptTokens)*entry.InputPerMTok/mtok +
+			float64(completionTokens)*entry.OutputPerMTok/mtok, true
+	}
+	if p, ok := pricing.Lookup(model); ok {
+		return float64(promptTokens)*p.InputPerMTok/mtok +
+			float64(completionTokens)*p.OutputPerMTok/mtok, true
+	}
+	return 0, false
+}
+
+func configPrice(model string) (ModelPrice, bool) {
+	table := GetConfig().ModelPricing
+	if len(table) == 0 {
+		return ModelPrice{}, false
+	}
+	if entry, ok := table[model]; ok {
+		return entry, true
+	}
+	if i := strings.LastIndexByte(model, '/'); i >= 0 {
+		if entry, ok := table[model[i+1:]]; ok {
+			return entry, true
+		}
+	}
+	return ModelPrice{}, false
+}

--- a/gateway/internal/auth/pricing_test.go
+++ b/gateway/internal/auth/pricing_test.go
@@ -1,0 +1,68 @@
+package auth
+
+import (
+	"testing"
+
+	"github.com/stakwork/stakgraph/gateway/internal/pricing"
+)
+
+func TestPriceCall(t *testing.T) {
+	SetConfigForTest(Config{ModelPricing: map[string]ModelPrice{
+		"claude-3-5-haiku-latest": {InputPerMTok: 0.80, OutputPerMTok: 4.00},
+	}})
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+
+	// 1000 in + 500 out = 0.0008 + 0.002 = 0.0028.
+	got, ok := PriceCall("claude-3-5-haiku-latest", 1000, 500)
+	if !ok || got != 0.0028 {
+		t.Fatalf("PriceCall = (%v, %v), want (0.0028, true)", got, ok)
+	}
+
+	// Provider-prefixed form resolves to the same entry.
+	got, ok = PriceCall("anthropic/claude-3-5-haiku-latest", 1000, 500)
+	if !ok || got != 0.0028 {
+		t.Fatalf("prefixed PriceCall = (%v, %v), want (0.0028, true)", got, ok)
+	}
+
+	// Unpriced model: (0, false), caller logs.
+	if _, ok := PriceCall("gpt-4o", 10, 10); ok {
+		t.Fatal("unpriced model must return ok=false")
+	}
+
+	// Empty table: never ok.
+	SetConfigForTest(Config{})
+	if _, ok := PriceCall("claude-3-5-haiku-latest", 10, 10); ok {
+		t.Fatal("empty pricing table must return ok=false")
+	}
+}
+
+func TestPriceCall_CatalogFallback(t *testing.T) {
+	pricing.SetTableForTest(map[string]pricing.Price{
+		"claude-sonnet-5": {InputPerMTok: 2.0, OutputPerMTok: 10.0},
+	})
+	t.Cleanup(func() {
+		pricing.SetTableForTest(nil)
+		SetConfigForTest(Config{})
+	})
+
+	// No config entry → catalog prices it: 1000*2/1e6 + 500*10/1e6.
+	SetConfigForTest(Config{})
+	got, ok := PriceCall("claude-sonnet-5", 1000, 500)
+	if !ok || got != 0.007 {
+		t.Fatalf("catalog PriceCall = (%v, %v), want (0.007, true)", got, ok)
+	}
+
+	// Config entry for the same model overrides the catalog.
+	SetConfigForTest(Config{ModelPricing: map[string]ModelPrice{
+		"claude-sonnet-5": {InputPerMTok: 4.0, OutputPerMTok: 20.0},
+	}})
+	got, ok = PriceCall("claude-sonnet-5", 1000, 500)
+	if !ok || got != 0.014 {
+		t.Fatalf("config-over-catalog PriceCall = (%v, %v), want (0.014, true)", got, ok)
+	}
+
+	// Neither source knows the model → (0, false).
+	if _, ok := PriceCall("mystery-model", 10, 10); ok {
+		t.Fatal("model absent from both sources must return ok=false")
+	}
+}

--- a/gateway/internal/auth/revocation.go
+++ b/gateway/internal/auth/revocation.go
@@ -175,31 +175,14 @@ func revokeCodeFor(i int) string {
 	}
 }
 
-// uaIATFromClaims pulls the user_authorization.iat out of the verified
-// claims. Pure verifier doesn't surface ua.iat directly on Claims
-// today — Claims.IAT is the invocation's iat — but the cutoff
-// comparison is against ua.iat per phase 6.
-//
-// We can fetch it because Claims.Nonces[0] = ua.nonce, and the wire
-// format requires that ua block to live on the original macaroon. We
-// kept the original bytes during peekOrgID; storing them on Claims
-// would be cleaner but would require modifying the pure verifier.
-// Instead, we re-derive at check time from what we have on the wire.
-//
-// For phase 4 the simpler answer is: surface ua.iat on Claims. Until
-// that lands, this helper exists as a no-op that uses Claims.IAT —
-// which is invocation.iat. This is technically more lenient than the
-// spec (a revoke cutoff between ua.iat and invocation.iat will let
-// the macaroon through), but in the common case where ua is re-used
-// across many invocations the difference is hours-to-days, well below
-// the operator-driven cutoff granularity (cutoffs are set when a user
-// is offboarded or a key rotated, both human-scale events).
-//
-// Phase 6's full implementation surfaces ua.iat as Claims.UAIAT —
-// that's a small addition to the pure verifier and is left as a
-// follow-up that doesn't block the adapter from landing.
+// uaIATFromClaims pulls the user_authorization.iat out of the
+// verified claims — the phase-6 comparison axis for
+// revoke_user_before (NOT the invocation's iat: user-level
+// revocation invalidates org-issued user authorizations, and an
+// invocation signed after the cutoff against a re-issued UA is
+// fine). The pure verifier surfaces it as Claims.UAIAT.
 func uaIATFromClaims(claims *macaroon.Claims) (time.Time, error) {
-	return time.Parse(time.RFC3339, claims.IAT)
+	return time.Parse(time.RFC3339, claims.UAIAT)
 }
 
 // redactNonce shortens a 32-char hex nonce to its first 8 chars +

--- a/gateway/internal/auth/revocation_test.go
+++ b/gateway/internal/auth/revocation_test.go
@@ -111,11 +111,12 @@ func TestCheckRevocations_UserCutoff_RejectsOldUA(t *testing.T) {
 	claims := &macaroon.Claims{
 		UserID: testUserID,
 		Nonces: []string{"aaaa000000000000000000000000aaaa"},
-		// UA issued before the cutoff (Claims.IAT is invocation.iat
-		// in the current pure verifier, but for revocation purposes
-		// we're comparing against the same time the UA's iat would
-		// most likely match — see uaIATFromClaims doc comment).
-		IAT: "2025-12-01T00:00:00Z",
+		// UA issued before the cutoff. The comparison axis is
+		// ua.iat (Claims.UAIAT), not the invocation's iat — an
+		// invocation signed after the cutoff against a re-issued
+		// UA is fine.
+		UAIAT: "2025-12-01T00:00:00Z",
+		IAT:   "2026-06-15T00:00:00Z",
 	}
 	err := CheckRevocations(context.Background(), claims)
 	if err == nil {
@@ -133,7 +134,8 @@ func TestCheckRevocations_UserCutoff_AcceptsNewerUA(t *testing.T) {
 	claims := &macaroon.Claims{
 		UserID: testUserID,
 		Nonces: []string{"aaaa000000000000000000000000aaaa"},
-		IAT:    "2026-06-15T00:00:00Z", // after cutoff
+		UAIAT:  "2026-06-15T00:00:00Z", // after cutoff
+		IAT:    "2026-06-15T00:00:00Z",
 	}
 	if err := CheckRevocations(context.Background(), claims); err != nil {
 		t.Fatalf("post-cutoff UA should pass, got %+v", err)
@@ -150,6 +152,7 @@ func TestCheckRevocations_UserCutoff_MalformedFailsOpen(t *testing.T) {
 	claims := &macaroon.Claims{
 		UserID: testUserID,
 		Nonces: []string{"aaaa000000000000000000000000aaaa"},
+		UAIAT:  "2026-06-15T00:00:00Z",
 		IAT:    "2026-06-15T00:00:00Z",
 	}
 	if err := CheckRevocations(context.Background(), claims); err != nil {

--- a/gateway/internal/duration/duration.go
+++ b/gateway/internal/duration/duration.go
@@ -1,0 +1,181 @@
+// Package duration mirrors Bifrost's duration vocabulary for windowed
+// budgets (phase-6 §"Duration vocabulary") without taking a dep on
+// bifrost/framework. The reference implementation is
+// bifrost/framework/configstore/tables/utils.go (ParseDuration and
+// GetCalendarPeriodStart); tests cross-check a fixed input set against
+// the outputs recorded from that implementation so drift is caught in
+// CI rather than in an operator's budget math.
+//
+// Vocabulary (case-sensitive — "1M" is months, "1m" is minutes):
+//
+//	Ns, Nm, Nh   rolling windows, no calendar boundary
+//	Nd           calendar day, midnight UTC
+//	Nw           calendar week, midnight UTC of the most recent Monday
+//	NM           calendar month, midnight UTC of the 1st
+//	NY           calendar year, midnight UTC of Jan 1
+//
+// Bucket-key formats follow the phase-6 schema table: calendar
+// windows use human-readable date keys ("2026-05-16", "2026-W20",
+// "2026-05", "2026"), sub-day rolling windows use the unix epoch of
+// the window start. All boundaries are UTC.
+package duration
+
+import (
+	"fmt"
+	"strconv"
+	"time"
+)
+
+// Window is a parsed duration string: a positive count and a unit
+// suffix. Phase 6 ships only N=1 calendar windows; larger N parses
+// (the vocabulary allows it) and buckets align to the N=1 boundary of
+// the unit, with the window length spanning N units from that
+// boundary.
+type Window struct {
+	N    int
+	Unit byte // one of 's' 'm' 'h' 'd' 'w' 'M' 'Y'
+}
+
+// Parse parses a Bifrost duration string ("10m", "2h", "1d", "1w",
+// "1M", "1Y"). The numeric prefix must be a positive base-10 integer
+// with no leading zeroes; the suffix must be exactly one of the seven
+// vocabulary units.
+func Parse(s string) (Window, error) {
+	if len(s) < 2 {
+		return Window{}, fmt.Errorf("duration %q: too short", s)
+	}
+	unit := s[len(s)-1]
+	switch unit {
+	case 's', 'm', 'h', 'd', 'w', 'M', 'Y':
+	default:
+		return Window{}, fmt.Errorf("duration %q: unknown unit %q", s, string(unit))
+	}
+	num := s[:len(s)-1]
+	if num[0] == '0' {
+		return Window{}, fmt.Errorf("duration %q: leading zero", s)
+	}
+	n, err := strconv.Atoi(num)
+	if err != nil || n <= 0 {
+		return Window{}, fmt.Errorf("duration %q: bad count", s)
+	}
+	return Window{N: n, Unit: unit}, nil
+}
+
+// Calendar reports whether the window aligns to a calendar boundary
+// (d/w/M/Y) as opposed to rolling sub-day semantics (s/m/h).
+func (w Window) Calendar() bool {
+	switch w.Unit {
+	case 'd', 'w', 'M', 'Y':
+		return true
+	}
+	return false
+}
+
+// Bounds returns the [start, end) interval of the bucket containing
+// `now`. Calendar windows anchor start at the unit's standard
+// boundary (midnight UTC / Monday / 1st / Jan 1) and span N units;
+// sub-day windows truncate `now` to the N×unit interval.
+//
+// `now` is converted to UTC before any boundary math — every bucket
+// boundary in the schema is UTC by contract.
+func (w Window) Bounds(now time.Time) (start, end time.Time) {
+	now = now.UTC()
+	switch w.Unit {
+	case 's', 'm', 'h':
+		interval := w.rollingInterval()
+		start = now.Truncate(interval)
+		return start, start.Add(interval)
+	case 'd':
+		start = time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(0, 0, w.N)
+	case 'w':
+		// Go's Weekday: Sunday=0..Saturday=6; ISO weeks start Monday.
+		wd := int(now.Weekday())
+		if wd == 0 {
+			wd = 7
+		}
+		start = time.Date(now.Year(), now.Month(), now.Day()-(wd-1), 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(0, 0, 7*w.N)
+	case 'M':
+		start = time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(0, w.N, 0)
+	case 'Y':
+		start = time.Date(now.Year(), 1, 1, 0, 0, 0, 0, time.UTC)
+		return start, start.AddDate(w.N, 0, 0)
+	}
+	return time.Time{}, time.Time{} // unreachable for parsed windows
+}
+
+// BucketKey returns the Redis bucket-key segment for the window
+// containing `now`, per the phase-6 schema table. The caller
+// assembles the full key (`bifrost:cost:agent:<name>:<key>`).
+func (w Window) BucketKey(now time.Time) string {
+	start, _ := w.Bounds(now)
+	switch w.Unit {
+	case 's', 'm', 'h':
+		return strconv.FormatInt(start.Unix(), 10)
+	case 'd':
+		return start.Format("2006-01-02")
+	case 'w':
+		y, wk := start.ISOWeek()
+		return fmt.Sprintf("%04d-W%02d", y, wk)
+	case 'M':
+		return start.Format("2006-01")
+	case 'Y':
+		return start.Format("2006")
+	}
+	return ""
+}
+
+// TTL is the Redis expiry for a bucket key: 2× the window duration
+// (phase-6 §cost:agent — "a 1d bucket lives 48h, a 1w bucket lives
+// 14d, a 1M bucket lives ~60d"). Calendar months and years use the
+// 30d/365d approximations; the imprecision only stretches or trims
+// how long a dead bucket lingers, never which bucket is written.
+func (w Window) TTL() time.Duration {
+	return 2 * w.length()
+}
+
+func (w Window) length() time.Duration {
+	n := time.Duration(w.N)
+	switch w.Unit {
+	case 's':
+		return n * time.Second
+	case 'm':
+		return n * time.Minute
+	case 'h':
+		return n * time.Hour
+	case 'd':
+		return n * 24 * time.Hour
+	case 'w':
+		return n * 7 * 24 * time.Hour
+	case 'M':
+		return n * 30 * 24 * time.Hour
+	case 'Y':
+		return n * 365 * 24 * time.Hour
+	}
+	return 0
+}
+
+func (w Window) rollingInterval() time.Duration {
+	switch w.Unit {
+	case 's':
+		return time.Duration(w.N) * time.Second
+	case 'm':
+		return time.Duration(w.N) * time.Minute
+	case 'h':
+		return time.Duration(w.N) * time.Hour
+	}
+	return 0
+}
+
+// BucketKey is the package-level convenience for one-shot callers:
+// parse + key in one call. Returns an error on a malformed window
+// string so hot-path callers can decide their own degrade behavior.
+func BucketKey(window string, now time.Time) (string, error) {
+	w, err := Parse(window)
+	if err != nil {
+		return "", err
+	}
+	return w.BucketKey(now), nil
+}

--- a/gateway/internal/duration/duration_test.go
+++ b/gateway/internal/duration/duration_test.go
@@ -1,0 +1,191 @@
+package duration
+
+import (
+	"strconv"
+	"testing"
+	"time"
+)
+
+// ─── Parse ────────────────────────────────────────────────────────────
+
+func TestParse_Valid(t *testing.T) {
+	cases := []struct {
+		in   string
+		want Window
+	}{
+		{"1s", Window{1, 's'}},
+		{"10m", Window{10, 'm'}},
+		{"2h", Window{2, 'h'}},
+		{"1d", Window{1, 'd'}},
+		{"3d", Window{3, 'd'}},
+		{"1w", Window{1, 'w'}},
+		{"1M", Window{1, 'M'}},
+		{"1Y", Window{1, 'Y'}},
+	}
+	for _, c := range cases {
+		got, err := Parse(c.in)
+		if err != nil {
+			t.Errorf("Parse(%q): unexpected error %v", c.in, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("Parse(%q) = %+v, want %+v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestParse_Invalid(t *testing.T) {
+	for _, in := range []string{
+		"", "1", "d", "1x", "0d", "01d", "-1d", "1.5h", "1 d", "d1", "1dd",
+	} {
+		if _, err := Parse(in); err == nil {
+			t.Errorf("Parse(%q): expected error, got nil", in)
+		}
+	}
+}
+
+// Case sensitivity is load-bearing: "1M" is months, "1m" is minutes.
+func TestParse_CaseSensitivity(t *testing.T) {
+	mo, err := Parse("1M")
+	if err != nil || mo.Unit != 'M' {
+		t.Fatalf("Parse(1M) = %+v, %v", mo, err)
+	}
+	mi, err := Parse("1m")
+	if err != nil || mi.Unit != 'm' {
+		t.Fatalf("Parse(1m) = %+v, %v", mi, err)
+	}
+	if mo.Calendar() == false || mi.Calendar() == true {
+		t.Fatalf("calendar flags: 1M=%v 1m=%v", mo.Calendar(), mi.Calendar())
+	}
+}
+
+// ─── BucketKey: cross-check table ─────────────────────────────────────
+//
+// These pairs mirror the phase-6 schema table and Bifrost's
+// GetCalendarPeriodStart semantics (midnight UTC / Monday / 1st /
+// Jan 1). If Bifrost's vocabulary ever changes, update both this
+// table and the parser together.
+
+func TestBucketKey_CalendarWindows(t *testing.T) {
+	// Friday 2026-05-16 14:30:00 UTC (matches the phase-6 examples).
+	now := time.Date(2026, 5, 16, 14, 30, 0, 0, time.UTC)
+	cases := []struct {
+		window string
+		want   string
+	}{
+		{"1d", "2026-05-16"},
+		{"1w", "2026-W20"},
+		{"1M", "2026-05"},
+		{"1Y", "2026"},
+	}
+	for _, c := range cases {
+		got, err := BucketKey(c.window, now)
+		if err != nil {
+			t.Errorf("BucketKey(%q): %v", c.window, err)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("BucketKey(%q) = %q, want %q", c.window, got, c.want)
+		}
+	}
+}
+
+func TestBucketKey_SubDayRolling(t *testing.T) {
+	now := time.Date(2026, 5, 16, 14, 37, 42, 0, time.UTC)
+	cases := []struct {
+		window string
+		start  time.Time // expected window start; key is its epoch
+	}{
+		{"1h", time.Date(2026, 5, 16, 14, 0, 0, 0, time.UTC)},
+		{"2h", time.Date(2026, 5, 16, 14, 0, 0, 0, time.UTC)},
+		{"10m", time.Date(2026, 5, 16, 14, 30, 0, 0, time.UTC)},
+		{"30s", time.Date(2026, 5, 16, 14, 37, 30, 0, time.UTC)},
+	}
+	for _, c := range cases {
+		got, err := BucketKey(c.window, now)
+		if err != nil {
+			t.Errorf("BucketKey(%q): %v", c.window, err)
+			continue
+		}
+		if want := strconv.FormatInt(c.start.Unix(), 10); got != want {
+			t.Errorf("BucketKey(%q) = %q, want %q (start %s)", c.window, got, want, c.start)
+		}
+	}
+}
+
+// ─── Bounds ───────────────────────────────────────────────────────────
+
+func TestBounds_WeekStartsMonday(t *testing.T) {
+	// Sunday 2026-05-17: the week bucket must start Monday 05-11,
+	// not Sunday (Go's Weekday numbering trap).
+	now := time.Date(2026, 5, 17, 8, 0, 0, 0, time.UTC)
+	w := Window{1, 'w'}
+	start, end := w.Bounds(now)
+	if want := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC); !start.Equal(want) {
+		t.Errorf("week start = %s, want %s", start, want)
+	}
+	if want := time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC); !end.Equal(want) {
+		t.Errorf("week end = %s, want %s", end, want)
+	}
+}
+
+func TestBounds_MondayIsOwnWeekStart(t *testing.T) {
+	now := time.Date(2026, 5, 11, 0, 0, 0, 0, time.UTC) // Monday midnight
+	start, _ := Window{1, 'w'}.Bounds(now)
+	if !start.Equal(now) {
+		t.Errorf("week start on a Monday = %s, want %s", start, now)
+	}
+}
+
+func TestBounds_YearBoundaryISOWeek(t *testing.T) {
+	// 2027-01-01 is a Friday, part of ISO week 2026-W53. The bucket
+	// key must carry the ISO year of the week's Monday, not the
+	// calendar year of `now`.
+	now := time.Date(2027, 1, 1, 12, 0, 0, 0, time.UTC)
+	key, err := BucketKey("1w", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key != "2026-W53" {
+		t.Errorf("year-boundary week key = %q, want 2026-W53", key)
+	}
+}
+
+func TestBounds_NonUTCInputNormalized(t *testing.T) {
+	// 2026-05-16 23:30 in UTC+10 is 13:30 UTC on the same day; a
+	// naive local-date bucket would say 05-17.
+	loc := time.FixedZone("UTC+10", 10*3600)
+	now := time.Date(2026, 5, 17, 9, 30, 0, 0, loc) // = 2026-05-16 23:30 UTC
+	key, err := BucketKey("1d", now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if key != "2026-05-16" {
+		t.Errorf("non-UTC day key = %q, want 2026-05-16", key)
+	}
+}
+
+// ─── TTL ──────────────────────────────────────────────────────────────
+
+func TestTTL_TwiceWindow(t *testing.T) {
+	cases := []struct {
+		window string
+		want   time.Duration
+	}{
+		{"1d", 48 * time.Hour},
+		{"1w", 14 * 24 * time.Hour},
+		{"1M", 60 * 24 * time.Hour},
+		{"1Y", 730 * 24 * time.Hour},
+		{"1h", 2 * time.Hour},
+		{"10m", 20 * time.Minute},
+	}
+	for _, c := range cases {
+		w, err := Parse(c.window)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got := w.TTL(); got != c.want {
+			t.Errorf("TTL(%q) = %s, want %s", c.window, got, c.want)
+		}
+	}
+}

--- a/gateway/internal/env/env.go
+++ b/gateway/internal/env/env.go
@@ -15,6 +15,7 @@ package env
 
 import (
 	"os"
+	"strings"
 )
 
 // Variable names. Kept as constants so a typo in a getter doesn't
@@ -84,6 +85,20 @@ const (
 	// "Namespace" for the keyspace contract.
 	RedisURL = "BIFROST_PLUGIN_REDIS_URL"
 
+	// PricingURL overrides where the model-price datasheet is
+	// fetched from. Default is bifrost's own published sheet — the
+	// same file bifrost-http prices logs.db rows from, so
+	// enforcement and reporting agree. Set to "off" to disable
+	// network fetch entirely (air-gapped deployments run from the
+	// persisted cache + config model_pricing).
+	PricingURL = "BIFROST_PLUGIN_PRICING_URL"
+
+	// PricingCache is the on-disk location of the last successfully
+	// fetched datasheet, loaded at boot so a restart during a network
+	// outage still prices from the last known-good table. Defaults
+	// next to trust.json on the data volume.
+	PricingCache = "BIFROST_PLUGIN_PRICING_CACHE"
+
 	// Production, when truthy, forces the `Secure` attribute on the
 	// session cookie regardless of the incoming request's scheme.
 	// Set in swarm/prod; left unset in dev so localhost HTTP works.
@@ -130,6 +145,15 @@ const (
 
 	// DefaultTrustReconcile is the safe default — see TrustReconcile.
 	DefaultTrustReconcile = "ignore"
+
+	// DefaultPricingURL is bifrost's published pricing datasheet —
+	// see framework/modelcatalog (DefaultPricingURL) in the bifrost
+	// source for the upstream twin of this constant.
+	DefaultPricingURL = "https://getbifrost.ai/datasheet"
+
+	// DefaultPricingCache sits on the same data volume as trust.json
+	// and logs.db.
+	DefaultPricingCache = "/app/data/pricing-datasheet.json"
 
 	// DefaultHiveOrigin is production Hive. Override via HIVE_ORIGIN
 	// for staging / dev (e.g. `http://localhost:8080`).
@@ -187,6 +211,21 @@ func TrustPathValue() string { return GetOr(TrustPath, DefaultTrustPath) }
 // validating it against the known set ("ignore", "overwrite",
 // "refuse") — keeping the env package free of policy logic.
 func TrustReconcileValue() string { return GetOr(TrustReconcile, DefaultTrustReconcile) }
+
+// PricingURLValue returns the datasheet URL, "" when fetch is
+// explicitly disabled with the "off" sentinel, and the default sheet
+// otherwise.
+func PricingURLValue() string {
+	v := GetOr(PricingURL, DefaultPricingURL)
+	if strings.EqualFold(v, "off") {
+		return ""
+	}
+	return v
+}
+
+// PricingCachePath returns the persisted-datasheet path, falling
+// back to DefaultPricingCache.
+func PricingCachePath() string { return GetOr(PricingCache, DefaultPricingCache) }
 
 // RedisURLValue returns (url, ok). `ok` is false when unset — callers
 // should treat that as "observability mode" and skip wiring the

--- a/gateway/internal/hooks/llm_posthook.go
+++ b/gateway/internal/hooks/llm_posthook.go
@@ -1,20 +1,27 @@
 package hooks
 
 import (
+	"strings"
+
 	"github.com/maximhq/bifrost/core/schemas"
 
+	"github.com/stakwork/stakgraph/gateway/internal/auth"
 	"github.com/stakwork/stakgraph/gateway/internal/pluginctx"
 	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
 )
 
 // LLMPost is the body of PostLLMHook. It fires after the upstream
 // provider call (or after a short-circuit). For STREAMING requests
-// this fires once when the response is set up; the actual chunks go
-// through StreamChunk.
+// this fires once when the response is set up — usage arrives on the
+// final chunk instead, so streaming accounting lives in StreamChunk
+// and this function skips it (see the request-type gate below).
 //
-// We pull usage tokens here when present. Once macaroon-verified
-// identity lands, this is the function that increments the per-(run,
-// agent, user) cost counters.
+// Phase-6 accounting: when a verified macaroon stamped claims on the
+// context, every completed call feeds the Redis accumulators
+// (cost:run / steps:run / cost:ua / cost:agent / tools:run) through
+// auth.ApplyToLLMPost. An errored call accounts cost=0 but still
+// counts the step — the run burned a call slot even if the provider
+// returned nothing billable.
 func LLMPost(
 	ctx *schemas.BifrostContext,
 	resp *schemas.BifrostResponse,
@@ -29,16 +36,38 @@ func LLMPost(
 	)
 
 	// Try to pull usage/cost if the provider populated it (Chat responses).
+	var usage *schemas.BifrostLLMUsage
+	if hadResp && resp.ChatResponse != nil {
+		usage = resp.ChatResponse.Usage
+	}
 	var promptTokens, completionTokens, totalTokens int
-	if hadResp && resp.ChatResponse != nil && resp.ChatResponse.Usage != nil {
-		u := resp.ChatResponse.Usage
-		promptTokens = u.PromptTokens
-		completionTokens = u.CompletionTokens
-		totalTokens = u.TotalTokens
+	if usage != nil {
+		promptTokens = usage.PromptTokens
+		completionTokens = usage.CompletionTokens
+		totalTokens = usage.TotalTokens
+	}
+
+	// Phase-6 accumulator writes. Streaming requests are accounted
+	// on their final usage-bearing chunk (StreamChunk), not here —
+	// this firing has no usage yet. MarkAccounted keeps the two
+	// sites from ever both counting the same call.
+	costUSD := 0.0
+	if claims := pluginctx.VerifiedClaims(ctx); claims != nil {
+		switch {
+		case hadErr:
+			if pluginctx.MarkAccounted(ctx) {
+				auth.ApplyToLLMPost(claims, 0, nil)
+			}
+		case hadResp && !isStreamRequest(resp):
+			if pluginctx.MarkAccounted(ctx) {
+				costUSD = resolveCost(resp.ChatResponse, usage, dims)
+				auth.ApplyToLLMPost(claims, costUSD, toolCallNames(resp.ChatResponse))
+			}
+		}
 	}
 
 	pluginlog.Logf(
-		"PostLLMHook run_id=%s agent=%s had_resp=%t had_err=%t prompt_tokens=%d completion_tokens=%d total_tokens=%d elapsed_ms=%d",
+		"PostLLMHook run_id=%s agent=%s had_resp=%t had_err=%t prompt_tokens=%d completion_tokens=%d total_tokens=%d cost_usd=%.6f elapsed_ms=%d",
 		dims[pluginctx.DimRunID],
 		dims[pluginctx.DimAgentName],
 		hadResp,
@@ -46,7 +75,77 @@ func LLMPost(
 		promptTokens,
 		completionTokens,
 		totalTokens,
+		costUSD,
 		elapsed.Milliseconds(),
 	)
 	return resp, bifrostErr, nil
+}
+
+// isStreamRequest reports whether the response belongs to a
+// streaming request type ("chat_completion_stream", etc.), whose
+// usage is delivered on the final chunk rather than here.
+func isStreamRequest(resp *schemas.BifrostResponse) bool {
+	ef := resp.GetExtraFields()
+	if ef == nil {
+		return false
+	}
+	return strings.HasSuffix(string(ef.RequestType), "_stream")
+}
+
+// resolveCost turns a chat response's usage into dollars. Precedence
+// per the phase-6 accumulator design:
+//
+//  1. Provider-computed Usage.Cost.TotalCost (only some providers).
+//  2. auth.PriceCall on the resolved model name — operator
+//     model_pricing config first, then the internal/pricing catalog
+//     (bifrost's own datasheet, refreshed daily).
+//  3. $0, with a loud log — an unpriced model must be visible in
+//     `docker logs`, not silently guessed at.
+func resolveCost(chat *schemas.BifrostChatResponse, usage *schemas.BifrostLLMUsage, dims map[string]string) float64 {
+	if usage == nil {
+		return 0
+	}
+	if usage.Cost != nil && usage.Cost.TotalCost > 0 {
+		return usage.Cost.TotalCost
+	}
+	model := ""
+	if chat != nil {
+		if model = chat.ExtraFields.ResolvedModelUsed; model == "" {
+			model = chat.Model
+		}
+	}
+	if cost, ok := auth.PriceCall(model, usage.PromptTokens, usage.CompletionTokens); ok {
+		return cost
+	}
+	if usage.TotalTokens > 0 {
+		pluginlog.Warnf(
+			"accounting: no price for model=%q (run_id=%s) — %d tokens accumulated as $0; add a model_pricing entry",
+			model, dims[pluginctx.DimRunID], usage.TotalTokens,
+		)
+	}
+	return 0
+}
+
+// toolCallNames collects the tool names invoked in a non-streaming
+// chat response, feeding the tools:run history that phase-6's
+// tool-loop heuristic reads. Nil when the response called no tools.
+func toolCallNames(chat *schemas.BifrostChatResponse) []string {
+	if chat == nil {
+		return nil
+	}
+	var names []string
+	for _, choice := range chat.Choices {
+		if choice.ChatNonStreamResponseChoice == nil || choice.Message == nil {
+			continue
+		}
+		if choice.Message.ChatAssistantMessage == nil {
+			continue
+		}
+		for _, tc := range choice.Message.ToolCalls {
+			if tc.Function.Name != nil && *tc.Function.Name != "" {
+				names = append(names, *tc.Function.Name)
+			}
+		}
+	}
+	return names
 }

--- a/gateway/internal/hooks/llm_posthook_test.go
+++ b/gateway/internal/hooks/llm_posthook_test.go
@@ -1,0 +1,100 @@
+package hooks
+
+import (
+	"testing"
+
+	"github.com/maximhq/bifrost/core/schemas"
+
+	"github.com/stakwork/stakgraph/gateway/internal/auth"
+)
+
+func strPtr(s string) *string { return &s }
+
+func TestToolCallNames(t *testing.T) {
+	chat := &schemas.BifrostChatResponse{
+		Choices: []schemas.BifrostResponseChoice{
+			{
+				ChatNonStreamResponseChoice: &schemas.ChatNonStreamResponseChoice{
+					Message: &schemas.ChatMessage{
+						ChatAssistantMessage: &schemas.ChatAssistantMessage{
+							ToolCalls: []schemas.ChatAssistantMessageToolCall{
+								{Function: schemas.ChatAssistantMessageToolCallFunction{Name: strPtr("grep")}},
+								{Function: schemas.ChatAssistantMessageToolCallFunction{Name: strPtr("read")}},
+								{Function: schemas.ChatAssistantMessageToolCallFunction{Name: nil}},
+							},
+						},
+					},
+				},
+			},
+			// Stream-shaped choice (no ChatNonStreamResponseChoice):
+			// must be skipped without panicking on the nil embed.
+			{},
+		},
+	}
+	got := toolCallNames(chat)
+	if len(got) != 2 || got[0] != "grep" || got[1] != "read" {
+		t.Fatalf("toolCallNames = %v, want [grep read]", got)
+	}
+	if toolCallNames(nil) != nil {
+		t.Fatal("nil chat must yield nil names")
+	}
+	if toolCallNames(&schemas.BifrostChatResponse{}) != nil {
+		t.Fatal("no choices must yield nil names")
+	}
+}
+
+func TestResolveCost_Precedence(t *testing.T) {
+	auth.SetConfigForTest(auth.Config{ModelPricing: map[string]auth.ModelPrice{
+		"claude-3-5-haiku-latest": {InputPerMTok: 1.0, OutputPerMTok: 10.0},
+	}})
+	t.Cleanup(func() { auth.SetConfigForTest(auth.Config{}) })
+
+	dims := map[string]string{}
+
+	// 1. Provider-computed cost wins over the table.
+	chat := &schemas.BifrostChatResponse{Model: "claude-3-5-haiku-latest"}
+	usage := &schemas.BifrostLLMUsage{
+		PromptTokens:     1000,
+		CompletionTokens: 1000,
+		TotalTokens:      2000,
+		Cost:             &schemas.BifrostCost{TotalCost: 0.5},
+	}
+	if got := resolveCost(chat, usage, dims); got != 0.5 {
+		t.Fatalf("provider cost should win, got %v", got)
+	}
+
+	// 2. Falls back to the pricing table: 1000*1/1e6 + 1000*10/1e6 = 0.011.
+	usage.Cost = nil
+	if got := resolveCost(chat, usage, dims); got != 0.011 {
+		t.Fatalf("table cost = %v, want 0.011", got)
+	}
+
+	// 3. Unpriced model → 0.
+	chat.Model = "mystery-model"
+	if got := resolveCost(chat, usage, dims); got != 0 {
+		t.Fatalf("unpriced model cost = %v, want 0", got)
+	}
+
+	// Nil usage → 0.
+	if got := resolveCost(chat, nil, dims); got != 0 {
+		t.Fatalf("nil usage cost = %v, want 0", got)
+	}
+}
+
+func TestResolveCost_PrefersResolvedModel(t *testing.T) {
+	auth.SetConfigForTest(auth.Config{ModelPricing: map[string]auth.ModelPrice{
+		"claude-3-5-haiku-latest": {InputPerMTok: 1.0, OutputPerMTok: 1.0},
+	}})
+	t.Cleanup(func() { auth.SetConfigForTest(auth.Config{}) })
+
+	chat := &schemas.BifrostChatResponse{
+		Model: "some-alias",
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			ResolvedModelUsed: "anthropic/claude-3-5-haiku-latest",
+		},
+	}
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 500, CompletionTokens: 500, TotalTokens: 1000}
+	if got := resolveCost(chat, usage, map[string]string{}); got != 0.001 {
+		t.Fatalf("resolved-model cost = %v, want 0.001", got)
+	}
+}

--- a/gateway/internal/hooks/stream_chunk.go
+++ b/gateway/internal/hooks/stream_chunk.go
@@ -3,19 +3,27 @@ package hooks
 import (
 	"github.com/maximhq/bifrost/core/schemas"
 
+	"github.com/stakwork/stakgraph/gateway/internal/auth"
 	"github.com/stakwork/stakgraph/gateway/internal/pluginctx"
 	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
 )
 
 // StreamChunk is the body of HTTPTransportStreamChunkHook. It fires
-// once per streamed chunk. PostHook does NOT fire for streaming
-// responses, so cost accounting on streams will eventually hook in
-// here (specifically on the final chunk that carries usage).
+// once per streamed chunk. PostLLMHook does NOT carry usage for
+// streaming responses, so phase-6 cost accounting for streams lives
+// here: Bifrost normalizes providers to the OpenAI stream shape,
+// where usage arrives once on the final chunk (include_usage is on
+// by default). MarkAccounted guards the "provider emits usage on
+// more than one chunk" case — first usage-bearing chunk wins, and a
+// second one is ignored rather than double-counted.
+//
+// Stream tool-call names arrive as per-chunk deltas that would need
+// cross-chunk assembly to reconstruct; the tools:run history
+// currently comes from non-streaming responses only. Revisit when
+// the phase-6 PreLLMHook tool-loop check lands.
 //
 // Logging policy: one log line per chunk would flood output, so we
-// only emit on error chunks. The "interesting boundary" chunks
-// (first/last) will eventually deserve their own targeted logging,
-// but for now stay quiet to keep `docker logs` readable.
+// only emit on error chunks and on the accounting chunk.
 func StreamChunk(
 	ctx *schemas.BifrostContext,
 	req *schemas.HTTPRequest,
@@ -24,6 +32,8 @@ func StreamChunk(
 	if chunk == nil {
 		return chunk, nil
 	}
+	claims := pluginctx.VerifiedClaims(ctx)
+
 	if chunk.BifrostError != nil {
 		dims := pluginctx.Dims(ctx)
 		pluginlog.Logf(
@@ -33,6 +43,34 @@ func StreamChunk(
 			dims[pluginctx.DimAgentName],
 			chunk.BifrostError.Error,
 		)
+		// A stream that died still burned a call slot: count the
+		// step with zero cost (any partial usage was never
+		// delivered on a final chunk).
+		if claims != nil && pluginctx.MarkAccounted(ctx) {
+			auth.ApplyToLLMPost(claims, 0, nil)
+		}
+		return chunk, nil
 	}
+
+	chat := chunk.BifrostChatResponse
+	if claims == nil || chat == nil || chat.Usage == nil || chat.Usage.TotalTokens == 0 {
+		return chunk, nil
+	}
+	if !pluginctx.MarkAccounted(ctx) {
+		return chunk, nil
+	}
+
+	dims := pluginctx.Dims(ctx)
+	costUSD := resolveCost(chat, chat.Usage, dims)
+	auth.ApplyToLLMPost(claims, costUSD, nil)
+	pluginlog.Logf(
+		"StreamChunk accounted run_id=%s agent=%s prompt_tokens=%d completion_tokens=%d total_tokens=%d cost_usd=%.6f",
+		dims[pluginctx.DimRunID],
+		dims[pluginctx.DimAgentName],
+		chat.Usage.PromptTokens,
+		chat.Usage.CompletionTokens,
+		chat.Usage.TotalTokens,
+		costUSD,
+	)
 	return chunk, nil
 }

--- a/gateway/internal/pluginctx/claims.go
+++ b/gateway/internal/pluginctx/claims.go
@@ -14,6 +14,7 @@ const (
 	keyVerifiedClaims schemas.BifrostContextKey = "stakgraph-gateway/verified-claims"
 	keyLeafRunID      schemas.BifrostContextKey = "stakgraph-gateway/leaf-run-id"
 	keyLeafAgent      schemas.BifrostContextKey = "stakgraph-gateway/leaf-agent"
+	keyAccounted      schemas.BifrostContextKey = "stakgraph-gateway/usage-accounted"
 )
 
 // SetRawMacaroon stashes the raw x-macaroon header value extracted
@@ -78,4 +79,19 @@ func LeafAgent(ctx *schemas.BifrostContext) string {
 		return v
 	}
 	return ""
+}
+
+// MarkAccounted claims this request's single phase-6 accounting
+// slot. Returns true exactly once per request; false on every later
+// call. Guards against double-counting when more than one hook site
+// could plausibly account the same call — PostLLMHook vs the
+// final stream chunk, an error surfaced in both, or a provider that
+// emits usage on more than one chunk. Hooks for one request run
+// sequentially, so a plain read-then-write is race-free here.
+func MarkAccounted(ctx *schemas.BifrostContext) bool {
+	if v, ok := ctx.Value(keyAccounted).(bool); ok && v {
+		return false
+	}
+	ctx.SetValue(keyAccounted, true)
+	return true
 }

--- a/gateway/internal/pricing/pricing.go
+++ b/gateway/internal/pricing/pricing.go
@@ -1,0 +1,262 @@
+// Package pricing maintains the model-price catalog the phase-6
+// accumulator uses to turn token usage into dollars.
+//
+// Source of truth: https://getbifrost.ai/datasheet — the SAME file
+// bifrost-http's framework syncs (framework/modelcatalog) to compute
+// the `cost` column in logs.db. Pricing enforcement from the same
+// datasheet means the gateway's Redis accumulators and Bifrost's own
+// reporting agree to the cent, with no reconciliation drift. Keys in
+// the datasheet are model names exactly as Bifrost resolves them
+// ("claude-sonnet-5", "gpt-5.2", "us.anthropic.claude-opus-5", …).
+//
+// Lifecycle (mirrors the trust registry's fail-soft posture):
+//
+//  1. Init loads the last persisted datasheet from disk, if any, so
+//     a restart during a network outage still prices from the last
+//     known-good table.
+//  2. A background goroutine fetches the datasheet immediately and
+//     then every 24h (the same cadence bifrost itself uses). Each
+//     successful fetch atomically swaps the in-memory table and
+//     persists the raw bytes for the next boot.
+//  3. Fetch failures log a warning and keep the last-good table.
+//
+// The hot path (Lookup) is a map read behind an atomic pointer — no
+// locks, no I/O, no allocation.
+//
+// Precedence is decided by the caller (internal/auth.PriceCall):
+// provider-computed cost → operator model_pricing config → this
+// catalog → $0 with a loud log. The config layer stays as the
+// operator override and the air-gapped fallback.
+package pricing
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/stakwork/stakgraph/gateway/internal/env"
+	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
+)
+
+// Price is one model's rates in dollars per million tokens — the
+// unit providers publish prices in. CacheReadPerMTok is carried for
+// the future cache-aware refinement (BifrostLLMUsage exposes cached
+// token counts); the current PriceCall uses only input/output.
+type Price struct {
+	InputPerMTok     float64
+	OutputPerMTok    float64
+	CacheReadPerMTok float64
+}
+
+const (
+	fetchTimeout  = 45 * time.Second // matches bifrost's DefaultPricingTimeout
+	fetchRetries  = 3                // attempts per cycle: 1 + retries
+	syncInterval  = 24 * time.Hour   // matches bifrost's DefaultSyncInterval
+	maxSheetBytes = 64 << 20         // hard cap on the response body (sheet is ~5MB today)
+)
+
+var (
+	table    atomic.Pointer[map[string]Price]
+	stopLoop context.CancelFunc
+
+	// retryBaseDelay is the first retry's backoff (doubling per
+	// attempt). Package-level so tests can shrink it.
+	retryBaseDelay = time.Second
+)
+
+// Lookup returns the catalog price for a model: exact key first,
+// then the name with any "provider/" prefix stripped (Bifrost
+// resolved names are usually bare, but callers occasionally hold the
+// prefixed form). ok=false when the catalog has no entry — the
+// caller falls through to its next price source.
+func Lookup(model string) (Price, bool) {
+	m := table.Load()
+	if m == nil || model == "" {
+		return Price{}, false
+	}
+	if p, ok := (*m)[model]; ok {
+		return p, true
+	}
+	if i := strings.LastIndexByte(model, '/'); i >= 0 {
+		if p, ok := (*m)[model[i+1:]]; ok {
+			return p, true
+		}
+	}
+	return Price{}, false
+}
+
+// Init loads the persisted datasheet (if any) and starts the
+// background fetch/refresh loop. Never fatal: with no cache, no
+// network, or BIFROST_PLUGIN_PRICING_URL=off, the plugin runs with
+// an empty catalog and pricing falls through to the config table.
+// Call Stop from plugin Cleanup.
+func Init() {
+	cachePath := env.PricingCachePath()
+	if raw, err := os.ReadFile(cachePath); err != nil {
+		// First boot (or a fresh volume): make the empty-catalog
+		// window visible — until the first fetch lands, unpriced
+		// models accumulate at $0 unless model_pricing covers them.
+		pluginlog.Logf("pricing: no persisted datasheet at %s — catalog empty until first fetch", cachePath)
+	} else if m, err := parseDatasheet(raw); err != nil {
+		pluginlog.Warnf("pricing: persisted datasheet %s unparseable (%v) — waiting for fetch", cachePath, err)
+	} else {
+		table.Store(&m)
+		pluginlog.Logf("pricing: loaded %d models from %s", len(m), cachePath)
+	}
+
+	url := env.PricingURLValue()
+	if url == "" {
+		pluginlog.Logf("pricing: fetch disabled (%s=off) — catalog is config/cache only", env.PricingURL)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopLoop = cancel
+	go refreshLoop(ctx, url, cachePath)
+}
+
+// Stop cancels the refresh loop. Safe to call without Init.
+func Stop() {
+	if stopLoop != nil {
+		stopLoop()
+	}
+}
+
+func refreshLoop(ctx context.Context, url, cachePath string) {
+	fetchAndSwap(ctx, url, cachePath)
+	ticker := time.NewTicker(syncInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			fetchAndSwap(ctx, url, cachePath)
+		}
+	}
+}
+
+// fetchAndSwap runs one fetch cycle with retries. On success it swaps
+// the in-memory table and persists the raw sheet; on failure it logs
+// and leaves the last-good table in place.
+func fetchAndSwap(ctx context.Context, url, cachePath string) {
+	var lastErr error
+	for attempt := 0; attempt <= fetchRetries; attempt++ {
+		if attempt > 0 {
+			backoff := time.Duration(1<<(attempt-1)) * retryBaseDelay
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(backoff):
+			}
+		}
+		raw, err := fetchOnce(ctx, url)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		m, err := parseDatasheet(raw)
+		if err != nil {
+			lastErr = err
+			continue
+		}
+		table.Store(&m)
+		pluginlog.Logf("pricing: datasheet refreshed models=%d source=%s", len(m), url)
+		persist(cachePath, raw)
+		return
+	}
+	pluginlog.Warnf("pricing: datasheet fetch failed after %d attempts (%v) — keeping last-good table", fetchRetries+1, lastErr)
+}
+
+func fetchOnce(ctx context.Context, url string) ([]byte, error) {
+	fctx, cancel := context.WithTimeout(ctx, fetchTimeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(fctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status %d", resp.StatusCode)
+	}
+	return io.ReadAll(io.LimitReader(resp.Body, maxSheetBytes))
+}
+
+// datasheetEntry is the subset of bifrost's PricingEntry the gateway
+// consumes. Costs are dollars PER TOKEN in the sheet; we convert to
+// per-Mtok at parse time.
+type datasheetEntry struct {
+	InputCostPerToken  float64 `json:"input_cost_per_token"`
+	OutputCostPerToken float64 `json:"output_cost_per_token"`
+	CacheReadPerToken  float64 `json:"cache_read_input_token_cost"`
+}
+
+func parseDatasheet(raw []byte) (map[string]Price, error) {
+	var sheet map[string]datasheetEntry
+	if err := json.Unmarshal(raw, &sheet); err != nil {
+		return nil, err
+	}
+	m := make(map[string]Price, len(sheet))
+	for model, e := range sheet {
+		if e.InputCostPerToken == 0 && e.OutputCostPerToken == 0 {
+			continue // free/embedding/no-price rows carry no signal for cost caps
+		}
+		const mtok = 1_000_000
+		m[model] = Price{
+			InputPerMTok:     e.InputCostPerToken * mtok,
+			OutputPerMTok:    e.OutputCostPerToken * mtok,
+			CacheReadPerMTok: e.CacheReadPerToken * mtok,
+		}
+	}
+	if len(m) == 0 {
+		return nil, fmt.Errorf("datasheet parsed to zero priced models")
+	}
+	return m, nil
+}
+
+// persist writes the raw sheet atomically (tmp + rename, same pattern
+// as trust persistence) so a crash mid-write can't corrupt the cache.
+// Failure is a warning, not an error — the cache only matters on the
+// next boot, and /app/data may not exist in local dev.
+func persist(path string, raw []byte) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		pluginlog.Warnf("pricing: persist mkdir %s: %v", filepath.Dir(path), err)
+		return
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, raw, 0o644); err != nil {
+		pluginlog.Warnf("pricing: persist write %s: %v", tmp, err)
+		return
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		pluginlog.Warnf("pricing: persist rename %s: %v", path, err)
+	}
+}
+
+// SetTableForTest replaces the in-memory table. Pass nil to clear.
+// Production code MUST go through Init.
+func SetTableForTest(m map[string]Price) {
+	if m == nil {
+		table.Store(nil)
+		return
+	}
+	table.Store(&m)
+}
+
+// FetchNowForTest runs one synchronous fetch cycle against the given
+// URL, persisting to cachePath. Exposed so tests can exercise the
+// fetch/parse/persist path without the background loop.
+func FetchNowForTest(url, cachePath string) {
+	fetchAndSwap(context.Background(), url, cachePath)
+}

--- a/gateway/internal/pricing/pricing_test.go
+++ b/gateway/internal/pricing/pricing_test.go
@@ -1,0 +1,142 @@
+package pricing
+
+import (
+	"math"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestMain(m *testing.M) {
+	retryBaseDelay = time.Millisecond
+	os.Exit(m.Run())
+}
+
+// sampleSheet mirrors the real datasheet shape: dollars per token,
+// extra fields the gateway ignores, and a free row that must be
+// dropped.
+const sampleSheet = `{
+  "claude-sonnet-5": {
+    "provider": "anthropic", "mode": "chat",
+    "input_cost_per_token": 2e-06,
+    "output_cost_per_token": 1e-05,
+    "cache_read_input_token_cost": 2e-07
+  },
+  "gpt-5.2": {
+    "provider": "openai", "mode": "chat",
+    "input_cost_per_token": 1.75e-06,
+    "output_cost_per_token": 1.4e-05
+  },
+  "some-free-model": {
+    "provider": "misc", "mode": "chat"
+  }
+}`
+
+func TestParseDatasheet_ConvertsToPerMTok(t *testing.T) {
+	m, err := parseDatasheet([]byte(sampleSheet))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m) != 2 {
+		t.Fatalf("parsed %d models, want 2 (free row dropped)", len(m))
+	}
+	sonnet := m["claude-sonnet-5"]
+	if sonnet.InputPerMTok != 2.0 || sonnet.OutputPerMTok != 10.0 {
+		t.Fatalf("claude-sonnet-5 = %+v, want {2 10 …}", sonnet)
+	}
+	// Per-token → per-Mtok multiplication is float math; compare with
+	// a tolerance rather than an exact decimal.
+	if diff := math.Abs(sonnet.CacheReadPerMTok - 0.2); diff > 1e-9 {
+		t.Fatalf("claude-sonnet-5 cache read = %v, want ≈0.2", sonnet.CacheReadPerMTok)
+	}
+}
+
+func TestParseDatasheet_RejectsGarbage(t *testing.T) {
+	if _, err := parseDatasheet([]byte("not json")); err == nil {
+		t.Fatal("expected parse error")
+	}
+	if _, err := parseDatasheet([]byte(`{"only-free": {"provider":"x"}}`)); err == nil {
+		t.Fatal("a sheet with zero priced models must be rejected, not swapped in")
+	}
+}
+
+func TestLookup_PrefixStrip(t *testing.T) {
+	SetTableForTest(map[string]Price{"claude-sonnet-5": {InputPerMTok: 2, OutputPerMTok: 10}})
+	t.Cleanup(func() { SetTableForTest(nil) })
+
+	if _, ok := Lookup("claude-sonnet-5"); !ok {
+		t.Fatal("exact lookup failed")
+	}
+	if _, ok := Lookup("anthropic/claude-sonnet-5"); !ok {
+		t.Fatal("prefix-stripped lookup failed")
+	}
+	if _, ok := Lookup("unknown-model"); ok {
+		t.Fatal("unknown model must miss")
+	}
+	if _, ok := Lookup(""); ok {
+		t.Fatal("empty model must miss")
+	}
+}
+
+func TestFetch_SwapsAndPersists(t *testing.T) {
+	SetTableForTest(nil)
+	t.Cleanup(func() { SetTableForTest(nil) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(sampleSheet))
+	}))
+	defer srv.Close()
+
+	cachePath := filepath.Join(t.TempDir(), "sheet.json")
+	FetchNowForTest(srv.URL, cachePath)
+
+	if p, ok := Lookup("gpt-5.2"); !ok || p.InputPerMTok != 1.75 {
+		t.Fatalf("post-fetch Lookup(gpt-5.2) = (%+v, %v)", p, ok)
+	}
+	raw, err := os.ReadFile(cachePath)
+	if err != nil {
+		t.Fatalf("cache not persisted: %v", err)
+	}
+	if string(raw) != sampleSheet {
+		t.Fatal("persisted cache must be the raw sheet bytes")
+	}
+}
+
+func TestFetch_FailureKeepsLastGood(t *testing.T) {
+	SetTableForTest(map[string]Price{"claude-sonnet-5": {InputPerMTok: 2, OutputPerMTok: 10}})
+	t.Cleanup(func() { SetTableForTest(nil) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	FetchNowForTest(srv.URL, filepath.Join(t.TempDir(), "sheet.json"))
+
+	if _, ok := Lookup("claude-sonnet-5"); !ok {
+		t.Fatal("failed fetch must keep the last-good table")
+	}
+}
+
+func TestFetch_BadBodyKeepsLastGood(t *testing.T) {
+	SetTableForTest(map[string]Price{"claude-sonnet-5": {InputPerMTok: 2, OutputPerMTok: 10}})
+	t.Cleanup(func() { SetTableForTest(nil) })
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("<html>captive portal</html>"))
+	}))
+	defer srv.Close()
+
+	cachePath := filepath.Join(t.TempDir(), "sheet.json")
+	FetchNowForTest(srv.URL, cachePath)
+
+	if _, ok := Lookup("claude-sonnet-5"); !ok {
+		t.Fatal("unparseable body must keep the last-good table")
+	}
+	if _, err := os.Stat(cachePath); err == nil {
+		t.Fatal("unparseable body must not be persisted over the cache")
+	}
+}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -27,6 +27,7 @@ import (
 	"github.com/stakwork/stakgraph/gateway/internal/auth"
 	"github.com/stakwork/stakgraph/gateway/internal/hooks"
 	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
+	"github.com/stakwork/stakgraph/gateway/internal/pricing"
 	"github.com/stakwork/stakgraph/gateway/internal/redisclient"
 	"github.com/stakwork/stakgraph/gateway/internal/trust"
 )
@@ -88,6 +89,13 @@ func Init(config any) error {
 	auth.SetTrustRegistry(reg)
 	pluginlog.Logf("auth: macaroon adapter wired enforce=%t", auth.GetConfig().EnforceMacaroons)
 
+	// Model-price catalog for the phase-6 accumulator: loads the
+	// persisted datasheet, then fetches bifrost's published sheet in
+	// the background and refreshes daily. Never fatal — with no
+	// cache and no network, pricing falls through to the config
+	// model_pricing table.
+	pricing.Init()
+
 	return adminapi.Start()
 }
 
@@ -100,6 +108,7 @@ func GetName() string { return PluginName }
 // clean error rather than the goroutine leak go-redis produces on
 // abrupt process exit; then stop the admin server.
 func Cleanup() error {
+	pricing.Stop()
 	if err := redisclient.Close(); err != nil {
 		pluginlog.Warnf("redis: close: %v", err)
 	}

--- a/gateway/plans/phases/phase-6-plugin-enforcement.md
+++ b/gateway/plans/phases/phase-6-plugin-enforcement.md
@@ -1,5 +1,30 @@
 # Phase 6 — Plugin Enforcement: Redis Schema, Hot-Path Ops, Failure Modes
 
+> **Status (write side landed):** The PostLLMHook accumulator
+> pipeline is implemented — `gateway/internal/auth/accumulator.go`
+> writes `cost:run` / `steps:run` per chain layer (each with its own
+> layer-exp TTL), `cost:ua` when the UA carries a budget,
+> `cost:agent:<name>:<bucket>` for configured agents, and
+> `tools:run` history (non-streaming responses only for now).
+> Streaming requests account on the final usage-bearing chunk in
+> `hooks/stream_chunk.go`; `pluginctx.MarkAccounted` guards
+> double-counting. Bucket keys come from `gateway/internal/duration`
+> (shared with the adminapi budget endpoint, so reader and writer
+> can't drift). Cost source: provider-computed `Usage.Cost` when
+> present, else the `model_pricing` config table (operator
+> override), else `gateway/internal/pricing` — bifrost's own
+> published datasheet (`getbifrost.ai/datasheet`, override with
+> `BIFROST_PLUGIN_PRICING_URL`, `off` to disable), fetched at boot,
+> refreshed every 24h, persisted to the data volume for restarts
+> during outages. It is the same file bifrost prices logs.db rows
+> from, so enforcement dollars and reported dollars agree. (Bifrost
+> core exposes no pricing manager to plugins — the canonical
+> logs.db cost is computed by the framework after our hook.)
+> The verifier now surfaces `Claims.UAIAT` / `UAExp` / `Chain` for
+> this. Still open: the PreLLMHook cost/step cap walk and its 402s,
+> tool-loop detection, kill switches + admin routes, and the
+> `/_plugin/config/*` override layer.
+>
 > **Status (phase 11 cutover):** Redis bucket keys and hot-path
 > flow are unchanged from the description below. Phase 11
 > (`phase-11-symmetric-recursive-authorization.md`) adds one


### PR DESCRIPTION
## What

The gateway now **writes the phase-6 Redis accumulators on every macaroon-verified LLM call**. This is the write half of phase 6 — shadow-safe by design (nothing gets rejected yet). The PreLLMHook cap walk lands separately once real accumulated state exists to validate against.

## Pieces

**`internal/duration`** — Bifrost's duration vocabulary (`1h`/`1d`/`1w`/`1M`/`1Y`, case-sensitive `m` vs `M`), bucket keys per the phase-6 schema table, 2×-window TTLs. The adminapi budget endpoint's `bucketBounds` now delegates here, so the endpoint that *reads* `cost:agent:*` and the hook that *writes* it share one implementation.

**Verifier `Claims` extension** (Go + TS in lockstep) — `Chain` (per-layer run_id/caps/exp, invocation first), `UAIAT`, `UAExp`. Also fixes the documented `revoke_user_before` leniency: the cutoff now compares against `ua.iat` as the spec requires, not the invocation's iat.

**`internal/auth/accumulator.go`** — one pipelined, fire-and-forget Redis round-trip per call:
- `cost:run` / `steps:run` for every distinct run_id in the chain (deduped; each layer keyed to its own exp for TTL)
- `cost:ua:<nonce>` when the UA carries a budget envelope
- `cost:agent:<name>:<bucket>` for configured agents (bucket computed at write time — "bucket by the time of the write")
- capped `tools:run` history for the future tool-loop check

Fails open per the phase-6 failure-mode contract: a Redis outage logs loudly and never blocks a response.

**Hook wiring** — non-streaming calls account in PostLLMHook with tool-call names; streaming calls account on the final usage-bearing chunk; errored calls count a step at $0; `pluginctx.MarkAccounted` guarantees exactly-once accounting per request (including provider double-usage-chunk weirdness).

**`internal/pricing`** — live model-price catalog. Bifrost core exposes no computed cost to plugins (`Usage.Cost` is only populated by a few providers; the pricing manager that fills logs.db runs in the framework *after* our hook), so the plugin prices tokens itself — from **bifrost's own published datasheet** (`getbifrost.ai/datasheet`), the identical file bifrost prices logs.db rows from. Enforcement dollars and reported dollars agree by construction, and current models (Sonnet 5 at \$2/\$10, Opus 5 at \$5/\$25, gpt-5.2, Bedrock/Azure regional variants) are covered without table maintenance.

- Fetched at boot (non-blocking), refreshed every 24h with retry/backoff — same constants bifrost uses
- Persisted to the data volume; restarts during outages load the last-good sheet
- Lock-free atomic-pointer lookup on the hot path
- `BIFROST_PLUGIN_PRICING_URL` overrides the source; `off` disables for air-gapped deploys
- Every startup path logs one obvious line (loaded-from-cache / empty-until-first-fetch / refreshed / disabled / fetch-failed)

**Cost precedence**: provider-computed `Usage.Cost` → `model_pricing` config (operator override / air-gap fallback) → catalog → \$0 with a loud "add a pricing entry" warning.

## Immediate payoff

`/_plugin/agents/:name/budget` stops falling back to summing logs.db — the Redis bucket it already reads now gets written.

## Testing

- 30+ new tests: duration parsing/buckets/TTLs (incl. ISO-week year boundary, non-UTC normalization), accumulator chain walk / per-layer TTLs / dedup / envelope gating / LTRIM cap / zero-cost steps (miniredis), pricing catalog parse/fetch/persist/fail-soft (httptest), config-over-catalog precedence, tool-call extraction
- Full `go test ./internal/... ./auth/go/...` green, `go vet` clean
- TS: `gatekey` build + all 7 cross-language fixtures pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)