### PR TITLE
Session ingest API: live Turn chains from out-of-process agents

### DIFF
--- a/mcp/docs/plans/session-cascade-hive-ui.md
+++ b/mcp/docs/plans/session-cascade-hive-ui.md
@@ -59,7 +59,13 @@ GET :3355/api/sessions/:id?recursive=true  → adds `descendants: [...]` (flat, 
 ```
 
 Children are also discoverable purely by id shape: `<parent>-sub-<8hex>` nests
-arbitrarily (`X-sub-a1b2c3d4-sub-e5f6a7b8`).
+arbitrarily (`X-sub-a1b2c3d4-sub-e5f6a7b8`), and each child carries
+`parent_session_id` plus a `(parent)-[:SPAWNED]->(child)` edge in the graph.
+
+Each child also carries **`spawn_tool_call_id`** — the id of the parent tool call
+that spawned it, matching `tool_call_id` on the parent's `graph_sub_agent`
+`tool_call` turn. That is the exact fork point in the parent's chain (see §2).
+Empty on sessions that predate the field.
 
 ### 1c. The turn chain of one session (the polling workhorse)
 
@@ -134,10 +140,12 @@ The mockup renders "story rows", not raw turns. The fold from a turn array to ro
   - Expanding a pill = rendering the turns already in memory (the fold keeps them);
     no extra fetch needed since 1c returns full pages of 1000.
 - **sub-agent fork row** ← a `tool_call` turn with `tool === "graph_sub_agent"`.
-  Join to the child session: the tool_call `content` JSON has `prompt`, and the
-  child's turn 0 (`user_input`) has the same text; fallback join by start-time
-  order among unmatched children. The matching `tool_result` (same `tool_call_id`)
-  is the **merge point** where the child's lane curves back.
+  Join to the child session on **`child.spawn_tool_call_id === turn.tool_call_id`**
+  — exact, and the reason that field exists (a prompt-text match can't separate
+  two sub-agents handed identical prompts, which a fan-out makes likely). Fall
+  back to prompt text only for sessions predating the field. The matching
+  `tool_result` (same `tool_call_id`) is the **merge point** where the child's
+  lane curves back.
   - The child session's own rows render on the next lane (depth = number of
     `-sub-` segments in its id), between fork and merge, exactly as the mockup
     draws lanes 1 and 2. Clicking the agent header reveals its turn-0 prompt

--- a/mcp/docs/session-ingest.md
+++ b/mcp/docs/session-ingest.md
@@ -53,6 +53,7 @@ POST /api/sessions/:id/turns
   ]
 }
 → 201 { "session_id": …, "written": 4, "next_order": 4,
+        "concepts_submitted": 1, "concepts_linked": 1,
         "turns": [{ "order": 0, "turn_id": "hive-…-turn-0", "node_key": "turn-…", "turn_type": "user_input" }, …] }
 ```
 
@@ -62,8 +63,10 @@ POST /api/sessions/:id/turns
   Pass `start_order` to pin it yourself (re-posting an order overwrites that turn).
 - One writer per session at a time. If you must post concurrently, pin `start_order`.
 - `timestamp` (epoch ms) is optional per turn; defaults to server receipt time.
-- `concepts` is optional per turn: `[{ "ref_id": … } | { "id": … }]` — gitree Concept
-  graph ref_id (preferred) or gitree id. Unmatched entries are skipped, not errors.
+- `concepts` is optional per turn — which gitree Concepts this turn read. See
+  [Identifying concepts](#identifying-concepts). Unmatched entries are skipped rather
+  than failing the batch; the response's `concepts_linked` vs `concepts_submitted` is
+  how you notice.
 - Max 500 turns per batch. Post one batch per agent step for a live feed.
 
 ### Mapping ai-sdk steps to turns
@@ -84,6 +87,30 @@ it to `response`.
 `tool_result` content is stored as `{"type":"text","value":<content>}` (or `"json"` for
 objects) truncated to 100 chars — parity with in-process sessions, and it keeps large
 payloads out of the graph. Other content is capped at 100k chars.
+
+### Identifying concepts
+
+Send whichever identifier the tool you read with actually gave you — the match mirrors
+gitree's own concept lookup, so anything that reached the concept's body also reaches
+its edge:
+
+| you have | send | where it comes from |
+|---|---|---|
+| graph `ref_id` | `{ "ref_id": "…" }` | `list_concepts` / `search-concepts` (both return `ref_id`) |
+| full gitree id | `{ "id": "owner/repo/slug" }` | `list_concepts`, and the id you pass to `learn_concept` |
+| bare slug | `{ "id": "slug", "repo": "owner/repo" }` | ids without a repo prefix — `repo` is what resolves them |
+| node_key | `{ "id": "…" }` | accepted as-is |
+
+`ref_id` wins when both are present. Note `GET /gitree/concepts/:id` returns **no**
+`ref_id` — an agent whose only concept read was `learn_concept` /
+`read_concept_documentation` holds just the id it asked with, so send that (plus `repo`
+if it was unprefixed). If you want the ranking layer too, capture `ref_id` from
+`list_concepts` while you have it.
+
+Record the concept on the **`tool_result`** turn that returned its body — the turn edge
+marks the moment it was read. Tools that only list names and descriptions
+(`list_concepts`, `read_concepts_for_repo`, search) are not reads; recording them makes
+every concept in the catalog look load-bearing.
 
 ## 3. End the session
 
@@ -116,11 +143,14 @@ load-bearing it was*.
 ```
 POST /api/sessions/:id/concepts
 { "concepts": [
-    { "ref_id": "…", "read_order": 0, "rank": 1,
+    { "ref_id": "…", "id": "owner/repo/slug", "repo": "owner/repo",
+      "read_order": 0, "rank": 1,
       "evidence": "why it mattered", "contradicts": "what it got wrong" }
 ] }
 → 200 { "session_id": …, "linked": 1, "submitted": 1 }
 ```
+
+Identifiers resolve exactly as in [Identifying concepts](#identifying-concepts).
 
 Full-state mirror, not a merge: every call overwrites the edge properties, and a `null`
 `rank` clears it. Send the complete list each time.

--- a/mcp/docs/session-ingest.md
+++ b/mcp/docs/session-ingest.md
@@ -1,0 +1,159 @@
+# Session ingest API
+
+Record an agent run that happens **outside stakgraph** (e.g. hive's ai-sdk agents) as a
+live Turn chain in the graph:
+
+```
+(AgentSession)-[:HAS_TURN]->(Turn)-[:NEXT]->(Turn)-[:NEXT]->…
+                              └─[:READ_CONCEPT]->(Concept)
+```
+
+Post turns as the run happens; the session is watchable in the sessions UI while it is
+still running. The chains are identical in shape to in-process ones (same `turn_id`,
+`node_key`, and edges), so nothing downstream can tell them apart.
+
+**Base URL** the stakgraph server (default `:3355`).
+**Auth** `x-api-token: $API_TOKEN` on every POST (or `Authorization: Bearer <jwt>`).
+When the server runs without `API_TOKEN` set, auth is skipped.
+All bodies are JSON. All writes are idempotent unless noted.
+
+---
+
+## 1. Start the session
+
+```
+POST /api/sessions
+{
+  "session_id": "hive-run-8f21",   // required; your id, becomes the node key
+  "source": "hive",                 // shows up as the session's source facet
+  "repo": "stakwork/hive",          // optional
+  "agent_name": "planner",          // optional; free-form label for grouping runs
+  "parent_session_id": "...",       // optional; creates (parent)-[:SPAWNED]->(this)
+  "spawn_tool_call_id": "...",      // optional; pins a sub-agent to the parent's Turn
+  "start_time": 1755400000000       // optional epoch ms, defaults to now
+}
+→ 201 { "session_id": "hive-run-8f21", "status": "running", "start_time": … }
+```
+
+Call this **first** — turns anchor on the session node, and posting turns for an unknown
+session returns `404`. Re-posting the same `session_id` is safe (keeps the original node).
+
+## 2. Stream turns
+
+```
+POST /api/sessions/:id/turns
+{
+  "agent": "hive",        // label in turn_ids ("hive-<session>-turn-0"); pass it consistently
+  "turns": [
+    { "turn_type": "user_input", "content": "fix the flaky test" },
+    { "turn_type": "reasoning",  "content": "checking the retry helper" },
+    { "turn_type": "tool_call",   "content": "{\"query\":\"retry\"}", "tool": "search", "tool_call_id": "c1" },
+    { "turn_type": "tool_result", "content": "…raw tool output…",      "tool": "search", "tool_call_id": "c1",
+      "concepts": [{ "ref_id": "…" }] }
+  ]
+}
+→ 201 { "session_id": …, "written": 4, "next_order": 4,
+        "turns": [{ "order": 0, "turn_id": "hive-…-turn-0", "node_key": "turn-…", "turn_type": "user_input" }, …] }
+```
+
+- `turn_type` ∈ `user_input` | `reasoning` | `tool_call` | `tool_result` | `response`.
+- **Ordering is automatic**: each batch continues from the session's highest existing
+  turn. The graph is the cursor, so a crashed process resumes by just posting again.
+  Pass `start_order` to pin it yourself (re-posting an order overwrites that turn).
+- One writer per session at a time. If you must post concurrently, pin `start_order`.
+- `timestamp` (epoch ms) is optional per turn; defaults to server receipt time.
+- `concepts` is optional per turn: `[{ "ref_id": … } | { "id": … }]` — gitree Concept
+  graph ref_id (preferred) or gitree id. Unmatched entries are skipped, not errors.
+- Max 500 turns per batch. Post one batch per agent step for a live feed.
+
+### Mapping ai-sdk steps to turns
+
+| ai-sdk part | `turn_type` | `content` | also send |
+|---|---|---|---|
+| user message text | `user_input` | the text | — |
+| assistant text | `reasoning` | the text | — |
+| `tool-call` | `tool_call` | `JSON.stringify(input)` | `tool`, `tool_call_id` |
+| `tool-result` | `tool_result` | the raw output (string or object) | `tool`, `tool_call_id` |
+
+Within a step, send assistant parts first and tool results after. Skip system messages
+and empty text parts — the in-process emitter does, and turns with no content are noise.
+
+Emit the run's final answer as `reasoning` like any other assistant text; `/end` retypes
+it to `response`.
+
+`tool_result` content is stored as `{"type":"text","value":<content>}` (or `"json"` for
+objects) truncated to 100 chars — parity with in-process sessions, and it keeps large
+payloads out of the graph. Other content is capped at 100k chars.
+
+## 3. End the session
+
+```
+POST /api/sessions/:id/end
+{
+  "status": "success",              // success | error | aborted (default success)
+  "error_message": "",              // optional
+  "model": "claude-opus-5",         // optional; provider is derived when omitted
+  "provider": "anthropic",          // optional
+  "end_time": 1755400123000,        // optional epoch ms, defaults to now
+  "duration_ms": 123000,            // optional, defaults to end_time - start_time
+  "usage": { "input_tokens": 0, "output_tokens": 0,
+             "cache_read_tokens": 0, "cache_write_tokens": 0, "total_tokens": 0 },
+  "finalize_response": true         // default true: retype the last `reasoning` turn to `response`
+}
+→ 200 { "session_id": …, "status": "success", "end_time": …, "finalized_turn": "turn-…" }
+```
+
+**Call this exactly once per run** — token counts accumulate on the session node, so a
+second call double-counts them. (Resuming a session later and ending it again is the one
+legitimate case: the totals are meant to sum across runs.)
+
+## 4. Concept rollup (optional)
+
+Session-level `READ_CONCEPT` edges with the agent's own ranking — the counterpart of the
+per-turn `concepts` above, which record *that* a concept was read; these record *how
+load-bearing it was*.
+
+```
+POST /api/sessions/:id/concepts
+{ "concepts": [
+    { "ref_id": "…", "read_order": 0, "rank": 1,
+      "evidence": "why it mattered", "contradicts": "what it got wrong" }
+] }
+→ 200 { "session_id": …, "linked": 1, "submitted": 1 }
+```
+
+Full-state mirror, not a merge: every call overwrites the edge properties, and a `null`
+`rank` clears it. Send the complete list each time.
+
+## Reading it back
+
+```
+GET /api/sessions/:id/turns?after=<order>&limit=1000   # poll for a live feed
+GET /api/sessions/:id                                  # session detail + totals
+GET /api/sessions?source=hive                          # list runs
+```
+
+`after` is exclusive; start at `-1`. Read endpoints need no auth.
+
+## Errors
+
+| code | meaning |
+|---|---|
+| 400 | malformed body (bad `turn_type`, empty batch, batch > 500, `start_order` < 0, bad session id) |
+| 401 | missing/invalid API token |
+| 404 | session node doesn't exist — `POST /api/sessions` first |
+| 503 | graph unavailable |
+
+## Minimal flow
+
+```bash
+H='-H content-type:application/json -H x-api-token:'"$API_TOKEN"
+curl -sX POST $STAKGRAPH/api/sessions $H \
+  -d '{"session_id":"hive-run-1","source":"hive","repo":"stakwork/hive"}'
+
+curl -sX POST $STAKGRAPH/api/sessions/hive-run-1/turns $H \
+  -d '{"agent":"hive","turns":[{"turn_type":"user_input","content":"fix the flaky test"}]}'
+
+curl -sX POST $STAKGRAPH/api/sessions/hive-run-1/end $H \
+  -d '{"status":"success","model":"claude-opus-5","usage":{"input_tokens":12000,"output_tokens":800}}'
+```

--- a/mcp/docs/session-ingest.md
+++ b/mcp/docs/session-ingest.md
@@ -25,7 +25,7 @@ All bodies are JSON. All writes are idempotent unless noted.
 POST /api/sessions
 {
   "session_id": "hive-run-8f21",   // required; your id, becomes the node key
-  "source": "hive",                 // shows up as the session's source facet
+  "source": "hive",                 // the session's source facet; defaults to "external"
   "repo": "stakwork/hive",          // optional
   "agent_name": "planner",          // optional; free-form label for grouping runs
   "parent_session_id": "...",       // optional; creates (parent)-[:SPAWNED]->(this)
@@ -121,6 +121,7 @@ POST /api/sessions/:id/end
   "error_message": "",              // optional
   "model": "claude-opus-5",         // optional; provider is derived when omitted
   "provider": "anthropic",          // optional
+  "repo": "stakwork/hive",          // optional; keeps what /sessions recorded when omitted
   "end_time": 1755400123000,        // optional epoch ms, defaults to now
   "duration_ms": 123000,            // optional, defaults to end_time - start_time
   "usage": { "input_tokens": 0, "output_tokens": 0,
@@ -153,7 +154,7 @@ POST /api/sessions/:id/concepts
 Identifiers resolve exactly as in [Identifying concepts](#identifying-concepts).
 
 Full-state mirror, not a merge: every call overwrites the edge properties, and a `null`
-`rank` clears it. Send the complete list each time.
+`rank` clears it. Send the complete list each time — up to 1000 concepts per call.
 
 ## Reading it back
 
@@ -169,10 +170,20 @@ GET /api/sessions?source=hive                          # list runs
 
 | code | meaning |
 |---|---|
-| 400 | malformed body (bad `turn_type`, empty batch, batch > 500, `start_order` < 0, bad session id) |
+| 400 | malformed body (bad `turn_type` or `status`, empty batch, batch > 500, > 1000 concepts, `start_order` < 0, bad session id) |
 | 401 | missing/invalid API token |
 | 404 | session node doesn't exist — `POST /api/sessions` first |
+| 500 | the graph write failed |
 | 503 | graph unavailable |
+
+**Retries.** `/sessions` and `/sessions/:id/turns` are safe to retry verbatim: a `500`
+from `/turns` means the batch itself didn't land (one atomic statement), and a failure
+to attach concept links doesn't fail the request — it returns `201` with a `warning`
+and `concepts_linked: 0`, because the turns are already in the graph and re-posting
+them would number a second copy from the new chain head.
+
+`/end` is the exception: token counts accumulate, so on a `500` the totals may already
+have landed. Retry it with `usage` omitted.
 
 ## Minimal flow
 

--- a/mcp/src/benchmark/ingest.ts
+++ b/mcp/src/benchmark/ingest.ts
@@ -1,0 +1,341 @@
+/**
+ * Session ingest — the write half of the sessions API.
+ *
+ * Lets an agent running in ANOTHER process (hive's ai-sdk agents) record the
+ * same live Turn chain the in-process emitter writes:
+ *
+ *   POST /api/sessions              stub the AgentSession (status 'running')
+ *   POST /api/sessions/:id/turns    append a batch of Turns as they happen
+ *   POST /api/sessions/:id/end      totals, status, final response retype
+ *   POST /api/sessions/:id/concepts session-level READ_CONCEPT rollup
+ *
+ * The graph is the only state: `order` comes from the session's chain head
+ * (GET_TURN_CHAIN_HEAD_QUERY) unless the caller pins it, and the agent label
+ * is recovered from the head's turn_id. So there is no server-side session
+ * state to lose, a crashed caller resumes by just posting again, and every
+ * write stays idempotent on the deterministic node_key.
+ *
+ * Turn writes anchor on the AgentSession node (see UPSERT_TURNS_QUERY), so a
+ * batch for an unknown session writes nothing — reported here as a 404 rather
+ * than a silent no-op, since that is a caller sequencing bug.
+ */
+
+import { Request, Response } from "express";
+import { db } from "../graph/neo4j.js";
+import { toNum } from "../graph/types.js";
+import {
+  buildExternalTurns,
+  agentFromTurnId,
+  EXTERNAL_TURN_TYPES,
+  type ExternalTurnInput,
+} from "../repo/turns.js";
+import { getProviderForModel } from "../aieo/src/provider.js";
+
+/** Turn-id label used when the caller names none and the chain is empty. */
+const DEFAULT_AGENT = "agent";
+const MAX_TURNS_PER_BATCH = 500;
+const MAX_CONCEPTS_PER_CALL = 1000;
+const VALID_TURN_TYPES = new Set<string>(EXTERNAL_TURN_TYPES);
+const VALID_STATUSES = new Set(["success", "error", "aborted"]);
+
+/**
+ * Per-session write serialization. Two batches for one session must not read
+ * the same chain head and both number themselves from it; within a process
+ * this queue prevents that. Cross-process concurrency for a single session is
+ * the caller's problem — post one session's turns from one place, or pin
+ * `start_order` yourself.
+ */
+const queues = new Map<string, Promise<unknown>>();
+
+function serialize<T>(id: string, fn: () => Promise<T>): Promise<T> {
+  const prev = queues.get(id) ?? Promise.resolve();
+  const run = prev.then(fn);
+  // The stored tail never rejects, so one failed batch doesn't poison the
+  // next; it is deleted once it IS the tail, so the map can't grow forever.
+  const tail = run.then(
+    () => undefined,
+    () => undefined,
+  );
+  queues.set(id, tail);
+  void tail.then(() => {
+    if (queues.get(id) === tail) queues.delete(id);
+  });
+  return run;
+}
+
+/** Session ids become Neo4j node_keys and (elsewhere) file paths. */
+function invalidId(id: string): boolean {
+  return !id || id.length > 256 || id.includes("..") || id.includes("/");
+}
+
+function str(v: unknown, max = 256): string {
+  return v === undefined || v === null ? "" : String(v).slice(0, max);
+}
+
+function int(v: unknown): number | null {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.trunc(n) : null;
+}
+
+/**
+ * Guard the graph handle. Called AFTER request validation in every handler:
+ * a malformed request is a 400 whether or not the graph happens to be up.
+ */
+function requireDb(res: Response): boolean {
+  if (db) return true;
+  res.status(503).json({ error: "Graph unavailable" });
+  return false;
+}
+
+/**
+ * POST /api/sessions — create (or refresh) the AgentSession node for an
+ * external run. Idempotent: re-posting the same id keeps the original node.
+ */
+export async function create_session(req: Request, res: Response) {
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const session_id = str(body.session_id);
+  if (invalidId(session_id)) {
+    res.status(400).json({ error: "Invalid session_id" });
+    return;
+  }
+  if (!requireDb(res)) return;
+  const start_time = int(body.start_time) ?? Date.now();
+  try {
+    await db!.create_agent_session_stub({
+      session_id,
+      parent_session_id: str(body.parent_session_id),
+      // 'external' rather than 'unknown': the list endpoint hides unknown
+      // zero-token sessions as junk.
+      source: str(body.source) || "external",
+      repo: str(body.repo, 512),
+      agent_name: str(body.agent_name, 128),
+      spawn_tool_call_id: str(body.spawn_tool_call_id),
+      start_time,
+    });
+  } catch (e) {
+    console.error("[ingest] create_session failed:", e);
+    res.status(500).json({ error: "Failed to create session" });
+    return;
+  }
+  res.status(201).json({ session_id, status: "running", start_time });
+}
+
+/**
+ * POST /api/sessions/:id/turns — append a batch of Turns to the chain.
+ * Turns are numbered from the graph's chain head unless `start_order` pins
+ * them; re-posting the same orders overwrites those turns in place.
+ */
+export async function append_turns(req: Request, res: Response) {
+  const id = String(req.params.id);
+  if (invalidId(id)) {
+    res.status(400).json({ error: "Invalid session id" });
+    return;
+  }
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const raw = body.turns;
+  if (!Array.isArray(raw) || raw.length === 0) {
+    res.status(400).json({ error: "turns must be a non-empty array" });
+    return;
+  }
+  if (raw.length > MAX_TURNS_PER_BATCH) {
+    res
+      .status(400)
+      .json({ error: `turns exceeds max batch size of ${MAX_TURNS_PER_BATCH}` });
+    return;
+  }
+  const parts: ExternalTurnInput[] = [];
+  for (const [i, t] of raw.entries()) {
+    const turn_type = str((t as any)?.turn_type, 32);
+    if (!VALID_TURN_TYPES.has(turn_type)) {
+      res.status(400).json({
+        error: `turns[${i}].turn_type must be one of: ${[...VALID_TURN_TYPES].join(", ")}`,
+      });
+      return;
+    }
+    parts.push({
+      turn_type,
+      content: (t as any)?.content,
+      tool: str((t as any)?.tool, 128) || null,
+      tool_call_id: str((t as any)?.tool_call_id) || null,
+      timestamp: int((t as any)?.timestamp),
+      concepts: Array.isArray((t as any)?.concepts) ? (t as any).concepts : [],
+    });
+  }
+  const pinnedOrder = int(body.start_order);
+  if (pinnedOrder !== null && pinnedOrder < 0) {
+    res.status(400).json({ error: "start_order must be >= 0" });
+    return;
+  }
+  const requestedAgent = str(body.agent, 64) || null;
+  if (!requireDb(res)) return;
+
+  try {
+    const result = await serialize(id, async () => {
+      let start = pinnedOrder;
+      let agent = requestedAgent;
+      if (start === null || !agent) {
+        const head = await db!.get_turn_chain_head(id);
+        if (start === null) start = head ? head.max_order + 1 : 0;
+        if (!agent) {
+          agent =
+            (head && agentFromTurnId(head.turn_id, id)) || DEFAULT_AGENT;
+        }
+      }
+      const turns = buildExternalTurns(id, agent, start, parts);
+      const written = await db!.upsert_turns(
+        id,
+        turns.map(({ concepts: _c, ...t }) => t),
+      );
+      // Zero written means the anchor MATCH found no AgentSession node.
+      if (written === 0) return null;
+      const links = turns.flatMap((t) =>
+        t.concepts.map((c) => ({
+          turn_node_key: t.node_key,
+          ref_id: c.ref_id,
+          id: c.id,
+        })),
+      );
+      if (links.length > 0) await db!.upsert_turn_concept_edges(links);
+      return { turns, written };
+    });
+
+    if (!result) {
+      res.status(404).json({
+        error: `Unknown session '${id}' — POST /api/sessions to create it first`,
+      });
+      return;
+    }
+    const last = result.turns[result.turns.length - 1];
+    res.status(201).json({
+      session_id: id,
+      written: result.written,
+      next_order: last.order + 1,
+      turns: result.turns.map((t) => ({
+        order: t.order,
+        turn_id: t.turn_id,
+        node_key: t.node_key,
+        turn_type: t.turn_type,
+      })),
+    });
+  } catch (e) {
+    console.error("[ingest] append_turns failed:", e);
+    res.status(500).json({ error: "Failed to write turns" });
+  }
+}
+
+/**
+ * POST /api/sessions/:id/end — finalize the run: totals, status, and the
+ * last reasoning turn retyped to 'response'.
+ *
+ * Token counts ACCUMULATE on the session node (same query the in-process
+ * path uses), so call this once per run — calling it twice double-counts.
+ */
+export async function end_session(req: Request, res: Response) {
+  const id = String(req.params.id);
+  if (invalidId(id)) {
+    res.status(400).json({ error: "Invalid session id" });
+    return;
+  }
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const status = str(body.status, 16) || "success";
+  if (!VALID_STATUSES.has(status)) {
+    res
+      .status(400)
+      .json({ error: `status must be one of: ${[...VALID_STATUSES].join(", ")}` });
+    return;
+  }
+  if (!requireDb(res)) return;
+
+  try {
+    // Read the node first: the upsert SETs repo unconditionally, so ending a
+    // session without echoing it back would wipe what /sessions recorded.
+    const node = await db!.get_agent_session(id);
+    if (!node) {
+      res.status(404).json({
+        error: `Unknown session '${id}' — POST /api/sessions to create it first`,
+      });
+      return;
+    }
+    const end_time = int(body.end_time) ?? Date.now();
+    const start_time = toNum(node.start_time) || end_time;
+    const usage = (body.usage ?? {}) as Record<string, unknown>;
+    const input_tokens = int(usage.input_tokens) ?? 0;
+    const output_tokens = int(usage.output_tokens) ?? 0;
+    const cache_read_tokens = int(usage.cache_read_tokens) ?? 0;
+    const cache_write_tokens = int(usage.cache_write_tokens) ?? 0;
+    const model = str(body.model, 128) || str(node.model, 128);
+    await db!.upsert_agent_session({
+      session_id: id,
+      // Empty strings are preserved by the query's CASE guards — these keep
+      // whatever the stub (or a SPAWNED parent) already set.
+      parent_session_id: "",
+      agent_name: "",
+      spawn_tool_call_id: "",
+      source: str(node.source) || "external",
+      repo: str(body.repo, 512) || str(node.repo, 512),
+      model,
+      provider: str(body.provider, 64) || (model ? getProviderForModel(model) : ""),
+      start_time,
+      end_time,
+      duration_ms: int(body.duration_ms) ?? Math.max(0, end_time - start_time),
+      input_tokens,
+      cache_read_tokens,
+      cache_write_tokens,
+      output_tokens,
+      total_tokens:
+        int(usage.total_tokens) ??
+        input_tokens + output_tokens + cache_read_tokens + cache_write_tokens,
+      status,
+      error_message: str(body.error_message, 2000),
+    });
+
+    let finalized_turn: string | null = null;
+    if (body.finalize_response !== false) {
+      finalized_turn = await db!.finalize_last_reasoning_turn(id);
+    }
+    res.json({ session_id: id, status, end_time, finalized_turn });
+  } catch (e) {
+    console.error("[ingest] end_session failed:", e);
+    res.status(500).json({ error: "Failed to end session" });
+  }
+}
+
+/**
+ * POST /api/sessions/:id/concepts — the session-level READ_CONCEPT rollup
+ * (rank/evidence/contradicts), the external counterpart of the reflection
+ * sidecar sync. Mirrors full state on every call: a null `rank` clears it.
+ */
+export async function link_session_concepts(req: Request, res: Response) {
+  const id = String(req.params.id);
+  if (invalidId(id)) {
+    res.status(400).json({ error: "Invalid session id" });
+    return;
+  }
+  const raw = (req.body ?? {}).concepts;
+  if (!Array.isArray(raw)) {
+    res.status(400).json({ error: "concepts must be an array" });
+    return;
+  }
+  if (raw.length > MAX_CONCEPTS_PER_CALL) {
+    res
+      .status(400)
+      .json({ error: `concepts exceeds max of ${MAX_CONCEPTS_PER_CALL}` });
+    return;
+  }
+  const concepts = raw.map((c: any) => ({
+    id: str(c?.id) || undefined,
+    ref_id: str(c?.ref_id) || undefined,
+    read_order: int(c?.read_order) ?? undefined,
+    rank: int(c?.rank),
+    evidence: str(c?.evidence, 2000) || undefined,
+    contradicts: str(c?.contradicts, 2000) || undefined,
+  }));
+  if (!requireDb(res)) return;
+  try {
+    const linked = await db!.upsert_session_concept_edges(id, concepts);
+    res.json({ session_id: id, linked, submitted: concepts.length });
+  } catch (e) {
+    console.error("[ingest] link_session_concepts failed:", e);
+    res.status(500).json({ error: "Failed to link concepts" });
+  }
+}

--- a/mcp/src/benchmark/ingest.ts
+++ b/mcp/src/benchmark/ingest.ts
@@ -193,10 +193,12 @@ export async function append_turns(req: Request, res: Response) {
           turn_node_key: t.node_key,
           ref_id: c.ref_id,
           id: c.id,
+          repo: c.repo ?? null,
         })),
       );
-      if (links.length > 0) await db!.upsert_turn_concept_edges(links);
-      return { turns, written };
+      const concepts_linked =
+        links.length > 0 ? await db!.upsert_turn_concept_edges(links) : 0;
+      return { turns, written, concepts_submitted: links.length, concepts_linked };
     });
 
     if (!result) {
@@ -210,6 +212,11 @@ export async function append_turns(req: Request, res: Response) {
       session_id: id,
       written: result.written,
       next_order: last.order + 1,
+      // Concept links that resolved to a node. Unmatched ids are skipped
+      // rather than failing the batch, so surface the count — a submitted >
+      // linked gap is the caller's signal that its identifiers are wrong.
+      concepts_submitted: result.concepts_submitted,
+      concepts_linked: result.concepts_linked,
       turns: result.turns.map((t) => ({
         order: t.order,
         turn_id: t.turn_id,
@@ -325,6 +332,7 @@ export async function link_session_concepts(req: Request, res: Response) {
   const concepts = raw.map((c: any) => ({
     id: str(c?.id) || undefined,
     ref_id: str(c?.ref_id) || undefined,
+    repo: str(c?.repo, 512) || undefined,
     read_order: int(c?.read_order) ?? undefined,
     rank: int(c?.rank),
     evidence: str(c?.evidence, 2000) || undefined,

--- a/mcp/src/benchmark/ingest.ts
+++ b/mcp/src/benchmark/ingest.ts
@@ -196,9 +196,27 @@ export async function append_turns(req: Request, res: Response) {
           repo: c.repo ?? null,
         })),
       );
-      const concepts_linked =
-        links.length > 0 ? await db!.upsert_turn_concept_edges(links) : 0;
-      return { turns, written, concepts_submitted: links.length, concepts_linked };
+      // Concept links are best-effort, exactly as in the live emitter: the
+      // turns already landed, so failing the request here would tell the
+      // caller to retry a batch that is now in the graph — and since order
+      // comes from the chain head, that retry would duplicate it.
+      let concepts_linked = 0;
+      let concepts_error: string | undefined;
+      if (links.length > 0) {
+        try {
+          concepts_linked = await db!.upsert_turn_concept_edges(links);
+        } catch (e) {
+          console.error("[ingest] concept edge write failed:", e);
+          concepts_error = "concept links failed to write; the turns landed";
+        }
+      }
+      return {
+        turns,
+        written,
+        concepts_submitted: links.length,
+        concepts_linked,
+        concepts_error,
+      };
     });
 
     if (!result) {
@@ -217,6 +235,7 @@ export async function append_turns(req: Request, res: Response) {
       // linked gap is the caller's signal that its identifiers are wrong.
       concepts_submitted: result.concepts_submitted,
       concepts_linked: result.concepts_linked,
+      ...(result.concepts_error ? { warning: result.concepts_error } : {}),
       turns: result.turns.map((t) => ({
         order: t.order,
         turn_id: t.turn_id,

--- a/mcp/src/benchmark/router.ts
+++ b/mcp/src/benchmark/router.ts
@@ -1,5 +1,12 @@
 import { Router } from "express";
 import { list_sessions, list_session_facets, get_session, get_session_turns, session_stats, add_annotation } from "./sessions.js";
+import {
+  create_session,
+  append_turns,
+  end_session,
+  link_session_concepts,
+} from "./ingest.js";
+import { authMiddleware } from "../graph/routes.js";
 
 export function benchmarkRouter(): Router {
   const router = Router();
@@ -11,6 +18,15 @@ export function benchmarkRouter(): Router {
   router.get("/sessions/:id", get_session);
   router.get("/sessions/:id/turns", get_session_turns);
   router.post("/sessions/:id/annotations", add_annotation);
+
+  // Ingest — out-of-process agents recording live Turn chains (see ingest.ts
+  // and docs/session-ingest.md). Auth-gated, unlike the read endpoints these
+  // sit beside: these write to the graph. authMiddleware is a no-op when
+  // API_TOKEN is unset (dev), so local callers are unaffected.
+  router.post("/sessions", authMiddleware, create_session);
+  router.post("/sessions/:id/turns", authMiddleware, append_turns);
+  router.post("/sessions/:id/end", authMiddleware, end_session);
+  router.post("/sessions/:id/concepts", authMiddleware, link_session_concepts);
 
   return router;
 }

--- a/mcp/src/benchmark/sessions.ts
+++ b/mcp/src/benchmark/sessions.ts
@@ -64,6 +64,7 @@ function buildOrphanRun(dir: string, file: string) {
     parent_session_id: id.match(/^(.+)-sub-[0-9a-f]{8}$/)?.[1] ?? "",
     source: "unknown",
     agent_name: "",
+    spawn_tool_call_id: "",
     provider: "",
     model: "",
     repo: "",
@@ -228,6 +229,9 @@ function buildRunFromNode(s: any, dir: string) {
     parent_session_id: String(s.parent_session_id ?? ""),
     source: String(s.source ?? "unknown"),
     agent_name: String(s.agent_name ?? ""),
+    // Sub-agents only: the parent tool call that spawned this run. Joins to
+    // the Turn in the parent's chain carrying the same tool_call_id.
+    spawn_tool_call_id: String(s.spawn_tool_call_id ?? ""),
     repo: String(s.repo ?? ""),
     provider: prov,
     model: mod,
@@ -485,6 +489,7 @@ async function buildFullSession(
           parent_session_id: String(s.parent_session_id ?? ""),
           source: String(s.source ?? "unknown"),
           agent_name: String(s.agent_name ?? ""),
+          spawn_tool_call_id: String(s.spawn_tool_call_id ?? ""),
           repo: String(s.repo ?? ""),
           provider: prov,
           model: mod,

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1682,6 +1682,7 @@ class Db {
     source: string;
     repo: string;
     agent_name: string;
+    spawn_tool_call_id: string;
     start_time: number;
   }): Promise<void> {
     const session = this.resilientSession();
@@ -1817,6 +1818,7 @@ class Db {
     source: string;
     repo: string;
     agent_name: string;
+    spawn_tool_call_id: string;
     model: string;
     provider: string;
     start_time: number;

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1800,6 +1800,49 @@ class Db {
   }
 
   /**
+   * The session's highest-order Turn, or null when it has none yet. The
+   * order cursor for out-of-process agents posting turns over HTTP.
+   */
+  async get_turn_chain_head(
+    session_id: string,
+  ): Promise<{ turn_id: string; max_order: number } | null> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(Q.GET_TURN_CHAIN_HEAD_QUERY, {
+        session_id,
+      });
+      const rec = result.records[0];
+      if (!rec) return null;
+      return {
+        turn_id: String(rec.get("turn_id") ?? ""),
+        max_order: toNum(rec.get("max_order")),
+      };
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Retype the session's last 'reasoning' Turn to 'response'. Same effect as
+   * finalize_turn_response, for callers with no emitter state to name the
+   * node. Returns the retyped node_key, or null when there was none.
+   */
+  async finalize_last_reasoning_turn(
+    session_id: string,
+  ): Promise<string | null> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(Q.FINALIZE_LAST_REASONING_TURN_QUERY, {
+        session_id,
+      });
+      const nodeKey = result.records[0]?.get("node_key");
+      return nodeKey ? String(nodeKey) : null;
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
    * Retype a run's final reasoning Turn to 'response' (matching the
    * post-hoc workflow, which retypes the last assistant text turn).
    */

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1742,12 +1742,22 @@ class Db {
    * session-level edge sync.
    */
   async upsert_turn_concept_edges(
-    links: Array<{ turn_node_key: string; ref_id: string | null; id: string | null }>,
-  ): Promise<void> {
-    if (links.length === 0) return;
+    links: Array<{
+      turn_node_key: string;
+      ref_id: string | null;
+      id: string | null;
+      /** Repo of a bare (unprefixed) gitree id, so `repo/id` also resolves. */
+      repo?: string | null;
+    }>,
+  ): Promise<number> {
+    if (links.length === 0) return 0;
     const session = this.resilientSession();
     try {
-      await session.run(Q.UPSERT_TURN_CONCEPT_EDGES_QUERY, { links });
+      const result = await session.run(Q.UPSERT_TURN_CONCEPT_EDGES_QUERY, {
+        links: links.map((l) => ({ repo: null, ...l })),
+      });
+      const linked = result.records[0]?.get("linked");
+      return linked?.toNumber?.() ?? Number(linked ?? 0);
     } finally {
       await session.close();
     }
@@ -1898,6 +1908,8 @@ class Db {
     concepts: Array<{
       id?: string;
       ref_id?: string;
+      /** Repo of a bare (unprefixed) gitree id, so `repo/id` also resolves. */
+      repo?: string;
       read_order?: number;
       rank?: number | null;
       evidence?: string;
@@ -1911,6 +1923,7 @@ class Db {
         concepts: concepts.map((c) => ({
           id: c.id ?? null,
           ref_id: c.ref_id ?? null,
+          repo: c.repo ?? null,
           read_order: c.read_order ?? null,
           rank: c.rank ?? null,
           evidence: c.evidence ?? null,

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -315,7 +315,7 @@ MERGE (n:AgentSession:${Data_Bank} {node_key: $session_id})
 ON CREATE SET n.ref_id = randomUUID(), n.date_added_to_graph = $ts, n.namespace = 'default',
   n.name = $session_id, n.file = 'session://generated', n.start = 0, n.end = 0, n.body = $source,
   n.source = $source, n.repo = $repo, n.model = $model, n.provider = $provider,
-  n.agent_name = $agent_name,
+  n.agent_name = $agent_name, n.spawn_tool_call_id = $spawn_tool_call_id,
   n.start_time = toInteger($start_time),
   n.input_tokens = 0, n.cache_read_tokens = 0, n.cache_write_tokens = 0,
   n.output_tokens = 0, n.total_tokens = 0, n.duration_ms = 0,
@@ -324,6 +324,7 @@ SET n.parent_session_id = CASE WHEN $parent_session_id = '' THEN coalesce(n.pare
     n.model = CASE WHEN $model = '' THEN coalesce(n.model, '') ELSE $model END,
     n.provider = CASE WHEN $provider = '' THEN coalesce(n.provider, '') ELSE $provider END,
     n.agent_name = CASE WHEN $agent_name = '' THEN coalesce(n.agent_name, '') ELSE $agent_name END,
+    n.spawn_tool_call_id = CASE WHEN $spawn_tool_call_id = '' THEN coalesce(n.spawn_tool_call_id, '') ELSE $spawn_tool_call_id END,
     n.end_time = toInteger($end_time),
     n.repo = $repo,
     n.input_tokens = coalesce(n.input_tokens, 0) + toInteger($input_tokens),
@@ -347,13 +348,14 @@ MERGE (n:AgentSession:${Data_Bank} {node_key: $session_id})
 ON CREATE SET n.ref_id = randomUUID(), n.date_added_to_graph = $ts, n.namespace = 'default',
   n.name = $session_id, n.file = 'session://generated', n.start = 0, n.end = 0, n.body = $source,
   n.source = $source, n.repo = $repo, n.model = '', n.provider = '',
-  n.agent_name = $agent_name,
+  n.agent_name = $agent_name, n.spawn_tool_call_id = $spawn_tool_call_id,
   n.start_time = toInteger($start_time), n.end_time = toInteger($start_time),
   n.input_tokens = 0, n.cache_read_tokens = 0, n.cache_write_tokens = 0,
   n.output_tokens = 0, n.total_tokens = 0, n.duration_ms = 0,
   n.status = 'running', n.error_message = ''
 SET n.parent_session_id = CASE WHEN $parent_session_id = '' THEN coalesce(n.parent_session_id, '') ELSE $parent_session_id END,
-    n.agent_name = CASE WHEN $agent_name = '' THEN coalesce(n.agent_name, '') ELSE $agent_name END
+    n.agent_name = CASE WHEN $agent_name = '' THEN coalesce(n.agent_name, '') ELSE $agent_name END,
+    n.spawn_tool_call_id = CASE WHEN $spawn_tool_call_id = '' THEN coalesce(n.spawn_tool_call_id, '') ELSE $spawn_tool_call_id END
 WITH n
 OPTIONAL MATCH (p:AgentSession {node_key: $parent_session_id})
 FOREACH (_ IN CASE WHEN p IS NULL THEN [] ELSE [1] END | MERGE (p)-[:SPAWNED]->(n))

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -403,19 +403,44 @@ SET s.turn_count = CASE WHEN max_order + 1 > coalesce(s.turn_count, 0)
 RETURN written
 `;
 
+// How a caller's concept identifier is resolved to a Concept node.
+//
+// Mirrors GraphStorage.getConcept — the resolution every gitree read already
+// goes through (`f.id = <repo-prefixed id> OR f.node_key OR f.ref_id`), so an
+// identifier that reached a Concept's body can also reach its edge. That
+// matters most for out-of-process callers: `GET /gitree/concepts/:id` returns
+// no ref_id, so an external agent (hive) only ever holds the gitree id it
+// read with — which may be a bare slug, a node_key, or a ref_id, all of which
+// that endpoint accepts. Under a strict `c.id = link.id` match those reads
+// silently produced no edge.
+//
+// Preference order is strictest-first (exact ref_id, then exact id, then the
+// looser forms) so a widened match can never outrank an exact one.
+const CONCEPT_LINK_MATCH = `
+WHERE (link.ref_id IS NOT NULL AND c.ref_id = link.ref_id)
+   OR (link.id IS NOT NULL AND (
+         c.id = link.id
+         OR c.node_key = link.id
+         OR c.ref_id = link.id
+         OR (link.repo IS NOT NULL AND c.id = link.repo + '/' + link.id)))
+`;
+const CONCEPT_LINK_PICK = `
+head([m IN matches WHERE link.ref_id IS NOT NULL AND m.ref_id = link.ref_id]
+   + [m IN matches WHERE link.id IS NOT NULL AND m.id = link.id]
+   + matches)
+`;
+
 // Live per-turn provenance: WHICH moment of the session read a Concept.
 // Complements the session-level ranked rollup (UPSERT_SESSION_CONCEPT_EDGES_
-// QUERY) — same concept matching (ref_id leads, gitree id as fallback), but
-// no judgment props: the turn edge records the fact, the session edge the
-// reflection's verdict.
+// QUERY) — same concept matching, but no judgment props: the turn edge
+// records the fact, the session edge the reflection's verdict.
 export const UPSERT_TURN_CONCEPT_EDGES_QUERY = `
 UNWIND $links AS link
 MATCH (t:Turn {node_key: link.turn_node_key})
 OPTIONAL MATCH (c:Concept)
-WHERE (link.ref_id IS NOT NULL AND c.ref_id = link.ref_id)
-   OR (link.id IS NOT NULL AND c.id = link.id)
+${CONCEPT_LINK_MATCH}
 WITH t, link, collect(c) AS matches
-WITH t, head([m IN matches WHERE link.ref_id IS NOT NULL AND m.ref_id = link.ref_id] + matches) AS c
+WITH t, ${CONCEPT_LINK_PICK} AS c
 WHERE c IS NOT NULL
 MERGE (t)-[r:READ_CONCEPT]->(c)
 ON CREATE SET r.weight = 1
@@ -588,26 +613,24 @@ RETURN n
 // Index a session's concept reflection as edges. The reflection sidecar file
 // is the source of truth; these edges mirror its fully-merged state on every
 // sync, so plain SET (not coalesce) is correct here — a null rank clears the
-// edge property exactly as the sidecar says. Matching prefers the graph ref_id
-// and falls back to the gitree id; a concept regenerated under a new ref_id
+// edge property exactly as the sidecar says. Matching is CONCEPT_LINK_MATCH,
+// shared with the per-turn edges; a concept regenerated under a new ref_id
 // simply stops matching (the sidecar still holds the record), and the MATCH on
 // the session node (never MERGE — see the guard in appendSessionEnd) makes the
 // whole write a no-op until the AgentSession node exists.
 export const UPSERT_SESSION_CONCEPT_EDGES_QUERY = `
 MATCH (s:AgentSession {node_key: $session_id})
-UNWIND $concepts AS con
+UNWIND $concepts AS link
 OPTIONAL MATCH (c:Concept)
-WHERE (con.ref_id IS NOT NULL AND c.ref_id = con.ref_id)
-   OR (con.id IS NOT NULL AND c.id = con.id)
-WITH s, con, collect(c) AS matches
-WITH s, con,
-     head([m IN matches WHERE con.ref_id IS NOT NULL AND m.ref_id = con.ref_id] + matches) AS c
+${CONCEPT_LINK_MATCH}
+WITH s, link, collect(c) AS matches
+WITH s, link, ${CONCEPT_LINK_PICK} AS c
 WHERE c IS NOT NULL
 MERGE (s)-[r:READ_CONCEPT]->(c)
-SET r.read_order = toInteger(con.read_order),
-    r.rank = toInteger(con.rank),
-    r.evidence = con.evidence,
-    r.contradicts = con.contradicts
+SET r.read_order = toInteger(link.read_order),
+    r.rank = toInteger(link.rank),
+    r.evidence = link.evidence,
+    r.contradicts = link.contradicts
 RETURN count(r) AS linked
 `;
 

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -422,6 +422,29 @@ ON CREATE SET r.weight = 1
 RETURN count(r) AS linked
 `;
 
+// Highest-order Turn of a session — the chain head. External ingest reads it
+// to place the next batch (and to recover the agent label from turn_id), so
+// the graph itself is the order cursor for out-of-process agents: no sidecar,
+// no server-side session state, and a caller that crashes mid-run resumes
+// exactly where it stopped.
+export const GET_TURN_CHAIN_HEAD_QUERY = `
+MATCH (t:Turn {session_id: $session_id})
+RETURN t.turn_id AS turn_id, toInteger(t.order) AS max_order
+ORDER BY toInteger(t.order) DESC
+LIMIT 1
+`;
+
+// finalizeTurns' counterpart for sessions with no in-process emitter state:
+// find this session's last 'reasoning' turn in the graph and retype it, so an
+// ingested chain ends in a 'response' like every other one.
+export const FINALIZE_LAST_REASONING_TURN_QUERY = `
+MATCH (t:Turn {session_id: $session_id})
+WHERE t.turn_type = 'reasoning'
+WITH t ORDER BY toInteger(t.order) DESC LIMIT 1
+SET t.turn_type = 'response'
+RETURN t.node_key AS node_key
+`;
+
 // The backfill workflow retypes the last assistant text turn from 'reasoning'
 // to 'response'. Live emission can't know a turn is last until the run ends,
 // so this runs from session end against the exact node the emitter tracked.

--- a/mcp/src/repo/__tests__/turn-ingest.test.ts
+++ b/mcp/src/repo/__tests__/turn-ingest.test.ts
@@ -1,0 +1,224 @@
+/**
+ * Session ingest (benchmark/ingest.ts + the buildExternalTurns half of
+ * turns.ts): the chain an out-of-process agent posts over HTTP must be
+ * indistinguishable from the one the in-process emitter writes.
+ *
+ * The parity test is the load-bearing one — same session id, same agent
+ * label, same content produces the same turn_ids and node_keys either way,
+ * which is what makes a hive chain and a local chain the same data.
+ *
+ * Runs with NO_DB=true: `db` is undefined, so the handlers are exercised for
+ * validation and the no-graph guard, and the builder (pure) for everything
+ * about turn shape.
+ */
+
+import { test, expect } from "../../testkit.js";
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+const tmpSessionsDir = path.join(os.tmpdir(), `test-ingest-${randomUUID()}`);
+fs.mkdirSync(tmpSessionsDir, { recursive: true });
+process.env.SESSIONS_DIR = tmpSessionsDir;
+process.env.NO_DB = "true";
+
+/** Minimal express Response double capturing the JSON body and status. */
+function mockRes() {
+  const captured: { status: number; body: any } = { status: 200, body: null };
+  const res: any = {
+    status(code: number) {
+      captured.status = code;
+      return res;
+    },
+    json(body: any) {
+      captured.body = body;
+      return res;
+    },
+  };
+  return { res, captured };
+}
+
+test.describe("buildExternalTurns", () => {
+  test("numbers from startOrder and chains each turn to its predecessor", async () => {
+    const { buildExternalTurns, turnNodeKey } = await import("../turns.js");
+    const sid = "sess-abc";
+
+    const turns = buildExternalTurns(sid, "hive", 4, [
+      { turn_type: "reasoning", content: "thinking" },
+      { turn_type: "tool_call", content: '{"q":"x"}', tool: "search" },
+    ]);
+
+    expect(turns.map((t) => t.order)).toEqual([4, 5]);
+    expect(turns[0].turn_id).toBe("hive-sess-abc-turn-4");
+    expect(turns[0].prev_node_key).toBe(turnNodeKey("hive-sess-abc-turn-3"));
+    expect(turns[1].prev_node_key).toBe(turns[0].node_key);
+    expect(turns[1].tool).toBe("search");
+  });
+
+  test("order 0 opens the chain with no predecessor", async () => {
+    const { buildExternalTurns } = await import("../turns.js");
+    const turns = buildExternalTurns("s1", "hive", 0, [
+      { turn_type: "user_input", content: "go" },
+    ]);
+    expect(turns[0].prev_node_key).toBe(null);
+  });
+
+  test("ingested turns match what the live emitter would have written", async () => {
+    const { buildExternalTurns, emitUserTurn, emitStepTurns } = await import(
+      "../turns.js"
+    );
+    const local = `sess-${randomUUID().slice(0, 8)}`;
+    const remote = local; // same id, other process
+
+    const localTurns = [
+      ...emitUserTurn(local, "hive", { role: "user", content: "fix it" }),
+      ...emitStepTurns(local, "hive", [
+        { type: "text", text: "looking" },
+        { type: "tool-call", toolCallId: "c1", toolName: "search", input: { q: "x" } },
+      ]),
+    ];
+    const ingested = buildExternalTurns(remote, "hive", 0, [
+      { turn_type: "user_input", content: "fix it" },
+      { turn_type: "reasoning", content: "looking" },
+      { turn_type: "tool_call", content: '{"q":"x"}', tool: "search", tool_call_id: "c1" },
+    ]);
+
+    expect(ingested.map((t) => t.node_key)).toEqual(
+      localTurns.map((t) => t.node_key),
+    );
+    expect(ingested.map((t) => t.turn_id)).toEqual(
+      localTurns.map((t) => t.turn_id),
+    );
+    expect(ingested.map((t) => t.turn_type)).toEqual(
+      localTurns.map((t) => t.turn_type),
+    );
+  });
+
+  test("tool_result content is wrapped and truncated like the live path", async () => {
+    const { buildExternalTurns } = await import("../turns.js");
+    const [wrapped] = buildExternalTurns("s1", "hive", 0, [
+      { turn_type: "tool_result", content: "ok", tool: "search" },
+    ]);
+    expect(wrapped.content).toBe('{"type":"text","value":"ok"}');
+
+    const [long] = buildExternalTurns("s1", "hive", 0, [
+      { turn_type: "tool_result", content: "x".repeat(500), tool: "search" },
+    ]);
+    expect(long.content.length).toBe(103); // 100 chars + "..."
+    expect(long.content.endsWith("...")).toBe(true);
+  });
+
+  test("concepts without any identifier are dropped", async () => {
+    const { buildExternalTurns } = await import("../turns.js");
+    const [turn] = buildExternalTurns("s1", "hive", 0, [
+      {
+        turn_type: "tool_result",
+        content: "ok",
+        concepts: [{ ref_id: "r1" }, { id: "c2" }, {}, { ref_id: null, id: null }],
+      },
+    ]);
+    expect(turn.concepts).toEqual([
+      { ref_id: "r1", id: null },
+      { ref_id: null, id: "c2" },
+    ]);
+  });
+});
+
+test.describe("agentFromTurnId", () => {
+  test("recovers the label so a batch without `agent` continues the chain", async () => {
+    const { agentFromTurnId } = await import("../turns.js");
+    expect(agentFromTurnId("hive-sess-abc-turn-7", "sess-abc")).toBe("hive");
+    // Session ids containing the marker text still resolve off the last one.
+    expect(agentFromTurnId("hive-a-turn-1-turn-2", "a-turn-1")).toBe("hive");
+    expect(agentFromTurnId("nonsense", "sess-abc")).toBe(null);
+  });
+});
+
+test.describe("ingest endpoints", () => {
+  test("POST /api/sessions rejects a missing or path-like session_id", async () => {
+    const { create_session } = await import("../../benchmark/ingest.js");
+
+    for (const session_id of [undefined, "", "../etc", "a/b"]) {
+      const { res, captured } = mockRes();
+      await create_session({ body: { session_id } } as any, res);
+      expect(captured.status).toBe(400);
+    }
+  });
+
+  test("POST /sessions/:id/turns validates the batch before touching the graph", async () => {
+    const { append_turns } = await import("../../benchmark/ingest.js");
+    const req = (body: any) => ({ params: { id: "s1" }, body }) as any;
+
+    const empty = mockRes();
+    await append_turns(req({ turns: [] }), empty.res);
+    expect(empty.captured.status).toBe(400);
+
+    const badType = mockRes();
+    await append_turns(
+      req({ turns: [{ turn_type: "nope", content: "x" }] }),
+      badType.res,
+    );
+    expect(badType.captured.status).toBe(400);
+    expect(String(badType.captured.body.error)).toContain("turns[0].turn_type");
+
+    const tooMany = mockRes();
+    await append_turns(
+      req({
+        turns: Array.from({ length: 501 }, () => ({
+          turn_type: "reasoning",
+          content: "x",
+        })),
+      }),
+      tooMany.res,
+    );
+    expect(tooMany.captured.status).toBe(400);
+
+    const negative = mockRes();
+    await append_turns(
+      req({ start_order: -1, turns: [{ turn_type: "reasoning", content: "x" }] }),
+      negative.res,
+    );
+    expect(negative.captured.status).toBe(400);
+  });
+
+  test("POST /sessions/:id/end rejects an unknown status", async () => {
+    const { end_session } = await import("../../benchmark/ingest.js");
+    const { res, captured } = mockRes();
+    await end_session(
+      { params: { id: "s1" }, body: { status: "finished" } } as any,
+      res,
+    );
+    expect(captured.status).toBe(400);
+  });
+
+  test("a valid request reports the graph as unavailable rather than silently dropping", async () => {
+    const { append_turns, end_session, link_session_concepts, create_session } =
+      await import("../../benchmark/ingest.js");
+
+    const create = mockRes();
+    await create_session({ body: { session_id: "s1" } } as any, create.res);
+    expect(create.captured.status).toBe(503);
+
+    const turns = mockRes();
+    await append_turns(
+      {
+        params: { id: "s1" },
+        body: { turns: [{ turn_type: "reasoning", content: "x" }] },
+      } as any,
+      turns.res,
+    );
+    expect(turns.captured.status).toBe(503);
+
+    const end = mockRes();
+    await end_session({ params: { id: "s1" }, body: {} } as any, end.res);
+    expect(end.captured.status).toBe(503);
+
+    const concepts = mockRes();
+    await link_session_concepts(
+      { params: { id: "s1" }, body: { concepts: [] } } as any,
+      concepts.res,
+    );
+    expect(concepts.captured.status).toBe(503);
+  });
+});

--- a/mcp/src/repo/__tests__/turn-ingest.test.ts
+++ b/mcp/src/repo/__tests__/turn-ingest.test.ts
@@ -119,8 +119,22 @@ test.describe("buildExternalTurns", () => {
       },
     ]);
     expect(turn.concepts).toEqual([
-      { ref_id: "r1", id: null },
-      { ref_id: null, id: "c2" },
+      { ref_id: "r1", id: null, repo: null },
+      { ref_id: null, id: "c2", repo: null },
+    ]);
+  });
+
+  test("a concept's repo rides along, so a bare gitree id can still resolve", async () => {
+    const { buildExternalTurns } = await import("../turns.js");
+    const [turn] = buildExternalTurns("s1", "hive", 0, [
+      {
+        turn_type: "tool_result",
+        content: "ok",
+        concepts: [{ id: "auth-flow", repo: "stakwork/hive" }],
+      },
+    ]);
+    expect(turn.concepts).toEqual([
+      { ref_id: null, id: "auth-flow", repo: "stakwork/hive" },
     ]);
   });
 });

--- a/mcp/src/repo/__tests__/turns.test.ts
+++ b/mcp/src/repo/__tests__/turns.test.ts
@@ -141,7 +141,7 @@ test.describe("turn emission", () => {
     ]);
 
     const result = turns.find((t) => t.turn_type === "tool_result")!;
-    expect(result.concepts).toEqual([{ ref_id: "abc-123", id: "gitree-9" }]);
+    expect(result.concepts).toEqual([{ ref_id: "abc-123", id: "gitree-9", repo: null }]);
     // Non-concept turns carry none.
     expect(turns.find((t) => t.turn_type === "tool_call")!.concepts).toEqual([]);
   });
@@ -256,7 +256,8 @@ test.describe("turn emission", () => {
 
     const turns = turnsFromTranscript("s2", "hive", messages);
     expect(turns.map((t) => t.turn_type)).toEqual(["user_input", "tool_call", "tool_result"]);
-    expect(turns[2].concepts).toEqual([{ ref_id: "r-1", id: "g-1" }]);
+    // `repo` rides along so a bare gitree id can still resolve to a node.
+    expect(turns[2].concepts).toEqual([{ ref_id: "r-1", id: "g-1", repo: null }]);
   });
 
   test("markTranscriptEmitted leaves the cursor a live resume continues from", async () => {

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -27,6 +27,7 @@ const sessionMeta = new Map<
     repo?: string;
     parent_session_id?: string;
     agent_name?: string;
+    spawn_tool_call_id?: string;
   }
 >();
 
@@ -120,6 +121,13 @@ export function createSession(
   repo?: string,
   parentSessionId?: string,
   agentName?: string,
+  /**
+   * For sub-agent sessions: the id of the parent's tool call that spawned
+   * this run. Pins the child to the exact Turn in the parent's chain (Turn
+   * nodes carry `tool_call_id`), which a prompt-text match can only
+   * approximate — two sub-agents can be handed identical prompts.
+   */
+  spawnToolCallId?: string,
 ): string {
   // Defense in depth against non-string ids from callers that skipped the
   // route-level coercion — a numeric id poisons the Neo4j node_key type.
@@ -130,6 +138,7 @@ export function createSession(
     repo,
     parent_session_id: parentSessionId,
     agent_name: agentName,
+    spawn_tool_call_id: spawnToolCallId,
   });
   // Stub the AgentSession node now (status 'running') rather than waiting for
   // appendSessionEnd: live turn chains need a HAS_TURN anchor, sub-agents get
@@ -142,6 +151,7 @@ export function createSession(
       source: source || "unknown",
       repo: repo || "",
       agent_name: agentName || "",
+      spawn_tool_call_id: spawnToolCallId || "",
       start_time: Date.now(),
     })
     .catch((e) => console.error("[sessions] Neo4j stub creation failed:", e));
@@ -190,6 +200,7 @@ export async function appendSessionEnd(
       source: stored.source,
       repo: stored.repo || "",
       agent_name: stored.agent_name || "",
+      spawn_tool_call_id: stored.spawn_tool_call_id || "",
       model: opts.model || "",
       provider: resolvedProvider,
       start_time,

--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -463,7 +463,7 @@ function registerGraphSubAgentTool(
           "The child cannot see this conversation.",
         ),
     }),
-    execute: async ({ prompt }: { prompt: string }) => {
+    execute: async ({ prompt }: { prompt: string }, options?: { toolCallId?: string }) => {
       const childTools: Record<string, Tool<any, any>> = {};
       // Persist the child run as its own session (linked to the parent) only
       // when the parent itself is session-backed. Grandchildren link to the
@@ -486,12 +486,19 @@ function registerGraphSubAgentTool(
       const runTools = withConceptCollection(childTools, conceptCollector);
 
       if (childSessionId) {
+        // The toolCallId is the exact link back to the parent's Turn chain:
+        // the parent's `graph_sub_agent` tool_call turn carries the same id.
+        // It must be captured here because that Turn does not exist yet — a
+        // step's turns are emitted when the step finishes, which is after
+        // this child has already run to completion.
         createSession(
           childSessionId,
           GRAPH_SUBAGENT_SYSTEM,
           "graph_sub_agent",
           sub.repo,
           sub.parentSessionId,
+          undefined,
+          options?.toolCallId,
         );
         emitUserTurn(childSessionId, "graph_sub_agent", {
           role: "user",

--- a/mcp/src/repo/turnBackfill.ts
+++ b/mcp/src/repo/turnBackfill.ts
@@ -108,6 +108,7 @@ async function writeChain(
         turn_node_key: t.node_key,
         ref_id: c.ref_id,
         id: c.id,
+        repo: c.repo ?? null,
       })),
     );
     if (links.length > 0) await db!.upsert_turn_concept_edges(links);

--- a/mcp/src/repo/turns.ts
+++ b/mcp/src/repo/turns.ts
@@ -514,6 +514,89 @@ export function markTranscriptEmitted(
   persistState(sessionId, state);
 }
 
+// ── External ingest ─────────────────────────────────────────────────
+// Same chain, built for agents that run in another process (hive's ai-sdk
+// agents) and post their turns over HTTP. Pure, like turnsFromTranscript:
+// no state map, no sidecar — an external session has no local transcript to
+// resume from, so the caller (or the graph itself) owns the order cursor and
+// the agent label. Everything else is byte-identical to the live path, so
+// ingested chains are indistinguishable from in-process ones.
+
+/** Turn types the ingest API accepts (the shapes the classifiers produce). */
+export const EXTERNAL_TURN_TYPES = [
+  "user_input",
+  "reasoning",
+  "tool_call",
+  "tool_result",
+  "response",
+] as const;
+
+/** Ceiling on non-tool_result content, so one runaway turn can't bloat the DB. */
+const MAX_CONTENT_CHARS = 100_000;
+
+export interface ExternalTurnInput {
+  turn_type: string;
+  /** String for every type; tool_result also accepts the raw output object. */
+  content?: unknown;
+  tool?: string | null;
+  tool_call_id?: string | null;
+  timestamp?: number | null;
+  concepts?: Array<{ ref_id?: string | null; id?: string | null }>;
+}
+
+/**
+ * Recover the agent label from an existing turn_id, so a caller that omits
+ * `agent` on a later batch continues the chain it started rather than
+ * forking a parallel one under a different label.
+ */
+export function agentFromTurnId(
+  turn_id: string,
+  sessionId: string,
+): string | null {
+  const marker = `-${sessionId}-turn-`;
+  const idx = turn_id.lastIndexOf(marker);
+  return idx > 0 ? turn_id.slice(0, idx) : null;
+}
+
+/**
+ * Build a Turn batch from externally-supplied parts, numbered from
+ * `startOrder`. tool_result content goes through the same `{type, value}`
+ * wrap + 100-char truncation the live emitter applies, so a hive tool result
+ * and a local one look the same in the graph.
+ */
+export function buildExternalTurns(
+  sessionId: string,
+  agent: string,
+  startOrder: number,
+  parts: ExternalTurnInput[],
+): EmittedTurn[] {
+  return parts.map((part, i) => {
+    const order = startOrder + i;
+    const id = turnId(agent, sessionId, order);
+    const content =
+      part.turn_type === "tool_result"
+        ? toolResultContent(part.content)
+        : String(part.content ?? "").slice(0, MAX_CONTENT_CHARS);
+    return {
+      node_key: turnNodeKey(id),
+      prev_node_key:
+        order === 0 ? null : turnNodeKey(turnId(agent, sessionId, order - 1)),
+      turn_id: id,
+      turn_type: part.turn_type,
+      order,
+      content,
+      tool: part.tool ? String(part.tool) : null,
+      tool_call_id: part.tool_call_id ? String(part.tool_call_id) : null,
+      timestamp: Number.isFinite(Number(part.timestamp))
+        ? Math.trunc(Number(part.timestamp))
+        : Date.now(),
+      concepts: (part.concepts ?? [])
+        .map((c) => ({ ref_id: c?.ref_id ?? null, id: c?.id ?? null }))
+        .filter((c) => c.ref_id || c.id),
+    };
+  });
+}
+
 /** Drop the sidecar + in-memory state; called when a session is deleted. */
 export function deleteTurnState(sessionId: string): void {
   states.delete(sessionId);

--- a/mcp/src/repo/turns.ts
+++ b/mcp/src/repo/turns.ts
@@ -55,6 +55,19 @@ interface TurnState extends TurnStateFile {
   queue: Promise<void>;
 }
 
+/**
+ * A Concept a turn read, as the identifiers the reader actually held.
+ *
+ * `repo` is carried so a BARE gitree id (`auth-flow` rather than
+ * `owner/repo/auth-flow`) still resolves: gitree's own reads accept both
+ * forms, so the edge match has to as well — see CONCEPT_LINK_MATCH.
+ */
+export interface ConceptLink {
+  ref_id: string | null;
+  id: string | null;
+  repo?: string | null;
+}
+
 export interface EmittedTurn {
   node_key: string;
   prev_node_key: string | null;
@@ -71,7 +84,7 @@ export interface EmittedTurn {
    * then leaves the property off entirely, which is more honest than a fake.
    */
   timestamp: number | null;
-  concepts: Array<{ ref_id: string | null; id: string | null }>;
+  concepts: ConceptLink[];
 }
 
 const states = new Map<string, TurnState>();
@@ -188,7 +201,7 @@ function buildTurn(
   turn_type: string,
   content: string,
   tool: string | null,
-  concepts: Array<{ ref_id: string | null; id: string | null }> = [],
+  concepts: ConceptLink[] = [],
   toolCallId?: string,
 ): EmittedTurn {
   const order = state.next_order++;
@@ -221,14 +234,15 @@ function scheduleWrite(
       turn_node_key: t.node_key,
       ref_id: c.ref_id,
       id: c.id,
+      repo: c.repo ?? null,
     })),
   );
   const batch = turns.map(({ concepts: _concepts, ...t }) => t);
   state.queue = state.queue
     .then(() => db!.upsert_turns(sessionId, batch))
-    .then(() =>
-      links.length > 0 ? db!.upsert_turn_concept_edges(links) : undefined,
-    )
+    .then(async () => {
+      if (links.length > 0) await db!.upsert_turn_concept_edges(links);
+    })
     .catch((e) => console.error("[turns] Neo4j turn write failed:", e));
 }
 
@@ -316,11 +330,11 @@ export function emitStepTurns(
         ? state.pendingToolInputs.get(part.toolCallId)
         : undefined;
       if (part.toolCallId) state.pendingToolInputs.delete(part.toolCallId);
-      let concepts: Array<{ ref_id: string | null; id: string | null }> = [];
+      let concepts: ConceptLink[] = [];
       try {
         concepts = conceptReadsFrom(toolName, input, toolResultValue(part.output))
           .filter((r) => r.ref_id || r.id)
-          .map((r) => ({ ref_id: r.ref_id ?? null, id: r.id ?? null }));
+          .map((r) => ({ ref_id: r.ref_id ?? null, id: r.id ?? null, repo: r.repo ?? null }));
       } catch {
         // concept detection is best-effort; the turn itself still lands
       }
@@ -411,7 +425,7 @@ export function turnsFromTranscript(
     content: string,
     tool: string | null,
     toolCallId?: string,
-    concepts: Array<{ ref_id: string | null; id: string | null }> = [],
+    concepts: ConceptLink[] = [],
   ) => {
     const order = turns.length;
     const id = turnId(agent, sessionId, order);
@@ -463,11 +477,11 @@ export function turnsFromTranscript(
         const toolName = part.toolName ?? "unknown";
         const input = part.toolCallId ? pendingInputs.get(part.toolCallId) : undefined;
         if (part.toolCallId) pendingInputs.delete(part.toolCallId);
-        let concepts: Array<{ ref_id: string | null; id: string | null }> = [];
+        let concepts: ConceptLink[] = [];
         try {
           concepts = conceptReadsFrom(toolName, input, toolResultValue(part.output))
             .filter((r) => r.ref_id || r.id)
-            .map((r) => ({ ref_id: r.ref_id ?? null, id: r.id ?? null }));
+            .map((r) => ({ ref_id: r.ref_id ?? null, id: r.id ?? null, repo: r.repo ?? null }));
         } catch {
           // best-effort, like the live path
         }
@@ -541,7 +555,7 @@ export interface ExternalTurnInput {
   tool?: string | null;
   tool_call_id?: string | null;
   timestamp?: number | null;
-  concepts?: Array<{ ref_id?: string | null; id?: string | null }>;
+  concepts?: Array<{ ref_id?: string | null; id?: string | null; repo?: string | null }>;
 }
 
 /**
@@ -591,7 +605,11 @@ export function buildExternalTurns(
         ? Math.trunc(Number(part.timestamp))
         : Date.now(),
       concepts: (part.concepts ?? [])
-        .map((c) => ({ ref_id: c?.ref_id ?? null, id: c?.id ?? null }))
+        .map((c) => ({
+          ref_id: c?.ref_id ?? null,
+          id: c?.id ?? null,
+          repo: c?.repo ?? null,
+        }))
         .filter((c) => c.ref_id || c.id),
     };
   });


### PR DESCRIPTION
Lets an agent running **outside** stakgraph — hive's ai-sdk agents — record its run in the graph as a live Turn chain, turn by turn, while it is still running.

Until now every write path (`createSession`, `emitUserTurn`/`emitStepTurns`, `finalizeTurns`, `appendSessionEnd`) was in-process library code coupled to the local `.sessions` directory and a direct Neo4j handle; the HTTP surface for sessions was read-only. The Cypher itself was already remote-safe — everything MERGEs on a deterministic `node_key`, NEXT MERGEs both endpoints so a lost batch self-heals, and every write anchors on `MATCH (s:AgentSession …)`. Only the state sidecar assumed a local caller.

## Endpoints

Four POSTs on the existing sessions API, all behind `authMiddleware` (the read endpoints beside them stay public, as before):

| | |
|---|---|
| `POST /api/sessions` | stub the AgentSession, status `running` |
| `POST /api/sessions/:id/turns` | append a batch of Turns as they happen |
| `POST /api/sessions/:id/end` | totals, status, final `reasoning` → `response` |
| `POST /api/sessions/:id/concepts` | session-level `READ_CONCEPT` rollup (rank/evidence/contradicts) |

## Design

**The graph is the only state.** Turn order comes from the session's chain head (new `GET_TURN_CHAIN_HEAD_QUERY`) unless the caller pins `start_order`, and the agent label is recovered from that head's `turn_id`. So there is no server-side session state to lose, a crashed caller resumes by just posting again, and re-posting an order overwrites that turn in place. In-process writers are untouched — they keep their sidecar cursor.

**Ingested chains are indistinguishable from local ones.** `buildExternalTurns` reuses the live emitter's id scheme (`{agent}-{session}-turn-{n}`, `node_key = "turn-" + stripped`) and its `{type,value}` wrap + 100-char truncation for tool results. A parity test asserts that posting the equivalent parts produces byte-identical `turn_id`s, `node_key`s and types to `emitUserTurn`/`emitStepTurns`.

**Failures are loud where it matters.** Turn writes anchor on the AgentSession node, so a batch for an unknown session writes nothing — reported as a `404` rather than a silent no-op, since it means the caller skipped step one. Validation runs before the graph handle is touched, so a malformed body is a `400` whether or not Neo4j is up.

Two caveats, both documented: token counts accumulate on the session node (so `/end` is once per run), and same-session concurrent posting needs a pinned `start_order` — the in-process serialization queue only covers one server.

## Docs

[`mcp/docs/session-ingest.md`](mcp/docs/session-ingest.md) — short, written for the agent implementing the caller: lifecycle, the ai-sdk part → `turn_type` mapping, ordering/idempotency rules, error table, curl walkthrough.

## Testing

`npm run test:node` — 550 pass, including 10 new cases in `src/repo/__tests__/turn-ingest.test.ts` (chain numbering, live-emitter parity, tool_result shaping, concept filtering, label recovery, every validation branch, and the no-graph guard).

Note this PR also carries `d9d4cc57` (*Pin sub-agent sessions to the Turn that spawned them*), which was already on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)