### PR TITLE
Enforce one AgentSession node per session id

### DIFF
--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1152,12 +1152,52 @@ class Db {
       await session.run(
         "CREATE INDEX turn_session_id_index IF NOT EXISTS FOR (n:Turn) ON (n.session_id)",
       );
+      await this.ensureAgentSessionUnique(session);
     } finally {
       if (session) {
         await session.close();
       }
     }
   }
+
+  /**
+   * Guarantee one AgentSession node per session id.
+   *
+   * Constraint creation fails outright when existing data violates it, so a
+   * failure here is the signal that duplicates are present: fold them (see
+   * DEDUPE_AGENT_SESSIONS_QUERY — edges are re-pointed, nothing is orphaned)
+   * and retry once. Doing the dedupe only on that failure means the
+   * destructive half never runs on a healthy graph, and never again once the
+   * constraint exists to prevent new duplicates.
+   *
+   * Never throws: a graph that can't take the constraint is a graph that
+   * keeps working exactly as it did before, and index setup must not be able
+   * to stop the service from booting.
+   */
+  private async ensureAgentSessionUnique(session: ResilientSession): Promise<void> {
+    try {
+      await session.run(Q.AGENT_SESSION_KEY_CONSTRAINT_QUERY);
+      return;
+    } catch (e) {
+      console.warn(
+        "[neo4j] AgentSession uniqueness constraint rejected (duplicate node_keys present); deduping…",
+      );
+    }
+    try {
+      const result = await session.run(Q.DEDUPE_AGENT_SESSIONS_QUERY);
+      const removed = result.records[0]?.get("removed");
+      const n = removed?.toNumber?.() ?? Number(removed ?? 0);
+      console.log(`[neo4j] removed ${n} duplicate AgentSession node(s)`);
+      await session.run(Q.AGENT_SESSION_KEY_CONSTRAINT_QUERY);
+      console.log("[neo4j] AgentSession uniqueness constraint created");
+    } catch (e) {
+      console.error(
+        "[neo4j] could not create the AgentSession uniqueness constraint:",
+        e,
+      );
+    }
+  }
+
   async get_rules_files(): Promise<Neo4jNode[]> {
     const session = this.resilientSession();
     try {

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -464,6 +464,69 @@ ORDER BY n.start_time DESC
 SKIP toInteger($offset) LIMIT toInteger($limit)
 `;
 
+// One AgentSession node per session id. `node_key` has only an index, and
+// MERGE is not atomic across concurrent transactions without a constraint —
+// so a retried write that had actually committed (or two racing writes for
+// the same session) could leave two nodes with the same key, which then show
+// up as duplicate sessions and duplicate HAS_TURN anchors.
+export const AGENT_SESSION_KEY_CONSTRAINT_QUERY = `
+CREATE CONSTRAINT agent_session_key_unique IF NOT EXISTS
+FOR (n:AgentSession) REQUIRE n.node_key IS UNIQUE
+`;
+
+// Fold pre-existing duplicate AgentSession nodes into one, so the uniqueness
+// constraint above can be created. Runs only when that creation fails.
+//
+// The survivor is the node with the most relationships (duplicates are
+// otherwise identical — same start_time, same totals — since they come from
+// one logical write landing twice). Every edge type this codebase creates on
+// an AgentSession is re-pointed to the survivor with its properties intact
+// before the duplicate is removed, so no anchor, spawn link, or concept
+// edge is lost. MERGE makes re-pointing idempotent: an edge the survivor
+// already has is left alone.
+export const DEDUPE_AGENT_SESSIONS_QUERY = `
+MATCH (s:AgentSession)
+WITH s.node_key AS key, collect(s) AS nodes
+WHERE size(nodes) > 1
+UNWIND nodes AS n
+WITH key, n, size([(n)--() | 1]) AS deg
+ORDER BY deg DESC
+WITH key, collect(n) AS ranked
+WITH head(ranked) AS keeper, tail(ranked) AS dupes
+UNWIND dupes AS d
+CALL {
+  WITH keeper, d
+  MATCH (d)-[r:HAS_TURN]->(t)
+  MERGE (keeper)-[k:HAS_TURN]->(t)
+  SET k += properties(r)
+  RETURN count(*) AS moved_turns
+}
+CALL {
+  WITH keeper, d
+  MATCH (d)-[r:READ_CONCEPT]->(c)
+  MERGE (keeper)-[k:READ_CONCEPT]->(c)
+  SET k += properties(r)
+  RETURN count(*) AS moved_concepts
+}
+CALL {
+  WITH keeper, d
+  MATCH (d)-[r:SPAWNED]->(child)
+  MERGE (keeper)-[k:SPAWNED]->(child)
+  SET k += properties(r)
+  RETURN count(*) AS moved_children
+}
+CALL {
+  WITH keeper, d
+  MATCH (p)-[r:SPAWNED]->(d)
+  MERGE (p)-[k:SPAWNED]->(keeper)
+  SET k += properties(r)
+  RETURN count(*) AS moved_parents
+}
+WITH DISTINCT d
+DETACH DELETE d
+RETURN count(*) AS removed
+`;
+
 export const LIST_SESSION_FACETS_QUERY = `
 MATCH (n:AgentSession)
 WHERE n.file = 'session://generated'


### PR DESCRIPTION
## What

Adds a uniqueness constraint on `AgentSession.node_key`, with a self-healing dedupe so it can actually be created on a graph that already has duplicates.

## Why

`node_key` had only an **index**, and Neo4j's `MERGE` is not atomic across concurrent transactions without a constraint. A retried write that had actually committed (or two racing writes for one session) could therefore create two nodes for the same session.

Prod has exactly such a pair — same `node_key`, identical `start_time` to the millisecond and identical `total_tokens`, different `ref_id`s:

```
"4:0c23…:352400" | ["Data_Bank","AgentSession"] | 5e89626a-… | repo_agent | success | 1786543684738 | 17630
"4:0c23…:352401" | ["Data_Bank","AgentSession"] | 2af5b268-… | repo_agent | success | 1786543684738 | 17630
```

Symptoms: the session appears twice in `/api/sessions`, and its chain shows two `HAS_TURN` anchors (2,861 anchors for 2,859 chained sessions). One pair in ~2,900 sessions, so cosmetic today — but a session list is about to become a UI surface, and duplicates there are confusing.

## How

`CREATE CONSTRAINT` fails outright when existing data violates it, so that failure is the signal rather than something to pre-check:

1. Try to create the constraint. On a healthy graph this is the whole story.
2. On failure, run `DEDUPE_AGENT_SESSIONS_QUERY`: for each duplicate group keep the node with the most relationships (they're otherwise identical), re-point **HAS_TURN**, **SPAWNED** (outgoing *and* incoming) and **READ_CONCEPT** onto the survivor with `SET k += properties(r)` so edge properties survive, then `DETACH DELETE` the rest.
3. Retry the constraint once.

Consequences of that ordering: the destructive half never runs on a healthy graph, and never runs again once the constraint exists to prevent new duplicates. `MERGE` makes the re-pointing idempotent, so an edge the survivor already has is left alone.

Everything is wrapped so failures log and are swallowed — index setup must not be able to stop the service from booting.

## Notes for reviewers

- The dedupe handles every edge type this codebase puts on an AgentSession. If some other writer adds a new edge type to these nodes later, it should be added to that query.
- Constraint creation implicitly provides the index, so `agent_session_id_index` is now redundant; left in place rather than dropped in the same change.
- Tests: full `test:node` suite green (540), `tsc --noEmit` clean. The Cypher itself has no unit coverage, consistent with the rest of `queries.ts` — it's exercised on boot against a real graph.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
