### PR TITLE
Add xAI Grok as a first-class aieo provider

### DIFF
--- a/mcp/src/aieo/package.json
+++ b/mcp/src/aieo/package.json
@@ -15,7 +15,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "try": "ts-node ./src/test/try.ts",
     "try-anthropic": "ts-node ./src/test/try-anthropic.ts",
-    "try-kimi": "ts-node ./src/test/try-kimi.ts"
+    "try-kimi": "ts-node ./src/test/try-kimi.ts",
+    "try-grok": "tsx ./src/test/try-grok.ts"
   },
   "keywords": [
     "llm",
@@ -28,6 +29,7 @@
     "@ai-sdk/anthropic": "3.0.105",
     "@ai-sdk/google": "3.0.67",
     "@ai-sdk/openai": "3.0.61",
+    "@ai-sdk/xai": "3.0.88",
     "@openrouter/ai-sdk-provider": "2.10.0",
     "ai": "6.0.175",
     "zod": "4.3.6"

--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -4,11 +4,12 @@ import {
   GoogleGenerativeAIProviderOptions,
 } from "@ai-sdk/google";
 import { createOpenAI, OpenAIResponsesProviderOptions } from "@ai-sdk/openai";
+import { createXai } from "@ai-sdk/xai";
 import { LanguageModel } from "ai";
 import { Logger } from "./logger.js";
 import { createOpenRouter, OpenRouterChatSettings } from "@openrouter/ai-sdk-provider";
 
-export type Provider = "anthropic" | "google" | "openai" | "openrouter";
+export type Provider = "anthropic" | "google" | "openai" | "openrouter" | "xai";
 
 /**
  * Optional LLM gateway URL (e.g. Bifrost: https://github.com/maximhq/bifrost,
@@ -25,12 +26,15 @@ const LLM_GATEWAY_URL = process.env.LLM_GATEWAY_URL?.replace(/\/$/, "");
  * NOTE: OpenRouter has no dedicated Bifrost route and rides the OpenAI
  * path. If you spawn an agent in a way where the runtime would override
  * the model to an OpenRouter model, you want the OpenAI suffix here too.
+ * xAI likewise rides the OpenAI-compat path (model id prefixed `xai/`
+ * in getModel), since Bifrost has no dedicated Grok route.
  */
 export const GATEWAY_PATHS: Record<Provider, string> = {
   anthropic: "/anthropic/v1",
   google: "/genai/v1beta",
   openai: "/openai/v1",
   openrouter: "/openai/v1",
+  xai: "/openai/v1",
 };
 
 export function getGatewayBaseURL(provider: Provider): string | undefined {
@@ -138,10 +142,11 @@ export const PROVIDERS: Provider[] = [
   "google",
   "openai",
   "openrouter",
+  "xai",
 ];
 
 // shortcuts to latest models
-export type ModelName = "sonnet" | "opus" | "haiku" | "gemini" | "gpt" | "kimi";
+export type ModelName = "sonnet" | "opus" | "haiku" | "gemini" | "gpt" | "kimi" | "grok";
 
 type ModelId = string;
 
@@ -159,7 +164,10 @@ const MODELS: Record<Provider, Partial<Record<ModelName, ModelId>>> = {
   },
   openrouter: {
     kimi: "moonshotai/kimi-k2.6"
-  }
+  },
+  xai: {
+    grok: "grok-4",
+  },
 };
 
 const DEFAULT_MODELS: Record<Provider, string> = {
@@ -167,6 +175,7 @@ const DEFAULT_MODELS: Record<Provider, string> = {
   google: MODELS.google.gemini!,
   openai: MODELS.openai.gpt!,
   openrouter: MODELS.openrouter.kimi!,
+  xai: MODELS.xai.grok!,
 };
 
 // Light/cheap models for batch operations (descriptions, learnings, etc.)
@@ -175,6 +184,7 @@ const LIGHT_MODELS: Record<Provider, string> = {
   google: "gemini-2.0-flash",
   openai: "gpt-4.1-mini",
   openrouter: "moonshotai/kimi-k2.6",
+  xai: "grok-4-fast-non-reasoning",
 };
 
 export function getLightModelForProvider(provider: Provider): string {
@@ -227,6 +237,8 @@ export function getProviderForModel(modelName?: ModelName | string): Provider {
       return "google";
     case "gpt":
       return "openai";
+    case "grok":
+      return "xai";
     // Full model IDs
     case "claude-sonnet-5":
     case "claude-opus-4-6":
@@ -239,6 +251,13 @@ export function getProviderForModel(modelName?: ModelName | string): Provider {
     case "gpt-4.1-mini":
       return "openai";
     default:
+      // Any bare Grok model id (grok-4, grok-4-fast-non-reasoning,
+      // grok-code-fast-1, ...) goes to xAI. OpenRouter-hosted Grok is
+      // namespaced ("openrouter/x-ai/grok-4") and handled by the prefix
+      // parse above, so this only catches direct-API ids.
+      if (typeof modelName === "string" && modelName.toLowerCase().startsWith("grok")) {
+        return "xai";
+      }
       if (
         process.env.LLM_PROVIDER &&
         PROVIDERS.includes(process.env.LLM_PROVIDER as Provider)
@@ -277,6 +296,8 @@ function lookupApiKeyForProvider(
       return normalizeApiKey(process.env.OPENAI_API_KEY);
     case "openrouter":
       return normalizeApiKey(process.env.OPENROUTER_API_KEY);
+    case "xai":
+      return normalizeApiKey(process.env.XAI_API_KEY);
     case "claude_code":
       return normalizeApiKey(process.env.CLAUDE_CODE_API_KEY);
     default:
@@ -401,6 +422,7 @@ export function getModel(
       "gemini",
       "gpt",
       "kimi",
+      "grok",
     ];
     if (knownShortcuts.includes(opts.modelName)) {
       modelId = getModelForProvider(provider, opts.modelName as ModelName);
@@ -500,6 +522,27 @@ export function getModel(
       };
       return openrouter(modelId, settings);
     }
+    case "xai": {
+      // Gatewayed Grok rides the OpenAI-compat route (GATEWAY_PATHS.xai is
+      // /openai/v1) with an `xai/`-prefixed model id, mirroring the google
+      // branch above. Direct calls use the official xAI provider, which maps
+      // usage (incl. cached prompt tokens) and hits https://api.x.ai/v1.
+      // Grok prompt caching is automatic prefix caching — nothing to set here;
+      // just keep the request prefix byte-stable across steps.
+      if (baseURL) {
+        const xaiCompat = createOpenAI({
+          apiKey,
+          baseURL,
+          ...(extraHeaders && { headers: extraHeaders }),
+        });
+        return xaiCompat.chat(`xai/${modelId}`);
+      }
+      const xai = createXai({
+        apiKey,
+        ...(extraHeaders && { headers: extraHeaders }),
+      });
+      return xai(modelId);
+    }
     // case "claude_code":
     //   try {
     //     const customProvider = createClaudeCode({
@@ -547,6 +590,18 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "moonshotai/kimi-k2.5": 262_144,
   "moonshotai/kimi-k2-thinking": 262_144,
   "moonshotai/kimi-k2": 131_072,
+  // xAI (and the same models via OpenRouter as x-ai/...). Getting these
+  // right matters beyond display: contextLimit drives truncateOldToolResults,
+  // and premature truncation rewrites old messages — which invalidates Grok's
+  // automatic prefix cache on every subsequent step.
+  "grok-4": 256_000,
+  "grok-4-fast": 2_000_000,
+  "grok-4-fast-reasoning": 2_000_000,
+  "grok-4-fast-non-reasoning": 2_000_000,
+  "grok-code-fast-1": 256_000,
+  "x-ai/grok-4": 256_000,
+  "x-ai/grok-4-fast": 2_000_000,
+  "x-ai/grok-code-fast-1": 256_000,
 };
 
 const DEFAULT_CONTEXT_LIMITS: Record<Provider, number> = {
@@ -554,6 +609,7 @@ const DEFAULT_CONTEXT_LIMITS: Record<Provider, number> = {
   google: 1_000_000,
   openai: 128_000,
   openrouter: 128_000,
+  xai: 256_000,
 };
 
 // Conservative fallback if both model and provider lookups miss
@@ -584,6 +640,15 @@ const TOKEN_PRICING: Record<Provider, TokenPricing> = {
   openrouter: {
     inputTokenPrice: 0.6,
     outputTokenPrice: 3.0,
+  },
+  // grok-4 rates. cacheReadPrice matters: computeSessionCost bills cache
+  // reads at full input price when it's absent, and Grok discounts cached
+  // prompt tokens 4x. (Grok has no cache-write charge — writes are billed
+  // as ordinary input, so no cacheWritePrice here.)
+  xai: {
+    inputTokenPrice: 3.0,
+    outputTokenPrice: 15.0,
+    cacheReadPrice: 0.75,
   },
 };
 
@@ -700,6 +765,12 @@ export function getProviderOptions(
     case "openrouter":
       return {
         openrouter: { usage: { include: true } } satisfies OpenRouterChatSettings,
+      };
+    case "xai":
+      // Grok prompt caching is automatic (prefix-based, no breakpoints), so
+      // there is no cacheControl analog to send.
+      return {
+        xai: {},
       };
     default:
       throw new Error(`Unsupported provider: ${provider}`);

--- a/mcp/src/aieo/src/test/try-grok.ts
+++ b/mcp/src/aieo/src/test/try-grok.ts
@@ -1,0 +1,48 @@
+import { generateText } from "ai";
+import * as dotenv from "dotenv";
+import { getModelDetails, getProviderOptions } from "../provider.js";
+import { normalizeUsage, withProviderCacheUsage } from "../usage.js";
+
+dotenv.config({ path: "../../.env" });
+
+// Two identical calls with a >1k-token shared prefix: the first is a plain
+// smoke test of the xai provider path, the second should surface Grok's
+// automatic prefix cache as cache_read in the normalized usage.
+async function doTheThing() {
+  if (!process.env.XAI_API_KEY) {
+    console.error("Missing XAI_API_KEY");
+    return;
+  }
+  const { model, provider, modelId, contextLimit } = getModelDetails(
+    "grok-4-fast-non-reasoning"
+  );
+  console.log({ provider, modelId, contextLimit });
+
+  const system =
+    "You are a terse assistant. Reply with one word only.\n" +
+    "Filler context (ignore): " + "lorem ipsum dolor sit amet ".repeat(300);
+
+  for (const label of ["first call", "second call"]) {
+    const res = await generateText({
+      model,
+      system,
+      prompt: "Say OK",
+      providerOptions: getProviderOptions(provider, "fast", modelId) as any,
+      maxOutputTokens: 512,
+    });
+    const usage = withProviderCacheUsage(
+      normalizeUsage(res.usage as any),
+      res.providerMetadata as Record<string, any> | undefined
+    );
+    console.log(label, {
+      text: res.text.slice(0, 40),
+      rawUsage: res.usage,
+      normalized: usage,
+      providerMetadata: res.providerMetadata,
+    });
+  }
+}
+
+doTheThing().catch((error) => {
+  console.error("Error occurred while calling model:", error);
+});

--- a/mcp/src/aieo/src/usage.ts
+++ b/mcp/src/aieo/src/usage.ts
@@ -24,6 +24,9 @@ type RawUsage = {
     cacheReadTokens?: number;
     cacheWriteTokens?: number;
   };
+  // OpenAI-compatible providers (xAI/Grok, OpenAI chat) surface cached prompt
+  // tokens as a flat `cachedInputTokens` instead of inputTokenDetails.
+  cachedInputTokens?: number;
   outputTokens?: number;
   totalTokens?: number;
 };
@@ -57,7 +60,8 @@ export function normalizeUsage(raw?: RawUsage | null): AiUsageWithLegacy {
   const cache_read =
     raw?.cache_read !== undefined
       ? tokenCount(raw.cache_read)
-      : tokenCount(raw?.inputTokenDetails?.cacheReadTokens);
+      : tokenCount(raw?.inputTokenDetails?.cacheReadTokens) ||
+        tokenCount(raw?.cachedInputTokens);
   const cache_write =
     raw?.cache_write !== undefined
       ? tokenCount(raw.cache_write)


### PR DESCRIPTION
## What

Adds `xai` as a first-class provider in `aieo/provider`, so Grok models work directly against `api.x.ai` instead of only via OpenRouter:

- `grok` model shortcut (→ `grok-4`), plus resolution for bare `grok-*` ids and `xai/...` namespacing; `openrouter/x-ai/...` still routes to OpenRouter as before
- API key from `XAI_API_KEY`; direct calls use `@ai-sdk/xai` (pinned to `3.0.88`, the version already in the mcp root deps), gatewayed calls ride the Bifrost OpenAI-compat route with an `xai/`-prefixed model id (mirroring the google branch)
- Context limits for the Grok family: `grok-4`/`grok-code-fast-1` at 256k, `grok-4-fast` family at 2M — including `x-ai/...` ids for OpenRouter-hosted Grok, which previously fell back to 128k
- `TOKEN_PRICING.xai` with `cacheReadPrice: 0.75` so cache hits bill at Grok's 4x discount instead of full input price
- `normalizeUsage` falls back to the flat `cachedInputTokens` field (OpenAI-compat usage shape) when `inputTokenDetails` is absent
- `npm run try-grok` script in aieo for a live two-call smoke test that prints raw + normalized usage

## Why

Grok's prompt caching is automatic prefix caching — there's nothing to send per-request, but two things on our side had to be right:

1. **Context limits.** With the 128k fallback, `truncateOldToolResults` starts rewriting old messages far too early on 2M-context models, and any rewrite invalidates the prefix cache on every subsequent agent step.
2. **Usage accounting.** Cached tokens must land in `cache_read` (and be priced at the cached rate) rather than being counted as full-price input.

## Verification

- `tsc --noEmit` clean; `npm run test:node` 525/525; aieo provider tests pass
- Live smoke test against xAI: warm prefix served **1664/1707 tokens from cache**, correctly normalized (`input: 43, cache_read: 1664`)
- `yarn.lock` unchanged — `@ai-sdk/xai@3.0.88` was already a (previously unused) root dependency

## Notes for review

- The xAI SDK reports cached tokens in both `inputTokenDetails.cacheReadTokens` and flat `cachedInputTokens`, so the existing normalize path already covers native calls; the new fallback covers compat shapes that only send the flat field
- `getProviderOptions("xai")` deliberately returns no `cacheControl` analog — Grok has no breakpoints and no cache-write charge
- xAI's cache takes a few seconds to propagate, so back-to-back identical calls may miss; irrelevant for agent runs with tool-execution gaps between steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)