### PR TITLE
Pin sub-agent sessions to the Turn that spawned them

### DIFF
--- a/mcp/docs/plans/session-cascade-hive-ui.md
+++ b/mcp/docs/plans/session-cascade-hive-ui.md
@@ -59,7 +59,13 @@ GET :3355/api/sessions/:id?recursive=true  → adds `descendants: [...]` (flat, 
 ```
 
 Children are also discoverable purely by id shape: `<parent>-sub-<8hex>` nests
-arbitrarily (`X-sub-a1b2c3d4-sub-e5f6a7b8`).
+arbitrarily (`X-sub-a1b2c3d4-sub-e5f6a7b8`), and each child carries
+`parent_session_id` plus a `(parent)-[:SPAWNED]->(child)` edge in the graph.
+
+Each child also carries **`spawn_tool_call_id`** — the id of the parent tool call
+that spawned it, matching `tool_call_id` on the parent's `graph_sub_agent`
+`tool_call` turn. That is the exact fork point in the parent's chain (see §2).
+Empty on sessions that predate the field.
 
 ### 1c. The turn chain of one session (the polling workhorse)
 
@@ -134,10 +140,12 @@ The mockup renders "story rows", not raw turns. The fold from a turn array to ro
   - Expanding a pill = rendering the turns already in memory (the fold keeps them);
     no extra fetch needed since 1c returns full pages of 1000.
 - **sub-agent fork row** ← a `tool_call` turn with `tool === "graph_sub_agent"`.
-  Join to the child session: the tool_call `content` JSON has `prompt`, and the
-  child's turn 0 (`user_input`) has the same text; fallback join by start-time
-  order among unmatched children. The matching `tool_result` (same `tool_call_id`)
-  is the **merge point** where the child's lane curves back.
+  Join to the child session on **`child.spawn_tool_call_id === turn.tool_call_id`**
+  — exact, and the reason that field exists (a prompt-text match can't separate
+  two sub-agents handed identical prompts, which a fan-out makes likely). Fall
+  back to prompt text only for sessions predating the field. The matching
+  `tool_result` (same `tool_call_id`) is the **merge point** where the child's
+  lane curves back.
   - The child session's own rows render on the next lane (depth = number of
     `-sub-` segments in its id), between fork and merge, exactly as the mockup
     draws lanes 1 and 2. Clicking the agent header reveals its turn-0 prompt

--- a/mcp/src/benchmark/sessions.ts
+++ b/mcp/src/benchmark/sessions.ts
@@ -64,6 +64,7 @@ function buildOrphanRun(dir: string, file: string) {
     parent_session_id: id.match(/^(.+)-sub-[0-9a-f]{8}$/)?.[1] ?? "",
     source: "unknown",
     agent_name: "",
+    spawn_tool_call_id: "",
     provider: "",
     model: "",
     repo: "",
@@ -228,6 +229,9 @@ function buildRunFromNode(s: any, dir: string) {
     parent_session_id: String(s.parent_session_id ?? ""),
     source: String(s.source ?? "unknown"),
     agent_name: String(s.agent_name ?? ""),
+    // Sub-agents only: the parent tool call that spawned this run. Joins to
+    // the Turn in the parent's chain carrying the same tool_call_id.
+    spawn_tool_call_id: String(s.spawn_tool_call_id ?? ""),
     repo: String(s.repo ?? ""),
     provider: prov,
     model: mod,
@@ -485,6 +489,7 @@ async function buildFullSession(
           parent_session_id: String(s.parent_session_id ?? ""),
           source: String(s.source ?? "unknown"),
           agent_name: String(s.agent_name ?? ""),
+          spawn_tool_call_id: String(s.spawn_tool_call_id ?? ""),
           repo: String(s.repo ?? ""),
           provider: prov,
           model: mod,

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1682,6 +1682,7 @@ class Db {
     source: string;
     repo: string;
     agent_name: string;
+    spawn_tool_call_id: string;
     start_time: number;
   }): Promise<void> {
     const session = this.resilientSession();
@@ -1817,6 +1818,7 @@ class Db {
     source: string;
     repo: string;
     agent_name: string;
+    spawn_tool_call_id: string;
     model: string;
     provider: string;
     start_time: number;

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -315,7 +315,7 @@ MERGE (n:AgentSession:${Data_Bank} {node_key: $session_id})
 ON CREATE SET n.ref_id = randomUUID(), n.date_added_to_graph = $ts, n.namespace = 'default',
   n.name = $session_id, n.file = 'session://generated', n.start = 0, n.end = 0, n.body = $source,
   n.source = $source, n.repo = $repo, n.model = $model, n.provider = $provider,
-  n.agent_name = $agent_name,
+  n.agent_name = $agent_name, n.spawn_tool_call_id = $spawn_tool_call_id,
   n.start_time = toInteger($start_time),
   n.input_tokens = 0, n.cache_read_tokens = 0, n.cache_write_tokens = 0,
   n.output_tokens = 0, n.total_tokens = 0, n.duration_ms = 0,
@@ -324,6 +324,7 @@ SET n.parent_session_id = CASE WHEN $parent_session_id = '' THEN coalesce(n.pare
     n.model = CASE WHEN $model = '' THEN coalesce(n.model, '') ELSE $model END,
     n.provider = CASE WHEN $provider = '' THEN coalesce(n.provider, '') ELSE $provider END,
     n.agent_name = CASE WHEN $agent_name = '' THEN coalesce(n.agent_name, '') ELSE $agent_name END,
+    n.spawn_tool_call_id = CASE WHEN $spawn_tool_call_id = '' THEN coalesce(n.spawn_tool_call_id, '') ELSE $spawn_tool_call_id END,
     n.end_time = toInteger($end_time),
     n.repo = $repo,
     n.input_tokens = coalesce(n.input_tokens, 0) + toInteger($input_tokens),
@@ -347,13 +348,14 @@ MERGE (n:AgentSession:${Data_Bank} {node_key: $session_id})
 ON CREATE SET n.ref_id = randomUUID(), n.date_added_to_graph = $ts, n.namespace = 'default',
   n.name = $session_id, n.file = 'session://generated', n.start = 0, n.end = 0, n.body = $source,
   n.source = $source, n.repo = $repo, n.model = '', n.provider = '',
-  n.agent_name = $agent_name,
+  n.agent_name = $agent_name, n.spawn_tool_call_id = $spawn_tool_call_id,
   n.start_time = toInteger($start_time), n.end_time = toInteger($start_time),
   n.input_tokens = 0, n.cache_read_tokens = 0, n.cache_write_tokens = 0,
   n.output_tokens = 0, n.total_tokens = 0, n.duration_ms = 0,
   n.status = 'running', n.error_message = ''
 SET n.parent_session_id = CASE WHEN $parent_session_id = '' THEN coalesce(n.parent_session_id, '') ELSE $parent_session_id END,
-    n.agent_name = CASE WHEN $agent_name = '' THEN coalesce(n.agent_name, '') ELSE $agent_name END
+    n.agent_name = CASE WHEN $agent_name = '' THEN coalesce(n.agent_name, '') ELSE $agent_name END,
+    n.spawn_tool_call_id = CASE WHEN $spawn_tool_call_id = '' THEN coalesce(n.spawn_tool_call_id, '') ELSE $spawn_tool_call_id END
 WITH n
 OPTIONAL MATCH (p:AgentSession {node_key: $parent_session_id})
 FOREACH (_ IN CASE WHEN p IS NULL THEN [] ELSE [1] END | MERGE (p)-[:SPAWNED]->(n))

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -27,6 +27,7 @@ const sessionMeta = new Map<
     repo?: string;
     parent_session_id?: string;
     agent_name?: string;
+    spawn_tool_call_id?: string;
   }
 >();
 
@@ -120,6 +121,13 @@ export function createSession(
   repo?: string,
   parentSessionId?: string,
   agentName?: string,
+  /**
+   * For sub-agent sessions: the id of the parent's tool call that spawned
+   * this run. Pins the child to the exact Turn in the parent's chain (Turn
+   * nodes carry `tool_call_id`), which a prompt-text match can only
+   * approximate — two sub-agents can be handed identical prompts.
+   */
+  spawnToolCallId?: string,
 ): string {
   // Defense in depth against non-string ids from callers that skipped the
   // route-level coercion — a numeric id poisons the Neo4j node_key type.
@@ -130,6 +138,7 @@ export function createSession(
     repo,
     parent_session_id: parentSessionId,
     agent_name: agentName,
+    spawn_tool_call_id: spawnToolCallId,
   });
   // Stub the AgentSession node now (status 'running') rather than waiting for
   // appendSessionEnd: live turn chains need a HAS_TURN anchor, sub-agents get
@@ -142,6 +151,7 @@ export function createSession(
       source: source || "unknown",
       repo: repo || "",
       agent_name: agentName || "",
+      spawn_tool_call_id: spawnToolCallId || "",
       start_time: Date.now(),
     })
     .catch((e) => console.error("[sessions] Neo4j stub creation failed:", e));
@@ -190,6 +200,7 @@ export async function appendSessionEnd(
       source: stored.source,
       repo: stored.repo || "",
       agent_name: stored.agent_name || "",
+      spawn_tool_call_id: stored.spawn_tool_call_id || "",
       model: opts.model || "",
       provider: resolvedProvider,
       start_time,

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -463,7 +463,7 @@ function registerGraphSubAgentTool(
           "The child cannot see this conversation.",
         ),
     }),
-    execute: async ({ prompt }: { prompt: string }) => {
+    execute: async ({ prompt }: { prompt: string }, options?: { toolCallId?: string }) => {
       const childTools: Record<string, Tool<any, any>> = {};
       // Persist the child run as its own session (linked to the parent) only
       // when the parent itself is session-backed. Grandchildren link to the
@@ -486,12 +486,19 @@ function registerGraphSubAgentTool(
       const runTools = withConceptCollection(childTools, conceptCollector);
 
       if (childSessionId) {
+        // The toolCallId is the exact link back to the parent's Turn chain:
+        // the parent's `graph_sub_agent` tool_call turn carries the same id.
+        // It must be captured here because that Turn does not exist yet — a
+        // step's turns are emitted when the step finishes, which is after
+        // this child has already run to completion.
         createSession(
           childSessionId,
           GRAPH_SUBAGENT_SYSTEM,
           "graph_sub_agent",
           sub.repo,
           sub.parentSessionId,
+          undefined,
+          options?.toolCallId,
         );
         emitUserTurn(childSessionId, "graph_sub_agent", {
           role: "user",


### PR DESCRIPTION
## What

Stamps `spawn_tool_call_id` on sub-agent `AgentSession` nodes, pinning each child to the exact `Turn` in its parent's chain that spawned it.

## Why

`(parent)-[:SPAWNED]->(child)` already tells you *which* session spawned a sub-agent. It does not tell you *where in the parent's timeline* that happened — which is what a trace visualization needs to draw the fork.

The only bridge available until now was matching the `graph_sub_agent` tool call's `prompt` against the child's turn-0 text. That's inference, and it fails exactly where sub-agents matter most: a fan-out that hands two children the same prompt produces two indistinguishable candidates.

## How

`graph_sub_agent`'s `execute` now takes the SDK's second argument and captures `options.toolCallId`, which flows through `createSession` onto the child's session node. `Turn` nodes already carry `tool_call_id` (added with live emission), so the join is exact and needs no new edge:

```cypher
MATCH (c:AgentSession {node_key: $childId})
MATCH (t:Turn {session_id: c.parent_session_id, tool_call_id: c.spawn_tool_call_id})
RETURN t.order;
```

**Why it's captured at child-creation time rather than derived later**: a step's turns are emitted when the step *finishes*, and the step doesn't finish until the child has run to completion. So at every point where the child could look up its own fork Turn — creation, session end — that Turn does not exist yet. The id has to be carried forward from the one place that has it.

## Notes for reviewers

- Empty-guarded in the end-of-run upsert (`CASE WHEN $spawn_tool_call_id = ''…`) exactly like `agent_name`, so a resume can't blank it.
- Surfaced on the sessions list and detail endpoints as `spawn_tool_call_id` (empty string for top-level sessions and anything predating this).
- A real `(Turn)-[:SPAWNED]->(AgentSession)` edge remains possible on top of this — emit it when the parent's tool_call turn lands — but the property answers the UI's question with no extra write, so the edge is deferred until graph traversal actually wants it.
- The hive cascade plan doc is updated in the same commit: the fork join is now the exact match, with prompt-text demoted to a fallback for pre-field sessions.
- Tests: full `test:node` suite green (540), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
