### PR TITLE
Add generic create_node and edit_node graph data-write tools

### DIFF
--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -18,7 +18,7 @@ import {
   normalizeUsage,
   withProviderCacheUsage,
 } from "../aieo/src/index.js";
-import { get_tools, ToolsConfig, SkillsConfig, GgnnConfig, MessagesRef, ProvenanceCollector, toolConfigEnabled, redactToolsConfig } from "./tools.js";
+import { get_tools, ToolsConfig, SkillsConfig, GgnnConfig, MessagesRef, ProvenanceCollector, toolConfigEnabled, graphWriteEnabled, redactToolsConfig } from "./tools.js";
 import {
   withConceptCollection,
   normalizeConceptReads,
@@ -226,20 +226,23 @@ Other rules:
  * (search-then-write) instead of minting duplicates.
  */
 const GRAPH_WRITE_GUIDANCE = `
-### Graph Writes (create_triplet — enabled)
-You can assert facts into the graph as DATA: source node -[edge]-> target node. Writes apply live to the graph immediately.
-- **Reuse before you create.** For each side of the triplet, \`graph_search\` for the entity first and pass its \`ref_id\`. Only create a node inline (\`*_type\` + \`*_data\`) when the entity genuinely does not exist yet — duplicate nodes fragment the graph.
+### Graph Writes (enabled)
+You can write DATA into the graph (instances, not schema). Writes apply live to the graph immediately.
+- \`create_triplet\` / \`create_batch_triplet\` — assert facts as source node -[edge]-> target node.
+- \`create_node\` — create (or merge) a single node with no edge. Prefer \`create_triplet\` when the new node should be connected to something — free-floating nodes are rarely useful.
+- \`edit_node\` — partial-update an existing node by ref_id: \`node_data\` merges over current properties, \`properties_to_be_deleted\` removes them. Inspect the node with \`graph_get\` before editing it.
+- **Reuse before you create.** \`graph_search\` for the entity first and pass its \`ref_id\`. Only create a node (inline \`*_type\` + \`*_data\`, or \`create_node\`) when the entity genuinely does not exist yet — duplicate nodes fragment the graph.
 - Node types and the edge type must exist in the ontology — verify with \`get_ontology\` (\`include_edges: true\` to see valid relationships). \`create_schema_if_missing\` auto-creates a missing edge schema; use it sparingly, and never to paper over a typo in \`edge_type\`.
 - Pass \`namespace\` when writing into a specific data partition.
-- Writes are create-or-merge: re-asserting an existing triplet is safe and returns the existing ref_ids (reported as a Warning).
-- After a write, report exactly what was created (source, edge, target ref_ids).
+- Creates are create-or-merge: re-asserting an existing triplet or node is safe and returns the existing ref_ids (reported as a Warning).
+- After a write, report exactly what was created or changed (ref_ids, properties).
 `;
 
 function GRAPH_SYSTEM(toolsConfig?: ToolsConfig) {
 
   const qs = toolConfigEnabled(toolsConfig?.ask_clarifying_questions);
   const ontologyEdit = toolConfigEnabled(toolsConfig?.ontology_edit);
-  const graphWrite = toolConfigEnabled(toolsConfig?.create_triplet);
+  const graphWrite = graphWriteEnabled(toolsConfig);
 
   return `${getCurrentDateSnippet()}
 
@@ -275,7 +278,7 @@ function WORKFLOW_SYSTEM(toolsConfig?: ToolsConfig, hasRunTools?: boolean) {
 
   const qs = toolConfigEnabled(toolsConfig?.ask_clarifying_questions);
   const ontologyEdit = toolConfigEnabled(toolsConfig?.ontology_edit);
-  const graphWrite = toolConfigEnabled(toolsConfig?.create_triplet);
+  const graphWrite = graphWriteEnabled(toolsConfig);
   const runStepEnabled = Boolean(hasRunTools) && toolConfigEnabled(toolsConfig?.stakwork_run_step);
 
   const runStepGuidance = runStepEnabled

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -109,6 +109,8 @@ type ToolName =
   | "graph_sub_agent"
   | "ontology_edit"
   | "create_triplet"
+  | "create_node"
+  | "edit_node"
   | "logs_agent"
   | "str_replace_based_edit_tool"
   | "apply_patch"
@@ -211,6 +213,20 @@ export function isToolConfigObject(v: unknown): v is ToolConfigObject {
   return typeof v === "object" && v !== null && !Array.isArray(v);
 }
 
+/**
+ * Whether the graph DATA write tool family (create_triplet,
+ * create_batch_triplet, create_node, edit_node) is enabled. Any one of the
+ * family's toolsConfig keys turns on the whole family — they share one
+ * registration gate.
+ */
+export function graphWriteEnabled(toolsConfig?: ToolsConfig): boolean {
+  return (
+    toolConfigEnabled(toolsConfig?.create_triplet) ||
+    toolConfigEnabled(toolsConfig?.create_node) ||
+    toolConfigEnabled(toolsConfig?.edit_node)
+  );
+}
+
 /** Whether a tool-config value should count as "on" (for opt-in tools). */
 export function toolConfigEnabled(v: ToolConfigValue | undefined): boolean {
   if (v === undefined || v === null) return false;
@@ -236,7 +252,7 @@ const TOOL_NAMES: Set<string> = new Set<string>([
   "list_skills", "load_skill",
   "list_workflows", "learn_workflow", "read_workflow_json",
   "vector_search", "stakgraph_search", "stakgraph_map", "stakgraph_code",
-  "graph_sub_agent", "ontology_edit", "create_triplet",
+  "graph_sub_agent", "ontology_edit", "create_triplet", "create_node", "edit_node",
   "str_replace_based_edit_tool", "apply_patch",
   "generate_docx", "generate_xlsx", "generate_xlsx_computed",
   "stakwork_run_step",
@@ -356,7 +372,9 @@ Rules:
   jarvis: '', // deprecated: Jarvis tools now auto-register whenever JARVIS_URL is set.
   graph_sub_agent: '', // default lives in toolsJarvis.ts; string value here overrides it.
   ontology_edit: '', // group gate: registers the ontology write tools (defaults live in toolsJarvis.ts).
-  create_triplet: '', // gate: registers the graph data-write tool (default lives in toolsJarvis.ts).
+  create_triplet: '', // gate: registers the graph data-write tools (defaults live in toolsJarvis.ts). Any one of create_triplet/create_node/edit_node enables the whole family.
+  create_node: '', // gate: same graph data-write family as create_triplet.
+  edit_node: '', // gate: same graph data-write family as create_triplet.
   logs_agent:
     "Query runtime logs (CloudWatch / Quickwit). Use when the user asks about errors, performance, or runtime behaviour. Pass a focused, specific question.",
   str_replace_based_edit_tool:
@@ -962,8 +980,9 @@ export async function get_tools(
       : undefined,
     // Opt-in ontology write tools (create/update/delete node & edge types).
     ontologyEdit: toolConfigEnabled(toolsConfig?.ontology_edit),
-    // Opt-in graph data-write tool (assert source -[edge]-> target triplets).
-    graphWrite: toolConfigEnabled(toolsConfig?.create_triplet),
+    // Opt-in graph data-write tools (triplets + generic node create/edit).
+    // Any one of the family's keys enables all of them.
+    graphWrite: graphWriteEnabled(toolsConfig),
     // Scope get_ontology to the caller's `ontologyDomains`, unless the model
     // asks for specific `domains` itself. Unset => no filter, all domains.
     defaultDomains: ontologyDomains,

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -384,10 +384,12 @@ export interface JarvisToolsOptions {
    */
   ontologyEdit?: boolean;
   /**
-   * When true, registers the `create_triplet` graph DATA write tool, which
-   * asserts source -[edge]-> target instance facts (creating/merging nodes as
-   * needed) via Jarvis `/v2/nodes` + `/v2/edges`. Distinct from `ontologyEdit`
-   * (schema writes). Opt-in and off by default.
+   * When true, registers the graph DATA write tools: `create_triplet` /
+   * `create_batch_triplet` (assert source -[edge]-> target instance facts,
+   * creating/merging nodes as needed), `create_node` (create/merge a single
+   * node without an edge) and `edit_node` (partial-update an existing node by
+   * ref_id) — all via Jarvis `/v2/nodes` + `/v2/edges`. Distinct from
+   * `ontologyEdit` (schema writes). Opt-in and off by default.
    */
   graphWrite?: boolean;
   /**
@@ -1035,8 +1037,10 @@ export function extractEdgeRefId(body: any): string | undefined {
 }
 
 /**
- * Register the graph DATA write tool (`create_triplet`): assert a fact as
- * source -[edge]-> target instance data (not schema). Gated by
+ * Register the graph DATA write tools: `create_triplet`/`create_batch_triplet`
+ * (assert a fact as source -[edge]-> target instance data, not schema),
+ * `create_node` (create/merge one node without an edge) and `edit_node`
+ * (partial-update an existing node by ref_id). Gated by
  * `JarvisToolsOptions.graphWrite`.
  *
  * Inline nodes are pre-created via `POST /v2/nodes` and the edge is then
@@ -1650,7 +1654,200 @@ function registerGraphWriteTools(
     },
   });
 
-  console.log("===> registered graph write tool: create_triplet + create_batch_triplet");
+  // ── create_node ───────────────────────────────────────────────────────────
+  allTools.create_node = tool({
+    description:
+      "Create (or merge) a SINGLE node in the Jarvis knowledge graph as DATA, with no edge " +
+      "(to assert a relationship at the same time, use create_triplet instead). Writes live to the graph. " +
+      "REUSE existing nodes: graph_search first, and only create when the entity genuinely doesn't exist yet — " +
+      "duplicate nodes fragment the graph. The node type must already exist in the ontology " +
+      "(check with get_ontology; get_ontology_type shows its attributes and which are required). " +
+      "Create-or-merge semantics: if a node with the same identity key already exists, its ref_id is " +
+      "returned (reported as a Warning) instead of creating a duplicate — so re-running is safe.",
+    inputSchema: z.object({
+      node_type: z
+        .string()
+        .describe(
+          "Node type (must exist in the ontology — see get_ontology). " +
+          "Never pass the wildcard sentinel \"*\".",
+        ),
+      node_data: z
+        .record(z.string(), z.any())
+        .describe(
+          'Properties for the node, e.g. {"name": "Alice"}. ' +
+          "Must satisfy the type's schema, including its node_key attribute.",
+        ),
+      namespace: z
+        .string()
+        .optional()
+        .describe(
+          "Jarvis namespace (data partition) to create the node in. Not an access-control boundary.",
+        ),
+    }),
+    execute: async (input: {
+      node_type: string;
+      node_data: Record<string, any>;
+      namespace?: string;
+    }) => {
+      const { node_type, node_data, namespace } = input;
+      console.log(`[create_node] type=${node_type} namespace=${namespace ?? "-"}`);
+      try {
+        const params = new URLSearchParams();
+        appendNamespace(params, namespace);
+        const qs = params.toString();
+        const url = `${jarvisUrl}/v2/nodes${qs ? `?${qs}` : ""}`;
+        const res = await jarvisMutate("post", url, jarvisHeaders, {
+          node_type,
+          node_data,
+        });
+        let body: any;
+        try {
+          body = JSON.parse(res.text);
+        } catch {
+          // non-JSON body — fall through to the error below
+        }
+        const refId = extractNodeRefId(body);
+        if (!refId) {
+          return `create_node failed — HTTP ${res.status}: ${res.text}`;
+        }
+        return JSON.stringify({
+          // "Warning" here means the node already existed (idempotent merge).
+          status: body?.status ?? "Success",
+          ref_id: refId,
+          node_type,
+          ...(Array.isArray(body?.status_messages) && body.status_messages.length > 0
+            ? { messages: body.status_messages }
+            : {}),
+        });
+      } catch (err: any) {
+        return `create_node failed: ${err?.message ?? String(err)}`;
+      }
+    },
+  });
+
+  // ── edit_node ─────────────────────────────────────────────────────────────
+  allTools.edit_node = tool({
+    description:
+      "Update an EXISTING node in the Jarvis knowledge graph by ref_id (writes live to the graph). " +
+      "PARTIAL update: properties in node_data are merged over the node's current properties " +
+      "(validated against the type's schema) — properties you omit are left untouched. " +
+      "Use properties_to_be_deleted to remove properties entirely. " +
+      "Get the ref_id from graph_search, and inspect the node with graph_get first so you know its " +
+      "current state before changing it. " +
+      "Pass node_type ONLY to change the node's type (with type_to_be_deleted listing the old type " +
+      "label(s) to remove); omit both for normal property edits. " +
+      "If the update would change the node's identity key to collide with another node, the write " +
+      "fails with 'Node already exists in the graph'.",
+    inputSchema: z.object({
+      ref_id: z.string().describe("The ref_id of the node to update (from graph_search/graph_get)."),
+      node_data: z
+        .record(z.string(), z.any())
+        .optional()
+        .describe(
+          'Properties to set/overwrite, e.g. {"description": "..."}. Merged over the node\'s ' +
+          "existing properties — omitted properties are untouched. Must satisfy the type's schema.",
+        ),
+      properties_to_be_deleted: z
+        .array(z.string())
+        .optional()
+        .describe("Property names to REMOVE from the node."),
+      node_type: z
+        .string()
+        .optional()
+        .describe(
+          "New node type — pass ONLY when changing the node's type (must exist in the ontology). " +
+          "Omit for property-only edits; the current type is inferred.",
+        ),
+      type_to_be_deleted: z
+        .array(z.string())
+        .optional()
+        .describe(
+          "When changing the node's type: the old type label(s) to remove from the node.",
+        ),
+      namespace: z
+        .string()
+        .optional()
+        .describe(
+          "Jarvis namespace (data partition) the node lives in. Not an access-control boundary.",
+        ),
+    }),
+    execute: async (input: {
+      ref_id: string;
+      node_data?: Record<string, any>;
+      properties_to_be_deleted?: string[];
+      node_type?: string;
+      type_to_be_deleted?: string[];
+      namespace?: string;
+    }) => {
+      const {
+        ref_id,
+        node_data,
+        properties_to_be_deleted,
+        node_type,
+        type_to_be_deleted,
+        namespace,
+      } = input;
+
+      const hasSet = node_data && Object.keys(node_data).length > 0;
+      const hasDelete = properties_to_be_deleted && properties_to_be_deleted.length > 0;
+      if (!hasSet && !hasDelete && !node_type) {
+        return (
+          "edit_node invalid input — pass at least one change: node_data (properties to set), " +
+          "properties_to_be_deleted, or node_type"
+        );
+      }
+
+      console.log(
+        `[edit_node] ref_id=${ref_id} set=${Object.keys(node_data ?? {}).length} ` +
+        `delete=${properties_to_be_deleted?.length ?? 0} namespace=${namespace ?? "-"}`,
+      );
+      try {
+        const params = new URLSearchParams();
+        appendNamespace(params, namespace);
+        const qs = params.toString();
+        const url = `${jarvisUrl}/v2/nodes/${encodeURIComponent(ref_id)}${qs ? `?${qs}` : ""}`;
+        // Always send node_data (even empty) — its presence selects Jarvis's
+        // modern schema-validated update path over the legacy flat-property one.
+        const res = await jarvisMutate("post", url, jarvisHeaders, {
+          node_data: node_data ?? {},
+          ...(hasDelete ? { properties_to_be_deleted } : {}),
+          ...(node_type ? { node_type } : {}),
+          ...(type_to_be_deleted && type_to_be_deleted.length > 0
+            ? { type_to_be_deleted }
+            : {}),
+        });
+        let body: any;
+        try {
+          body = JSON.parse(res.text);
+        } catch {
+          // non-JSON body — fall through to the error below
+        }
+        // Jarvis returns HTTP 200 with {status: "fail", message} on some write
+        // failures (e.g. node_key collision), so res.ok alone is not enough.
+        const succeeded = res.ok && body?.status === "success";
+        if (!succeeded) {
+          const detail = body?.message ?? body?.errorCode ?? res.text;
+          return `edit_node failed — HTTP ${res.status}: ${detail}`;
+        }
+        // Compact confirmation — deliberately NOT the full updated node, whose
+        // properties include bulky derived fields (Data_Bank search text etc.).
+        // The agent can graph_get the node if it needs to verify contents.
+        return JSON.stringify({
+          status: "Success",
+          ref_id,
+          ...(hasSet ? { updated: Object.keys(node_data!) } : {}),
+          ...(hasDelete ? { deleted: properties_to_be_deleted } : {}),
+          ...(node_type ? { node_type } : {}),
+        });
+      } catch (err: any) {
+        return `edit_node failed: ${err?.message ?? String(err)}`;
+      }
+    },
+  });
+
+  console.log(
+    "===> registered graph write tools: create_triplet + create_batch_triplet + create_node + edit_node",
+  );
 }
 
 /**


### PR DESCRIPTION
## What

Adds two generic Jarvis graph data-write tools alongside `create_triplet` / `create_batch_triplet` in `registerGraphWriteTools`:

- **`create_node`** — create (or merge) a single node with no edge, via `POST /v2/nodes`. Idempotent: if a node with the same identity key exists, its `ref_id` comes back as a Warning instead of a duplicate.
- **`edit_node`** — partial-update an existing node by ref_id, via `POST /v2/nodes/<ref_id>`. `node_data` merges over the node's current properties (schema-validated by Jarvis), `properties_to_be_deleted` removes properties, and optional `node_type` + `type_to_be_deleted` change the node's type.

## Config

Both tools are gated by the existing `graphWrite` registration flag. Any one of the family's `toolsConfig` keys now enables the whole family (new `graphWriteEnabled` helper in `tools.ts`):

```json
{ "toolsConfig": { "create_node": true } }
```

is equivalent to enabling via `create_triplet` or `edit_node`. The same helper drives the `GRAPH_WRITE_GUIDANCE` system-prompt injection in `agent.ts`, so enabling via any key also gets the agent the write guidance (updated to cover the node tools).

## Reviewer notes

- `edit_node` always sends `node_data` (even empty `{}`): its presence is what routes jarvis-backend's `update_node` onto the modern schema-validated path instead of the legacy flat-property Cypher path.
- `edit_node` checks `body.status === "success"` rather than trusting the HTTP code — Jarvis returns HTTP 200 with `{"status": "fail", "message": ...}` on some write failures (e.g. node_key collisions).
- On success `edit_node` returns a compact `{status, ref_id, updated, deleted}` confirmation instead of the full updated node the endpoint returns, since node properties carry bulky derived fields (`Data_Bank` search text); the agent can `graph_get` to verify contents.
- `tsc --noEmit` clean; all 102 tests in `toolsJarvis.test.ts` + `tools.test.ts` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)