### PR TITLE
Confine the create_pr write path: fail-closed arming, bash guard, pr sentinel, ephemeral preview worktrees

### DIFF
--- a/mcp/src/repo/__tests__/confinement.test.ts
+++ b/mcp/src/repo/__tests__/confinement.test.ts
@@ -1,0 +1,363 @@
+/**
+ * Tests for write-path confinement (plan: code-change-async-and-confinement):
+ *   tools.ts    — confinedBashRejection guard, bash env token withholding
+ *   agent.ts    — terminalPrResult sentinel (create_pr_not_called)
+ *   git_pr.ts   — acquireEphemeralWorktree lifecycle
+ *
+ * Harness: node:test (tsx --test). No mocks — real git fixtures, real bash.
+ */
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import fs from "fs";
+import path from "path";
+import os from "os";
+import { execSync } from "child_process";
+import { randomUUID } from "crypto";
+
+import {
+  confinedBashRejection,
+  get_tools,
+  type GetToolsOptions,
+  type PrCollector,
+} from "../tools.js";
+import { terminalPrResult } from "../agent.js";
+import {
+  acquireWorktree,
+  acquireEphemeralWorktree,
+  releaseWorktree,
+  gitEnv,
+  type AgentIdentity,
+  type GitHubClient,
+  type WorktreeHandle,
+  type LandChangeResult,
+} from "../git_pr.js";
+
+// ---------------------------------------------------------------------------
+// Helpers / fixtures
+// ---------------------------------------------------------------------------
+
+function tmpDir(): string {
+  return fs.mkdtempSync(path.join(os.tmpdir(), "confinement_test_"));
+}
+
+function localEnv(): NodeJS.ProcessEnv {
+  return {
+    PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+    HOME: os.tmpdir(),
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_ASKPASS: "",
+    GIT_CONFIG_GLOBAL: "/dev/null",
+    GIT_CONFIG_SYSTEM: "/dev/null",
+    GIT_AUTHOR_NAME: "Test",
+    GIT_AUTHOR_EMAIL: "test@example.com",
+    GIT_COMMITTER_NAME: "Test",
+    GIT_COMMITTER_EMAIL: "test@example.com",
+  };
+}
+
+const TEST_IDENTITY: AgentIdentity = {
+  login: "octocat",
+  name: "Octocat",
+  email: "1+octocat@users.noreply.github.com",
+  id: 1,
+};
+
+const FAKE_PAT = "ghp_fakepat123456789012345678901234";
+
+function makeStubClient(): GitHubClient {
+  return {
+    users: {
+      getAuthenticated: async () => ({
+        data: { login: "octocat", id: 1, email: null, name: "Octocat" },
+      }),
+    },
+    repos: {
+      get: async () => ({
+        data: { default_branch: "main", permissions: { push: true } },
+      }),
+    },
+    pulls: {
+      create: async (params: any) => ({
+        data: { number: 1, html_url: `https://github.com/${params.owner}/${params.repo}/pull/1` },
+      }),
+    },
+  } as GitHubClient;
+}
+
+function fakeHandle(worktreePath: string): WorktreeHandle {
+  return {
+    worktreePath,
+    baseDir: "/tmp/owner/repo",
+    baseSha: "abc",
+    baseName: "main",
+    branch: "swarm/swarm-change-abc12345",
+    owner: "owner",
+    repo: "repo",
+    runId: randomUUID(),
+    runHome: os.tmpdir(),
+    _children: new Set(),
+    _released: false,
+  } as WorktreeHandle;
+}
+
+const PR_MODE_OPTS = (worktreePath: string): GetToolsOptions => ({
+  prCollector: { result: undefined },
+  prMode: {
+    handle: fakeHandle(worktreePath),
+    identity: TEST_IDENTITY,
+    env: gitEnv(TEST_IDENTITY, FAKE_PAT, os.tmpdir()),
+    githubClient: makeStubClient(),
+  },
+  baseCheckoutPath: "/tmp/owner/repo",
+});
+
+let testRootDir: string;
+let baseCloneDir: string;
+
+before(() => {
+  testRootDir = tmpDir();
+  baseCloneDir = path.join(testRootDir, "base-clone");
+  fs.mkdirSync(baseCloneDir, { recursive: true });
+  const env = localEnv();
+  execSync("git init -b main .", { cwd: baseCloneDir, env, stdio: "ignore" });
+  fs.writeFileSync(path.join(baseCloneDir, "README.md"), "# confinement test repo\n");
+  execSync("git add README.md", { cwd: baseCloneDir, env, stdio: "ignore" });
+  execSync('git commit -m "Initial commit"', { cwd: baseCloneDir, env, stdio: "ignore" });
+});
+
+after(() => {
+  fs.rmSync(testRootDir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// 1. confinedBashRejection
+// ---------------------------------------------------------------------------
+
+describe("confinedBashRejection", () => {
+  const armed = PR_MODE_OPTS("/tmp/.swarm-work/x/owner/repo");
+  const ephemeral: GetToolsOptions = { ephemeral: true, baseCheckoutPath: "/tmp/owner/repo" };
+
+  it("allows everything when unarmed", () => {
+    assert.equal(confinedBashRejection("git push origin main", undefined), undefined);
+    assert.equal(confinedBashRejection('git commit -m "x"', {}), undefined);
+    assert.equal(confinedBashRejection("gh pr create --title x", {}), undefined);
+  });
+
+  it("still rejects shared-checkout references (baseCheckoutPath guard)", () => {
+    const msg = confinedBashRejection("cat /tmp/owner/repo/README.md", armed);
+    assert.match(msg ?? "", /shared checkout/);
+  });
+
+  it("prMode: rejects git push / commit / remote and gh writes", () => {
+    for (const cmd of [
+      "git push origin main",
+      "git -C /somewhere push --force",
+      'git commit -m "sneaky"',
+      "git add -A && git commit -m x",
+      "git remote get-url origin",
+      "gh pr create --title x --body y",
+      "gh api -X POST /repos/o/r/pulls",
+      "gh repo clone o/r",
+    ]) {
+      const msg = confinedBashRejection(cmd, armed);
+      assert.ok(msg, `should reject: ${cmd}`);
+      assert.match(msg!, /rejected/);
+    }
+  });
+
+  it("prMode: allows read-only git and unrelated commands", () => {
+    for (const cmd of [
+      "git status",
+      "git diff HEAD",
+      "git log --oneline -5",
+      "git log | grep push",
+      "ls -la && cat package.json",
+      "grep -rn 'commit' src/",
+      "echo push commit remote",
+    ]) {
+      assert.equal(confinedBashRejection(cmd, armed), undefined, `should allow: ${cmd}`);
+    }
+  });
+
+  it("ephemeral: same blocklist, preview hint", () => {
+    const msg = confinedBashRejection("git push origin main", ephemeral);
+    assert.ok(msg);
+    assert.match(msg!, /read-only preview/);
+    assert.equal(confinedBashRejection("git diff HEAD", ephemeral), undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. bash tool env — tokens withheld on confined runs
+// ---------------------------------------------------------------------------
+
+describe("bash tool GitHub token env", () => {
+  async function runBashEcho(options: GetToolsOptions | undefined, repoPath: string): Promise<string> {
+    const tools = await get_tools(
+      repoPath,
+      "fake-api-key",
+      FAKE_PAT,
+      { bash: true },
+      undefined, // provider (non-Anthropic branch)
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      undefined, undefined, undefined, undefined, undefined, undefined,
+      options,
+    );
+    const bash = (tools as any).bash;
+    assert.ok(bash?.execute, "bash tool must exist");
+    return String(await bash.execute({ command: 'echo "T:${GH_TOKEN}:${GITHUB_TOKEN}:"' }));
+  }
+
+  it("unconfined run: PAT is exported to bash", async () => {
+    const out = await runBashEcho(undefined, baseCloneDir);
+    assert.ok(out.includes(`T:${FAKE_PAT}:${FAKE_PAT}:`), `got: ${out}`);
+  });
+
+  it("prMode run: tokens are blanked, masking ambient env too", async () => {
+    const prevGh = process.env.GH_TOKEN;
+    process.env.GH_TOKEN = "ambient-container-token";
+    try {
+      const out = await runBashEcho(PR_MODE_OPTS(baseCloneDir), baseCloneDir);
+      assert.ok(out.includes("T:::"), `tokens must be empty, got: ${out}`);
+      assert.ok(!out.includes(FAKE_PAT), "PAT must not leak into confined bash");
+      assert.ok(!out.includes("ambient-container-token"), "ambient token must be masked");
+    } finally {
+      if (prevGh === undefined) delete process.env.GH_TOKEN;
+      else process.env.GH_TOKEN = prevGh;
+    }
+  });
+
+  it("ephemeral run: tokens are blanked", async () => {
+    const out = await runBashEcho(
+      { ephemeral: true, baseCheckoutPath: "/tmp/owner/repo" },
+      baseCloneDir,
+    );
+    assert.ok(out.includes("T:::"), `tokens must be empty, got: ${out}`);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. terminalPrResult sentinel
+// ---------------------------------------------------------------------------
+
+describe("terminalPrResult", () => {
+  const success: LandChangeResult = {
+    ok: true,
+    url: "https://github.com/o/r/pull/1",
+    number: 1,
+    branch: "swarm/swarm-change-abc12345",
+    base: "main",
+    headSha: "deadbeef",
+    diff: "--- a\n+++ b\n",
+    filesChanged: 1,
+  };
+
+  it("passes a collector result through untouched", () => {
+    assert.equal(terminalPrResult(success, { create_pr: true }, undefined), success);
+  });
+
+  it("create_pr enabled + no result → create_pr_not_called sentinel", () => {
+    const pr = terminalPrResult(undefined, { create_pr: true }, undefined);
+    assert.ok(pr && !pr.ok);
+    if (pr && !pr.ok) {
+      assert.equal(pr.failure, "create_pr_not_called");
+      assert.equal(pr.diff, "");
+      assert.match(pr.error, /without invoking the create_pr tool/);
+    }
+  });
+
+  it("sentinel names the worktree branch when prMode is present", () => {
+    const prMode = {
+      handle: fakeHandle("/tmp/.swarm-work/x/owner/repo"),
+      identity: TEST_IDENTITY,
+      env: {},
+      githubClient: makeStubClient(),
+    };
+    const pr = terminalPrResult(undefined, { create_pr: true }, prMode);
+    assert.ok(pr && !pr.ok);
+    if (pr && !pr.ok) {
+      assert.match(pr.error, /swarm\/swarm-change-abc12345/);
+    }
+  });
+
+  it("create_pr disabled → undefined (no sentinel noise on normal runs)", () => {
+    assert.equal(terminalPrResult(undefined, { bash: true }, undefined), undefined);
+    assert.equal(terminalPrResult(undefined, undefined, undefined), undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. acquireEphemeralWorktree lifecycle
+// ---------------------------------------------------------------------------
+
+describe("acquireEphemeralWorktree", () => {
+  it("creates a detached worktree at HEAD; base checkout stays clean; release removes it", async () => {
+    const runId = randomUUID();
+    const env = localEnv();
+    const baseHead = execSync("git rev-parse HEAD", { cwd: baseCloneDir, env, encoding: "utf8" }).trim();
+
+    const result = await acquireEphemeralWorktree({
+      baseDir: baseCloneDir,
+      owner: "owner",
+      repo: "repo",
+      runId,
+    });
+    assert.ok(result.ok, `acquire failed: ${(result as any).error}`);
+    const handle = result.handle;
+
+    try {
+      assert.ok(fs.existsSync(handle.worktreePath), "worktree dir must exist");
+      const wtHead = execSync("git rev-parse HEAD", { cwd: handle.worktreePath, env, encoding: "utf8" }).trim();
+      assert.equal(wtHead, baseHead, "worktree must be at the base HEAD");
+      assert.equal(handle.branch, "", "ephemeral worktree is detached — no branch");
+
+      // Dirty the worktree — the base must stay pristine.
+      fs.writeFileSync(path.join(handle.worktreePath, "README.md"), "dirtied by preview\n");
+      const baseStatus = execSync("git status --porcelain", { cwd: baseCloneDir, env, encoding: "utf8" }).trim();
+      assert.equal(baseStatus, "", "base checkout must remain clean while worktree is dirty");
+    } finally {
+      await releaseWorktree(handle);
+    }
+
+    assert.ok(!fs.existsSync(handle.worktreePath), "worktree dir must be removed on release");
+    const baseStatusAfter = execSync("git status --porcelain", { cwd: baseCloneDir, env: localEnv(), encoding: "utf8" }).trim();
+    assert.equal(baseStatusAfter, "", "base checkout must remain clean after release");
+  });
+
+  it("PR worktree release deletes the swarm/swarm-change-* branch ref from the base repo", async () => {
+    const runId = randomUUID();
+    const env = localEnv();
+    const baseSha = execSync("git rev-parse HEAD", { cwd: baseCloneDir, env, encoding: "utf8" }).trim();
+    const result = await acquireWorktree({
+      baseDir: baseCloneDir,
+      owner: "owner",
+      repo: "repo",
+      runId,
+      pat: FAKE_PAT,
+      githubClient: makeStubClient(),
+      commit: baseSha, // pin to a local sha so no fetch happens
+    });
+    assert.ok(result.ok, `acquire failed: ${(result as any).error}`);
+    const handle = result.handle;
+    assert.equal(handle.branch, `swarm/swarm-change-${runId.slice(0, 8)}`);
+
+    const listBranches = () =>
+      execSync("git branch --list 'swarm/*'", { cwd: baseCloneDir, env, encoding: "utf8" }).trim();
+    assert.ok(listBranches().includes(handle.branch), "branch ref must exist while worktree is live");
+
+    await releaseWorktree(handle);
+    assert.equal(listBranches(), "", "branch ref must be deleted on release");
+  });
+
+  it("rejects a traversal runId before any filesystem side effect", async () => {
+    const result = await acquireEphemeralWorktree({
+      baseDir: baseCloneDir,
+      owner: "owner",
+      repo: "repo",
+      runId: "../../etc",
+    });
+    assert.ok(!result.ok, "traversal runId must be rejected");
+    if (!result.ok) assert.match(result.error, /Path traversal rejected/);
+  });
+});

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -441,6 +441,14 @@ export interface GetContextOptions {
     env: NodeJS.ProcessEnv;
     githubClient: import("./git_pr.js").GitHubClient;
   };
+  /**
+   * Ephemeral throwaway-worktree run (read-only preview isolation). Arms the
+   * same bash/editor confinement as prMode — no git write commands, no ambient
+   * GitHub tokens — with `baseCheckoutPath` (the shared clone) rejected in
+   * bash commands. The caller acquires/releases the worktree; repoPath must
+   * already point inside it.
+   */
+  ephemeral?: { baseCheckoutPath: string };
   toolsConfig?: ToolsConfig;
   systemOverride?: string;
   // Selects the base system prompt persona. "graph" uses a generalized
@@ -573,6 +581,30 @@ function isAbortError(err: unknown): boolean {
   return false;
 }
 
+/**
+ * Terminal `pr` field for a run. When create_pr was enabled, an absent
+ * collector result becomes an explicit `create_pr_not_called` sentinel, so a
+ * receiver can distinguish "the tool never ran" from a malformed payload —
+ * exactly the confusion the 2026-08-19 incident presented as.
+ */
+export function terminalPrResult(
+  collectorResult: import("./git_pr.js").LandChangeResult | undefined,
+  toolsConfig: ToolsConfig | undefined,
+  prMode: GetContextOptions["prMode"],
+): import("./git_pr.js").LandChangeResult | undefined {
+  if (collectorResult) return collectorResult;
+  if (!toolConfigEnabled(toolsConfig?.create_pr)) return undefined;
+  const branchNote = prMode?.handle?.branch
+    ? ` The run's worktree branch '${prMode.handle.branch}' was never pushed.`
+    : "";
+  return {
+    ok: false,
+    failure: "create_pr_not_called",
+    diff: "",
+    error: `The run completed without invoking the create_pr tool; this run opened no PR.${branchNote}`,
+  };
+}
+
 async function prepareAgent(
   prompt: string | ModelMessage[],
   repoPath: string,
@@ -603,6 +635,16 @@ async function prepareAgent(
   const { model, apiKey, provider, contextLimit, modelId } = getModelDetails(modelName, apiKeyIn, baseUrl, opts.headers, opts.abortSignal);
   console.log("===> model", modelId, "provider", provider, "contextLimit", contextLimit);
 
+  // Fail closed: a run that asked for create_pr but has no armed worktree
+  // must error, never degrade into an unconfined shared-checkout run with a
+  // live push token (see the 2026-08-19 incident: an agent hand-rolled a PR
+  // with bash + gh because nothing was confined and create_pr had no handle).
+  if (toolConfigEnabled(toolsConfig?.create_pr) && !opts.prMode) {
+    throw new Error(
+      "create_pr was requested but no worktree/identity was armed for this run — refusing to run unconfined",
+    );
+  }
+
   const messagesRef: MessagesRef = { current: [] };
   const provenanceCollector: ProvenanceCollector = { entries: [] };
   const prCollector: import("./tools.js").PrCollector = { result: undefined };
@@ -629,13 +671,19 @@ async function prepareAgent(
     // Thread the run's AbortSignal so Jarvis HTTP calls honour abort/timeout.
     opts.abortSignal,
     // create_pr path: worktree handle, collector, and base checkout guard.
+    // Ephemeral path: confinement only — same guards, no create_pr tool.
     opts.prMode
       ? {
           prCollector,
           prMode: opts.prMode,
           baseCheckoutPath: `/tmp/${opts.prMode.handle.owner}/${opts.prMode.handle.repo}`,
         }
-      : undefined,
+      : opts.ephemeral
+        ? {
+            ephemeral: true,
+            baseCheckoutPath: opts.ephemeral.baseCheckoutPath,
+          }
+        : undefined,
   );
 
   // Load and merge MCP server tools if configured.
@@ -1429,7 +1477,7 @@ export async function get_context(
     logs: opts.logs ? JSON.stringify(steps, null, 2) : undefined,
     sessionId,
     reflection,
-    pr: prepared.prCollector.result,
+    pr: terminalPrResult(prepared.prCollector.result, opts.toolsConfig, opts.prMode),
   };
 }
 

--- a/mcp/src/repo/git_pr.ts
+++ b/mcp/src/repo/git_pr.ts
@@ -609,6 +609,119 @@ async function _acquireWorktree(
 }
 
 // ---------------------------------------------------------------------------
+// acquireEphemeralWorktree — throwaway isolation for read-only preview runs
+// ---------------------------------------------------------------------------
+
+export interface AcquireEphemeralWorktreeOpts {
+  baseDir: string;
+  owner: string;
+  repo: string;
+  runId: string;
+  signal?: AbortSignal;
+}
+
+/**
+ * Acquire a throwaway detached worktree at the base checkout's current HEAD.
+ * No fetch, no identity, no branch, no credentials — purely local isolation so
+ * a run can apply and inspect changes without dirtying the shared checkout.
+ * Released with the same releaseWorktree as PR worktrees; everything the run
+ * wrote is discarded.
+ */
+export async function acquireEphemeralWorktree(
+  opts: AcquireEphemeralWorktreeOpts
+): Promise<AcquireWorktreeResult> {
+  return withRepoLock(opts.baseDir, () => _acquireEphemeralWorktree(opts));
+}
+
+async function _acquireEphemeralWorktree(
+  opts: AcquireEphemeralWorktreeOpts
+): Promise<AcquireWorktreeResult> {
+  const { baseDir, owner, repo, runId, signal } = opts;
+
+  // Same traversal guard as _acquireWorktree: anchor against the static root.
+  const worktreePath = path.resolve(
+    path.join(SWARM_WORK_ROOT, runId, owner, repo)
+  );
+  const rel = path.relative(path.resolve(SWARM_WORK_ROOT), worktreePath);
+  if (rel.startsWith("..") || rel.split(path.sep).length !== 3) {
+    return {
+      ok: false,
+      failure: "base_repo_vanished",
+      error: `Path traversal rejected: ${worktreePath}`,
+    };
+  }
+
+  if (!fs.existsSync(path.join(baseDir, ".git"))) {
+    return {
+      ok: false,
+      failure: "base_repo_vanished",
+      error: `Not a git repository (no .git): ${baseDir}`,
+    };
+  }
+
+  const localEnv: NodeJS.ProcessEnv = {
+    PATH: process.env.PATH ?? "/usr/local/bin:/usr/bin:/bin",
+    HOME: os.tmpdir(),
+    GIT_TERMINAL_PROMPT: "0",
+    GIT_ASKPASS: "",
+  };
+
+  const shaRes = await runGit(["rev-parse", "HEAD"], {
+    cwd: baseDir,
+    env: localEnv,
+    timeoutMs: 10_000,
+    signal,
+  });
+  if (shaRes.code !== 0) {
+    return {
+      ok: false,
+      failure: "base_repo_vanished",
+      error: `Cannot resolve HEAD in ${baseDir}: ${shaRes.stderr}`,
+    };
+  }
+  const baseSha = shaRes.stdout.trim();
+
+  const runHome = path.join(SWARM_WORK_ROOT, runId, ".home");
+  fs.mkdirSync(runHome, { mode: 0o700, recursive: true });
+
+  fs.mkdirSync(worktreePath, { mode: 0o700, recursive: true });
+  try {
+    fs.rmdirSync(worktreePath);
+  } catch {
+    // non-empty or doesn't exist — git will fail with its own message
+  }
+
+  const worktreeRes = await runGit(
+    ["worktree", "add", "--detach", worktreePath, baseSha],
+    { cwd: baseDir, env: localEnv, timeoutMs: 30_000, signal }
+  );
+  if (worktreeRes.code !== 0) {
+    fs.rmSync(worktreePath, { recursive: true, force: true });
+    return {
+      ok: false,
+      failure: "base_repo_vanished",
+      error: `git worktree add failed: ${worktreeRes.stderr}`,
+    };
+  }
+  try { fs.chmodSync(worktreePath, 0o700); } catch { /* best-effort */ }
+
+  const handle: WorktreeHandle = {
+    worktreePath,
+    baseDir,
+    baseSha,
+    baseName: "",
+    branch: "",
+    owner,
+    repo,
+    runId,
+    runHome,
+    _children: new Set(),
+    _released: false,
+  };
+  return { ok: true, handle };
+}
+
+// ---------------------------------------------------------------------------
 // releaseWorktree — idempotent cleanup
 // ---------------------------------------------------------------------------
 
@@ -657,6 +770,19 @@ export async function releaseWorktree(handle: WorktreeHandle): Promise<void> {
       env: localEnv,
       timeoutMs: 10_000,
     }).catch(() => {});
+
+    // Delete the run's branch ref — it was created in the worktree but lives
+    // in the base repo's shared refs, so without this every PR run leaves a
+    // swarm/swarm-change-* branch behind. Must come after worktree remove
+    // (git refuses to delete a branch checked out anywhere). Ephemeral
+    // worktrees are detached (branch === "").
+    if (handle.branch) {
+      await runGit(["branch", "-D", handle.branch], {
+        cwd: handle.baseDir,
+        env: localEnv,
+        timeoutMs: 10_000,
+      }).catch(() => {});
+    }
   }
 
   const runDir = path.join(SWARM_WORK_ROOT, handle.runId);
@@ -728,7 +854,12 @@ export type LandChangeFailure = {
     | "identity_mismatch"
     | "no_push_permission"
     | "aborted"
-    | "already_landed";
+    | "already_landed"
+    // Sentinel emitted by the run terminal (never by landChange itself): the
+    // run had create_pr enabled but finished without ever invoking the tool.
+    // Its presence makes "tool not called" distinguishable from a malformed
+    // payload on the receiving side.
+    | "create_pr_not_called";
   diff: string;
   error: string;
 };

--- a/mcp/src/repo/index.ts
+++ b/mcp/src/repo/index.ts
@@ -29,9 +29,11 @@ import {
 import { db } from "../graph/neo4j.js";
 import {
   acquireWorktree,
+  acquireEphemeralWorktree,
   releaseWorktree,
   resolveIdentity,
   gitEnv,
+  branchName,
   OctokitGitHubClient,
   type WorktreeHandle,
 } from "./git_pr.js";
@@ -87,6 +89,28 @@ function resolveRepoDir(repoList: string[]): string {
     }
   }
   return "/tmp";
+}
+
+/**
+ * Confined-run variant of prependRepoInfo. The standard block advertises the
+ * shared clones under /tmp/{owner}/{repo} — exactly where a confined run must
+ * NOT work (the bash guard rejects any command referencing that path). Live
+ * testing showed the model dutifully cd-ing into the shared checkout for every
+ * command because the preamble told it to. This block points it at its
+ * worktree cwd instead.
+ */
+function prependWorktreeInfo(prompt: any, repo: string): any {
+  const info =
+    `You are working in an isolated git worktree checkout of ${repo}. ` +
+    `It is your current working directory — use relative paths for every file and git operation. ` +
+    `Do NOT cd into or reference /tmp/${repo} (the shared checkout); commands referencing it are rejected.\n\n`;
+  if (typeof prompt === "string") return info + prompt;
+  if (Array.isArray(prompt)) {
+    return prompt.map((msg: any, i: number) =>
+      i === 0 && msg.role === "user" ? { ...msg, content: info + msg.content } : msg,
+    );
+  }
+  return prompt;
 }
 
 function prependRepoInfo(prompt: any, clonedRepos: string[], graphRepos: string[]): any {
@@ -228,6 +252,11 @@ function parseAgentBody(req: Request) {
     typeof req.body.webhookUrl === "string" && req.body.webhookUrl.trim()
       ? req.body.webhookUrl.trim()
       : undefined;
+  // Run the agent in a throwaway detached worktree of the (single) repo and
+  // discard everything on completion. For read-only preview runs that apply a
+  // diff locally: the shared checkout stays clean, and the run gets the same
+  // bash/editor confinement as a create_pr run (no git writes, no tokens).
+  const ephemeral = req.body.ephemeral === true;
 
   const repoList = (repoUrl || "")
     .split(",")
@@ -238,7 +267,7 @@ function parseAgentBody(req: Request) {
     repoUrl, username, pat, commitList, prompt, messages, toolsConfig, schema,
     modelName, apiKey, baseUrl, logs, sessionId, sessionConfig, mcpServers,
     systemOverride, mode, skills, ontologyDomains, subAgents, ggnn, stream, repoList, maxTurns, headers,
-    ignoreRepoInfo, attachments, _metadata, agentName, webhookUrl, reflect,
+    ignoreRepoInfo, attachments, _metadata, agentName, webhookUrl, reflect, ephemeral,
     stakwork: stakworkApiKey ? { apiKey: stakworkApiKey, baseUrl: stakworkBaseUrl } : undefined,
     googleSheets,
   };
@@ -576,6 +605,20 @@ export async function repo_agent(req: Request, res: Response) {
   let prRepo = "";
   let prWorktreeHandle: WorktreeHandle | undefined;
 
+  // ── ephemeral admission checks ────────────────────────────────────────
+  if (body.ephemeral) {
+    // create_pr manages its own worktree; combining the two is ambiguous.
+    if (toolConfigEnabled(body.toolsConfig?.create_pr)) {
+      res.status(400).json({ error: "ephemeral cannot be combined with toolsConfig.create_pr" });
+      return;
+    }
+    // The worktree is created from one base checkout — no multi-repo runs.
+    if (body.repoList.length !== 1) {
+      res.status(400).json({ error: "ephemeral requires exactly one explicit repo_url" });
+      return;
+    }
+  }
+
   if (toolConfigEnabled(body.toolsConfig?.create_pr)) {
     // 1. Auth bypass guard: authMiddleware returns next() when API_TOKEN is unset.
     //    A git write path must never be reachable via that bypass.
@@ -645,11 +688,16 @@ export async function repo_agent(req: Request, res: Response) {
   // Only prepend repo info on the first message of a session (or when there's no session).
   // In transparent mode the replayed messages are sent verbatim — no repo info.
   const isExistingSession = body.sessionId && sessionExists(body.sessionId);
+  // Confined runs (create_pr or ephemeral) work in a per-run worktree — the
+  // standard repo-info block would misdirect them to the shared checkout.
+  const confinedRun = body.ephemeral || toolConfigEnabled(body.toolsConfig?.create_pr);
   const promptInput: string | ModelMessage[] = transparent
     ? body.messages!
-    : (isExistingSession || body.ignoreRepoInfo || body.mode === "graph" || body.mode === "workflow")
-      ? body.prompt
-      : prependRepoInfo(body.prompt, body.repoList, graphRepos);
+    : confinedRun && body.repoList.length === 1
+      ? prependWorktreeInfo(body.prompt, body.repoList[0])
+      : (isExistingSession || body.ignoreRepoInfo || body.mode === "graph" || body.mode === "workflow")
+        ? body.prompt
+        : prependRepoInfo(body.prompt, body.repoList, graphRepos);
   // ── Streaming path: direct SSE response ──────────────────────────────
   if (body.stream) {
     // Register abort controller keyed by sessionId so a separate request can cancel it
@@ -665,7 +713,19 @@ export async function repo_agent(req: Request, res: Response) {
       // create_pr path: acquire a per-run worktree and use it as the agent's
       // working directory so all file edits are isolated from the shared clone.
       let streamPrMode: Parameters<typeof stream_context>[2]["prMode"] | undefined;
-      if (toolConfigEnabled(body.toolsConfig?.create_pr) && prResolvedIdentity?.ok) {
+      let streamEphemeral: Parameters<typeof stream_context>[2]["ephemeral"] | undefined;
+      if (toolConfigEnabled(body.toolsConfig?.create_pr)) {
+        // Fail closed: admission sets prResolvedIdentity for every create_pr
+        // run, so its absence here means the run would otherwise proceed
+        // unconfined in the shared checkout with a live push token. Refuse.
+        if (!prResolvedIdentity?.ok) {
+          endTracking(opId);
+          unregisterAbortController(body.sessionId, abortController);
+          res.status(500).json({
+            error: "create_pr was requested but identity resolution did not complete — refusing unconfined run",
+          });
+          return;
+        }
         const identity = prResolvedIdentity.identity;
         const githubClient = new OctokitGitHubClient(body.pat!);
         const baseDir = repoDir;
@@ -687,12 +747,38 @@ export async function repo_agent(req: Request, res: Response) {
         prWorktreeHandle = worktreeResult.handle;
         activeWorktrees.set(runId, prWorktreeHandle);
         repoDir = worktreeResult.handle.worktreePath;
+        console.log(
+          `[repo_agent] prMode armed (stream): runId=${runId} worktree=${prWorktreeHandle.worktreePath} branch=${prWorktreeHandle.branch}`,
+        );
         streamPrMode = {
           handle: worktreeResult.handle,
           identity,
           env: gitEnv(identity, body.pat!, worktreeResult.handle.runHome),
           githubClient,
         };
+      } else if (body.ephemeral) {
+        const baseDir = repoDir;
+        const parts = baseDir.split(path.sep).filter(Boolean);
+        const ephResult = await acquireEphemeralWorktree({
+          baseDir,
+          owner: parts[parts.length - 2] ?? "repo",
+          repo: parts[parts.length - 1] ?? "repo",
+          runId,
+          signal: abortController.signal,
+        });
+        if (!ephResult.ok) {
+          endTracking(opId);
+          unregisterAbortController(body.sessionId, abortController);
+          res.status(500).json({ error: ephResult.error, failure: ephResult.failure });
+          return;
+        }
+        prWorktreeHandle = ephResult.handle;
+        activeWorktrees.set(runId, prWorktreeHandle);
+        repoDir = ephResult.handle.worktreePath;
+        console.log(
+          `[repo_agent] ephemeral worktree armed (stream): runId=${runId} worktree=${repoDir} base=${baseDir}`,
+        );
+        streamEphemeral = { baseCheckoutPath: baseDir };
       }
 
       const { streamResult, prCollector, finalizeSession, closeMcpClients } = await stream_context(
@@ -731,6 +817,7 @@ export async function repo_agent(req: Request, res: Response) {
           ignoreRepoInfo: body.ignoreRepoInfo,
           reflect: body.reflect,
           prMode: streamPrMode,
+          ephemeral: streamEphemeral,
         },
       );
 
@@ -859,7 +946,16 @@ export async function repo_agent(req: Request, res: Response) {
         // create_pr path: acquire worktree for the non-streaming agent run.
         let effectiveRepoDir = repoDir;
         let nonStreamPrMode: Parameters<typeof get_context>[2]["prMode"] | undefined;
-        if (toolConfigEnabled(body.toolsConfig?.create_pr) && prResolvedIdentity?.ok) {
+        let nonStreamEphemeral: Parameters<typeof get_context>[2]["ephemeral"] | undefined;
+        if (toolConfigEnabled(body.toolsConfig?.create_pr)) {
+          // Fail closed: never degrade a create_pr run into an unconfined
+          // shared-checkout run (admission guarantees prResolvedIdentity; if
+          // that invariant ever breaks, the run must error, not proceed).
+          if (!prResolvedIdentity?.ok) {
+            throw new Error(
+              "create_pr was requested but identity resolution did not complete — refusing unconfined run",
+            );
+          }
           const identity = prResolvedIdentity.identity;
           const githubClient = new OctokitGitHubClient(body.pat!);
           const wResult = await acquireWorktree({
@@ -876,12 +972,32 @@ export async function repo_agent(req: Request, res: Response) {
           prWorktreeHandle = wResult.handle;
           activeWorktrees.set(runId, wResult.handle);
           effectiveRepoDir = wResult.handle.worktreePath;
+          console.log(
+            `[repo_agent] prMode armed: request_id=${request_id} runId=${runId} worktree=${effectiveRepoDir} branch=${wResult.handle.branch}`,
+          );
           nonStreamPrMode = {
             handle: wResult.handle,
             identity,
             env: gitEnv(identity, body.pat!, wResult.handle.runHome),
             githubClient,
           };
+        } else if (body.ephemeral) {
+          const parts = repoDir.split(path.sep).filter(Boolean);
+          const ephResult = await acquireEphemeralWorktree({
+            baseDir: repoDir,
+            owner: parts[parts.length - 2] ?? "repo",
+            repo: parts[parts.length - 1] ?? "repo",
+            runId,
+            signal: abortController.signal,
+          });
+          if (!ephResult.ok) throw new Error(`${ephResult.failure}: ${ephResult.error}`);
+          nonStreamWorktreeHandle = ephResult.handle;
+          activeWorktrees.set(runId, ephResult.handle);
+          effectiveRepoDir = ephResult.handle.worktreePath;
+          console.log(
+            `[repo_agent] ephemeral worktree armed: request_id=${request_id} runId=${runId} worktree=${effectiveRepoDir} base=${repoDir}`,
+          );
+          nonStreamEphemeral = { baseCheckoutPath: repoDir };
         }
         return get_context(promptInput, effectiveRepoDir, {
           transparent,
@@ -889,6 +1005,7 @@ export async function repo_agent(req: Request, res: Response) {
           username: body.username,
           toolsConfig: body.toolsConfig,
           prMode: nonStreamPrMode,
+          ephemeral: nonStreamEphemeral,
           schema: body.schema,
           modelName: body.modelName,
           apiKey: body.apiKey,
@@ -1010,7 +1127,19 @@ export async function repo_agent(req: Request, res: Response) {
         }
         endTracking(opId);
       });
-    res.json({ request_id, status: "pending", sessionId: body.sessionId, ...(events_token && { events_token }) });
+    res.json({
+      request_id,
+      status: "pending",
+      sessionId: body.sessionId,
+      ...(events_token && { events_token }),
+      // create_pr runs: the exact branch landChange will push, deterministic
+      // from the per-run runId. Returned because request_id is NOT the runId —
+      // a caller cannot derive the branch itself, and GitHub's `head` filter
+      // is an exact match, so reconciliation needs the real name.
+      ...(toolConfigEnabled(body.toolsConfig?.create_pr) && {
+        pr_branch: branchName(runId, "swarm-change"),
+      }),
+    });
   } catch (error) {
     console.log("===> error");
     // Guard: skip terminal disk write + webhook during shutdown; drain owns them.

--- a/mcp/src/repo/tools.ts
+++ b/mcp/src/repo/tools.ts
@@ -113,6 +113,58 @@ export interface GetToolsOptions {
   };
   /** create_pr path: base checkout path (shared clone) to reject in bash commands */
   baseCheckoutPath?: string;
+  /**
+   * Ephemeral (throwaway-worktree) run: arms the same bash/editor confinement
+   * as prMode — no git write commands, no ambient GitHub tokens, strict editor
+   * roots — without a create_pr tool. Used by read-only preview runs.
+   */
+  ephemeral?: boolean;
+}
+
+/** Whether this run is confined to a per-run worktree (PR run or ephemeral preview). */
+function confinedRun(options?: GetToolsOptions): boolean {
+  return Boolean(options?.prMode || options?.ephemeral);
+}
+
+/**
+ * Bash confinement for worktree-confined runs. Returns a rejection message,
+ * or undefined when the command is allowed.
+ *
+ * A guard, not a sandbox — the backstops are the withheld GitHub tokens and,
+ * on the create_pr path, base-dirty detection. `git push` must be blocked even
+ * with tokens withheld because the shared clone's origin URL embeds the PAT
+ * (clone.ts inlines credentials), and a worktree shares the base repo's
+ * remote config.
+ */
+export function confinedBashRejection(
+  command: string,
+  options?: GetToolsOptions,
+): string | undefined {
+  if (options?.baseCheckoutPath && command.includes(options.baseCheckoutPath)) {
+    return (
+      `bash command rejected: references the shared checkout '${options.baseCheckoutPath}'. ` +
+      `Your current working directory is an isolated worktree of the same repo — rerun the command there using relative paths.`
+    );
+  }
+  if (!confinedRun(options)) return undefined;
+  // [regex, label]: the char class stops at command separators so a match
+  // never spans two piped/chained commands ("git log | grep push" is fine —
+  // each chained command gets its own `\bgit\b … \bpush\b` evaluation).
+  const blocked: Array<[RegExp, string]> = [
+    [/\bgit\b[^\n|;&]*\bpush\b/, "git push"],
+    [/\bgit\b[^\n|;&]*\bcommit\b/, "git commit"],
+    [/\bgit\b[^\n|;&]*\bremote\b/, "git remote"],
+    [/\bgh\s+(pr|api|repo|release)\b/, "gh write commands"],
+  ];
+  for (const [re, label] of blocked) {
+    if (re.test(command)) {
+      const hint = options?.prMode
+        ? "Commit/push/PR creation happen exclusively through the create_pr tool."
+        : "This is a read-only preview run — no remote writes.";
+      return `bash command rejected: ${label} is not allowed on this run. ${hint}`;
+    }
+  }
+  return undefined;
 }
 
 type ToolName =
@@ -683,9 +735,30 @@ export async function get_tools(
 
   // Per-request GitHub auth for the `gh` CLI (and any tool reading GH_TOKEN).
   // Scoped to this request's PAT so `gh` acts as the requesting user.
-  const ghEnv: NodeJS.ProcessEnv | undefined = pat
-    ? { GH_TOKEN: pat, GITHUB_TOKEN: pat }
-    : undefined;
+  //
+  // Confined runs (create_pr worktree or ephemeral preview) get the tokens
+  // BLANKED instead: executeBashCommand spreads process.env under this
+  // overlay, so an empty string is the only way to also mask any ambient
+  // container token. On the create_pr path landChange() supplies its own
+  // credentialed env via gitEnv() — bash never needs a push token.
+  const ghEnv: NodeJS.ProcessEnv | undefined = confinedRun(options)
+    ? { GH_TOKEN: "", GITHUB_TOKEN: "" }
+    : pat
+      ? { GH_TOKEN: pat, GITHUB_TOKEN: pat }
+      : undefined;
+
+  const executeGuardedBash = async ({ command }: { command: string }) => {
+    const rejection = confinedBashRejection(command, options);
+    if (rejection) {
+      console.log(`[bash-guard] rejected: ${command.slice(0, 200)}`);
+      return rejection;
+    }
+    try {
+      return await executeBashCommand(command, repoPath, 60000, ghEnv);
+    } catch (e) {
+      return `Command execution failed: ${e}`;
+    }
+  };
 
   // Always register bash tool — Anthropic uses native provider tool, others use executeBashCommand
   if (bash_tool) {
@@ -695,19 +768,7 @@ export async function get_tools(
       inputSchema: z.object({
         command: z.string().describe("The bash command to execute"),
       }),
-      execute: async ({ command }: { command: string }) => {
-        // Bash confinement (create_pr path): reject commands referencing the
-        // shared checkout — a guard, not a sandbox; base-dirty detection is
-        // the backstop for anything that slips through.
-        if (options?.baseCheckoutPath && command.includes(options.baseCheckoutPath)) {
-          return `bash command rejected: references the shared checkout '${options.baseCheckoutPath}'. Work inside the worktree instead.`;
-        }
-        try {
-          return await executeBashCommand(command, repoPath, 60000, ghEnv);
-        } catch (e) {
-          return `Command execution failed: ${e}`;
-        }
-      },
+      execute: executeGuardedBash,
     });
   } else {
     // Non-Anthropic: use executeBashCommand directly
@@ -716,19 +777,7 @@ export async function get_tools(
       inputSchema: z.object({
         command: z.string().describe("The bash command to execute"),
       }),
-      execute: async ({ command }: { command: string }) => {
-        // Bash confinement (create_pr path): reject commands referencing the
-        // shared checkout — a guard, not a sandbox; base-dirty detection is
-        // the backstop for anything that slips through.
-        if (options?.baseCheckoutPath && command.includes(options.baseCheckoutPath)) {
-          return `bash command rejected: references the shared checkout '${options.baseCheckoutPath}'. Work inside the worktree instead.`;
-        }
-        try {
-          return await executeBashCommand(command, repoPath, 60000, ghEnv);
-        } catch (e) {
-          return `Command execution failed: ${e}`;
-        }
-      },
+      execute: executeGuardedBash,
     });
   }
 
@@ -1339,7 +1388,7 @@ export async function get_tools(
         const baseURL = getGatewayBaseURL("anthropic");
         const ant = createAnthropic({ apiKey, ...(baseURL && { baseURL }) });
         allTools.str_replace_based_edit_tool = ant.tools.textEditor_20250728({
-          execute: async (input) => textEdit(input as TextEditInput, editorRoots(repoPath, Boolean(options?.prMode))),
+          execute: async (input) => textEdit(input as TextEditInput, editorRoots(repoPath, confinedRun(options))),
         }) as any as Tool<any, any>;
       } else {
         // Generic fallback for OpenAI / other providers
@@ -1357,7 +1406,7 @@ export async function get_tools(
             insert_text: z.string().optional(),
             view_range: z.array(z.number().int()).length(2).optional(),
           }),
-          execute: async (input) => textEdit(input as TextEditInput, editorRoots(repoPath, Boolean(options?.prMode))),
+          execute: async (input) => textEdit(input as TextEditInput, editorRoots(repoPath, confinedRun(options))),
         });
       }
     }
@@ -1415,8 +1464,12 @@ export async function get_tools(
           body: string;
         }) => {
           if (!prOpts) {
+            console.error("[create_pr] invoked with no worktree handle — refusing");
             return "create_pr is not available: no worktree handle was resolved for this run";
           }
+          console.log(
+            `[create_pr] invoked: runId=${prOpts.handle.runId} branch=${prOpts.handle.branch} title=${JSON.stringify(title.slice(0, 120))}`,
+          );
           const result = await landChange({
             handle: prOpts.handle,
             identity: prOpts.identity,
@@ -1428,6 +1481,11 @@ export async function get_tools(
           if (prColl) {
             prColl.result = result;
           }
+          console.log(
+            result.ok
+              ? `[create_pr] landed: ${result.url} (${result.filesChanged} files)`
+              : `[create_pr] failed: ${result.failure} — ${result.error.slice(0, 300)}`,
+          );
           if (result.ok) {
             return (
               `PR created successfully!\n` +


### PR DESCRIPTION
## Why

The first real end-to-end `propose_code_change` approval (2026-08-19) produced a PR that **bypassed the entire landing pipeline**: the agent hand-rolled it with `bash` + `gh` from the shared checkout on its own branch, because `prMode` was not armed and nothing refused the remote write. Hive then misreported "tool never ran" as a shape error, and the proposal was left permanently blocked. Full analysis lives in `hive/docs/plans/code-change-async-and-confinement.md` (Part 2 = this PR).

## What

**Fail closed (2.3).** A run with `toolsConfig.create_pr` that cannot arm its worktree/identity now errors — both arming sites in `index.ts`, plus a belt-and-braces guard in `prepareAgent` covering every other `get_context` caller. No more silent degradation into an unconfined run holding a live push token.

**Bash confinement (2.1).** New `confinedBashRejection()`: on confined runs, `git push`, `git commit`, `git remote`, and `gh pr|api|repo|release` are refused, on top of the existing shared-checkout path guard. `GH_TOKEN`/`GITHUB_TOKEN` are **blanked** (not omitted — the executor spreads `process.env`, so only an empty override masks ambient tokens). `git push`/`git remote` must be blocked at the command layer regardless, because the shared clone's `origin` URL embeds the PAT and worktrees share the base repo's remote config (`git remote get-url origin` printed the PAT to the model).

**`pr` sentinel (2.5).** `create_pr` runs always carry a terminal `pr` field. When the tool never ran: `{ ok: false, failure: "create_pr_not_called", ... }` naming the unpushed branch — the incident's failure mode is now explicit instead of indistinguishable from a malformed payload.

**Ephemeral preview worktrees (2.4).** New `ephemeral: true` body flag: the run executes in a throwaway detached worktree at the base checkout's HEAD (no fetch, no credentials, no branch) with the same confinement, released on every exit path. Read-only preview runs stop dirtying the shared checkout. `ephemeral` + `create_pr` and `ephemeral` without exactly one `repo_url` are 400s at admission.

**`pr_branch` in the dispatch response.** `runId !== request_id`, so callers could never derive the `swarm/swarm-change-<runId8>` branch for reconciliation — the dispatch response now returns it.

**Smaller fixes found during live testing:**
- `releaseWorktree` deletes the run's branch ref from the base repo (previously leaked one per PR run)
- Confined runs get a worktree-aware prompt preamble — the standard repo-info block pointed the model at `/tmp/{owner}/{repo}`, and it dutifully `cd`'d into the shared checkout for every command
- Diagnostics logging: `prMode armed`, `ephemeral worktree armed`, `[create_pr] invoked/landed/failed`, `[bash-guard] rejected`

## Testing

`mcp/src/repo/__tests__/confinement.test.ts` — 15 tests over the guard patterns, token blanking through the real bash tool, the sentinel, and ephemeral/branch-cleanup lifecycle against real git fixtures. Full `src/repo` suite green (534 tests), `tsc` clean.

Verified live against a local server with real agent runs: success path (real PR opened on stakwork/hive and closed after), `push_rejected` and `secrets_detected` failure paths, sentinel path, ephemeral isolation with guard rejections, webhook delivery for both `completed` and `failed` runs, and zero leftover worktrees/branches/dirty files after every run.

## Deploy notes

- `gitleaks` must be on the container PATH — `landChange` fails closed without it
- Shared checkouts already dirtied by past preview runs need a one-time `git reset --hard`

🤖 Generated with [Claude Code](https://claude.com/claude-code)