### PR TITLE
Generated with Hive: Include token_usage in error and abort session-end for agent.ts and graph_agent/agent.ts

### DIFF
--- a/mcp/src/graph_agent/__tests__/graph-agent-error-token-usage.test.ts
+++ b/mcp/src/graph_agent/__tests__/graph-agent-error-token-usage.test.ts
@@ -1,0 +1,552 @@
+/**
+ * Unit tests for token_usage on error/abort session-end branches in
+ * graph_agent/agent.ts — both get_context (non-streaming) and finalizeSession
+ * (streaming).
+ *
+ * These tests verify Requirement #3 of the "Fix persistence gaps" feature:
+ *   "Error/abort session-end records carry token usage."
+ *
+ * The two error branches covered:
+ *
+ * A. get_context catch (~lines 308-335 of graph_agent/agent.ts):
+ *    Triggered when agent.generate() throws. The catch persists session_end
+ *    with token_usage computed as:
+ *      stepMetas.length > 0
+ *        ? normalizeUsage(addUsage(...stepMetas.map(s => s.usage)))
+ *        : normalizeUsage(totalUsage)
+ *    where totalUsage comes from the failed generate result (undefined if
+ *    generate never returned anything).
+ *
+ * B. finalizeSession catch (~lines 429-458 of graph_agent/agent.ts):
+ *    Triggered when stream consumption (steps/usage await) throws. The catch
+ *    persists session_end with token_usage computed as:
+ *      stepMetas.length > 0
+ *        ? normalizeUsage(addUsage(...stepMetas.map(s => s.usage)))
+ *        : normalizeUsage(undefined)
+ *    (stream usage not available since it may be what threw).
+ *
+ * Because importing graph_agent/agent.ts directly pulls in ToolLoopAgent and
+ * neo4j, these tests use inline mirrors of the catch-block logic — the same
+ * pattern as get-context-stream.test.ts and graph-agent-session.test.ts.
+ * Mirrors are kept in lockstep with the real code via explicit comments.
+ */
+
+import { test, expect } from "../../testkit.js";
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// ---------------------------------------------------------------------------
+// Session file helpers
+// ---------------------------------------------------------------------------
+
+function makeSessionsDir(): string {
+  const dir = path.join(os.tmpdir(), `test-ga-error-${randomUUID()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function sessionFilePath(sessionsDir: string, sessionId: string): string {
+  return path.join(sessionsDir, `${sessionId}.jsonl`);
+}
+
+interface SessionEntry {
+  type?: string;
+  status?: string;
+  error_message?: string;
+  token_usage?: Record<string, unknown>;
+  model?: string;
+  provider?: string;
+  duration_ms?: number;
+  [key: string]: unknown;
+}
+
+function appendToSession(sessionsDir: string, sessionId: string, entry: SessionEntry): void {
+  const filePath = sessionFilePath(sessionsDir, sessionId);
+  fs.appendFileSync(filePath, JSON.stringify(entry) + "\n");
+}
+
+function loadSessionEntries(sessionsDir: string, sessionId: string): SessionEntry[] {
+  const filePath = sessionFilePath(sessionsDir, sessionId);
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as SessionEntry);
+}
+
+// ---------------------------------------------------------------------------
+// Type helpers
+// ---------------------------------------------------------------------------
+
+interface LanguageModelUsage {
+  inputTokens?: number;
+  outputTokens?: number;
+  promptTokens?: number;
+  completionTokens?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Mirrors of aieo / agent utilities
+// ---------------------------------------------------------------------------
+
+function isAbortError(err: unknown): boolean {
+  if (!err) return false;
+  if (err instanceof Error) {
+    if (err.name === "AbortError") return true;
+    const cause: any = (err as any).cause;
+    if (cause && cause.name === "AbortError") return true;
+    if (/abort/i.test(err.message)) return true;
+  }
+  return false;
+}
+
+function normalizeUsage(usage: LanguageModelUsage | undefined): LanguageModelUsage {
+  if (!usage) return {};
+  return {
+    inputTokens: usage.inputTokens ?? usage.promptTokens ?? 0,
+    outputTokens: usage.outputTokens ?? usage.completionTokens ?? 0,
+  };
+}
+
+function addUsage(...usages: LanguageModelUsage[]): LanguageModelUsage {
+  return usages.reduce(
+    (acc, u) => ({
+      inputTokens: (acc.inputTokens ?? 0) + (u.inputTokens ?? 0),
+      outputTokens: (acc.outputTokens ?? 0) + (u.outputTokens ?? 0),
+    }),
+    {}
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Shared test opts
+// ---------------------------------------------------------------------------
+
+interface SimulateOpts {
+  sessionsDir: string;
+  sessionId: string;
+  modelId: string;
+  provider: string;
+  startTime: number;
+  stepMetas?: Array<{ usage: LanguageModelUsage }>;
+}
+
+// ---------------------------------------------------------------------------
+// A. Mirror of graph_agent/agent.ts get_context catch block.
+//
+// MIRROR NOTE: Keep in lockstep with the catch block in get_context
+// (~lines 308-335 of graph_agent/agent.ts).
+//
+// Key differences from the streaming finalizeSession catch:
+//   - totalUsage comes from agent.generate() result (unavailable on throw;
+//     passed in here as an explicit parameter to exercise the fallback).
+//   - Uses normalizeUsage(totalUsage as any) — same as real code.
+// ---------------------------------------------------------------------------
+
+async function simulateGraphAgentGetContextError(
+  err: Error,
+  opts: SimulateOpts & { totalUsage?: LanguageModelUsage }
+): Promise<void> {
+  const { sessionsDir, sessionId, modelId, provider, startTime } = opts;
+  const stepMetas = opts.stepMetas ?? [];
+  const totalUsage = opts.totalUsage;
+
+  const aborted = isAbortError(err);
+  const duration = Date.now() - startTime;
+
+  // Mirror: stepMetas.length > 0 ? normalizeUsage(addUsage(...)) : normalizeUsage(totalUsage as any)
+  const errorUsage =
+    stepMetas.length > 0
+      ? normalizeUsage(addUsage(...stepMetas.map((s) => s.usage)))
+      : normalizeUsage(totalUsage as any);
+
+  appendToSession(sessionsDir, sessionId, {
+    type: "session_end",
+    session_id: sessionId,
+    end_time: new Date().toISOString(),
+    model: modelId,
+    provider,
+    duration_ms: duration,
+    status: aborted ? "aborted" : "error",
+    error_message: err.message,
+    token_usage: errorUsage,
+  });
+
+  throw err;
+}
+
+// ---------------------------------------------------------------------------
+// B. Mirror of graph_agent/agent.ts finalizeSession catch block.
+//
+// MIRROR NOTE: Keep in lockstep with the catch block in finalizeSession
+// (~lines 429-458 of graph_agent/agent.ts).
+//
+// Key difference: stream usage is not available (may be what threw), so
+// the fallback is normalizeUsage(undefined) — a safe empty object.
+// ---------------------------------------------------------------------------
+
+async function simulateGraphAgentFinalizeSessionError(
+  err: Error,
+  opts: SimulateOpts
+): Promise<void> {
+  const { sessionsDir, sessionId, modelId, provider, startTime } = opts;
+  const stepMetas = opts.stepMetas ?? [];
+
+  const aborted = isAbortError(err);
+
+  // Mirror: stepMetas.length > 0 ? normalizeUsage(addUsage(...)) : normalizeUsage(undefined)
+  const errorUsage =
+    stepMetas.length > 0
+      ? normalizeUsage(addUsage(...stepMetas.map((s) => s.usage)))
+      : normalizeUsage(undefined);
+
+  // .catch(() => {}) guard is present in the real code; the test writes directly
+  appendToSession(sessionsDir, sessionId, {
+    type: "session_end",
+    session_id: sessionId,
+    end_time: new Date().toISOString(),
+    model: modelId,
+    provider,
+    duration_ms: Date.now() - startTime,
+    status: aborted ? "aborted" : "error",
+    error_message: err.message,
+    token_usage: errorUsage,
+  });
+
+  // Note: real code uses .catch(() => {}) and does NOT re-throw; for testing
+  // we don't throw so callers can inspect the written entry directly.
+}
+
+// ---------------------------------------------------------------------------
+// Tests — A. get_context error branch
+// ---------------------------------------------------------------------------
+
+test.describe("graph_agent get_context error branch: token_usage on error/abort", () => {
+  let sessionsDir: string;
+
+  test.beforeEach(() => {
+    sessionsDir = makeSessionsDir();
+  });
+
+  test.afterEach(() => {
+    try {
+      fs.rmSync(sessionsDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // A1. Error with stepMetas — addUsage path produces correct token_usage
+  // -------------------------------------------------------------------------
+  test("error with stepMetas: token_usage sums stepMetas (addUsage path)", async () => {
+    const sessionId = randomUUID();
+    const stepMeta1 = { usage: { inputTokens: 120, outputTokens: 60 } };
+    const stepMeta2 = { usage: { inputTokens: 180, outputTokens: 90 } };
+    // totalUsage that would give wrong results if used instead of stepMetas
+    const totalUsage = { inputTokens: 999, outputTokens: 999 };
+
+    let threw = false;
+    try {
+      await simulateGraphAgentGetContextError(new Error("context window exceeded"), {
+        sessionsDir,
+        sessionId,
+        modelId: "claude-3-5-sonnet",
+        provider: "anthropic",
+        startTime: Date.now() - 400,
+        stepMetas: [stepMeta1, stepMeta2],
+        totalUsage,
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+    expect(endEntry!.error_message).toBe("context window exceeded");
+
+    // addUsage: 120+180=300 input, 60+90=150 output — NOT 999
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(300);
+    expect(tokenUsage.outputTokens).toBe(150);
+  });
+
+  // -------------------------------------------------------------------------
+  // A2. Error with no stepMetas — falls back to totalUsage
+  // -------------------------------------------------------------------------
+  test("error with empty stepMetas: token_usage falls back to totalUsage", async () => {
+    const sessionId = randomUUID();
+    const totalUsage = { inputTokens: 350, outputTokens: 175 };
+
+    let threw = false;
+    try {
+      await simulateGraphAgentGetContextError(new Error("rate limit"), {
+        sessionsDir,
+        sessionId,
+        modelId: "gpt-4o",
+        provider: "openai",
+        startTime: Date.now() - 200,
+        stepMetas: [],
+        totalUsage,
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(350);
+    expect(tokenUsage.outputTokens).toBe(175);
+  });
+
+  // -------------------------------------------------------------------------
+  // A3. Error with no stepMetas and undefined totalUsage
+  //     normalizeUsage(undefined) must return a safe empty object, not throw
+  // -------------------------------------------------------------------------
+  test("error with empty stepMetas and undefined totalUsage: token_usage is safe empty object", async () => {
+    const sessionId = randomUUID();
+
+    let threw = false;
+    try {
+      await simulateGraphAgentGetContextError(new Error("pre-flight failure"), {
+        sessionsDir,
+        sessionId,
+        modelId: "claude-3-haiku",
+        provider: "anthropic",
+        startTime: Date.now() - 50,
+        stepMetas: [],
+        totalUsage: undefined,
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+    // token_usage must be present (not missing) — safe empty object is acceptable
+    expect(endEntry!.token_usage).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // A4. Abort path — status is aborted, token_usage still present
+  // -------------------------------------------------------------------------
+  test("abort path: status is aborted and token_usage is still present", async () => {
+    const sessionId = randomUUID();
+    const stepMeta = { usage: { inputTokens: 90, outputTokens: 45 } };
+
+    const abortErr = new Error("request aborted by client");
+    abortErr.name = "AbortError";
+
+    let threw = false;
+    try {
+      await simulateGraphAgentGetContextError(abortErr, {
+        sessionsDir,
+        sessionId,
+        modelId: "gpt-4o",
+        provider: "openai",
+        startTime: Date.now() - 300,
+        stepMetas: [stepMeta],
+        totalUsage: { inputTokens: 999, outputTokens: 999 },
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("aborted");
+
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(90);
+    expect(tokenUsage.outputTokens).toBe(45);
+  });
+
+  // -------------------------------------------------------------------------
+  // A5. Error always re-throws (best-effort, never fatal)
+  // -------------------------------------------------------------------------
+  test("error is always re-thrown — best-effort, never fatal", async () => {
+    const sessionId = randomUUID();
+    const original = new Error("network failure");
+
+    let caught: Error | undefined;
+    try {
+      await simulateGraphAgentGetContextError(original, {
+        sessionsDir,
+        sessionId,
+        modelId: "claude-3-5-sonnet",
+        provider: "anthropic",
+        startTime: Date.now() - 100,
+      });
+    } catch (e) {
+      caught = e as Error;
+    }
+
+    expect(caught).toBeDefined();
+    expect(caught).toBe(original); // same reference
+    expect(caught!.message).toBe("network failure");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Tests — B. finalizeSession error branch
+// ---------------------------------------------------------------------------
+
+test.describe("graph_agent finalizeSession error branch: token_usage on error/abort", () => {
+  let sessionsDir: string;
+
+  test.beforeEach(() => {
+    sessionsDir = makeSessionsDir();
+  });
+
+  test.afterEach(() => {
+    try {
+      fs.rmSync(sessionsDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // B1. Error with stepMetas — addUsage path produces correct token_usage
+  // -------------------------------------------------------------------------
+  test("error with stepMetas: token_usage sums stepMetas (addUsage path)", async () => {
+    const sessionId = randomUUID();
+    const stepMeta1 = { usage: { inputTokens: 200, outputTokens: 100 } };
+    const stepMeta2 = { usage: { inputTokens: 300, outputTokens: 150 } };
+
+    const err = new Error("stream interrupted");
+    await simulateGraphAgentFinalizeSessionError(err, {
+      sessionsDir,
+      sessionId,
+      modelId: "claude-3-5-sonnet",
+      provider: "anthropic",
+      startTime: Date.now() - 500,
+      stepMetas: [stepMeta1, stepMeta2],
+    });
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+    expect(endEntry!.error_message).toBe("stream interrupted");
+
+    // addUsage: 200+300=500 input, 100+150=250 output
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(500);
+    expect(tokenUsage.outputTokens).toBe(250);
+  });
+
+  // -------------------------------------------------------------------------
+  // B2. Error with no stepMetas — falls back to safe empty object
+  //     (stream usage unavailable since it may be what threw)
+  // -------------------------------------------------------------------------
+  test("error with empty stepMetas: token_usage is safe empty object (stream unavailable)", async () => {
+    const sessionId = randomUUID();
+
+    const err = new Error("stream usage fetch failed");
+    await simulateGraphAgentFinalizeSessionError(err, {
+      sessionsDir,
+      sessionId,
+      modelId: "gpt-4o",
+      provider: "openai",
+      startTime: Date.now() - 100,
+      stepMetas: [],
+    });
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+    // token_usage must be present — safe empty object is acceptable
+    expect(endEntry!.token_usage).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // B3. Abort path — status is aborted, token_usage still present
+  // -------------------------------------------------------------------------
+  test("abort path: status is aborted and token_usage is still present", async () => {
+    const sessionId = randomUUID();
+    const stepMeta = { usage: { inputTokens: 110, outputTokens: 55 } };
+
+    const abortErr = new Error("client disconnected");
+    abortErr.name = "AbortError";
+
+    await simulateGraphAgentFinalizeSessionError(abortErr, {
+      sessionsDir,
+      sessionId,
+      modelId: "claude-3-5-sonnet",
+      provider: "anthropic",
+      startTime: Date.now() - 200,
+      stepMetas: [stepMeta],
+    });
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("aborted");
+
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(110);
+    expect(tokenUsage.outputTokens).toBe(55);
+  });
+
+  // -------------------------------------------------------------------------
+  // B4. Success-path token_usage matches the success path computation
+  //     (regression guard: verify finalizeSession success writes correctly too)
+  // -------------------------------------------------------------------------
+  test("success path still writes token_usage correctly (regression guard)", async () => {
+    const sessionId = randomUUID();
+    const stepMeta1 = { usage: { inputTokens: 400, outputTokens: 200 } };
+    const stepMeta2 = { usage: { inputTokens: 600, outputTokens: 300 } };
+    const streamUsage = { inputTokens: 1, outputTokens: 1 }; // should be overridden by stepMetas
+
+    // Simulate the success path directly
+    const stepUsage =
+      [stepMeta1, stepMeta2].length > 0
+        ? normalizeUsage(addUsage(...[stepMeta1, stepMeta2].map((s) => s.usage)))
+        : normalizeUsage(streamUsage);
+
+    appendToSession(sessionsDir, sessionId, {
+      type: "session_end",
+      session_id: sessionId,
+      end_time: new Date().toISOString(),
+      model: "claude-3-5-sonnet",
+      provider: "anthropic",
+      duration_ms: 500,
+      status: "success",
+      token_usage: stepUsage,
+    });
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry!.status).toBe("success");
+
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage.inputTokens).toBe(1000); // 400+600
+    expect(tokenUsage.outputTokens).toBe(500); // 200+300
+  });
+});

--- a/mcp/src/graph_agent/agent.ts
+++ b/mcp/src/graph_agent/agent.ts
@@ -312,6 +312,14 @@ export async function get_context(opts: GraphAgentOptions): Promise<{
       `[graph_agent] graph_agent_run_end requestId=${prepared.requestId} sessionId=${sessionId ?? "none"} model=${modelId} duration=${duration}ms status=${aborted ? "aborted" : "error"}`,
     );
     if (sessionId) {
+      // Mirror the success path's token_usage computation so a failed run still
+      // records however many tokens were spent before the throw. Falls back to
+      // totalUsage when no step-metas were recorded (normalizeUsage tolerates
+      // undefined), matching the success path below.
+      const errorUsage =
+        stepMetas.length > 0
+          ? normalizeUsage(addUsage(...stepMetas.map((s) => s.usage)))
+          : normalizeUsage(totalUsage as any);
       await appendSessionEnd(sessionId, {
         end_time: new Date().toISOString(),
         model: modelId,
@@ -319,6 +327,7 @@ export async function get_context(opts: GraphAgentOptions): Promise<{
         duration_ms: duration,
         status: aborted ? "aborted" : "error",
         error_message: err instanceof Error ? err.message : String(err),
+        token_usage: errorUsage,
       });
     }
     throw err;
@@ -420,6 +429,14 @@ export async function stream_context(opts: GraphAgentOptions) {
         } else {
           console.error(`[graph_agent] Failed to finalize session:`, e);
         }
+        // Mirror the success path's token_usage computation: prefer step-metas
+        // (accumulated during the run) over the stream's own usage (which may
+        // itself have thrown and is therefore unavailable in this scope).
+        // normalizeUsage tolerates undefined, so the no-step-meta fallback is safe.
+        const errorUsage =
+          stepMetas.length > 0
+            ? normalizeUsage(addUsage(...stepMetas.map((s) => s.usage)))
+            : normalizeUsage(undefined);
         await appendSessionEnd(sessionId, {
           end_time: new Date().toISOString(),
           model: modelId,
@@ -427,6 +444,7 @@ export async function stream_context(opts: GraphAgentOptions) {
           duration_ms: Date.now() - startTime,
           status: aborted ? "aborted" : "error",
           error_message: e instanceof Error ? e.message : String(e),
+          token_usage: errorUsage,
         }).catch(() => {});
         console.log(
           `[graph_agent] graph_agent_run_end (stream) requestId=${prepared.requestId} sessionId=${sessionId} model=${modelId} status=${aborted ? "aborted" : "error"}`,

--- a/mcp/src/repo/__tests__/get-context-error-token-usage.test.ts
+++ b/mcp/src/repo/__tests__/get-context-error-token-usage.test.ts
@@ -1,0 +1,368 @@
+/**
+ * Unit tests for token_usage on error/abort session-end branches in
+ * get_context (non-streaming path) in repo/agent.ts.
+ *
+ * These tests verify Requirement #3 of the "Fix persistence gaps" feature:
+ *   "Error/abort session-end records carry token usage."
+ *
+ * The non-streaming path (get_context) throws from within the loop body;
+ * the catch at ~lines 1385-1415 of agent.ts should include token_usage
+ * computed the same way as the success path:
+ *   stepMetas.length > 0
+ *     ? normalizeUsage(addUsage(...stepMetas.map(s => s.usage)))
+ *     : normalizeUsage(streamTotalUsage)
+ *
+ * Because importing get_context directly pulls in neo4j, ToolLoopAgent, and
+ * file-system tools, these tests use an inline mirror of the catch-block logic
+ * — the same pattern as get-context-stream.test.ts and logs-agent-session.test.ts.
+ * The mirror is kept in lockstep with agent.ts via explicit comments.
+ */
+
+import { test, expect } from "../../testkit.js";
+import { randomUUID } from "crypto";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+
+// ---------------------------------------------------------------------------
+// Session file helpers
+// ---------------------------------------------------------------------------
+
+function makeSessionsDir(): string {
+  const dir = path.join(os.tmpdir(), `test-gc-error-${randomUUID()}`);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function sessionFilePath(sessionsDir: string, sessionId: string): string {
+  return path.join(sessionsDir, `${sessionId}.jsonl`);
+}
+
+interface SessionEntry {
+  type?: string;
+  status?: string;
+  error_message?: string;
+  token_usage?: Record<string, unknown>;
+  model?: string;
+  provider?: string;
+  duration_ms?: number;
+  [key: string]: unknown;
+}
+
+function appendToSession(sessionsDir: string, sessionId: string, entry: SessionEntry): void {
+  const filePath = sessionFilePath(sessionsDir, sessionId);
+  fs.appendFileSync(filePath, JSON.stringify(entry) + "\n");
+}
+
+function loadSessionEntries(sessionsDir: string, sessionId: string): SessionEntry[] {
+  const filePath = sessionFilePath(sessionsDir, sessionId);
+  if (!fs.existsSync(filePath)) return [];
+  return fs.readFileSync(filePath, "utf-8")
+    .split("\n")
+    .filter((l) => l.trim())
+    .map((l) => JSON.parse(l) as SessionEntry);
+}
+
+// ---------------------------------------------------------------------------
+// Type helpers
+// ---------------------------------------------------------------------------
+
+interface LanguageModelUsage {
+  promptTokens?: number;
+  completionTokens?: number;
+  totalTokens?: number;
+  inputTokens?: number;
+  outputTokens?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — mirrors from agent.ts / aieo
+// ---------------------------------------------------------------------------
+
+function isAbortError(err: unknown): boolean {
+  if (!err) return false;
+  if (err instanceof Error) {
+    if (err.name === "AbortError") return true;
+    const cause: any = (err as any).cause;
+    if (cause && cause.name === "AbortError") return true;
+    if (/abort/i.test(err.message)) return true;
+  }
+  return false;
+}
+
+function normalizeUsage(usage: LanguageModelUsage | undefined): LanguageModelUsage {
+  if (!usage) return {};
+  return {
+    inputTokens: usage.inputTokens ?? usage.promptTokens ?? 0,
+    outputTokens: usage.outputTokens ?? usage.completionTokens ?? 0,
+  };
+}
+
+function addUsage(...usages: LanguageModelUsage[]): LanguageModelUsage {
+  return usages.reduce(
+    (acc, u) => ({
+      inputTokens: (acc.inputTokens ?? 0) + (u.inputTokens ?? 0),
+      outputTokens: (acc.outputTokens ?? 0) + (u.outputTokens ?? 0),
+    }),
+    {}
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Simulate the non-streaming get_context catch block.
+//
+// Mirrors the catch block in repo/agent.ts get_context (~lines 1385-1415).
+//
+// Key invariants under test:
+//   1. token_usage is always present in the session_end entry on error/abort.
+//   2. token_usage derives from stepMetas when available (addUsage path).
+//   3. token_usage falls back to streamTotalUsage (normalizeUsage) when
+//      stepMetas is empty — even if streamTotalUsage is undefined,
+//      normalizeUsage returns a safe empty object rather than throwing.
+//   4. The original error always re-throws (best-effort, never fatal).
+// ---------------------------------------------------------------------------
+
+interface SimulateOpts {
+  sessionsDir: string;
+  sessionId: string;
+  modelId: string;
+  provider: string;
+  startTime: number;
+  /** stepMetas accumulated before the error (may be empty) */
+  stepMetas?: Array<{ usage: LanguageModelUsage }>;
+  /** last known stream total usage at error time (may be undefined) */
+  streamTotalUsage?: LanguageModelUsage;
+}
+
+/**
+ * Simulates the error branch of get_context's catch block.
+ * Always throws the supplied error after persisting session_end.
+ *
+ * MIRROR NOTE: Keep in lockstep with the catch block in repo/agent.ts
+ * get_context. If the real catch block changes its token_usage computation,
+ * update this mirror accordingly.
+ */
+async function simulateGetContextError(err: Error, opts: SimulateOpts): Promise<void> {
+  const { sessionsDir, sessionId, modelId, provider, startTime } = opts;
+  const stepMetas = opts.stepMetas ?? [];
+  const streamTotalUsage = opts.streamTotalUsage;
+
+  const aborted = isAbortError(err);
+
+  // Mirror: stepMetas.length > 0 ? normalizeUsage(addUsage(...)) : normalizeUsage(streamTotalUsage)
+  const errorUsage =
+    stepMetas.length > 0
+      ? normalizeUsage(addUsage(...stepMetas.map((step) => step.usage)))
+      : normalizeUsage(streamTotalUsage);
+
+  const endTime = new Date();
+  appendToSession(sessionsDir, sessionId, {
+    type: "session_end",
+    session_id: sessionId,
+    end_time: endTime.toISOString(),
+    model: modelId,
+    provider,
+    duration_ms: endTime.getTime() - startTime,
+    status: aborted ? "aborted" : "error",
+    error_message: err.message,
+    token_usage: errorUsage,
+  });
+
+  throw err;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+test.describe("get_context non-stream error branch: token_usage on error/abort", () => {
+  let sessionsDir: string;
+
+  test.beforeEach(() => {
+    sessionsDir = makeSessionsDir();
+  });
+
+  test.afterEach(() => {
+    try {
+      fs.rmSync(sessionsDir, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+  });
+
+  // -------------------------------------------------------------------------
+  // 1. Error with stepMetas — addUsage path produces correct token_usage
+  // -------------------------------------------------------------------------
+  test("error with stepMetas: token_usage sums stepMetas (addUsage path)", async () => {
+    const sessionId = randomUUID();
+    const stepMeta1 = { usage: { inputTokens: 100, outputTokens: 50 } };
+    const stepMeta2 = { usage: { inputTokens: 200, outputTokens: 80 } };
+
+    // A streamTotalUsage that would give wrong results if used instead of stepMetas
+    const streamTotalUsage = { inputTokens: 999, outputTokens: 999 };
+
+    let threw = false;
+    try {
+      await simulateGetContextError(new Error("model overloaded"), {
+        sessionsDir,
+        sessionId,
+        modelId: "claude-3-5-sonnet",
+        provider: "anthropic",
+        startTime: Date.now() - 300,
+        stepMetas: [stepMeta1, stepMeta2],
+        streamTotalUsage,
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+    expect(endEntry!.error_message).toBe("model overloaded");
+
+    // addUsage path: 100+200=300 input, 50+80=130 output — NOT 999
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(300);
+    expect(tokenUsage.outputTokens).toBe(130);
+  });
+
+  // -------------------------------------------------------------------------
+  // 2. Error with empty stepMetas — falls back to streamTotalUsage
+  // -------------------------------------------------------------------------
+  test("error with empty stepMetas: token_usage falls back to streamTotalUsage", async () => {
+    const sessionId = randomUUID();
+    const streamTotalUsage = { inputTokens: 450, outputTokens: 220 };
+
+    let threw = false;
+    try {
+      await simulateGetContextError(new Error("network timeout"), {
+        sessionsDir,
+        sessionId,
+        modelId: "gpt-4o",
+        provider: "openai",
+        startTime: Date.now() - 150,
+        stepMetas: [],          // no step metas accumulated
+        streamTotalUsage,
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+
+    // Fallback to streamTotalUsage
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(450);
+    expect(tokenUsage.outputTokens).toBe(220);
+  });
+
+  // -------------------------------------------------------------------------
+  // 3. Error with empty stepMetas and undefined streamTotalUsage
+  //    normalizeUsage(undefined) should return a safe empty object, not throw
+  // -------------------------------------------------------------------------
+  test("error with empty stepMetas and undefined streamTotalUsage: token_usage is safe empty object", async () => {
+    const sessionId = randomUUID();
+
+    let threw = false;
+    try {
+      await simulateGetContextError(new Error("early failure"), {
+        sessionsDir,
+        sessionId,
+        modelId: "claude-3-haiku",
+        provider: "anthropic",
+        startTime: Date.now() - 50,
+        stepMetas: [],
+        streamTotalUsage: undefined,  // never populated before error
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+    expect(endEntry!.error_message).toBe("early failure");
+
+    // Must be present (not undefined) — safe empty object is acceptable
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // 4. Abort path — isAbortError triggers status: aborted; token_usage still present
+  // -------------------------------------------------------------------------
+  test("abort path: status is aborted and token_usage is still present", async () => {
+    const sessionId = randomUUID();
+    const stepMeta = { usage: { inputTokens: 80, outputTokens: 40 } };
+
+    const abortErr = new Error("Request aborted");
+    abortErr.name = "AbortError";
+
+    let threw = false;
+    try {
+      await simulateGetContextError(abortErr, {
+        sessionsDir,
+        sessionId,
+        modelId: "gpt-4o",
+        provider: "openai",
+        startTime: Date.now() - 200,
+        stepMetas: [stepMeta],
+        streamTotalUsage: { inputTokens: 999, outputTokens: 999 },
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("aborted");
+
+    // addUsage path: 80 input, 40 output from stepMeta
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(80);
+    expect(tokenUsage.outputTokens).toBe(40);
+  });
+
+  // -------------------------------------------------------------------------
+  // 5. Error always re-throws (best-effort, never fatal)
+  // -------------------------------------------------------------------------
+  test("error is always re-thrown — best-effort, never fatal", async () => {
+    const sessionId = randomUUID();
+    const originalError = new Error("connection refused");
+
+    let caughtError: Error | undefined;
+    try {
+      await simulateGetContextError(originalError, {
+        sessionsDir,
+        sessionId,
+        modelId: "claude-3-5-sonnet",
+        provider: "anthropic",
+        startTime: Date.now() - 100,
+      });
+    } catch (e) {
+      caughtError = e as Error;
+    }
+
+    expect(caughtError).toBeDefined();
+    expect(caughtError).toBe(originalError); // same reference — not wrapped
+    expect(caughtError!.message).toBe("connection refused");
+  });
+});

--- a/mcp/src/repo/__tests__/get-context-stream.test.ts
+++ b/mcp/src/repo/__tests__/get-context-stream.test.ts
@@ -192,6 +192,14 @@ async function simulateGetContextStream(
   } catch (err) {
     const aborted = isAbortError(err);
     const endTime = new Date();
+    // Mirror the success path's token_usage computation: prefer step-metas
+    // (accumulated during the run) over the stream's own usage (which may
+    // itself have thrown and is therefore unavailable in this scope).
+    // normalizeUsage tolerates undefined, so the no-step-meta fallback is safe.
+    const errorUsage =
+      stepMetas.length > 0
+        ? normalizeUsage(addUsage(...stepMetas.map((s) => s.usage)))
+        : normalizeUsage(undefined);
     appendToSession(sessionsDir, sessionId, {
       type: "session_end",
       session_id: sessionId,
@@ -201,6 +209,7 @@ async function simulateGetContextStream(
       duration_ms: endTime.getTime() - startTime,
       status: aborted ? "aborted" : "error",
       error_message: err instanceof Error ? err.message : String(err),
+      token_usage: errorUsage,
     });
     throw err;
   }
@@ -384,6 +393,49 @@ test.describe("get_context streaming (agent.generate → agent.stream)", () => {
     expect(endEntry!.model).toBe("claude-3-opus");
     expect(endEntry!.provider).toBe("anthropic");
     expect(typeof endEntry!.duration_ms).toBe("number");
+    // token_usage must be present on error path (Fix #2)
+    expect(endEntry!.token_usage).toBeDefined();
+  });
+
+  // -------------------------------------------------------------------------
+  // 3b. Error path with stepMetas — token_usage derived from accumulated steps
+  // -------------------------------------------------------------------------
+  test("error path with stepMetas: token_usage derives from stepMetas, not stream", async () => {
+    const sessionId = randomUUID();
+    const stepMeta1 = { usage: { inputTokens: 150, outputTokens: 75 } };
+    const stepMeta2 = { usage: { inputTokens: 250, outputTokens: 100 } };
+
+    const streamResultFactory = (): StreamResult => ({
+      steps: Promise.reject(new Error("rate limit")),
+      totalUsage: Promise.resolve({ inputTokens: 999, outputTokens: 999 }),
+      usage: Promise.resolve({ inputTokens: 999, outputTokens: 999 }),
+    });
+
+    let threw = false;
+    try {
+      await simulateGetContextStream(streamResultFactory, {
+        sessionsDir,
+        sessionId,
+        modelId: "claude-3-opus",
+        provider: "anthropic",
+        startTime: Date.now() - 200,
+        stepMetas: [stepMeta1, stepMeta2],
+      });
+    } catch {
+      threw = true;
+    }
+
+    expect(threw).toBe(true);
+
+    const entries = loadSessionEntries(sessionsDir, sessionId);
+    const endEntry = entries.find((e) => e.type === "session_end");
+    expect(endEntry).toBeDefined();
+    expect(endEntry!.status).toBe("error");
+    // addUsage path: 150+250=400 input, 75+100=175 output — NOT 999 from stream
+    const tokenUsage = endEntry!.token_usage as LanguageModelUsage;
+    expect(tokenUsage).toBeDefined();
+    expect(tokenUsage.inputTokens).toBe(400);
+    expect(tokenUsage.outputTokens).toBe(175);
   });
 
   // -------------------------------------------------------------------------
@@ -422,6 +474,8 @@ test.describe("get_context streaming (agent.generate → agent.stream)", () => {
     expect(endEntry!.status).toBe("aborted");
     expect(typeof endEntry!.error_message).toBe("string");
     expect((endEntry!.error_message as string).length).toBeGreaterThan(0);
+    // token_usage must be present on abort path (Fix #2)
+    expect(endEntry!.token_usage).toBeDefined();
   });
 
   // -------------------------------------------------------------------------

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -1391,6 +1391,14 @@ export async function get_context(
     enrichErrorMessage(err);
     if (sessionId) {
       const endTime = new Date();
+      // Mirror the success path's token_usage computation so a failed run still
+      // records however many tokens were spent before the throw. Falls back to
+      // streamTotalUsage when no step-metas were recorded (normalizeUsage
+      // tolerates undefined), matching the success path below.
+      const errorUsage =
+        stepMetas.length > 0
+          ? normalizeUsage(addUsage(...stepMetas.map((step) => step.usage)))
+          : normalizeUsage(streamTotalUsage);
       await appendSessionEnd(sessionId, {
         end_time: endTime.toISOString(),
         model: modelId,
@@ -1398,6 +1406,7 @@ export async function get_context(
         duration_ms: endTime.getTime() - startTime,
         status: aborted ? "aborted" : "error",
         error_message: err instanceof Error ? err.message : String(err),
+        token_usage: errorUsage,
       });
     }
     throw err;
@@ -1564,6 +1573,14 @@ export async function stream_context(
         } else {
           console.error("[stream_context] Failed to finalize session:", e);
         }
+        // Mirror the success path's token_usage computation: prefer step-metas
+        // (accumulated during the run) over the stream's own usage (which may
+        // itself have thrown and is therefore unavailable in this scope).
+        // normalizeUsage tolerates undefined, so the no-step-meta fallback is safe.
+        const errorUsage =
+          stepMetas.length > 0
+            ? normalizeUsage(addUsage(...stepMetas.map((step) => step.usage)))
+            : normalizeUsage(undefined);
         await appendSessionEnd(sessionId, {
           end_time: new Date().toISOString(),
           model: modelId,
@@ -1571,6 +1588,7 @@ export async function stream_context(
           duration_ms: Date.now() - startTime,
           status: aborted ? "aborted" : "error",
           error_message: e instanceof Error ? e.message : String(e),
+          token_usage: errorUsage,
         }).catch(() => {});
       }
     },


### PR DESCRIPTION
Include token_usage in error and abort session-end for agent.ts and graph_agent/agent.ts