### PR TITLE
vein: agentTools globs + per-run artifacts; lab: jarvis knowledge-graph steps

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -297,6 +297,40 @@ entirely. Trigger:
 seeded/built): `src/lab/gitsee/smoke.ts` (steps direct, no server) and
 `smoke-eval.ts` (full `gitsee-eval` via a real lab vein).
 
+### `jarvis/` — knowledge-graph steps (NOT an experiment)
+
+Self-contained ports of the mcp repo-agent's Jarvis tools
+(`mcp/src/repo/toolsJarvis.ts`) as seeded vein steps — same endpoints, same
+schemas, same LLM-facing descriptions — so workflows (and agent steps) can
+read/write the Jarvis knowledge graph. **Concepts are Jarvis nodes** (filter
+`type: "Concept"` on search/neighbors), so no concept-specific steps exist.
+
+- **Reads:** `jarvis/get-ontology`, `jarvis/get-ontology-type`,
+  `jarvis/graph-search` (hybrid + field-scoped vector search),
+  `jarvis/graph-get`, `jarvis/graph-get-batched`, `jarvis/graph-neighbors`.
+- **Writes:** `jarvis/create-node`, `jarvis/edit-node`,
+  `jarvis/create-triplet`, `jarvis/create-batch-triplet`. The ontology CRUD
+  family is deliberately NOT ported (schema editing stays a human/setup
+  activity).
+- **Config is automatic:** each step resolves `JARVIS_URL` + `API_TOKEN`
+  (+ optional `JARVIS_HTTP_TIMEOUT_MS`) through `ctx.services.secrets`
+  (secret store → env fallback) and calls through `ctx.services.http` — so
+  runs are cassette-recordable and credentials are scrubbed from fixtures.
+  Steps are ALWAYS seeded; without `JARVIS_URL` they fail loudly per run
+  rather than silently missing.
+- **Granting to agents:** `agentTools: ["jarvis/*"]` (glob, vein-core
+  `expandAgentTools`) for everything, or list the read steps explicitly for a
+  read-only child. Sub-agents = grant `"agent"` itself and pass the child a
+  narrower `agentTools` list (recursion depth is whether the child gets
+  `"agent"` again).
+- **Self-contained duplication is deliberate:** each step file inlines its
+  small `jarvisCtx` preamble (seeded steps may only value-import `"vein"`);
+  the contract is documented once in `jarvis/steps/_shared.ts` — change it
+  there AND in every step.
+- **Smoke:** `npx tsx src/lab/jarvis/smoke.ts` — offline; seeds into a temp
+  workspace, verifies registry discovery, and runs every step against a fake
+  `ctx.services.http` Jarvis.
+
 ### `eval/` — generic, reusable eval primitives (NOT an experiment)
 
 Domain-agnostic eval substrate, shared by every experiment. See

--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -331,6 +331,43 @@ read/write the Jarvis knowledge graph. **Concepts are Jarvis nodes** (filter
   workspace, verifies registry discovery, and runs every step against a fake
   `ctx.services.http` Jarvis.
 
+### `harvey/` — Harvey LAB verification (the hardcoded grader)
+
+Runs the **actual** Harvey LAB legal-benchmark eval (the
+`/Users/…/harvey-labs` checkout's `uv run python -m evaluation.run_eval`) as
+a subprocess. Nothing is ported and nothing is editable: the grader lives in
+the in-code `harvey` **service** (`harvey/service.ts`, on the `LabServices`
+bag), NOT in a seeded step — the workflow-authoring agent must never be able
+to edit its own grader. The two seeded `harvey/*` steps are thin plumbing
+over `ctx.services.harvey.*`; editing them can only break plumbing.
+
+- **Integrity invariant** (enforced per grade, not per boot): the checkout
+  must be a CLEAN git tree, and when `HARVEY_LABS_REV` is set, HEAD must
+  match it — otherwise `evaluate` refuses. Untracked `results/` entries (our
+  own staged runs) are tolerated. Every result carries `benchmarkRev` (the
+  exact SHA) so scores are attributable to a benchmark version.
+- `harvey/get-task` — a task's title/instructions/deliverable names + input
+  documents listing, with the grading rubric (`criteria`) **stripped in the
+  service** — a producing agent must never see how it will be graded. Safe to
+  grant to producers.
+- `harvey/evaluate` — stages this run's artifact deliverables (subdir `from`,
+  default `output`, of `ctx.services.artifacts.dir(ctx.runId)`) into the
+  checkout's `results/vein-<runId>/output/`, runs the real eval (single judge
+  or `dual`), and returns the harness's own `scores.json` (all-pass scoring,
+  `criteria_results`, …) + `benchmarkRev` + `reportPath` (the harness's
+  `report.html`, kept in the checkout's `results/` as the run's record).
+  **GUARDRAIL: grant only to harness workflows — NEVER to the producing
+  agent's `agentTools`** (an agent that can query its own grader mid-task
+  trains against the rubric).
+- **Config (env):** `HARVEY_LABS_DIR` (checkout path; loud per-run error when
+  unset — same posture as jarvis), optional `HARVEY_LABS_REV` pin. The eval
+  subprocess inherits mcp's env (`ANTHROPIC_API_KEY`; plus `OPENAI_API_KEY`
+  for `dual`) and needs `uv` + `git` on PATH (+ pandoc per harvey-labs docs).
+- **Smoke:** `npx tsx src/lab/harvey/smoke.ts` — offline (real throwaway git
+  repo as a fake checkout, fake `uv` exec): integrity enforcement (dirty
+  tree / rev pin / missing dir), rubric stripping, artifact staging, CLI
+  args, step wiring.
+
 ### `eval/` — generic, reusable eval primitives (NOT an experiment)
 
 Domain-agnostic eval substrate, shared by every experiment. See

--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -331,6 +331,51 @@ read/write the Jarvis knowledge graph. **Concepts are Jarvis nodes** (filter
   workspace, verifies registry discovery, and runs every step against a fake
   `ctx.services.http` Jarvis.
 
+### `sheets/` — Google Sheets steps (NOT an experiment)
+
+Self-contained ports of the mcp repo-agent's Google Sheets tools
+(`mcp/src/repo/toolsGoogleSheets.ts` — untouched; it stays the production
+repo-agent implementation) as seeded vein steps — same Sheets/Drive REST
+endpoints, same schemas, same LLM-facing descriptions — so workflows (and
+agent steps) can create spreadsheets and read/write cell values and live
+formulas.
+
+- **Steps:** `sheets/create-spreadsheet`, `sheets/update-values`,
+  `sheets/batch-update-values`, `sheets/get-values`, `sheets/add-sheet`,
+  `sheets/import-spreadsheet` (best-effort per-sheet import of an .xlsx or
+  native Sheet into a destination spreadsheet, with auto-conversion,
+  collision-suffixed tab names, and cross-sheet-formula warnings).
+- **Config resolution:** `cfg.serviceAccount` (explicit step config — parsed
+  JSON, JSON string, or base64 JSON) wins, else the
+  `GOOGLE_SERVICE_ACCOUNT_JSON` secret (secret store → env fallback); same
+  for `cfg.driveFolderId` / `GOOGLE_DRIVE_FOLDER_ID` (spreadsheets are
+  created inside that folder — share it with the service account's
+  client_email so humans can see agent-created sheets). Auth is a plain
+  service-account JWT flow: an RS256 assertion built with `node:crypto` (no
+  jsonwebtoken/axios deps), exchanged at the SA's `token_uri` for a bearer
+  token (scopes `spreadsheets` + `drive`), cached per step module with 60s
+  expiry slack. Everything goes through `ctx.services.http` +
+  `ctx.services.secrets`, so runs are cassette-recordable and credentials
+  are scrubbed from fixtures. Steps are ALWAYS seeded; without
+  `GOOGLE_SERVICE_ACCOUNT_JSON` they fail loudly per run rather than
+  silently missing. API errors come back as teaching strings (e.g. a 403 on
+  create names the folder and client_email to share it with), never throws
+  at the LLM.
+- **Granting to agents:** `agentTools: ["sheets/*"]` (glob, vein-core
+  `expandAgentTools`) for everything, or an explicit subset — e.g. a
+  read-only child gets just `sheets/get-values`.
+- **Self-contained duplication is deliberate:** each step file inlines its
+  `sheetsCtx` auth/request preamble (seeded steps may only value-import
+  `"vein"` + node builtins); the contract is documented once in
+  `sheets/steps/_shared.ts` — change it there AND in every step.
+- **Smoke:** `npx tsx src/lab/sheets/smoke.ts` — offline; seeds into a temp
+  workspace, verifies registry discovery, then runs every step against a
+  fake `ctx.services.http` Google (real RSA keypair so the JWT signature is
+  verified; covers token caching, bearer headers, round-trip shapes, the
+  loud missing-credentials error, and a teaching-error case). No live
+  Google call has been made yet — end-to-end verification with a real
+  service account is pending.
+
 ### `harvey/` — Harvey LAB verification (the hardcoded grader)
 
 Runs the **actual** Harvey LAB legal-benchmark eval (the

--- a/mcp/src/lab/artifacts/seed.ts
+++ b/mcp/src/lab/artifacts/seed.ts
@@ -1,0 +1,25 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { WorkspaceManager } from "vein";
+
+/** Generic artifact plumbing steps (NOT an experiment). Today just
+ *  `artifacts/dir` — see steps/dir.ts. */
+const SEED_STEPS: Array<{ file: string; type: string }> = [
+  { file: "dir.ts", type: "artifacts/dir" },
+];
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function seedArtifactSteps(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "steps");
+  for (const { file, type } of SEED_STEPS) {
+    try {
+      const code = await readFile(join(dir, file), "utf-8");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "artifacts-seed");
+      if (changed) console.log(`[artifacts] seeded step: ${type} @ ${version}`);
+    } catch (err) {
+      console.warn(`[artifacts] could not seed step "${type}":`, err instanceof Error ? err.message : err);
+    }
+  }
+}

--- a/mcp/src/lab/artifacts/steps/dir.ts
+++ b/mcp/src/lab/artifacts/steps/dir.ts
@@ -1,0 +1,24 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/**
+ * Resolve THIS run's artifacts directory (creating it) and return its
+ * absolute path. The bridge between the artifacts capability (keyed by
+ * ctx.runId, which workflow expressions can't see) and steps that take a
+ * path — point an `agent` step's `cwd` at `{{ dir.path }}` so its file tools
+ * write into the run's artifact store, servable at GET /artifacts/:runId.
+ */
+export default defineStep({
+  type: "artifacts/dir",
+  description:
+    "Return this run's artifacts directory (absolute path, created on demand). " +
+    "Use as an early workflow step and point an agent step's cwd at its `path` output " +
+    "so produced files land in the run's artifact store (browsable at GET /artifacts/:runId).",
+  input: z.object({}),
+  output: z.any(),
+  async run(_cfg, ctx) {
+    const c = ctx as StepContext<VeinCapabilities>;
+    const artifacts = c.services?.artifacts;
+    if (!artifacts) throw new Error("artifacts capability unavailable");
+    return { path: await artifacts.dir(c.runId), runId: c.runId };
+  },
+});

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -12,6 +12,7 @@ import {
 import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
 import { seedEvalSteps } from "./eval/seed.js";
 import { seedGitseeWorkflows, seedGitseeSteps } from "./gitsee/seed.js";
+import { seedJarvisSteps } from "./jarvis/seed.js";
 import { buildGitseeServices, type GitseeServices } from "./gitsee/services/index.js";
 
 /**
@@ -112,6 +113,10 @@ export async function createLabVein(
   // gitsee experiment: self-contained steps (no services bag needed).
   await seedGitseeWorkflows(workspace);
   await seedGitseeSteps(workspace);
+  // jarvis knowledge-graph steps (self-contained; reach Jarvis over
+  // ctx.services.http with JARVIS_URL/API_TOKEN from ctx.services.secrets).
+  // Grantable to agents via agentTools: ["jarvis/*"].
+  await seedJarvisSteps(workspace);
 
   const vein = await createVein<LabServices>({
     workspace,

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -13,6 +13,7 @@ import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
 import { seedEvalSteps } from "./eval/seed.js";
 import { seedGitseeWorkflows, seedGitseeSteps } from "./gitsee/seed.js";
 import { seedJarvisSteps } from "./jarvis/seed.js";
+import { seedSheetsSteps } from "./sheets/seed.js";
 import { seedHarveySteps, seedHarveyWorkflows } from "./harvey/seed.js";
 import { seedArtifactSteps } from "./artifacts/seed.js";
 import { buildHarveyServices, type HarveyServices } from "./harvey/service.js";
@@ -131,6 +132,11 @@ export async function createLabVein(
   // ctx.services.http with JARVIS_URL/API_TOKEN from ctx.services.secrets).
   // Grantable to agents via agentTools: ["jarvis/*"].
   await seedJarvisSteps(workspace);
+  // google sheets steps (self-contained; reach the Sheets/Drive REST APIs
+  // over ctx.services.http with GOOGLE_SERVICE_ACCOUNT_JSON /
+  // GOOGLE_DRIVE_FOLDER_ID from ctx.services.secrets). Grantable to agents
+  // via agentTools: ["sheets/*"].
+  await seedSheetsSteps(workspace);
   // harvey verification steps (thin plumbing over services.harvey; grant
   // harvey/evaluate only to harness workflows, never the producing agent).
   await seedHarveySteps(workspace);

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -13,6 +13,8 @@ import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
 import { seedEvalSteps } from "./eval/seed.js";
 import { seedGitseeWorkflows, seedGitseeSteps } from "./gitsee/seed.js";
 import { seedJarvisSteps } from "./jarvis/seed.js";
+import { seedHarveySteps } from "./harvey/seed.js";
+import { buildHarveyServices, type HarveyServices } from "./harvey/service.js";
 import { buildGitseeServices, type GitseeServices } from "./gitsee/services/index.js";
 
 /**
@@ -42,6 +44,10 @@ export interface LabServices extends ConceptServices {
   /** Gitsee QA harness: per-run browser + stack session managers + vision judge,
    *  reached by the gitsee tool-steps via `ctx.services.gitsee.*`. */
   gitsee?: GitseeServices;
+  /** Harvey LAB verification: subprocess-runs the REAL legal-benchmark eval
+   *  from the pinned harvey-labs checkout (HARVEY_LABS_DIR). In-code on
+   *  purpose — the grader must stay outside the agent-editable surface. */
+  harvey?: HarveyServices;
   /** Generic per-run teardown hook called by the vein runner in a `finally`
    *  (success AND error). Disposes a run's gitsee browser + booted stack. */
   onRunEnd?(runId: string): Promise<void>;
@@ -92,6 +98,13 @@ export async function createLabVein(
     };
   }
 
+  // Harvey LAB grader — in-code, NOT seeded (see harvey/service.ts). Only
+  // added when absent, to respect a caller-provided bag. Construction is
+  // cheap; HARVEY_LABS_DIR is checked at call time (loud per-run error).
+  if (!services.harvey) {
+    services.harvey = buildHarveyServices();
+  }
+
   const workspacePath =
     opts.workspacePath ??
     process.env["VEIN_LAB_WORKSPACE"] ??
@@ -117,6 +130,9 @@ export async function createLabVein(
   // ctx.services.http with JARVIS_URL/API_TOKEN from ctx.services.secrets).
   // Grantable to agents via agentTools: ["jarvis/*"].
   await seedJarvisSteps(workspace);
+  // harvey verification steps (thin plumbing over services.harvey; grant
+  // harvey/evaluate only to harness workflows, never the producing agent).
+  await seedHarveySteps(workspace);
 
   const vein = await createVein<LabServices>({
     workspace,

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -13,7 +13,8 @@ import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
 import { seedEvalSteps } from "./eval/seed.js";
 import { seedGitseeWorkflows, seedGitseeSteps } from "./gitsee/seed.js";
 import { seedJarvisSteps } from "./jarvis/seed.js";
-import { seedHarveySteps } from "./harvey/seed.js";
+import { seedHarveySteps, seedHarveyWorkflows } from "./harvey/seed.js";
+import { seedArtifactSteps } from "./artifacts/seed.js";
 import { buildHarveyServices, type HarveyServices } from "./harvey/service.js";
 import { buildGitseeServices, type GitseeServices } from "./gitsee/services/index.js";
 
@@ -133,6 +134,9 @@ export async function createLabVein(
   // harvey verification steps (thin plumbing over services.harvey; grant
   // harvey/evaluate only to harness workflows, never the producing agent).
   await seedHarveySteps(workspace);
+  await seedHarveyWorkflows(workspace);
+  // generic artifact plumbing (artifacts/dir — bridge runId → path for cwd).
+  await seedArtifactSteps(workspace);
 
   const vein = await createVein<LabServices>({
     workspace,

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -1,0 +1,39 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { WorkspaceManager } from "vein";
+
+/**
+ * Harvey LAB verification steps — THIN plumbing only. The actual grader is
+ * the in-code `harvey` service (`service.ts`), which subprocess-runs the real
+ * eval from the harvey-labs checkout; editing these seeded steps can only
+ * break plumbing, never change how grading works. That split is deliberate:
+ * the benchmark verifier must stay outside the agent-editable surface.
+ *
+ * - `harvey/get-task` — instructions + documents, rubric stripped. Safe for
+ *   producing agents.
+ * - `harvey/evaluate` — stage this run's artifact deliverables + run the real
+ *   eval. Grant ONLY to harness workflows, never to the producing agent.
+ */
+const SEED_STEPS: Array<{ file: string; type: string }> = [
+  { file: "get-task.ts", type: "harvey/get-task" },
+  { file: "evaluate.ts", type: "harvey/evaluate" },
+];
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function seedHarveySteps(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "steps");
+  for (const { file, type } of SEED_STEPS) {
+    try {
+      const code = await readFile(join(dir, file), "utf-8");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "harvey-seed");
+      if (changed) console.log(`[harvey] seeded step: ${type} @ ${version}`);
+    } catch (err) {
+      console.warn(
+        `[harvey] could not seed step "${type}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -22,6 +22,21 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
+const SEED_WORKFLOWS = ["harvey-run"];
+
+export async function seedHarveyWorkflows(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "workflows");
+  for (const name of SEED_WORKFLOWS) {
+    try {
+      const yaml = await readFile(join(dir, `${name}.yaml`), "utf-8");
+      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, "harvey-seed");
+      if (changed) console.log(`[harvey] seeded workflow: ${name} @ ${version}`);
+    } catch (err) {
+      console.warn(`[harvey] could not seed workflow "${name}":`, err instanceof Error ? err.message : err);
+    }
+  }
+}
+
 export async function seedHarveySteps(workspace: WorkspaceManager): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {

--- a/mcp/src/lab/harvey/service.ts
+++ b/mcp/src/lab/harvey/service.ts
@@ -1,0 +1,298 @@
+import { spawn } from "node:child_process";
+import { cp, mkdir, readFile, readdir, writeFile, stat } from "node:fs/promises";
+import { join, resolve } from "node:path";
+
+/**
+ * Harvey LAB (Legal Agent Benchmark) verification service — the lab's
+ * hardcoded, NON-EDITABLE grader.
+ *
+ * Runs the ACTUAL eval from the harvey-labs checkout
+ * (`uv run python -m evaluation.run_eval`) as a subprocess — nothing is
+ * ported, so scores always come from the real benchmark. The eval logic
+ * lives here in the services bag (not in a seeded step) precisely so the
+ * workflow-authoring agent can never edit its own grader; the seeded
+ * `harvey/*` steps are thin plumbing over `ctx.services.harvey.*`.
+ *
+ * Integrity invariant: before any run, the checkout must be a CLEAN git tree
+ * (no local modifications), and — when `HARVEY_LABS_REV` is set — HEAD must
+ * match the pinned rev. A dirty or mispinned checkout refuses to grade.
+ * Every result carries the checkout's exact SHA (`benchmarkRev`) so a score
+ * is always attributable to a benchmark version.
+ *
+ * Config (env):
+ *   HARVEY_LABS_DIR — path to the harvey-labs checkout (required at call time)
+ *   HARVEY_LABS_REV — optional pinned commit SHA (prefix ok)
+ * The eval subprocess inherits process.env (it needs ANTHROPIC_API_KEY, and
+ * OPENAI_API_KEY too for --dual); harvey-labs also auto-loads its own .env.
+ */
+
+export interface ExecResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/** Injectable subprocess runner (fake it in smokes — no uv/python needed). */
+export type ExecFn = (
+  cmd: string,
+  args: string[],
+  opts: { cwd: string; timeoutMs: number; env?: NodeJS.ProcessEnv },
+) => Promise<ExecResult>;
+
+export interface HarveyTask {
+  task: string;
+  title: string;
+  work_type?: string;
+  tags?: string[];
+  instructions: string;
+  /** Expected deliverable filenames (from task.json `deliverables`). */
+  deliverables: string[];
+  /** Absolute path of the task's input documents directory (read-only). */
+  documentsDir: string;
+  /** Relative paths of the input documents. */
+  documents: string[];
+  // NOTE: `criteria` (the grading rubric) is DELIBERATELY not returned —
+  // the producing agent must never see its own rubric.
+}
+
+export interface HarveyEvalArgs {
+  /** Task id, e.g. "corporate-ma/review-data-room-red-flag-review". */
+  task: string;
+  /** Directory whose CONTENTS are the deliverables (staged to
+   *  `results/<runId>/output/` in the checkout). */
+  sourceDir: string;
+  /** Benchmark run id (also the results dir name). Sanitized. */
+  runId: string;
+  /** Optional producer metrics folded into the score report
+   *  (input_tokens, output_tokens, wall_clock_seconds, …). */
+  metrics?: Record<string, unknown>;
+  /** Single-judge model (default: the harness default, claude-sonnet-4-6). */
+  judgeModel?: string;
+  /** Dual-judge official-style grading (needs OPENAI_API_KEY too). */
+  dual?: boolean;
+  /** Concurrent judge calls (harness default 6). */
+  parallel?: number;
+  timeoutMs?: number;
+}
+
+export interface HarveyServices {
+  /** Verify the checkout (exists, clean tree, pinned rev) and return
+   *  `{ root, rev }`. Cached after first success. */
+  verifyCheckout(): Promise<{ root: string; rev: string }>;
+  /** Load a task's instructions + document listing — WITHOUT the rubric. */
+  getTask(task: string): Promise<HarveyTask>;
+  /** Stage deliverables and run the real eval; returns the parsed
+   *  scores.json (or scores_dual.json) plus benchmarkRev/runDir/reportPath. */
+  evaluate(args: HarveyEvalArgs): Promise<Record<string, unknown>>;
+}
+
+const DEFAULT_EVAL_TIMEOUT_MS = 30 * 60_000;
+
+function defaultExec(): ExecFn {
+  return (cmd, args, opts) =>
+    new Promise<ExecResult>((resolvePromise, reject) => {
+      const child = spawn(cmd, args, {
+        cwd: opts.cwd,
+        env: opts.env ?? process.env,
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+      let stdout = "";
+      let stderr = "";
+      child.stdout.on("data", (d) => (stdout += d));
+      child.stderr.on("data", (d) => (stderr += d));
+      const timer = setTimeout(() => {
+        child.kill("SIGKILL");
+        reject(new Error(`${cmd} timed out after ${opts.timeoutMs}ms`));
+      }, opts.timeoutMs);
+      child.on("error", (err) => {
+        clearTimeout(timer);
+        reject(err);
+      });
+      child.on("close", (code) => {
+        clearTimeout(timer);
+        resolvePromise({ code, stdout, stderr });
+      });
+    });
+}
+
+/** results dir names must be single, safe path segments. */
+function sanitizeRunId(runId: string): string {
+  const safe = runId.replace(/[^a-zA-Z0-9._-]/g, "-");
+  if (!safe || safe === "." || safe === ".." || safe.startsWith(".")) {
+    throw new Error(`harvey: invalid runId "${runId}"`);
+  }
+  return safe;
+}
+
+/** Task ids are slash-joined path segments under tasks/ — no traversal. */
+function sanitizeTask(root: string, task: string): string {
+  const dir = resolve(root, "tasks", task);
+  if (!dir.startsWith(resolve(root, "tasks") + "/")) {
+    throw new Error(`harvey: invalid task "${task}"`);
+  }
+  return dir;
+}
+
+export interface BuildHarveyOptions {
+  /** Checkout path; defaults to env HARVEY_LABS_DIR (checked at call time). */
+  dir?: string;
+  /** Pinned commit SHA; defaults to env HARVEY_LABS_REV (optional). */
+  rev?: string;
+  /** Subprocess runner override (for offline smokes). */
+  exec?: ExecFn;
+}
+
+export function buildHarveyServices(opts: BuildHarveyOptions = {}): HarveyServices {
+  const exec = opts.exec ?? defaultExec();
+  // Cached after first successful verification. Re-verified per evaluate()
+  // call anyway (cheap: two git commands) so a checkout dirtied mid-session
+  // is still caught; the cache only backs getTask.
+  let verified: { root: string; rev: string } | undefined;
+
+  async function verifyCheckout(): Promise<{ root: string; rev: string }> {
+    const root = opts.dir ?? process.env.HARVEY_LABS_DIR;
+    if (!root) {
+      throw new Error(
+        "harvey: HARVEY_LABS_DIR not configured — point it at the harvey-labs checkout",
+      );
+    }
+    const abs = resolve(root);
+    try {
+      const s = await stat(abs);
+      if (!s.isDirectory()) throw new Error("not a directory");
+    } catch {
+      throw new Error(`harvey: HARVEY_LABS_DIR does not exist: ${abs}`);
+    }
+
+    const head = await exec("git", ["rev-parse", "HEAD"], { cwd: abs, timeoutMs: 10_000 });
+    if (head.code !== 0) {
+      throw new Error(`harvey: ${abs} is not a git checkout: ${head.stderr.trim()}`);
+    }
+    const rev = head.stdout.trim();
+
+    // The benchmark must be unmodified: refuse to grade from a dirty tree.
+    // (results/ is gitignored upstream, so staged runs don't dirty it.)
+    const status = await exec("git", ["status", "--porcelain"], { cwd: abs, timeoutMs: 10_000 });
+    if (status.code !== 0) {
+      throw new Error(`harvey: git status failed in ${abs}: ${status.stderr.trim()}`);
+    }
+    const dirty = status.stdout
+      .split("\n")
+      .filter((l) => l.trim().length > 0)
+      .filter((l) => {
+        // Untracked entries under results/ are our own staged runs (results/
+        // is gitignored upstream; tolerate it untracked too). Anything else
+        // counts as a modification.
+        const path = l.slice(3);
+        return !(l.startsWith("??") && (path.startsWith("results/") || path === "results"));
+      });
+    if (dirty.length > 0) {
+      throw new Error(
+        `harvey: benchmark checkout has local modifications — refusing to grade. ` +
+        `Restore it to a clean tree first:\n${dirty.slice(0, 10).join("\n")}`,
+      );
+    }
+
+    const pin = opts.rev ?? process.env.HARVEY_LABS_REV;
+    if (pin && !rev.startsWith(pin)) {
+      throw new Error(
+        `harvey: checkout HEAD ${rev.slice(0, 12)} does not match pinned HARVEY_LABS_REV ${pin} — refusing to grade`,
+      );
+    }
+
+    verified = { root: abs, rev };
+    return verified;
+  }
+
+  async function getTask(task: string): Promise<HarveyTask> {
+    const { root } = verified ?? (await verifyCheckout());
+    const taskDir = sanitizeTask(root, task);
+    let config: any;
+    try {
+      config = JSON.parse(await readFile(join(taskDir, "task.json"), "utf-8"));
+    } catch (err) {
+      throw new Error(`harvey: task "${task}" not found or unreadable: ${err instanceof Error ? err.message : err}`);
+    }
+    const documentsDir = join(taskDir, "documents");
+    let documents: string[] = [];
+    try {
+      documents = (await readdir(documentsDir, { recursive: true, withFileTypes: true }))
+        .filter((e) => e.isFile())
+        .map((e) => join(e.parentPath, e.name).slice(documentsDir.length + 1))
+        .sort();
+    } catch {
+      // task without documents — fine
+    }
+    const deliverables =
+      config.deliverables && typeof config.deliverables === "object"
+        ? Object.keys(config.deliverables)
+        : [];
+    // criteria are DELIBERATELY dropped here — never expose the rubric.
+    return {
+      task,
+      title: config.title,
+      work_type: config.work_type,
+      tags: config.tags,
+      instructions: config.instructions,
+      deliverables,
+      documentsDir,
+      documents,
+    };
+  }
+
+  async function evaluate(args: HarveyEvalArgs): Promise<Record<string, unknown>> {
+    const { root, rev } = await verifyCheckout(); // fresh check every grade
+    sanitizeTask(root, args.task);
+    const runId = sanitizeRunId(args.runId);
+
+    // Stage deliverables where the harness looks: results/<runId>/output/.
+    const runDir = join(root, "results", runId);
+    const outputDir = join(runDir, "output");
+    await mkdir(outputDir, { recursive: true });
+    try {
+      await cp(args.sourceDir, outputDir, { recursive: true });
+    } catch (err) {
+      throw new Error(
+        `harvey: could not stage deliverables from ${args.sourceDir}: ${err instanceof Error ? err.message : err}`,
+      );
+    }
+    if (args.metrics) {
+      await writeFile(join(runDir, "metrics.json"), JSON.stringify(args.metrics, null, 2));
+    }
+
+    const cli = ["run", "python", "-m", "evaluation.run_eval", "--run-id", runId, "--task", args.task];
+    if (args.dual) cli.push("--dual");
+    else if (args.judgeModel) cli.push("--judge-model", args.judgeModel);
+    if (args.parallel) cli.push("--parallel", String(args.parallel));
+
+    const res = await exec("uv", cli, {
+      cwd: root,
+      timeoutMs: args.timeoutMs ?? DEFAULT_EVAL_TIMEOUT_MS,
+      env: process.env,
+    });
+
+    // The harness writes scores next to the staged run; read them back.
+    const scoresFile = args.dual ? "scores_dual.json" : "scores.json";
+    let scores: Record<string, unknown> | undefined;
+    try {
+      scores = JSON.parse(await readFile(join(runDir, scoresFile), "utf-8"));
+    } catch {
+      // fall through — combined with exit code below
+    }
+    if (res.code !== 0 || !scores) {
+      throw new Error(
+        `harvey: eval failed (exit ${res.code}, ${scoresFile}${scores ? " present" : " missing"}).\n` +
+        `stdout tail:\n${res.stdout.slice(-2000)}\nstderr tail:\n${res.stderr.slice(-2000)}`,
+      );
+    }
+
+    return {
+      ...scores,
+      benchmarkRev: rev,
+      runDir,
+      reportPath: join(runDir, "report.html"),
+    };
+  }
+
+  return { verifyCheckout, getTask, evaluate };
+}

--- a/mcp/src/lab/harvey/smoke.ts
+++ b/mcp/src/lab/harvey/smoke.ts
@@ -1,0 +1,214 @@
+/**
+ * Offline smoke test for the Harvey LAB verification service + steps — no
+ * uv/python, no LLM. Uses a REAL throwaway git repo as a fake harvey-labs
+ * checkout and a FAKE exec for the `uv` eval invocation (writes a plausible
+ * scores.json like the real harness would). Verifies:
+ *   - checkout integrity enforcement: missing dir, dirty tree, rev-pin
+ *     mismatch all refuse; untracked results/ runs are tolerated
+ *   - getTask returns instructions/documents and STRIPS the rubric
+ *   - evaluate stages artifact deliverables into results/<runId>/output/,
+ *     invokes the eval CLI with the right args, and returns scores +
+ *     benchmarkRev
+ *   - the seeded steps wire through ctx.services (registry discovery)
+ *
+ * Run: npx tsx src/lab/harvey/smoke.ts
+ */
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { WorkspaceManager, buildRegistry, fileArtifactsCapability, type StepContext } from "vein";
+import { buildHarveyServices, type ExecFn, type ExecResult } from "./service.js";
+import { seedHarveySteps } from "./seed.js";
+
+const TASK = "corporate-ma/test-task";
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync("git", args, { cwd, encoding: "utf-8" });
+}
+
+/** A minimal fake harvey-labs checkout: tasks/<TASK>/{task.json,documents}, committed. */
+function makeFakeCheckout(dir: string): void {
+  git(dir, "init", "-q");
+  git(dir, "config", "user.email", "smoke@test");
+  git(dir, "config", "user.name", "smoke");
+  const taskDir = join(dir, "tasks", TASK);
+  mkdirSync(join(taskDir, "documents"), { recursive: true });
+  writeFileSync(join(taskDir, "documents", "psa.md"), "# purchase agreement");
+  writeFileSync(
+    join(taskDir, "task.json"),
+    JSON.stringify({
+      title: "Test task",
+      work_type: "review",
+      tags: ["m&a"],
+      instructions: "Review the PSA. Output: `memo.md`.",
+      deliverables: { "memo.md": "memo.md" },
+      criteria: [{ id: "c1", title: "secret rubric", match_criteria: "must mention X", deliverables: ["memo.md"] }],
+    }),
+  );
+  writeFileSync(join(dir, ".gitignore"), "results/\n");
+  git(dir, "add", "-A");
+  git(dir, "commit", "-qm", "init");
+}
+
+/** Fake `uv run python -m evaluation.run_eval …`: writes scores.json the way
+ *  the real harness does. git commands pass through to the real git. */
+function makeFakeExec(checkout: string, log: Array<{ cmd: string; args: string[] }>): ExecFn {
+  return async (cmd, args, opts): Promise<ExecResult> => {
+    log.push({ cmd, args });
+    if (cmd === "git") {
+      try {
+        const out = execFileSync("git", args, { cwd: opts.cwd, encoding: "utf-8" });
+        return { code: 0, stdout: out, stderr: "" };
+      } catch (err: any) {
+        return { code: err.status ?? 1, stdout: err.stdout?.toString() ?? "", stderr: err.stderr?.toString() ?? String(err) };
+      }
+    }
+    // the eval CLI
+    const runId = args[args.indexOf("--run-id") + 1];
+    const runDir = join(checkout, "results", runId);
+    // the real harness requires the staged output dir — mimic that check
+    if (!existsSync(join(runDir, "output", "memo.md"))) {
+      return { code: 1, stdout: "", stderr: "run directory not found or empty" };
+    }
+    const scores = {
+      score: 1.0, max_score: 1.0, summary: "1/1 criteria passed.  ALL-PASS.",
+      all_pass: true, n_criteria: 1, n_passed: 1,
+      criteria_results: [{ id: "c1", verdict: "pass", reasoning: "mentions X" }],
+      run_id: runId, task: args[args.indexOf("--task") + 1],
+      judge_model: "claude-sonnet-4-6", scored_at: "2026-08-21T00:00:00Z",
+      ...(existsSync(join(runDir, "metrics.json"))
+        ? { cost: JSON.parse(readFileSync(join(runDir, "metrics.json"), "utf-8")) }
+        : {}),
+    };
+    writeFileSync(join(runDir, "scores.json"), JSON.stringify(scores));
+    return { code: 0, stdout: "ok", stderr: "" };
+  };
+}
+
+async function main() {
+  const base = mkdtempSync(join(process.cwd(), ".harvey-smoke-"));
+  try {
+    const checkout = join(base, "harvey-labs");
+    mkdirSync(checkout);
+    makeFakeCheckout(checkout);
+    const headRev = git(checkout, "rev-parse", "HEAD").trim();
+    const log: Array<{ cmd: string; args: string[] }> = [];
+    const harvey = buildHarveyServices({ dir: checkout, exec: makeFakeExec(checkout, log) });
+
+    // ── integrity: happy path ────────────────────────────────────────────
+    const v = await harvey.verifyCheckout();
+    assert.equal(v.rev, headRev);
+    console.log("✔ verifyCheckout (clean tree)");
+
+    // missing dir
+    await assert.rejects(
+      () => buildHarveyServices({ dir: join(base, "nope"), exec: makeFakeExec(checkout, []) }).verifyCheckout(),
+      /does not exist/,
+    );
+    // unset dir
+    delete process.env.HARVEY_LABS_DIR;
+    await assert.rejects(
+      () => buildHarveyServices({ exec: makeFakeExec(checkout, []) }).verifyCheckout(),
+      /HARVEY_LABS_DIR not configured/,
+    );
+    // rev-pin mismatch
+    await assert.rejects(
+      () => buildHarveyServices({ dir: checkout, rev: "deadbeef", exec: makeFakeExec(checkout, []) }).verifyCheckout(),
+      /does not match pinned/,
+    );
+    // matching pin (prefix) passes
+    await buildHarveyServices({ dir: checkout, rev: headRev.slice(0, 8), exec: makeFakeExec(checkout, []) }).verifyCheckout();
+    console.log("✔ integrity: missing dir / unset env / rev pin");
+
+    // dirty tree refuses; untracked results/ tolerated
+    writeFileSync(join(checkout, "tasks", TASK, "task.json.bak"), "tamper");
+    await assert.rejects(() => harvey.verifyCheckout(), /local modifications/);
+    rmSync(join(checkout, "tasks", TASK, "task.json.bak"));
+    mkdirSync(join(checkout, "results", "old-run"), { recursive: true });
+    writeFileSync(join(checkout, "results", "old-run", "scores.json"), "{}");
+    // results/ is gitignored in the fake checkout, but ALSO verify the
+    // untracked-results tolerance directly with the ignore removed:
+    rmSync(join(checkout, ".gitignore"));
+    git(checkout, "add", "-A");
+    git(checkout, "commit", "-qm", "drop gitignore");
+    await harvey.verifyCheckout(); // untracked results/** only → clean
+    console.log("✔ integrity: dirty tree refuses; untracked results/ tolerated");
+
+    // ── getTask strips the rubric ────────────────────────────────────────
+    const task = await harvey.getTask(TASK);
+    assert.equal(task.title, "Test task");
+    assert.deepEqual(task.deliverables, ["memo.md"]);
+    assert.deepEqual(task.documents, ["psa.md"]);
+    assert.ok(!("criteria" in task), "criteria must be stripped");
+    assert.ok(!JSON.stringify(task).includes("secret rubric"), "rubric text must not leak");
+    await assert.rejects(() => harvey.getTask("../../etc"), /invalid task/);
+    console.log("✔ getTask strips rubric + rejects traversal");
+
+    // ── evaluate: stage artifacts → run CLI → scores + rev ───────────────
+    const artifactsRoot = join(base, "artifacts");
+    const artifacts = fileArtifactsCapability(artifactsRoot);
+    await artifacts.write("run42", "output/memo.md", "memo mentioning X");
+
+    const result = await harvey.evaluate({
+      task: TASK,
+      sourceDir: join(artifactsRoot, "run42", "output"),
+      runId: "vein-run42",
+      metrics: { input_tokens: 100, output_tokens: 50 },
+    });
+    assert.equal(result.all_pass, true);
+    assert.equal(result.benchmarkRev, git(checkout, "rev-parse", "HEAD").trim());
+    assert.ok(String(result.reportPath).endsWith("report.html"));
+    // staged where the harness looks
+    assert.equal(
+      readFileSync(join(checkout, "results", "vein-run42", "output", "memo.md"), "utf-8"),
+      "memo mentioning X",
+    );
+    // CLI invoked correctly
+    const uvCall = log.find((c) => c.cmd === "uv")!;
+    assert.deepEqual(uvCall.args.slice(0, 4), ["run", "python", "-m", "evaluation.run_eval"]);
+    assert.ok(uvCall.args.includes("vein-run42") && uvCall.args.includes(TASK));
+    console.log("✔ evaluate: staging + CLI + scores + benchmarkRev");
+
+    // runId sanitization
+    await assert.rejects(
+      () => harvey.evaluate({ task: TASK, sourceDir: join(artifactsRoot, "run42", "output"), runId: "." }),
+      /invalid runId/,
+    );
+    console.log("✔ evaluate rejects bad runId");
+
+    // ── seeded steps: discovery + wiring through ctx.services ────────────
+    const wsDir = join(base, "ws");
+    const workspace = new WorkspaceManager(wsDir);
+    await seedHarveySteps(workspace);
+    const { registry } = await buildRegistry(workspace.path);
+    assert.ok(registry["harvey/get-task"] && registry["harvey/evaluate"]);
+
+    const ctx = {
+      runId: "run42", path: "smoke", scope: {}, input: undefined,
+      emit: async () => {},
+      services: { harvey, artifacts },
+    } as unknown as StepContext;
+
+    const stepTask: any = await registry["harvey/get-task"].run(
+      registry["harvey/get-task"].input.parse({ task: TASK }), ctx,
+    );
+    assert.equal(stepTask.title, "Test task");
+    assert.ok(!("criteria" in stepTask));
+
+    const stepScores: any = await registry["harvey/evaluate"].run(
+      registry["harvey/evaluate"].input.parse({ task: TASK }), ctx,
+    );
+    assert.equal(stepScores.all_pass, true);
+    console.log("✔ seeded steps wire through ctx.services");
+
+    console.log("\nALL HARVEY SMOKE CHECKS PASSED");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp/src/lab/harvey/steps/evaluate.ts
+++ b/mcp/src/lab/harvey/steps/evaluate.ts
@@ -1,0 +1,68 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import type { HarveyServices } from "../service.js";
+
+/**
+ * Thin plumbing over the in-code Harvey LAB service (`ctx.services.harvey`) —
+ * the grader itself is NOT in this file and cannot be edited here. It runs
+ * the REAL benchmark eval (uv subprocess in the pinned, clean harvey-labs
+ * checkout) against deliverables this run wrote to its artifacts dir.
+ *
+ * GUARDRAIL: grant this step only to the eval/harness workflow — NEVER to the
+ * producing agent's agentTools (an agent that can query its own grader
+ * mid-task trains against the rubric and contaminates the benchmark).
+ */
+export default defineStep({
+  type: "harvey/evaluate",
+  description:
+    "Grade this run's deliverables against a Harvey LAB task rubric by running the REAL " +
+    "benchmark eval (LLM judge, all-pass scoring) from the pinned harvey-labs checkout. " +
+    "Reads deliverables from this run's artifacts directory (subdir `from`, default 'output') — " +
+    "produce files there first (e.g. an agent step with cwd at the artifacts dir). " +
+    "Returns the benchmark's scores (score, all_pass, criteria_results, summary, …) plus " +
+    "benchmarkRev (the exact benchmark commit) and reportPath. " +
+    "Refuses to run if the benchmark checkout has local modifications.",
+  input: z.object({
+    task: z.string().describe("Task id, e.g. 'corporate-ma/review-data-room-red-flag-review'."),
+    from: z
+      .string()
+      .optional()
+      .default("output")
+      .describe("Subdirectory of this run's artifacts dir holding the deliverables (default 'output')."),
+    metrics: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe("Optional producer metrics folded into the report: input_tokens, output_tokens, wall_clock_seconds, …"),
+    judgeModel: z
+      .string()
+      .optional()
+      .describe("Single-judge model override (harness default: claude-sonnet-4-6). Ignored when dual=true."),
+    dual: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe("Official-style dual judging (Sonnet + GPT judges; needs OPENAI_API_KEY too)."),
+    parallel: z.number().int().positive().optional().describe("Concurrent judge calls (harness default 6)."),
+    timeoutMs: z.number().int().positive().optional().describe("Eval subprocess timeout (default 30 min)."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const services = ctx.services as ({ harvey?: HarveyServices } & VeinCapabilities) | undefined;
+    const harvey = services?.harvey;
+    if (!harvey) throw new Error("harvey service unavailable — is this the lab vein?");
+    const artifacts = services?.artifacts;
+    if (!artifacts) throw new Error("artifacts capability unavailable");
+    const typedCtx = ctx as StepContext<VeinCapabilities>;
+    const dir = await artifacts.dir(typedCtx.runId);
+    const sub = (cfg.from ?? "output").replace(/^\/+|\/+$/g, "");
+    return harvey.evaluate({
+      task: cfg.task,
+      sourceDir: sub ? `${dir}/${sub}` : dir,
+      runId: `vein-${typedCtx.runId}`,
+      metrics: cfg.metrics,
+      judgeModel: cfg.judgeModel,
+      dual: cfg.dual,
+      parallel: cfg.parallel,
+      timeoutMs: cfg.timeoutMs,
+    });
+  },
+});

--- a/mcp/src/lab/harvey/steps/get-task.ts
+++ b/mcp/src/lab/harvey/steps/get-task.ts
@@ -1,0 +1,28 @@
+import { z, defineStep } from "vein";
+import type { HarveyServices } from "../service.js";
+
+/**
+ * Thin plumbing over the in-code Harvey LAB service (`ctx.services.harvey`) —
+ * the eval logic itself is NOT in this file and cannot be edited here.
+ *
+ * Returns the task's instructions + input-document listing WITHOUT the
+ * grading rubric (the service strips `criteria`; a producing agent must never
+ * see how it will be graded). Safe to grant to producing agents.
+ */
+export default defineStep({
+  type: "harvey/get-task",
+  description:
+    "Load a Harvey LAB (Legal Agent Benchmark) task: title, instructions, expected deliverable " +
+    "filenames, and the input documents directory + file listing. Does NOT include the grading " +
+    "rubric. Task ids look like 'corporate-ma/review-data-room-red-flag-review' " +
+    "(practice-area/task-slug, sometimes with a /scenario-NN suffix).",
+  input: z.object({
+    task: z.string().describe("Task id, e.g. 'corporate-ma/review-data-room-red-flag-review'."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const harvey = (ctx.services as { harvey?: HarveyServices } | undefined)?.harvey;
+    if (!harvey) throw new Error("harvey service unavailable — is this the lab vein?");
+    return harvey.getTask(cfg.task);
+  },
+});

--- a/mcp/src/lab/harvey/workflows/harvey-run.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-run.yaml
@@ -27,8 +27,11 @@ steps:
     # A severed API connection mid-generation kills an otherwise-healthy run
     # (seen live: "other side closed" after the AI SDK's own 3 reconnects).
     # One workflow-level retry restarts the agent step fresh — worst case one
-    # duplicate read phase, vs. a dead 10-minute run.
-    retry: { max: 1, delayMs: 15000 }
+    # duplicate read phase, vs. a dead 10-minute run. NOTE: must nest under
+    # `options:` — the runner reads step.options.retry; a flat retry: key is
+    # silently ignored (learned the hard way).
+    options:
+      retry: { max: 1, delayMs: 15000 }
     config:
       cwd: "{{ dir.path }}"
       system: "{{ params.system }}"
@@ -50,7 +53,8 @@ steps:
     depends: produce
     # Same hardening: the judge pass is long (dozens of LLM calls); staging is
     # idempotent (same runId dir re-copied), so a retry is safe.
-    retry: { max: 1, delayMs: 15000 }
+    options:
+      retry: { max: 1, delayMs: 15000 }
     config:
       task: "{{ input.task }}"
       from: output

--- a/mcp/src/lab/harvey/workflows/harvey-run.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-run.yaml
@@ -70,6 +70,11 @@ params:
     Work ONLY from the documents provided in the task — do not invent facts,
     parties, dates, or terms, and do not use outside sources.
 
+    Your WORKING DIRECTORY is where ALL your writes go — always use relative
+    paths (./draft.md, ./output/<name>.docx). The task documents directory is
+    READ-ONLY and OUTSIDE your working directory: read from its absolute path,
+    but NEVER write there — writes outside the working directory are rejected.
+
     Method:
     1. Read EVERY input document fully before drafting (convert .docx with
        `pandoc <file> -t markdown`; .eml files are plain text). The client's

--- a/mcp/src/lab/harvey/workflows/harvey-run.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-run.yaml
@@ -77,8 +77,10 @@ params:
 
     Method:
     1. Read EVERY input document fully before drafting (convert .docx with
-       `pandoc <file> -t markdown`; .eml files are plain text). The client's
-       playbook and internal instructions control — follow them precisely,
+       `pandoc <file> -t markdown`; read .xlsx with python3 + openpyxl,
+       printing EVERY sheet, row, and column — spreadsheets often hold the
+       facts the analysis hinges on; .eml files are plain text). The client's
+       instructions and any playbook control — follow them precisely,
        including priorities and fallback positions.
     2. Draft each deliverable as markdown first (work files in your working
        directory are fine), covering every requirement in the instructions.

--- a/mcp/src/lab/harvey/workflows/harvey-run.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-run.yaml
@@ -1,0 +1,87 @@
+name: harvey-run
+# Harvey LAB harness: load a benchmark task → agent produces the deliverables
+# into this run's artifacts dir → grade with the REAL benchmark eval.
+#
+# The producing agent NEVER sees the rubric (harvey/get-task strips it in the
+# service) and is NOT granted harvey/evaluate — grading happens after the
+# agent finishes, in the harness. Prompts live in `params` (the experiment
+# surface). Deliverables are real files (usually .docx via pandoc) written to
+# ./output/ of the artifacts dir; the grade step stages exactly that dir.
+#
+# Needs: ANTHROPIC_API_KEY, HARVEY_LABS_DIR (+ uv, git, pandoc on PATH).
+# Input:  { task }  e.g. "arbitration-international-dispute-resolution/draft-markup-of-arbitration-agreement"
+# Output: the benchmark's own scores (score, all_pass, criteria_results, …)
+#         + benchmarkRev + reportPath, plus produceCost/produceSteps passthrough.
+steps:
+  - id: dir
+    type: artifacts/dir
+
+  - id: task
+    type: harvey/get-task
+    config:
+      task: "{{ input.task }}"
+
+  - id: produce
+    type: agent
+    depends: [dir, task]
+    config:
+      cwd: "{{ dir.path }}"
+      system: "{{ params.system }}"
+      prompt: |
+        {{ task.instructions }}
+
+        The task's input documents are in this READ-ONLY directory:
+        {{ task.documentsDir }}
+        List it first; extract .docx content with `pandoc <file> -t markdown`.
+
+        Required deliverable files (EXACT names, in ./output/ of your working
+        directory): {{ task.deliverables }}
+      model: "{{ params.model }}"
+      maxSteps: "{{ params.maxSteps }}"
+      toolFilter: "{{ params.toolFilter }}"
+
+  - id: grade
+    type: harvey/evaluate
+    depends: produce
+    config:
+      task: "{{ input.task }}"
+      from: output
+      metrics:
+        input_tokens: "{{ produce.usage.inputTokens }}"
+        output_tokens: "{{ produce.usage.outputTokens }}"
+        produce_cost: "{{ produce.cost }}"
+        produce_steps: "{{ produce.steps }}"
+      dual: "{{ params.dual }}"
+      timeoutMs: "{{ params.evalTimeoutMs }}"
+
+params:
+  model: claude-sonnet-4-6
+  # Generous budget: read 3-4 documents, draft substantial legal deliverables,
+  # convert to docx. The agent forces a final turn if it runs out.
+  maxSteps: 80
+  # No web_search: benchmark purity — the task is closed-book against the
+  # provided documents. (Empty would mean ALL built-ins, including web_search.)
+  toolFilter: ["bash", "str_replace_based_edit_tool", "repo_overview", "fulltext_search"]
+  dual: false
+  # 59-criterion tasks with parallel judges can take a while.
+  evalTimeoutMs: 2400000
+  system: |
+    You are a senior lawyer producing REAL work product for a demanding client.
+    Work ONLY from the documents provided in the task — do not invent facts,
+    parties, dates, or terms, and do not use outside sources.
+
+    Method:
+    1. Read EVERY input document fully before drafting (convert .docx with
+       `pandoc <file> -t markdown`; .eml files are plain text). The client's
+       playbook and internal instructions control — follow them precisely,
+       including priorities and fallback positions.
+    2. Draft each deliverable as markdown first (work files in your working
+       directory are fine), covering every requirement in the instructions.
+       Be thorough and specific: cite the exact clauses/sections you change,
+       show precise replacement language, and explain each change briefly.
+    3. Produce the FINAL deliverables as real .docx files with EXACTLY the
+       requested filenames in ./output/ :  `pandoc draft.md -o output/<name>.docx`
+    4. Verify before finishing: `ls -la output/` shows every required file,
+       and each converts back cleanly (`pandoc output/<name>.docx -t markdown | head`).
+
+    Only files in ./output/ are graded. Missing or misnamed files score zero.

--- a/mcp/src/lab/harvey/workflows/harvey-run.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-run.yaml
@@ -24,6 +24,11 @@ steps:
   - id: produce
     type: agent
     depends: [dir, task]
+    # A severed API connection mid-generation kills an otherwise-healthy run
+    # (seen live: "other side closed" after the AI SDK's own 3 reconnects).
+    # One workflow-level retry restarts the agent step fresh — worst case one
+    # duplicate read phase, vs. a dead 10-minute run.
+    retry: { max: 1, delayMs: 15000 }
     config:
       cwd: "{{ dir.path }}"
       system: "{{ params.system }}"
@@ -43,6 +48,9 @@ steps:
   - id: grade
     type: harvey/evaluate
     depends: produce
+    # Same hardening: the judge pass is long (dozens of LLM calls); staging is
+    # idempotent (same runId dir re-copied), so a retry is safe.
+    retry: { max: 1, delayMs: 15000 }
     config:
       task: "{{ input.task }}"
       from: output

--- a/mcp/src/lab/jarvis/seed.ts
+++ b/mcp/src/lab/jarvis/seed.ts
@@ -1,0 +1,54 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { WorkspaceManager } from "vein";
+
+/**
+ * Jarvis knowledge-graph steps, seeded into the vein workspace. Each is a
+ * self-contained port of the matching mcp repo-agent tool
+ * (`mcp/src/repo/toolsJarvis.ts`) speaking the same Jarvis HTTP contract —
+ * but routed through `ctx.services.http` + `ctx.services.secrets`
+ * (JARVIS_URL / API_TOKEN, env-backed) so runs are cassette-recordable and
+ * credentials stay scrubbed. Reconciled by content hash on boot (edits via
+ * the vein UI publish a new active version).
+ *
+ * Grant them to an agent step with `agentTools: ["jarvis/*"]` (glob), or a
+ * read-only subset by listing the read steps explicitly.
+ *
+ * Steps are ALWAYS seeded (deterministic workspace, deterministic registry);
+ * a deployment without JARVIS_URL gets a loud per-run error instead of a
+ * silently missing tool. The ontology CRUD family (schema editing) is
+ * deliberately not ported — schema changes stay a human/setup activity.
+ */
+const SEED_STEPS: Array<{ file: string; type: string }> = [
+  // reads
+  { file: "get-ontology.ts", type: "jarvis/get-ontology" },
+  { file: "get-ontology-type.ts", type: "jarvis/get-ontology-type" },
+  { file: "graph-search.ts", type: "jarvis/graph-search" },
+  { file: "graph-get.ts", type: "jarvis/graph-get" },
+  { file: "graph-get-batched.ts", type: "jarvis/graph-get-batched" },
+  { file: "graph-neighbors.ts", type: "jarvis/graph-neighbors" },
+  // writes
+  { file: "create-node.ts", type: "jarvis/create-node" },
+  { file: "edit-node.ts", type: "jarvis/edit-node" },
+  { file: "create-triplet.ts", type: "jarvis/create-triplet" },
+  { file: "create-batch-triplet.ts", type: "jarvis/create-batch-triplet" },
+];
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function seedJarvisSteps(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "steps");
+  for (const { file, type } of SEED_STEPS) {
+    try {
+      const code = await readFile(join(dir, file), "utf-8");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "jarvis-seed");
+      if (changed) console.log(`[jarvis] seeded step: ${type} @ ${version}`);
+    } catch (err) {
+      console.warn(
+        `[jarvis] could not seed step "${type}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/mcp/src/lab/jarvis/smoke.ts
+++ b/mcp/src/lab/jarvis/smoke.ts
@@ -1,0 +1,257 @@
+/**
+ * Offline smoke test for the jarvis/* steps — no vein server, no Neo4j, no
+ * live Jarvis. Verifies:
+ *   1. seeding: seedJarvisSteps publishes into a temp workspace and
+ *      buildRegistry discovers every step from disk;
+ *   2. step logic: each step is run against a FAKE `ctx.services.http` that
+ *      replays canned Jarvis response bodies, asserting the output shapes.
+ *
+ * Run: npx tsx src/lab/jarvis/smoke.ts
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { WorkspaceManager, buildRegistry, type StepContext, type HttpResponse } from "vein";
+import { seedJarvisSteps } from "./seed.js";
+
+// ── fake ctx: canned Jarvis over ctx.services.http ─────────────────────────
+
+type Call = { url: string; opts: any };
+const calls: Call[] = [];
+
+function fakeHttp(routes: Array<{ match: (url: string, opts: any) => boolean; body: unknown; status?: number }>) {
+  return async (url: string, opts: any = {}): Promise<HttpResponse> => {
+    calls.push({ url, opts });
+    for (const r of routes) {
+      if (r.match(url, opts)) {
+        return { status: r.status ?? 200, ok: (r.status ?? 200) < 300, headers: {}, body: r.body };
+      }
+    }
+    return { status: 404, ok: false, headers: {}, body: `no fake route for ${opts.method ?? "GET"} ${url}` };
+  };
+}
+
+function makeCtx(routes: Parameters<typeof fakeHttp>[0]): StepContext {
+  return {
+    runId: "smoke",
+    path: "smoke",
+    scope: {},
+    input: undefined,
+    emit: async () => {},
+    services: {
+      http: fakeHttp(routes),
+      secrets: {
+        get: async (name: string) =>
+          name === "JARVIS_URL" ? "http://jarvis.fake" : name === "API_TOKEN" ? "tok-123" : undefined,
+      },
+    },
+  } as unknown as StepContext;
+}
+
+async function main() {
+  // ── 1. seed + discover ───────────────────────────────────────────────────
+  // Under the mcp dir (not os tmpdir) so the seeded steps' dynamic
+  // `import "vein"` resolves via mcp/node_modules — same as the real
+  // lab-workspace location.
+  const dir = mkdtempSync(join(process.cwd(), ".jarvis-smoke-"));
+  try {
+    const workspace = new WorkspaceManager(dir);
+    await seedJarvisSteps(workspace);
+    const { registry } = await buildRegistry(workspace.path);
+    const expected = [
+      "jarvis/get-ontology", "jarvis/get-ontology-type", "jarvis/graph-search",
+      "jarvis/graph-get", "jarvis/graph-get-batched", "jarvis/graph-neighbors",
+      "jarvis/create-node", "jarvis/edit-node", "jarvis/create-triplet",
+      "jarvis/create-batch-triplet",
+    ];
+    for (const t of expected) assert.ok(registry[t], `registry missing ${t}`);
+    console.log(`✔ seeded + discovered ${expected.length} jarvis steps`);
+
+    // ── 2. run each against the fake Jarvis ────────────────────────────────
+    const node = {
+      ref_id: "r1", node_type: "Concept",
+      properties: { name: "Duty of Care", description: "d" },
+      edges: { PARENT_OF: 3 },
+    };
+
+    // graph-search
+    let out: any = await registry["jarvis/graph-search"].run(
+      registry["jarvis/graph-search"].input.parse({ q: "duty", type: "Concept" }),
+      makeCtx([{ match: (u) => u.includes("/v2/nodes"), body: { nodes: [node] } }]),
+    );
+    assert.equal(out[0].ref_id, "r1");
+    assert.equal(out[0].name, "Duty of Care");
+    assert.deepEqual(out[0].edges, { PARENT_OF: 3 });
+    // auth + params actually sent
+    let last = calls[calls.length - 1];
+    assert.equal(last.opts.headers["X-Api-Token"], "tok-123");
+    assert.equal(last.opts.query.type, "Concept");
+    assert.equal(last.opts.query.include_edge_counts, true);
+    console.log("✔ graph-search");
+
+    // graph-search requires a query
+    out = await registry["jarvis/graph-search"].run(
+      registry["jarvis/graph-search"].input.parse({}),
+      makeCtx([]),
+    );
+    assert.match(String(out), /requires at least one/);
+    console.log("✔ graph-search rejects empty query");
+
+    // graph-get (node + connection-counts collapse)
+    out = await registry["jarvis/graph-get"].run(
+      registry["jarvis/graph-get"].input.parse({ ref_id: "r1" }),
+      makeCtx([
+        { match: (u) => u.includes("/connection-counts"), body: { counts: [
+          { edge_type: "PARENT_OF", target_type: "Concept", count: 2 },
+          { edge_type: "PARENT_OF", target_type: "File", count: 1 },
+          { edge_type: "CITES", count: 5 },
+        ] } },
+        { match: (u) => u.includes("/v2/nodes/r1"), body: { nodes: [node] } },
+      ]),
+    );
+    assert.equal(out.ref_id, "r1");
+    assert.equal(out.name, "Duty of Care");
+    assert.deepEqual(out.edges, { PARENT_OF: 3, CITES: 5 });
+    console.log("✔ graph-get");
+
+    // graph-get-batched (one good, one bad; dedup)
+    out = await registry["jarvis/graph-get-batched"].run(
+      registry["jarvis/graph-get-batched"].input.parse({ ref_ids: ["r1", "r1", "missing"] }),
+      makeCtx([
+        { match: (u) => u.includes("/connection-counts"), body: { counts: [] } },
+        { match: (u) => u.includes("/v2/nodes/r1"), body: { nodes: [node] } },
+        { match: (u) => u.includes("/v2/nodes/missing"), body: { nodes: [] } },
+      ]),
+    );
+    assert.equal(out.requested, 3);
+    assert.equal(out.returned, 2); // deduped
+    assert.equal(out.nodes[0].ref_id, "r1");
+    assert.match(out.nodes[1].error, /not found/);
+    console.log("✔ graph-get-batched");
+
+    // graph-neighbors
+    out = await registry["jarvis/graph-neighbors"].run(
+      registry["jarvis/graph-neighbors"].input.parse({ ref_id: "r1", edge_type: ["PARENT_OF"] }),
+      makeCtx([
+        { match: (u) => u.includes("/v2/nodes/r1"), body: {
+          nodes: [node, { ref_id: "r2", node_type: "Concept", properties: { name: "Negligence" }, edges: { CITES: 1 } }],
+          edges: [{ source: "r1", target: "r2", edge_type: "PARENT_OF", properties: { importance: 0.9 } }],
+        } },
+      ]),
+    );
+    assert.equal(out[0].ref_id, "r2");
+    assert.equal(out[0].direction, "forward");
+    assert.equal(out[0].importance, 0.9);
+    last = calls[calls.length - 1];
+    assert.equal(last.opts.query.edge_type, '["PARENT_OF"]');
+    console.log("✔ graph-neighbors");
+
+    // get-ontology (grouping + domains)
+    out = await registry["jarvis/get-ontology"].run(
+      registry["jarvis/get-ontology"].input.parse({}),
+      makeCtx([{ match: (u) => u.includes("/v2/schema"), body: { schemas: [
+        { type: "Concept", domain: "Legal", type_description: "a legal concept" },
+        { type: "Person", domain: null, description: "a person" },
+        { type: "*", domain: "Legal" },
+        { type: "Old", is_deleted: true },
+      ], edges: [] } }]),
+    );
+    assert.deepEqual(out.domains, ["legal"]);
+    assert.equal(out.node_types.legal[0].type, "Concept");
+    assert.equal(out.node_types.ungrouped[0].type, "Person");
+    assert.equal(out.edges, undefined);
+    console.log("✔ get-ontology");
+
+    // get-ontology-type (trims to attributes)
+    out = await registry["jarvis/get-ontology-type"].run(
+      registry["jarvis/get-ontology-type"].input.parse({ type: "Concept" }),
+      makeCtx([{ match: (u) => u.includes("/v2/schema/Concept"), body: { attributes: { name: "string", body: "?string" }, icon: "x", ref_id: "s1" } }]),
+    );
+    assert.deepEqual(out, { attributes: { name: "string", body: "?string" } });
+    console.log("✔ get-ontology-type");
+
+    // create-node
+    out = await registry["jarvis/create-node"].run(
+      registry["jarvis/create-node"].input.parse({ node_type: "Concept", node_data: { name: "New" } }),
+      makeCtx([{ match: (u, o) => u.endsWith("/v2/nodes") && o.method === "POST", body: { status: "Success", data: { ref_id: "n1" } } }]),
+    );
+    assert.equal(out.ref_id, "n1");
+    console.log("✔ create-node");
+
+    // edit-node (soft-fail body detection)
+    out = await registry["jarvis/edit-node"].run(
+      registry["jarvis/edit-node"].input.parse({ ref_id: "n1", node_data: { body: "x" } }),
+      makeCtx([{ match: (u, o) => u.includes("/v2/nodes/n1") && o.method === "POST", body: { status: "fail", message: "Node already exists in the graph" } }]),
+    );
+    assert.match(String(out), /Node already exists/);
+    out = await registry["jarvis/edit-node"].run(
+      registry["jarvis/edit-node"].input.parse({ ref_id: "n1", node_data: { body: "x" } }),
+      makeCtx([{ match: (u, o) => u.includes("/v2/nodes/n1") && o.method === "POST", body: { status: "success" } }]),
+    );
+    assert.deepEqual(out.updated, ["body"]);
+    console.log("✔ edit-node");
+
+    // create-triplet (inline source resolution + edge)
+    out = await registry["jarvis/create-triplet"].run(
+      registry["jarvis/create-triplet"].input.parse({
+        source_type: "Concept", source_data: { name: "A" },
+        target_ref_id: "r1", edge_type: "PARENT_OF",
+      }),
+      makeCtx([
+        { match: (u, o) => u.endsWith("/v2/nodes") && o.method === "POST", body: { data: { ref_id: "src1" } } },
+        { match: (u, o) => u.endsWith("/v2/edges") && o.method === "POST", body: { edges: [{ ref_id: "e1" }] } },
+      ]),
+    );
+    assert.equal(out.source_ref_id, "src1");
+    assert.equal(out.target_ref_id, "r1");
+    assert.equal(out.edge_ref_id, "e1");
+    // invalid input is a soft error
+    out = await registry["jarvis/create-triplet"].run(
+      registry["jarvis/create-triplet"].input.parse({ source_ref_id: "r1", source_type: "X", edge_type: "E" }),
+      makeCtx([]),
+    );
+    assert.match(String(out), /not both/);
+    console.log("✔ create-triplet");
+
+    // create-batch-triplet (dedup of identical inline sides + per-item errors)
+    out = await registry["jarvis/create-batch-triplet"].run(
+      registry["jarvis/create-batch-triplet"].input.parse({ triplets: [
+        { source_type: "Concept", source_data: { name: "A" }, target_ref_id: "r1", edge_type: "PARENT_OF" },
+        { source_type: "Concept", source_data: { name: "A" }, target_ref_id: "r2", edge_type: "PARENT_OF" },
+        { source_ref_id: "bad", source_type: "X", edge_type: "E" }, // invalid
+      ] }),
+      makeCtx([
+        { match: (u, o) => u.endsWith("/v2/nodes") && o.method === "POST", body: { data: { ref_id: "src1" } } },
+        { match: (u, o) => u.endsWith("/v2/edges") && o.method === "POST", body: { edges: [{ ref_id: "e1" }] } },
+      ]),
+    );
+    assert.equal(out.requested, 3);
+    assert.equal(out.succeeded, 2);
+    assert.equal(out.failed, 1);
+    const nodeCreates = calls.filter((c) => c.url.endsWith("/v2/nodes") && c.opts.method === "POST");
+    // The two identical inline sides resolved once within THIS batch call
+    // (calls[] is cumulative across the smoke, so count only recent ones).
+    assert.ok(nodeCreates.length >= 1);
+    console.log("✔ create-batch-triplet");
+
+    // missing JARVIS_URL is a loud error
+    const noUrlCtx = {
+      ...makeCtx([]),
+      services: { http: fakeHttp([]), secrets: { get: async () => undefined } },
+    } as unknown as StepContext;
+    await assert.rejects(
+      () => registry["jarvis/graph-search"].run(registry["jarvis/graph-search"].input.parse({ q: "x" }), noUrlCtx),
+      /JARVIS_URL not configured/,
+    );
+    console.log("✔ loud error without JARVIS_URL");
+
+    console.log("\nALL JARVIS SMOKE CHECKS PASSED");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp/src/lab/jarvis/steps/_shared.ts
+++ b/mcp/src/lab/jarvis/steps/_shared.ts
@@ -1,0 +1,18 @@
+/**
+ * NOT a seeded step — shared TYPES + the canonical copy of the per-step
+ * preamble for the jarvis/* steps.
+ *
+ * Seeded steps must be SELF-CONTAINED (value-imports from "vein" only), so
+ * each step file inlines its own copy of the small `jarvisCtx` helper below.
+ * If you change the contract (env names, auth header), update every step in
+ * this directory — they are deliberately duplicated, not shared.
+ *
+ * Contract:
+ *   - `JARVIS_URL`  — base URL of the Jarvis backend (same-compose container).
+ *   - `API_TOKEN`   — sent as `X-Api-Token` (the same shared secret mcp uses).
+ *   - `JARVIS_HTTP_TIMEOUT_MS` — optional request timeout (default 180s).
+ * All three resolve through `ctx.services.secrets` (secret store → env
+ * fallback), and every request goes through `ctx.services.http`, so the steps
+ * are cassette-recordable and secret values are scrubbed from fixtures.
+ */
+export {};

--- a/mcp/src/lab/jarvis/steps/create-batch-triplet.ts
+++ b/mcp/src/lab/jarvis/steps/create-batch-triplet.ts
@@ -1,0 +1,174 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+/** Validate one side of a triplet: either ref_id XOR (type + data). */
+function validateTripletSide(
+  side: "source" | "target",
+  refId?: string,
+  nodeType?: string,
+  nodeData?: Record<string, any>,
+): string | null {
+  const hasRef = typeof refId === "string" && refId.length > 0;
+  const hasInline = Boolean(nodeType) || Boolean(nodeData);
+  if (hasRef && hasInline) return `${side}: pass either ${side}_ref_id OR ${side}_type + ${side}_data, not both`;
+  if (hasRef) return null;
+  if (nodeType && nodeData) return null;
+  return `${side}: pass ${side}_ref_id (an existing node), or both ${side}_type and ${side}_data (create/merge inline)`;
+}
+
+/** Created/merged node ref_id from a Jarvis POST /v2/nodes response body. */
+function extractNodeRefId(body: any): string | undefined {
+  const refId = body?.data?.ref_id;
+  return typeof refId === "string" && refId.length > 0 ? refId : undefined;
+}
+
+/** Edge ref_id from a Jarvis POST /v2/edges response body. */
+function extractEdgeRefId(body: any): string | undefined {
+  const refId = body?.edges?.[0]?.ref_id ?? body?.data?.ref_id;
+  return typeof refId === "string" && refId.length > 0 ? refId : undefined;
+}
+
+/** Stable dedup key for an inline node side (type + canonical sorted JSON),
+ *  so identical inline sides across the batch resolve once. */
+function nodeDedupKey(nodeType: string, nodeData: Record<string, any>): string {
+  function sortedJson(v: any): any {
+    if (v === null || typeof v !== "object" || Array.isArray(v)) return v;
+    const s: Record<string, any> = {};
+    for (const k of Object.keys(v).sort()) s[k] = sortedJson(v[k]);
+    return s;
+  }
+  return `${nodeType}::${JSON.stringify(sortedJson(nodeData))}`;
+}
+
+const TripletSchema = z.object({
+  source_ref_id: z.string().optional(),
+  source_type: z.string().optional(),
+  source_data: z.record(z.string(), z.any()).optional(),
+  target_ref_id: z.string().optional(),
+  target_type: z.string().optional(),
+  target_data: z.record(z.string(), z.any()).optional(),
+  edge_type: z.string(),
+  edge_data: z.record(z.string(), z.any()).optional(),
+  weight: z.number().optional(),
+  create_schema_if_missing: z.boolean().optional().default(false),
+});
+
+export default defineStep({
+  type: "jarvis/create-batch-triplet",
+  description:
+    "Assert MANY facts into the Jarvis knowledge graph in a single call. " +
+    "Each item in `triplets` has the same shape as jarvis_create_triplet (source/target as ref_id or inline " +
+    "node_type+node_data, plus edge_type and optional edge_data/weight/create_schema_if_missing). " +
+    "A single top-level `namespace` applies to all inline node creation. " +
+    "REUSE existing nodes wherever possible: supply ref_ids from jarvis_graph_search when entities already exist — " +
+    "inline creation is a last resort. Identical inline sides across the batch are resolved once (deduped). " +
+    "Triplets are written sequentially in input order; the result is a per-triplet array in the same order, " +
+    "each entry either the created edge info or `{ error }` — one failed triplet never fails the rest.",
+  input: z.object({
+    triplets: z.array(TripletSchema).min(1).describe("The facts to assert, in order."),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Jarvis namespace (data partition) for all inline node creation. Not an access-control boundary."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+
+    // Inline-node resolution cache: identical sides resolve once per batch.
+    const refCache = new Map<string, string>();
+
+    const resolveSide = async (
+      side: "source" | "target",
+      refId?: string,
+      nodeType?: string,
+      nodeData?: Record<string, any>,
+    ): Promise<string> => {
+      if (refId) return refId;
+      const key = nodeDedupKey(nodeType!, nodeData!);
+      const cached = refCache.get(key);
+      if (cached) return cached;
+      const query: Record<string, string> = {};
+      if (cfg.namespace) query.namespace = cfg.namespace;
+      const res = await http(`${base}/v2/nodes`, {
+        method: "POST",
+        headers,
+        query,
+        timeout,
+        body: { node_type: nodeType, node_data: nodeData },
+      });
+      const created = extractNodeRefId(res.body);
+      if (!created) {
+        throw new Error(`could not create/merge ${side} node (HTTP ${res.status}): ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`);
+      }
+      refCache.set(key, created);
+      return created;
+    };
+
+    const results: any[] = [];
+    for (const t of cfg.triplets) {
+      const invalid =
+        validateTripletSide("source", t.source_ref_id, t.source_type, t.source_data) ??
+        validateTripletSide("target", t.target_ref_id, t.target_type, t.target_data);
+      if (invalid) {
+        results.push({ error: `invalid input — ${invalid}`, edge_type: t.edge_type });
+        continue;
+      }
+      try {
+        const sourceRef = await resolveSide("source", t.source_ref_id, t.source_type, t.source_data);
+        const targetRef = await resolveSide("target", t.target_ref_id, t.target_type, t.target_data);
+        const res = await http(`${base}/v2/edges`, {
+          method: "POST",
+          headers,
+          timeout,
+          body: {
+            edge: {
+              edge_type: t.edge_type,
+              ...(t.weight !== undefined ? { weight: t.weight } : {}),
+              ...(t.edge_data ? { edge_data: t.edge_data } : {}),
+            },
+            source: { ref_id: sourceRef },
+            target: { ref_id: targetRef },
+            create_schema_if_missing: t.create_schema_if_missing ?? false,
+          },
+        });
+        const body = res.body as any;
+        const edgeRef = extractEdgeRefId(body);
+        if (!res.ok || !edgeRef) {
+          results.push({
+            error: `edge write failed — HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`,
+            source_ref_id: sourceRef,
+            target_ref_id: targetRef,
+            edge_type: t.edge_type,
+          });
+          continue;
+        }
+        results.push({
+          status: body?.status ?? "Success",
+          source_ref_id: sourceRef,
+          target_ref_id: targetRef,
+          edge_ref_id: edgeRef,
+          edge_type: t.edge_type,
+        });
+      } catch (err: any) {
+        results.push({ error: err?.message ?? String(err), edge_type: t.edge_type });
+      }
+    }
+
+    const failed = results.filter((r) => r.error).length;
+    return { requested: cfg.triplets.length, succeeded: results.length - failed, failed, results };
+  },
+});

--- a/mcp/src/lab/jarvis/steps/create-node.ts
+++ b/mcp/src/lab/jarvis/steps/create-node.ts
@@ -1,0 +1,73 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+/** Created/merged node ref_id from a Jarvis POST /v2/nodes response body.
+ *  Both plain success and the "already exists" warning carry data.ref_id. */
+function extractNodeRefId(body: any): string | undefined {
+  const refId = body?.data?.ref_id;
+  return typeof refId === "string" && refId.length > 0 ? refId : undefined;
+}
+
+export default defineStep({
+  type: "jarvis/create-node",
+  description:
+    "Create (or merge) a SINGLE node in the Jarvis knowledge graph as DATA, with no edge " +
+    "(to assert a relationship at the same time, use jarvis_create_triplet instead). Writes live to the graph. " +
+    "REUSE existing nodes: jarvis_graph_search first, and only create when the entity genuinely doesn't exist yet — " +
+    "duplicate nodes fragment the graph. The node type must already exist in the ontology " +
+    "(check with jarvis_get_ontology; jarvis_get_ontology_type shows its attributes and which are required). " +
+    "Create-or-merge semantics: if a node with the same identity key already exists, its ref_id is " +
+    "returned (reported as a Warning) instead of creating a duplicate — so re-running is safe.",
+  input: z.object({
+    node_type: z
+      .string()
+      .describe('Node type (must exist in the ontology — see jarvis_get_ontology). Never pass the wildcard sentinel "*".'),
+    node_data: z
+      .record(z.string(), z.any())
+      .describe('Properties for the node, e.g. {"name": "Alice"}. Must satisfy the type\'s schema, including its node_key attribute.'),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Jarvis namespace (data partition) to create the node in. Not an access-control boundary."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+    const query: Record<string, string> = {};
+    if (cfg.namespace) query.namespace = cfg.namespace;
+    const res = await http(`${base}/v2/nodes`, {
+      method: "POST",
+      headers,
+      query,
+      timeout,
+      body: { node_type: cfg.node_type, node_data: cfg.node_data },
+    });
+    const body = res.body as any;
+    const refId = extractNodeRefId(body);
+    if (!refId) {
+      return `jarvis/create-node failed — HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
+    }
+    return {
+      // "Warning" here means the node already existed (idempotent merge).
+      status: body?.status ?? "Success",
+      ref_id: refId,
+      node_type: cfg.node_type,
+      ...(Array.isArray(body?.status_messages) && body.status_messages.length > 0
+        ? { messages: body.status_messages }
+        : {}),
+    };
+  },
+});

--- a/mcp/src/lab/jarvis/steps/create-triplet.ts
+++ b/mcp/src/lab/jarvis/steps/create-triplet.ts
@@ -1,0 +1,189 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+/** Validate one side of a triplet: either ref_id XOR (type + data). */
+function validateTripletSide(
+  side: "source" | "target",
+  refId?: string,
+  nodeType?: string,
+  nodeData?: Record<string, any>,
+): string | null {
+  const hasRef = typeof refId === "string" && refId.length > 0;
+  const hasInline = Boolean(nodeType) || Boolean(nodeData);
+  if (hasRef && hasInline) return `${side}: pass either ${side}_ref_id OR ${side}_type + ${side}_data, not both`;
+  if (hasRef) return null;
+  if (nodeType && nodeData) return null;
+  return `${side}: pass ${side}_ref_id (an existing node), or both ${side}_type and ${side}_data (create/merge inline)`;
+}
+
+/** Created/merged node ref_id from a Jarvis POST /v2/nodes response body. */
+function extractNodeRefId(body: any): string | undefined {
+  const refId = body?.data?.ref_id;
+  return typeof refId === "string" && refId.length > 0 ? refId : undefined;
+}
+
+/** Edge ref_id from a Jarvis POST /v2/edges response body: a fresh edge lands
+ *  in edges[0].ref_id; the "already exists" warning carries data.ref_id. */
+function extractEdgeRefId(body: any): string | undefined {
+  const refId = body?.edges?.[0]?.ref_id ?? body?.data?.ref_id;
+  return typeof refId === "string" && refId.length > 0 ? refId : undefined;
+}
+
+export default defineStep({
+  type: "jarvis/create-triplet",
+  description:
+    "Assert a fact into the Jarvis knowledge graph as DATA: a triplet of source node -[edge]-> target node " +
+    "(instances, not schema). Writes live to the graph. " +
+    "For each side pass EITHER the ref_id of an existing node (preferred — find it with jarvis_graph_search) " +
+    "OR a node type + data object to create/merge the node inline. " +
+    "REUSE existing nodes wherever possible: search first, and only create inline when the entity " +
+    "genuinely doesn't exist yet — duplicate nodes fragment the graph. " +
+    "Node types and the edge type must already exist in the ontology (check with jarvis_get_ontology); " +
+    "create_schema_if_missing auto-creates a missing edge schema as a last resort. " +
+    "WILDCARD EDGE MATCHING: when checking source_type/target_type against jarvis_get_ontology's edges for validity, " +
+    'an edge entry with "*" on either side matches any concrete type on that side. ' +
+    '"*" is NEVER a valid value to SUPPLY as source_type or target_type — it is a backend sentinel, not a real node type.',
+  input: z.object({
+    source_ref_id: z
+      .string()
+      .optional()
+      .describe("ref_id of an EXISTING source node (from jarvis_graph_search/jarvis_graph_get). Preferred over inline creation."),
+    source_type: z
+      .string()
+      .optional()
+      .describe("Node type for an INLINE source node (must exist in the ontology). Requires source_data; omit when source_ref_id is set."),
+    source_data: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe('Properties for an INLINE source node, e.g. {"name": "Alice"}. Must satisfy the type\'s schema, including its node_key attribute.'),
+    target_ref_id: z
+      .string()
+      .optional()
+      .describe("ref_id of an EXISTING target node. Preferred over inline creation."),
+    target_type: z
+      .string()
+      .optional()
+      .describe("Node type for an INLINE target node (must exist in the ontology). Requires target_data; omit when target_ref_id is set."),
+    target_data: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe('Properties for an INLINE target node, e.g. {"name": "Acme Corp"}.'),
+    edge_type: z
+      .string()
+      .describe("The relationship type, e.g. 'WORKS_AT'. Uppercased by Jarvis. Must exist in the ontology between the two node types unless create_schema_if_missing is set."),
+    edge_data: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe("Optional properties to set on the edge."),
+    weight: z.number().optional().describe("Optional edge weight (defaults to 1)."),
+    create_schema_if_missing: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Auto-create the edge schema when the (source_type, edge_type, target_type) relationship is not yet in the ontology. " +
+        'Last resort — check jarvis_get_ontology\'s edges for an existing wildcard ("*") rule covering the same edge_type first.',
+      ),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Jarvis namespace (data partition) for inline node creation. Not an access-control boundary."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    for (const err of [
+      validateTripletSide("source", cfg.source_ref_id, cfg.source_type, cfg.source_data),
+      validateTripletSide("target", cfg.target_ref_id, cfg.target_type, cfg.target_data),
+    ]) {
+      if (err) return `jarvis/create-triplet invalid input — ${err}`;
+    }
+
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+
+    // Resolve one side to a concrete ref_id, creating/merging an inline node
+    // via POST /v2/nodes when no ref_id was given. Inline nodes are
+    // pre-created (rather than sent straight to /v2/edges) both for per-node
+    // error attribution and because Jarvis's edge endpoint mis-orders its
+    // ref_id list when only the source is inline (which would reverse the
+    // edge direction). Namespace applies to node creation only — the edge
+    // endpoint matches by globally-unique ref_id.
+    const resolveSide = async (
+      side: "source" | "target",
+      refId?: string,
+      nodeType?: string,
+      nodeData?: Record<string, any>,
+    ): Promise<string> => {
+      if (refId) return refId;
+      const query: Record<string, string> = {};
+      if (cfg.namespace) query.namespace = cfg.namespace;
+      const res = await http(`${base}/v2/nodes`, {
+        method: "POST",
+        headers,
+        query,
+        timeout,
+        body: { node_type: nodeType, node_data: nodeData },
+      });
+      const created = extractNodeRefId(res.body);
+      if (!created) {
+        throw new Error(`could not create/merge ${side} node (HTTP ${res.status}): ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`);
+      }
+      return created;
+    };
+
+    try {
+      // Sequential so a failure names the side that broke.
+      const sourceRef = await resolveSide("source", cfg.source_ref_id, cfg.source_type, cfg.source_data);
+      const targetRef = await resolveSide("target", cfg.target_ref_id, cfg.target_type, cfg.target_data);
+
+      const res = await http(`${base}/v2/edges`, {
+        method: "POST",
+        headers,
+        timeout,
+        body: {
+          edge: {
+            edge_type: cfg.edge_type,
+            ...(cfg.weight !== undefined ? { weight: cfg.weight } : {}),
+            ...(cfg.edge_data ? { edge_data: cfg.edge_data } : {}),
+          },
+          source: { ref_id: sourceRef },
+          target: { ref_id: targetRef },
+          create_schema_if_missing: cfg.create_schema_if_missing ?? false,
+        },
+      });
+      const body = res.body as any;
+      const edgeRef = extractEdgeRefId(body);
+      if (!res.ok || !edgeRef) {
+        return (
+          `jarvis/create-triplet: nodes resolved (source=${sourceRef}, target=${targetRef}) ` +
+          `but the edge write failed — HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`
+        );
+      }
+      return {
+        // "Warning" here means the edge already existed (idempotent merge).
+        status: body?.status ?? "Success",
+        source_ref_id: sourceRef,
+        target_ref_id: targetRef,
+        edge_ref_id: edgeRef,
+        edge_type: cfg.edge_type,
+        ...(Array.isArray(body?.status_messages) && body.status_messages.length > 0
+          ? { messages: body.status_messages }
+          : {}),
+      };
+    } catch (err: any) {
+      return `jarvis/create-triplet failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/jarvis/steps/edit-node.ts
+++ b/mcp/src/lab/jarvis/steps/edit-node.ts
@@ -1,0 +1,97 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+export default defineStep({
+  type: "jarvis/edit-node",
+  description:
+    "Update an EXISTING node in the Jarvis knowledge graph by ref_id (writes live to the graph). " +
+    "PARTIAL update: properties in node_data are merged over the node's current properties " +
+    "(validated against the type's schema) — properties you omit are left untouched. " +
+    "Use properties_to_be_deleted to remove properties entirely. " +
+    "Get the ref_id from jarvis_graph_search, and inspect the node with jarvis_graph_get first so you know its " +
+    "current state before changing it. " +
+    "Pass node_type ONLY to change the node's type (with type_to_be_deleted listing the old type " +
+    "label(s) to remove); omit both for normal property edits. " +
+    "If the update would change the node's identity key to collide with another node, the write " +
+    "fails with 'Node already exists in the graph'.",
+  input: z.object({
+    ref_id: z.string().describe("The ref_id of the node to update (from jarvis_graph_search/jarvis_graph_get)."),
+    node_data: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe('Properties to set/overwrite, e.g. {"description": "..."}. Merged over the node\'s existing properties.'),
+    properties_to_be_deleted: z
+      .array(z.string())
+      .optional()
+      .describe("Property names to REMOVE from the node."),
+    node_type: z
+      .string()
+      .optional()
+      .describe("New node type — pass ONLY when changing the node's type (must exist in the ontology)."),
+    type_to_be_deleted: z
+      .array(z.string())
+      .optional()
+      .describe("When changing the node's type: the old type label(s) to remove from the node."),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Jarvis namespace (data partition) the node lives in. Not an access-control boundary."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const hasSet = cfg.node_data && Object.keys(cfg.node_data).length > 0;
+    const hasDelete = cfg.properties_to_be_deleted && cfg.properties_to_be_deleted.length > 0;
+    if (!hasSet && !hasDelete && !cfg.node_type) {
+      return "jarvis/edit-node invalid input — pass at least one change: node_data (properties to set), properties_to_be_deleted, or node_type";
+    }
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+    const query: Record<string, string> = {};
+    if (cfg.namespace) query.namespace = cfg.namespace;
+    // Always send node_data (even empty) — its presence selects Jarvis's
+    // modern schema-validated update path over the legacy flat-property one.
+    const res = await http(`${base}/v2/nodes/${encodeURIComponent(cfg.ref_id)}`, {
+      method: "POST",
+      headers,
+      query,
+      timeout,
+      body: {
+        node_data: cfg.node_data ?? {},
+        ...(hasDelete ? { properties_to_be_deleted: cfg.properties_to_be_deleted } : {}),
+        ...(cfg.node_type ? { node_type: cfg.node_type } : {}),
+        ...(cfg.type_to_be_deleted && cfg.type_to_be_deleted.length > 0
+          ? { type_to_be_deleted: cfg.type_to_be_deleted }
+          : {}),
+      },
+    });
+    const body = res.body as any;
+    // Jarvis returns HTTP 200 with {status: "fail", message} on some write
+    // failures (e.g. node_key collision), so res.ok alone is not enough.
+    const succeeded = res.ok && body?.status === "success";
+    if (!succeeded) {
+      const detail = body?.message ?? body?.errorCode ?? (typeof res.body === "string" ? res.body : JSON.stringify(res.body));
+      return `jarvis/edit-node failed — HTTP ${res.status}: ${detail}`;
+    }
+    // Compact confirmation — deliberately NOT the full updated node, whose
+    // properties include bulky derived fields. jarvis_graph_get to verify.
+    return {
+      status: "Success",
+      ref_id: cfg.ref_id,
+      ...(hasSet ? { updated: Object.keys(cfg.node_data!) } : {}),
+      ...(hasDelete ? { deleted: cfg.properties_to_be_deleted } : {}),
+      ...(cfg.node_type ? { node_type: cfg.node_type } : {}),
+    };
+  },
+});

--- a/mcp/src/lab/jarvis/steps/get-ontology-type.ts
+++ b/mcp/src/lab/jarvis/steps/get-ontology-type.ts
@@ -1,0 +1,47 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+export default defineStep({
+  type: "jarvis/get-ontology-type",
+  description:
+    "Fetch the attribute schema for a SINGLE ontology node type. Returns exactly " +
+    "one field — `attributes` — and nothing else; for a type's domain, parent or " +
+    "description, use jarvis_get_ontology. " +
+    "Each attribute value is a type string (e.g. 'string', 'int'); a `?` prefix " +
+    "(e.g. '?string') means the attribute is OPTIONAL, no prefix means REQUIRED. " +
+    "`attributes` is complete: it already includes everything inherited from parent types. " +
+    "Lookup is case-insensitive for every type EXCEPT the root type 'Thing' (exact casing). " +
+    "A schema ref_id is also accepted instead of a type name. NODE types only — edge type " +
+    "names (e.g. 'KNOWS') are not schema nodes. Call jarvis_get_ontology first if you " +
+    "don't already know the exact type name.",
+  input: z.object({
+    type: z.string().describe(
+      "The node type name, e.g. 'Person' (case-insensitive, except the literal root type 'Thing'). A schema ref_id is also accepted.",
+    ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+    const res = await http(`${base}/v2/schema/${encodeURIComponent(cfg.type)}`, { headers, timeout });
+    if (!res.ok) return `HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
+    const data = res.body as any;
+    // Trim to the attribute schema (own + inherited are already merged into
+    // `attributes` on this endpoint). If the shape is unexpected, return it
+    // untouched so it stays debuggable.
+    if (!data || typeof data !== "object" || Array.isArray(data)) return data;
+    return data.attributes !== undefined ? { attributes: data.attributes } : data;
+  },
+});

--- a/mcp/src/lab/jarvis/steps/get-ontology.ts
+++ b/mcp/src/lab/jarvis/steps/get-ontology.ts
@@ -1,0 +1,116 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+/** Build the enriched ontology payload from the raw /v2/schema response:
+ *  filter "*"/deleted schemas, group node types by (lowercased) domain
+ *  ("ungrouped" for null), derive the sorted domains list, and optionally
+ *  append deduped compact edge triples sorted by edge_type. */
+function buildOntologyPayload(schemaData: any, includeEdges: boolean, includeAttributes: boolean) {
+  const schemas: any[] = schemaData?.schemas ?? [];
+  const rawEdges: any[] = schemaData?.edges ?? [];
+
+  const nodeTypes = schemas
+    .filter((s: any) => s.type && s.type !== "*" && !s.is_deleted)
+    .map((s: any) => {
+      const td = (s.type_description as string) ?? "";
+      const desc = (s.description as string) ?? "";
+      return {
+        type: s.type as string,
+        _domain: s.domain ? (s.domain as string).toLowerCase() : null,
+        description: td.trim() !== "" ? td : desc,
+        ...(includeAttributes && {
+          attributes: (s.attributes ?? {}) as Record<string, string>,
+          inherited_attributes: (s.inherited_attributes ?? {}) as Record<string, string>,
+        }),
+      };
+    });
+
+  const domains = Array.from(new Set(nodeTypes.map((n) => n._domain).filter((d): d is string => d !== null))).sort();
+
+  const grouped: Record<string, any[]> = {};
+  for (const { _domain, ...entry } of nodeTypes) {
+    const key = _domain ?? "ungrouped";
+    (grouped[key] ??= []).push(entry);
+  }
+
+  if (!includeEdges) return { domains, node_types: grouped };
+
+  const edgeSeen = new Set<string>();
+  const edges: Array<{ edge_type: string; source_type: string; target_type: string }> = [];
+  for (const e of rawEdges) {
+    const triple = { edge_type: e.edge_type as string, source_type: e.source_type as string, target_type: e.target_type as string };
+    const key = `${triple.edge_type}|${triple.source_type}|${triple.target_type}`;
+    if (!edgeSeen.has(key)) {
+      edgeSeen.add(key);
+      edges.push(triple);
+    }
+  }
+  edges.sort((a, b) => a.edge_type.localeCompare(b.edge_type));
+  return { domains, node_types: grouped, edges };
+}
+
+export default defineStep({
+  type: "jarvis/get-ontology",
+  description:
+    "Fetch the ontology of the Jarvis knowledge graph: node types grouped by domain " +
+    "and the canonical list of valid `domains`. " +
+    "Call this once before jarvis_graph_search to discover valid values for both the `type` and `domains` parameters. " +
+    "Node types are grouped by domain key in `node_types[<domain>]`; types with no domain land in the `ungrouped` bucket. " +
+    "Pass `domains` to filter results (comma-separated, e.g. 'Legal,Entity'); omit to receive all domains. " +
+    "Relationship edges are omitted by default — jarvis_graph_neighbors returns edge types live as you traverse. " +
+    "Set `include_edges` to also get the full relationship map (source_type -> target_type triples). " +
+    "Set `include_attributes` to also get each node type's attribute schema (field names, types, required/optional status). " +
+    "WILDCARD EDGES: when include_edges is true, an edge entry whose source_type and/or target_type is \"*\" " +
+    "means that edge type applies to ANY node type on that side. \"*\" is intentionally absent from node_types — " +
+    "it is a backend sentinel, not a real type.",
+  input: z.object({
+    domains: z
+      .string()
+      .optional()
+      .describe(
+        "Comma-separated list of domains to filter results to (e.g. 'Legal,Entity'). " +
+        "Omit to receive node types from all domains. Matched case-insensitively.",
+      ),
+    include_edges: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Include the full list of relationship edges (source_type/edge_type/target_type triples). " +
+        "Off by default — the edge list is large and jarvis_graph_neighbors surfaces edge types live.",
+      ),
+    include_attributes: z
+      .boolean()
+      .optional()
+      .default(false)
+      .describe(
+        "Include each node type's attribute schema maps (`attributes` and `inherited_attributes`). " +
+        "Off by default to keep the payload lean. A `?` prefix on a value type (e.g. '?string') means optional.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+    const query: Record<string, string | boolean> = {
+      include_edges: cfg.include_edges ?? false,
+      include_attributes: cfg.include_attributes ?? false,
+    };
+    if (cfg.domains && cfg.domains.trim() !== "") query.domains = cfg.domains.trim();
+    const res = await http(`${base}/v2/schema`, { headers, query, timeout });
+    if (!res.ok) return `HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
+    return buildOntologyPayload(res.body, cfg.include_edges ?? false, cfg.include_attributes ?? false);
+  },
+});

--- a/mcp/src/lab/jarvis/steps/graph-get-batched.ts
+++ b/mcp/src/lab/jarvis/steps/graph-get-batched.ts
@@ -58,7 +58,8 @@ export default defineStep({
     "`nodes` is either the full node (ref_id, node_type, name, properties, edges) or " +
     "`{ ref_id, error }` if that one could not be resolved — one bad ref_id never fails the rest. " +
     `If you pass more than ${BATCH_MAX} ref_ids, the excess comes back in ` +
-    "`omitted_ref_ids` and `truncated` is true; call again with those to finish the job.",
+    "`omitted_ref_ids` and `truncated` is true; call again with those to finish the job. " +
+    "An EMPTY `edges` map is NOT proof the node has no relationships (edge-count computation can be unavailable on some deployments) — confirm with jarvis_graph_neighbors before concluding a node is unconnected. ",
   input: z.object({
     ref_ids: z
       .array(z.string())

--- a/mcp/src/lab/jarvis/steps/graph-get-batched.ts
+++ b/mcp/src/lab/jarvis/steps/graph-get-batched.ts
@@ -1,0 +1,142 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+const LABEL_MAX = 160;
+const BATCH_MAX = 50;
+const CONCURRENCY = 8;
+
+/** Jarvis nodes keep their human label under wildly different keys depending
+ *  on node type — try a generous ordered candidate list. */
+function deriveNodeName(node: any, p: Record<string, any>): string {
+  const candidates = [
+    node?.name, p.name, p.title, p.label, p.display_name, p.displayName,
+    p.identifier, p.file_name, p.fileName, p.file, p.path, p.symbol,
+    p.function_name, p.class_name, p.method_name, p.operation_id, p.endpoint,
+    p.route, p.url, p.entity, p.key, p.slug, p.episode_title, p.show_title,
+    p.username, p.email, p.summary, p.description, p.text, p.content, p.body, p.docs,
+  ];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim().length > 0) {
+      const t = c.trim();
+      return t.length > LABEL_MAX ? t.slice(0, LABEL_MAX) : t;
+    }
+  }
+  return "";
+}
+
+/** Collapse /connection-counts rows into a compact {EDGE_TYPE: total} map. */
+function collapseConnectionCounts(
+  counts: Array<{ edge_type: string; target_type?: string; count: number }>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const c of counts ?? []) {
+    if (!c?.edge_type) continue;
+    out[c.edge_type] = (out[c.edge_type] ?? 0) + Number(c.count ?? 0);
+  }
+  return out;
+}
+
+export default defineStep({
+  type: "jarvis/graph-get-batched",
+  description:
+    `Resolve up to ${BATCH_MAX} nodes in one call by ref_id — the batched form of jarvis_graph_get. ` +
+    "ALWAYS prefer this over calling jarvis_graph_get in a loop: it fetches them concurrently in a single call. " +
+    "Returns `{ requested, returned, truncated, omitted_ref_ids, nodes }`, where each entry in " +
+    "`nodes` is either the full node (ref_id, node_type, name, properties, edges) or " +
+    "`{ ref_id, error }` if that one could not be resolved — one bad ref_id never fails the rest. " +
+    `If you pass more than ${BATCH_MAX} ref_ids, the excess comes back in ` +
+    "`omitted_ref_ids` and `truncated` is true; call again with those to finish the job.",
+  input: z.object({
+    ref_ids: z
+      .array(z.string())
+      .min(1)
+      .describe(`The ref_ids to resolve, in the order you want them back. Up to ${BATCH_MAX} per call.`),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Scope edge-count computation to a Jarvis namespace (data partition). Only affects each node's `edges` map."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+
+    async function fetchNode(
+      ref_id: string,
+    ): Promise<Record<string, any>> {
+      try {
+        const res = await http(`${base}/v2/nodes/${encodeURIComponent(ref_id)}`, {
+          headers,
+          query: { limit: 1 },
+          timeout,
+        });
+        if (!res.ok) {
+          return { ref_id, error: `HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}` };
+        }
+        const data = res.body as any;
+        const raw = Array.isArray(data?.nodes)
+          ? data.nodes.find((n: any) => n.ref_id === ref_id) ?? data.nodes[0]
+          : data;
+        if (!raw || !raw.ref_id) return { ref_id, error: `node not found: ${ref_id}` };
+        const properties = (raw.properties ?? {}) as Record<string, any>;
+        let edges: Record<string, number> = {};
+        try {
+          const ccQuery: Record<string, string> = {};
+          if (cfg.namespace) ccQuery.namespace = cfg.namespace;
+          const cc = await http(`${base}/v2/nodes/${encodeURIComponent(ref_id)}/connection-counts`, {
+            headers,
+            query: ccQuery,
+            timeout,
+          });
+          if (cc.ok) edges = collapseConnectionCounts((cc.body as any)?.counts ?? []);
+        } catch {
+          // best effort — edges stays {}
+        }
+        return {
+          ref_id: raw.ref_id,
+          node_type: raw.node_type,
+          name: deriveNodeName(raw, properties),
+          properties: raw.properties,
+          edges,
+        };
+      } catch (err: any) {
+        return { ref_id, error: `graph-get failed: ${err?.message ?? String(err)}` };
+      }
+    }
+
+    // Dedupe while preserving the caller's ordering.
+    const unique = Array.from(new Set(cfg.ref_ids.filter((r) => r && r.trim())));
+    if (unique.length === 0) {
+      return { requested: cfg.ref_ids.length, returned: 0, truncated: false, omitted_ref_ids: [], nodes: [], note: "no usable ref_ids supplied" };
+    }
+    const selected = unique.slice(0, BATCH_MAX);
+    const omitted = unique.slice(BATCH_MAX);
+
+    // Bounded concurrency without a queue dep: chunked waves.
+    const nodes: Record<string, any>[] = [];
+    for (let i = 0; i < selected.length; i += CONCURRENCY) {
+      const wave = selected.slice(i, i + CONCURRENCY);
+      nodes.push(...(await Promise.all(wave.map(fetchNode))));
+    }
+
+    return {
+      requested: cfg.ref_ids.length,
+      returned: nodes.length,
+      truncated: omitted.length > 0,
+      omitted_ref_ids: omitted,
+      nodes,
+    };
+  },
+});

--- a/mcp/src/lab/jarvis/steps/graph-get.ts
+++ b/mcp/src/lab/jarvis/steps/graph-get.ts
@@ -1,0 +1,110 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+const LABEL_MAX = 160;
+
+/** Jarvis nodes keep their human label under wildly different keys depending
+ *  on node type — try a generous ordered candidate list. */
+function deriveNodeName(node: any, p: Record<string, any>): string {
+  const candidates = [
+    node?.name, p.name, p.title, p.label, p.display_name, p.displayName,
+    p.identifier, p.file_name, p.fileName, p.file, p.path, p.symbol,
+    p.function_name, p.class_name, p.method_name, p.operation_id, p.endpoint,
+    p.route, p.url, p.entity, p.key, p.slug, p.episode_title, p.show_title,
+    p.username, p.email, p.summary, p.description, p.text, p.content, p.body, p.docs,
+  ];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim().length > 0) {
+      const t = c.trim();
+      return t.length > LABEL_MAX ? t.slice(0, LABEL_MAX) : t;
+    }
+  }
+  return "";
+}
+
+/** Collapse /connection-counts rows into a compact {EDGE_TYPE: total} map. */
+function collapseConnectionCounts(
+  counts: Array<{ edge_type: string; target_type?: string; count: number }>,
+): Record<string, number> {
+  const out: Record<string, number> = {};
+  for (const c of counts ?? []) {
+    if (!c?.edge_type) continue;
+    out[c.edge_type] = (out[c.edge_type] ?? 0) + Number(c.count ?? 0);
+  }
+  return out;
+}
+
+export default defineStep({
+  type: "jarvis/graph-get",
+  description:
+    "Resolve a single node in the Jarvis knowledge graph to its full content by ref_id. " +
+    "Use the ref_id from jarvis_graph_search or jarvis_graph_neighbors results. " +
+    "Returns the node's ref_id, node_type, derived name, properties, and an " +
+    "`edges` map ({EDGE_TYPE: count}) showing how connected the node is and " +
+    "which relationship types you can traverse next with jarvis_graph_neighbors. " +
+    "To resolve several ref_ids at once, use jarvis_graph_get_batched instead.",
+  input: z.object({
+    ref_id: z.string().describe("The ref_id of the node to resolve."),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Scope edge-count computation to a Jarvis namespace (data partition). Only affects the `edges` map."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+    // limit=1 keeps Jarvis from materializing the node's whole neighborhood
+    // (which can OOM Neo4j for hub nodes) — we only read the node itself.
+    const res = await http(`${base}/v2/nodes/${encodeURIComponent(cfg.ref_id)}`, {
+      headers,
+      query: { limit: 1 },
+      timeout,
+    });
+    if (!res.ok) return `HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
+    const data = res.body as any;
+    // Deployed Jarvis wraps the node in `{ nodes, edges, status }`; some
+    // builds return the node directly. Handle both shapes.
+    const raw = Array.isArray(data?.nodes)
+      ? data.nodes.find((n: any) => n.ref_id === cfg.ref_id) ?? data.nodes[0]
+      : data;
+    if (!raw || !raw.ref_id) return `node not found: ${cfg.ref_id}`;
+    const properties = (raw.properties ?? {}) as Record<string, any>;
+
+    // Edge-type connectivity from the cheap counts endpoint. Best effort —
+    // never fail the whole call if this lookup errors.
+    let edges: Record<string, number> = {};
+    try {
+      const ccQuery: Record<string, string> = {};
+      if (cfg.namespace) ccQuery.namespace = cfg.namespace;
+      const cc = await http(`${base}/v2/nodes/${encodeURIComponent(cfg.ref_id)}/connection-counts`, {
+        headers,
+        query: ccQuery,
+        timeout,
+      });
+      if (cc.ok) edges = collapseConnectionCounts((cc.body as any)?.counts ?? []);
+    } catch {
+      // best effort — edges stays {}
+    }
+
+    return {
+      ref_id: raw.ref_id,
+      node_type: raw.node_type,
+      name: deriveNodeName(raw, properties),
+      properties: raw.properties,
+      edges,
+    };
+  },
+});

--- a/mcp/src/lab/jarvis/steps/graph-get.ts
+++ b/mcp/src/lab/jarvis/steps/graph-get.ts
@@ -55,6 +55,7 @@ export default defineStep({
     "Returns the node's ref_id, node_type, derived name, properties, and an " +
     "`edges` map ({EDGE_TYPE: count}) showing how connected the node is and " +
     "which relationship types you can traverse next with jarvis_graph_neighbors. " +
+    "An EMPTY `edges` map is NOT proof the node has no relationships (edge-count computation can be unavailable on some deployments) — confirm with jarvis_graph_neighbors before concluding a node is unconnected. " +
     "To resolve several ref_ids at once, use jarvis_graph_get_batched instead.",
   input: z.object({
     ref_id: z.string().describe("The ref_id of the node to resolve."),

--- a/mcp/src/lab/jarvis/steps/graph-neighbors.ts
+++ b/mcp/src/lab/jarvis/steps/graph-neighbors.ts
@@ -1,0 +1,130 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+const LABEL_MAX = 160;
+const NEIGHBOR_CAP = 50;
+const EXCLUDED_NODE_TYPES = ["Hint", "Memory", "Clip", "Turn"];
+
+/** Encode an array as a Python list literal, e.g. `["MODIFIES","CITES"]`
+ *  (the format the Jarvis endpoint parses for list params). */
+function toPythonListLiteral(arr: string[]): string {
+  return `[${arr.map((s) => `"${s}"`).join(",")}]`;
+}
+
+/** Jarvis nodes keep their human label under wildly different keys depending
+ *  on node type — try a generous ordered candidate list. */
+function deriveNodeName(node: any, p: Record<string, any>): string {
+  const candidates = [
+    node?.name, p.name, p.title, p.label, p.display_name, p.displayName,
+    p.identifier, p.file_name, p.fileName, p.file, p.path, p.symbol,
+    p.function_name, p.class_name, p.method_name, p.operation_id, p.endpoint,
+    p.route, p.url, p.entity, p.key, p.slug, p.episode_title, p.show_title,
+    p.username, p.email, p.summary, p.description, p.text, p.content, p.body, p.docs,
+  ];
+  for (const c of candidates) {
+    if (typeof c === "string" && c.trim().length > 0) {
+      const t = c.trim();
+      return t.length > LABEL_MAX ? t.slice(0, LABEL_MAX) : t;
+    }
+  }
+  return "";
+}
+
+export default defineStep({
+  type: "jarvis/graph-neighbors",
+  description:
+    "Return all nodes adjacent (one hop) to a node in the Jarvis knowledge graph, " +
+    "with edge_type and direction. Use the ref_id from jarvis_graph_search or jarvis_graph_get. " +
+    "Each neighbor also includes an `edges` map ({EDGE_TYPE: count}) showing how " +
+    "connected that neighbor is and which relationship types you can hop along next. " +
+    "Optionally filter by edge_type and/or node_type. " +
+    "Use this to traverse relationships between people, topics, concepts, code, etc.",
+  input: z.object({
+    ref_id: z.string().describe("The ref_id of the node to expand."),
+    edge_type: z
+      .array(z.string())
+      .optional()
+      .describe('Filter edges by type, e.g. ["MODIFIES", "CITES"].'),
+    node_type: z
+      .array(z.string())
+      .optional()
+      .describe('Filter neighbor nodes by type, e.g. ["File", "Concept"].'),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Scope neighbor edge-count computation to a Jarvis namespace (data partition). Only affects each neighbor's `edges` map."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+    // `limit` bounds the Cypher traversal so a hub node doesn't OOM Neo4j.
+    // `sort_by=importance` orders edges before LIMIT so the cap keeps the most
+    // important neighbors. `canonicalize=false` matches the real Neo4j label.
+    const query: Record<string, string | number | boolean> = {
+      expand: "edges",
+      limit: NEIGHBOR_CAP,
+      sort_by: "importance",
+      canonicalize: "false",
+      exclude_node_type: toPythonListLiteral(EXCLUDED_NODE_TYPES),
+      include_edge_counts: true,
+    };
+    if (cfg.edge_type && cfg.edge_type.length > 0) query.edge_type = toPythonListLiteral(cfg.edge_type);
+    if (cfg.node_type && cfg.node_type.length > 0) query.node_type = toPythonListLiteral(cfg.node_type);
+    if (cfg.namespace) query.namespace = cfg.namespace;
+
+    const res = await http(`${base}/v2/nodes/${encodeURIComponent(cfg.ref_id)}`, { headers, query, timeout });
+    if (!res.ok) return `HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
+    const data = res.body as any;
+
+    // Node details by ref_id (excluding the queried node) so each neighbor
+    // carries a label and its own connectivity map alongside its ref_id.
+    const nodeMap = new Map<string, { node_type: string; name: string; edges: Record<string, number> }>();
+    for (const node of data.nodes ?? []) {
+      if (node.ref_id !== cfg.ref_id) {
+        nodeMap.set(node.ref_id, {
+          node_type: node.node_type,
+          name: deriveNodeName(node, (node.properties ?? {}) as Record<string, any>),
+          edges: (node.edges ?? {}) as Record<string, number>,
+        });
+      }
+    }
+
+    const neighbors: any[] = [];
+    const seen = new Set<string>();
+    for (const edge of data.edges ?? []) {
+      const direction = edge.source === cfg.ref_id ? "forward" : "reverse";
+      const neighborRefId = direction === "forward" ? edge.target : edge.source;
+      if (neighborRefId === cfg.ref_id) continue; // self-loop guard
+      if (seen.has(neighborRefId)) continue; // parallel-edge dedup: keep the first
+      seen.add(neighborRefId);
+
+      const detail = nodeMap.get(neighborRefId);
+      const importance = edge.properties?.importance as number | undefined;
+      neighbors.push({
+        ref_id: neighborRefId,
+        node_type: detail?.node_type ?? "unknown",
+        name: detail?.name ?? "",
+        edge_type: edge.edge_type,
+        direction,
+        edges: detail?.edges ?? {},
+        ...(importance !== undefined ? { importance } : {}),
+      });
+      if (neighbors.length >= NEIGHBOR_CAP) break;
+    }
+
+    return neighbors;
+  },
+});

--- a/mcp/src/lab/jarvis/steps/graph-search.ts
+++ b/mcp/src/lab/jarvis/steps/graph-search.ts
@@ -1,0 +1,99 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/** Resolve the Jarvis base URL + auth via the secrets capability (secret
+ *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
+async function jarvisCtx(ctx?: StepContext<VeinCapabilities>) {
+  const http = ctx?.services?.http;
+  if (!http) throw new Error("jarvis: ctx.services.http unavailable — run with a services bag");
+  const secrets = ctx?.services?.secrets;
+  const base = (await secrets?.get("JARVIS_URL"))?.replace(/\/+$/, "");
+  if (!base) throw new Error("jarvis: JARVIS_URL not configured (set it in the mcp env or the vein secret store)");
+  const token = (await secrets?.get("API_TOKEN")) ?? "";
+  const rawTimeout = Number(await secrets?.get("JARVIS_HTTP_TIMEOUT_MS"));
+  const timeout = Number.isFinite(rawTimeout) && rawTimeout > 0 ? rawTimeout : 180_000;
+  return { base, http, timeout, headers: { "X-Api-Token": token } };
+}
+
+export default defineStep({
+  type: "jarvis/graph-search",
+  description:
+    "Search the Jarvis knowledge graph for ontology nodes — people, topics, concepts, organizations, workflows, and more. " +
+    "Provide at least one of `q`, `input_q`, `output_q` — they can be combined, each acting as its own " +
+    "retriever fused into one ranked result set. " +
+    "Each result includes an `edges` map ({EDGE_TYPE: count}) showing how connected the node is and " +
+    "which relationship types you can traverse next with jarvis_graph_neighbors. " +
+    "Call jarvis_get_ontology first to discover valid values for the `type` parameter.",
+  input: z.object({
+    q: z
+      .string()
+      .optional()
+      .describe("General hybrid (keyword + semantic) search query over node names, descriptions, bodies, and schemas."),
+    input_q: z
+      .string()
+      .optional()
+      .describe(
+        "Semantic search scoped to node INPUT schemas — find nodes by what they take as input, " +
+        "e.g. 'a video file url'. Applies to node types with input embeddings (Workflow, Skill).",
+      ),
+    output_q: z
+      .string()
+      .optional()
+      .describe(
+        "Semantic search scoped to node OUTPUT schemas — find nodes by what they produce, " +
+        "e.g. 'transcript with word-level timestamps'. Applies to node types with output embeddings (Workflow, Skill).",
+      ),
+    type: z
+      .string()
+      .optional()
+      .describe("Comma-separated node type filter, e.g. 'Concept' or 'Person,Topic'. Call jarvis_get_ontology to see all valid values."),
+    limit: z.number().optional().default(10).describe("Maximum number of results to return"),
+    domains: z
+      .string()
+      .optional()
+      .describe("Comma-separated domain filter, e.g. 'entity' or 'content,entity'. Not required. Call jarvis_get_ontology to see valid domains."),
+    namespace: z
+      .string()
+      .optional()
+      .describe("Scope the search to a Jarvis namespace (data partition). Not an access-control boundary."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    if (!cfg.q && !cfg.input_q && !cfg.output_q) {
+      return "jarvis/graph-search requires at least one of: q, input_q, output_q";
+    }
+    const { base, http, timeout, headers } = await jarvisCtx(ctx as StepContext<VeinCapabilities>);
+    const query: Record<string, string | number | boolean> = {
+      limit: cfg.limit ?? 10,
+      // Per-node {EDGE_TYPE: count} map inline, so connectivity + hop targets
+      // come back in one call.
+      include_edge_counts: true,
+    };
+    if (cfg.q) query.q = cfg.q;
+    // Field-scoped vector search: Jarvis embeds these against the per-field
+    // input/output schema embeddings and fuses them with `q` via RRF.
+    if (cfg.input_q) query.input_q = cfg.input_q;
+    if (cfg.output_q) query.output_q = cfg.output_q;
+    if (cfg.type) query.type = cfg.type;
+    if (cfg.domains) query.domains = cfg.domains;
+    if (cfg.namespace) query.namespace = cfg.namespace;
+
+    const res = await http(`${base}/v2/nodes`, { headers, query, timeout });
+    if (!res.ok) return `HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
+    const data = res.body as any;
+    const nodes: any[] = Array.isArray(data) ? data : (data?.nodes ?? []);
+    return nodes.map((n: any) => ({
+      ref_id: n.ref_id ?? n.properties?.ref_id,
+      name:
+        n.properties?.name ??
+        n.properties?.workflow_name ??
+        n.properties?.episode_title ??
+        n.properties?.entity,
+      node_type: n.node_type,
+      description: n.properties?.description ?? n.properties?.summary ?? n.properties?.text ?? "",
+      // {EDGE_TYPE: count} map of this node's relationships.
+      edges: (n.edges ?? {}) as Record<string, number>,
+      ...(n.properties?.workflow_id !== undefined ? { workflow_id: n.properties.workflow_id } : {}),
+      ...(n.properties?.skill_id !== undefined ? { skill_id: n.properties.skill_id } : {}),
+    }));
+  },
+});

--- a/mcp/src/lab/jarvis/steps/graph-search.ts
+++ b/mcp/src/lab/jarvis/steps/graph-search.ts
@@ -22,7 +22,8 @@ export default defineStep({
     "retriever fused into one ranked result set. " +
     "Each result includes an `edges` map ({EDGE_TYPE: count}) showing how connected the node is and " +
     "which relationship types you can traverse next with jarvis_graph_neighbors. " +
-    "Call jarvis_get_ontology first to discover valid values for the `type` parameter.",
+    "Call jarvis_get_ontology first to discover valid values for the `type` parameter. " +
+    "An EMPTY `edges` map is NOT proof the node has no relationships (edge-count computation can be unavailable on some deployments) — confirm with jarvis_graph_neighbors before concluding a node is unconnected. ",
   input: z.object({
     q: z
       .string()

--- a/mcp/src/lab/sheets/seed.ts
+++ b/mcp/src/lab/sheets/seed.ts
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { WorkspaceManager } from "vein";
+
+/**
+ * Google Sheets steps, seeded into the vein workspace. Each is a
+ * self-contained port of the matching mcp repo-agent tool
+ * (`mcp/src/repo/toolsGoogleSheets.ts`) speaking the same Sheets/Drive REST
+ * contract — but routed through `ctx.services.http` + `ctx.services.secrets`
+ * (GOOGLE_SERVICE_ACCOUNT_JSON / GOOGLE_DRIVE_FOLDER_ID, env-backed) so runs
+ * are cassette-recordable and credentials stay scrubbed. Reconciled by
+ * content hash on boot (edits via the vein UI publish a new active version).
+ *
+ * Grant them to an agent step with `agentTools: ["sheets/*"]` (glob), or an
+ * explicit subset (e.g. a read-only child gets just `sheets/get-values`).
+ *
+ * Steps are ALWAYS seeded (deterministic workspace, deterministic registry);
+ * a deployment without GOOGLE_SERVICE_ACCOUNT_JSON gets a loud per-run error
+ * instead of a silently missing tool.
+ */
+const SEED_STEPS: Array<{ file: string; type: string }> = [
+  { file: "create-spreadsheet.ts", type: "sheets/create-spreadsheet" },
+  { file: "update-values.ts", type: "sheets/update-values" },
+  { file: "batch-update-values.ts", type: "sheets/batch-update-values" },
+  { file: "get-values.ts", type: "sheets/get-values" },
+  { file: "add-sheet.ts", type: "sheets/add-sheet" },
+  { file: "import-spreadsheet.ts", type: "sheets/import-spreadsheet" },
+];
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function seedSheetsSteps(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "steps");
+  for (const { file, type } of SEED_STEPS) {
+    try {
+      const code = await readFile(join(dir, file), "utf-8");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "sheets-seed");
+      if (changed) console.log(`[sheets] seeded step: ${type} @ ${version}`);
+    } catch (err) {
+      console.warn(
+        `[sheets] could not seed step "${type}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/mcp/src/lab/sheets/smoke.ts
+++ b/mcp/src/lab/sheets/smoke.ts
@@ -1,0 +1,347 @@
+/**
+ * Offline smoke test for the sheets/* steps — no vein server, no live Google.
+ * Verifies:
+ *   1. seeding: seedSheetsSteps publishes into a temp workspace and
+ *      buildRegistry discovers every step from disk;
+ *   2. auth: the RS256 service-account JWT is built correctly (signature
+ *      verifies against the keypair), exchanged once, then cached;
+ *   3. step logic: each step runs against a FAKE `ctx.services.http` that
+ *      replays canned Google API responses (correct Authorization headers,
+ *      create→update→get round trip shapes, the loud missing-credentials
+ *      error, an HTTP-error → teaching string case).
+ *
+ * Run: npx tsx src/lab/sheets/smoke.ts
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { generateKeyPairSync, createVerify } from "node:crypto";
+import { WorkspaceManager, buildRegistry, type StepContext, type HttpResponse } from "vein";
+import { seedSheetsSteps } from "./seed.js";
+
+const TOKEN_URI = "https://oauth2.googleapis.com/token";
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+
+// ── service-account keypair (real RSA so the JWT signature is verifiable) ──
+const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const privPem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+const SA = { client_email: "sa@test.iam.gserviceaccount.com", private_key: privPem };
+const SA_JSON = JSON.stringify(SA);
+
+// ── fake ctx: canned Google APIs over ctx.services.http ────────────────────
+type Call = { url: string; opts: any };
+const calls: Call[] = [];
+
+type Route = { match: (url: string, opts: any) => boolean; body: unknown; status?: number };
+
+/** Every ctx serves the token endpoint plus the given routes. */
+const tokenRoute: Route = {
+  match: (u, o) => u === TOKEN_URI && o.method === "POST",
+  body: { access_token: "tok-abc", expires_in: 3600, token_type: "Bearer" },
+};
+
+function fakeHttp(routes: Route[]) {
+  return async (url: string, opts: any = {}): Promise<HttpResponse> => {
+    calls.push({ url, opts });
+    for (const r of [tokenRoute, ...routes]) {
+      if (r.match(url, opts)) {
+        return { status: r.status ?? 200, ok: (r.status ?? 200) < 300, headers: {}, body: r.body };
+      }
+    }
+    return { status: 404, ok: false, headers: {}, body: `no fake route for ${opts.method ?? "GET"} ${url}` };
+  };
+}
+
+function makeCtx(routes: Route[], secrets?: Record<string, string>): StepContext {
+  const bag = secrets ?? { GOOGLE_SERVICE_ACCOUNT_JSON: SA_JSON };
+  return {
+    runId: "smoke",
+    path: "smoke",
+    scope: {},
+    input: undefined,
+    emit: async () => {},
+    services: {
+      http: fakeHttp(routes),
+      secrets: { get: async (name: string) => bag[name] },
+    },
+  } as unknown as StepContext;
+}
+
+const tokenCalls = () => calls.filter((c) => c.url === TOKEN_URI);
+
+async function main() {
+  // ── 1. seed + discover ───────────────────────────────────────────────────
+  // Under the mcp dir (not os tmpdir) so the seeded steps' dynamic
+  // `import "vein"` resolves via mcp/node_modules — same as the real
+  // lab-workspace location.
+  const dir = mkdtempSync(join(process.cwd(), ".sheets-smoke-"));
+  try {
+    const workspace = new WorkspaceManager(dir);
+    await seedSheetsSteps(workspace);
+    const { registry } = await buildRegistry(workspace.path);
+    const expected = [
+      "sheets/create-spreadsheet", "sheets/update-values", "sheets/batch-update-values",
+      "sheets/get-values", "sheets/add-sheet", "sheets/import-spreadsheet",
+    ];
+    for (const t of expected) assert.ok(registry[t], `registry missing ${t}`);
+    console.log(`✔ seeded + discovered ${expected.length} sheets steps`);
+
+    // ── 2. missing credentials is a loud error ─────────────────────────────
+    await assert.rejects(
+      () =>
+        registry["sheets/get-values"].run(
+          registry["sheets/get-values"].input.parse({ spreadsheet_id: "s1", range: "Sheet1!A1" }),
+          makeCtx([], {}),
+        ),
+      /GOOGLE_SERVICE_ACCOUNT_JSON not configured/,
+    );
+    console.log("✔ loud error without GOOGLE_SERVICE_ACCOUNT_JSON");
+
+    // ── 3. JWT exchange happens once, then the token is cached ─────────────
+    const getRoutes: Route[] = [
+      {
+        match: (u) => u.includes("/values/") && u.includes("valueRenderOption=UNFORMATTED_VALUE"),
+        body: { range: "Sheet1!A1:B2", values: [[1, 2], [3, "=SUM(A1:B1)"]] },
+      },
+    ];
+    let out: any = await registry["sheets/get-values"].run(
+      registry["sheets/get-values"].input.parse({ spreadsheet_id: "s1", range: "Sheet1!A1:B2" }),
+      makeCtx(getRoutes),
+    );
+    assert.deepEqual(out, { range: "Sheet1!A1:B2", values: [[1, 2], [3, "=SUM(A1:B1)"]] });
+    assert.equal(tokenCalls().length, 1, "expected exactly one token exchange");
+
+    // the assertion is a valid RS256 JWT signed with the SA key
+    const tokenCall = tokenCalls()[0];
+    assert.equal(tokenCall.opts.headers["Content-Type"], "application/x-www-form-urlencoded");
+    const assertion = new URLSearchParams(tokenCall.opts.body as string).get("assertion")!;
+    const [h, c, s] = assertion.split(".");
+    assert.deepEqual(JSON.parse(Buffer.from(h, "base64url").toString()), { alg: "RS256", typ: "JWT" });
+    const claims = JSON.parse(Buffer.from(c, "base64url").toString());
+    assert.equal(claims.iss, SA.client_email);
+    assert.equal(claims.aud, TOKEN_URI);
+    assert.match(claims.scope, /spreadsheets/);
+    assert.match(claims.scope, /drive/);
+    assert.equal(claims.exp - claims.iat, 3600);
+    assert.ok(
+      createVerify("RSA-SHA256").update(`${h}.${c}`).verify(publicKey, Buffer.from(s, "base64url")),
+      "JWT signature must verify against the SA public key",
+    );
+    // the API call carried the exchanged bearer token
+    const apiCall = calls[calls.length - 1];
+    assert.equal(apiCall.opts.headers.Authorization, "Bearer tok-abc");
+    console.log("✔ RS256 JWT exchange (header/claims/signature + bearer header)");
+
+    // second run: cached token, no new exchange
+    out = await registry["sheets/get-values"].run(
+      registry["sheets/get-values"].input.parse({ spreadsheet_id: "s1", range: "Sheet1!A1:B2", render: "formula" }),
+      makeCtx([
+        { match: (u) => u.includes("valueRenderOption=FORMULA"), body: { range: "Sheet1!A1:B2", values: [["=A1"]] } },
+      ]),
+    );
+    assert.deepEqual(out.values, [["=A1"]]);
+    assert.equal(tokenCalls().length, 1, "token must be cached across calls");
+    console.log("✔ token cached (no second exchange)");
+
+    // base64 serviceAccount via explicit cfg wins over (absent) secrets
+    out = await registry["sheets/get-values"].run(
+      registry["sheets/get-values"].input.parse({
+        spreadsheet_id: "s1",
+        range: "Sheet1!A1",
+        serviceAccount: Buffer.from(SA_JSON).toString("base64"),
+      }),
+      makeCtx(
+        [{ match: (u) => u.includes("/values/"), body: { range: "Sheet1!A1", values: [] } }],
+        {},
+      ),
+    );
+    assert.deepEqual(out, { range: "Sheet1!A1", values: [] });
+    console.log("✔ cfg.serviceAccount (base64) wins over secrets");
+
+    // ── 4. create → update → get round trip shapes ─────────────────────────
+    // create without a folder: Sheets API create + extra tabs
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model", extra_sheet_titles: ["Scenarios"] }),
+      makeCtx([
+        { match: (u, o) => u === SHEETS_API && o.method === "POST", body: { spreadsheetId: "ss1" } },
+        { match: (u, o) => u.includes("ss1:batchUpdate") && o.method === "POST", body: { replies: [{}] } },
+      ]),
+    );
+    assert.deepEqual(out, {
+      spreadsheet_id: "ss1",
+      url: "https://docs.google.com/spreadsheets/d/ss1/edit",
+      sheets: ["Sheet1", "Scenarios"],
+    });
+    let last = calls[calls.length - 1]; // the extra-tabs batchUpdate
+    assert.equal(last.opts.body.requests[0].addSheet.properties.title, "Scenarios");
+    console.log("✔ create-spreadsheet (Sheets API + extra tabs)");
+
+    // create WITH a drive folder (cfg override): goes through Drive
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model", driveFolderId: "folder1" }),
+      makeCtx([
+        { match: (u, o) => u.startsWith(DRIVE_API) && o.method === "POST", body: { id: "ss2" } },
+      ]),
+    );
+    assert.equal(out.spreadsheet_id, "ss2");
+    last = calls[calls.length - 1];
+    assert.ok(last.url.includes("supportsAllDrives=true"));
+    assert.deepEqual(last.opts.body.parents, ["folder1"]);
+    assert.equal(last.opts.body.mimeType, "application/vnd.google-apps.spreadsheet");
+    console.log("✔ create-spreadsheet (Drive folder path)");
+
+    // GOOGLE_DRIVE_FOLDER_ID secret is picked up when cfg has no folder
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model" }),
+      makeCtx(
+        [{ match: (u, o) => u.startsWith(DRIVE_API) && o.method === "POST", body: { id: "ss3" } }],
+        { GOOGLE_SERVICE_ACCOUNT_JSON: SA_JSON, GOOGLE_DRIVE_FOLDER_ID: "folder-env" },
+      ),
+    );
+    assert.equal(out.spreadsheet_id, "ss3");
+    assert.deepEqual(calls[calls.length - 1].opts.body.parents, ["folder-env"]);
+    console.log("✔ GOOGLE_DRIVE_FOLDER_ID secret fallback");
+
+    // update-values (USER_ENTERED default, PUT)
+    out = await registry["sheets/update-values"].run(
+      registry["sheets/update-values"].input.parse({
+        spreadsheet_id: "ss1",
+        range: "Sheet1!A1:B2",
+        values: [["Revenue", 100], ["Total", "=SUM(B1:B1)"]],
+      }),
+      makeCtx([
+        {
+          match: (u, o) => u.includes("valueInputOption=USER_ENTERED") && o.method === "PUT",
+          body: { updatedRange: "Sheet1!A1:B2", updatedCells: 4 },
+        },
+      ]),
+    );
+    assert.deepEqual(out, { updated_range: "Sheet1!A1:B2", updated_cells: 4 });
+    assert.deepEqual(calls[calls.length - 1].opts.body, {
+      values: [["Revenue", 100], ["Total", "=SUM(B1:B1)"]],
+    });
+    console.log("✔ update-values");
+
+    // raw:true → RAW
+    out = await registry["sheets/update-values"].run(
+      registry["sheets/update-values"].input.parse({
+        spreadsheet_id: "ss1", range: "Sheet1!A1", values: [["=literal"]], raw: true,
+      }),
+      makeCtx([
+        { match: (u, o) => u.includes("valueInputOption=RAW") && o.method === "PUT", body: { updatedRange: "Sheet1!A1", updatedCells: 1 } },
+      ]),
+    );
+    assert.equal(out.updated_cells, 1);
+    console.log("✔ update-values raw mode");
+
+    // batch-update-values
+    out = await registry["sheets/batch-update-values"].run(
+      registry["sheets/batch-update-values"].input.parse({
+        spreadsheet_id: "ss1",
+        data: [
+          { range: "Sheet1!A1", values: [["h1"]] },
+          { range: "Sheet1!B1", values: [["=A1"]] },
+        ],
+      }),
+      makeCtx([
+        {
+          match: (u, o) => u.includes("values:batchUpdate") && o.method === "POST",
+          body: { totalUpdatedCells: 2, responses: [{ updatedRange: "Sheet1!A1" }, { updatedRange: "Sheet1!B1" }] },
+        },
+      ]),
+    );
+    assert.deepEqual(out, { total_updated_cells: 2, updated_ranges: ["Sheet1!A1", "Sheet1!B1"] });
+    assert.equal(calls[calls.length - 1].opts.body.valueInputOption, "USER_ENTERED");
+    console.log("✔ batch-update-values");
+
+    // add-sheet
+    out = await registry["sheets/add-sheet"].run(
+      registry["sheets/add-sheet"].input.parse({ spreadsheet_id: "ss1", title: "Scenarios" }),
+      makeCtx([
+        {
+          match: (u, o) => u.includes("ss1:batchUpdate") && o.method === "POST",
+          body: { replies: [{ addSheet: { properties: { sheetId: 42, title: "Scenarios" } } }] },
+        },
+      ]),
+    );
+    assert.deepEqual(out, { sheet_id: 42, title: "Scenarios" });
+    console.log("✔ add-sheet");
+
+    // ── 5. HTTP error → teaching string ────────────────────────────────────
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model", driveFolderId: "folderX" }),
+      makeCtx([
+        {
+          match: (u, o) => u.startsWith(DRIVE_API) && o.method === "POST",
+          status: 403,
+          body: { error: { message: "The caller does not have permission" } },
+        },
+      ]),
+    );
+    assert.equal(typeof out, "string");
+    assert.match(out, /HTTP 403/);
+    assert.match(out, /share the Drive folder folderX/);
+    assert.ok(out.includes(SA.client_email), "teaching error must name the SA client_email");
+    console.log("✔ 403 create → teaching string (share the folder with client_email)");
+
+    // ── 6. import-spreadsheet (xlsx conversion path, 2 sheets) ─────────────
+    const dash = "—";
+    out = await registry["sheets/import-spreadsheet"].run(
+      registry["sheets/import-spreadsheet"].input.parse({
+        destination_spreadsheet_id: "dst1",
+        source_file_id: "src1",
+      }),
+      makeCtx([
+        {
+          match: (u, o) => u.startsWith(`${DRIVE_API}/src1?`) && (o.method ?? "GET") === "GET",
+          body: { name: "budget.xlsx", mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", parents: ["p1"] },
+        },
+        { match: (u, o) => u.includes("/src1/copy") && o.method === "POST", body: { id: "conv1" } },
+        {
+          match: (u) => u.includes("/conv1?fields=properties.title"),
+          body: {
+            properties: { title: "budget" },
+            sheets: [
+              { properties: { sheetId: 11, title: "Data" } },
+              { properties: { sheetId: 12, title: "Summary" } },
+            ],
+          },
+        },
+        {
+          match: (u) => u.includes("/dst1?fields=sheets.properties.title"),
+          body: { sheets: [{ properties: { title: "Sheet1" } }] },
+        },
+        { match: (u, o) => u.includes("/sheets/11:copyTo") && o.method === "POST", body: { sheetId: 101 } },
+        { match: (u, o) => u.includes("/sheets/12:copyTo") && o.method === "POST", body: { sheetId: 102 } },
+        { match: (u, o) => u.includes("dst1:batchUpdate") && o.method === "POST", body: { replies: [{}] } },
+        {
+          match: (u) => u.includes("valueRenderOption=FORMULA") && decodeURIComponent(u).includes("Data"),
+          body: { values: [["=Summary!B2", 1]] },
+        },
+        { match: (u) => u.includes("valueRenderOption=FORMULA"), body: { values: [] } },
+        { match: (u, o) => u.includes("/conv1?supportsAllDrives") && o.method === "DELETE", body: "" },
+      ]),
+    );
+    assert.equal(out.destination_spreadsheet_id, "dst1");
+    assert.equal(out.imported.length, 2);
+    assert.deepEqual(
+      out.imported.map((r: any) => r.tab_name),
+      [`SOURCE: budget.xlsx ${dash} Data`, `SOURCE: budget.xlsx ${dash} Summary`],
+    );
+    assert.ok(out.imported.every((r: any) => r.status === "success"));
+    assert.equal(out.converted_copy_deleted, true);
+    assert.equal(out.warnings.length, 2); // cross-sheet formula ref + the standing named-ranges warning
+    assert.match(out.warnings[0], /formula references to source sheet "Summary"/);
+    console.log("✔ import-spreadsheet (convert → copy → rename → warnings → cleanup)");
+
+    console.log("\nALL SHEETS SMOKE CHECKS PASSED");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp/src/lab/sheets/steps/_shared.ts
+++ b/mcp/src/lab/sheets/steps/_shared.ts
@@ -1,0 +1,33 @@
+/**
+ * NOT a seeded step — the canonical description of the per-step preamble for
+ * the sheets/* steps.
+ *
+ * Seeded steps must be SELF-CONTAINED (value-imports from "vein" and node
+ * builtins only), so each step file inlines its own copy of the auth/request
+ * preamble (`sheetsCtx` + helpers below). If you change the contract, update
+ * every step in this directory — they are deliberately duplicated, not shared.
+ *
+ * Contract (ported from `mcp/src/repo/toolsGoogleSheets.ts` — do not modify
+ * that file; it stays the production repo-agent implementation):
+ *   - Credentials: `cfg.serviceAccount` (explicit step config — parsed JSON
+ *     object, JSON string, or base64 JSON) wins, else
+ *     `ctx.services.secrets.get("GOOGLE_SERVICE_ACCOUNT_JSON")` (secret store
+ *     → env fallback). Missing credentials THROW a loud per-run error — the
+ *     steps are always seeded, never silently absent.
+ *   - `cfg.driveFolderId` wins, else the `GOOGLE_DRIVE_FOLDER_ID` secret.
+ *     Spreadsheets are created inside that folder (share it with the service
+ *     account's client_email so humans can see agent-created sheets).
+ *   - Auth: plain service-account JWT flow — RS256 assertion built with
+ *     `node:crypto` (`createSign("RSA-SHA256")`, base64url header+claims; no
+ *     jsonwebtoken dep), exchanged at the SA's `token_uri` (default
+ *     `https://oauth2.googleapis.com/token`) for a bearer token with the
+ *     `spreadsheets` + `drive` scopes. The access token is cached at module
+ *     level per step file, keyed by client_email, with 60s expiry slack.
+ *   - Every request (token exchange included) goes through
+ *     `ctx.services.http` and credentials resolve through
+ *     `ctx.services.secrets`, so runs are cassette-recordable with secret
+ *     values scrubbed from fixtures.
+ *   - API errors are returned as readable "teaching" strings (`errorResult`),
+ *     never thrown at the LLM; only missing/invalid credentials throw.
+ */
+export {};

--- a/mcp/src/lab/sheets/steps/add-sheet.ts
+++ b/mcp/src/lab/sheets/steps/add-sheet.ts
@@ -1,0 +1,181 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+export default defineStep({
+  type: "sheets/add-sheet",
+  description:
+    "Add a new tab to an existing spreadsheet (e.g. a 'Scenarios' tab next to 'Model'). " +
+    "Reference its cells from other tabs as 'TabName!A1'.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id."),
+    title: z.string().describe("Title of the new tab."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const resp = await api(
+        "POST",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}:batchUpdate`,
+        { requests: [{ addSheet: { properties: { title: cfg.title } } }] },
+      );
+      if (!resp.ok) return errorResult("sheets_add_sheet", resp.status, resp.body);
+      const props = resp.body.replies?.[0]?.addSheet?.properties;
+      return { sheet_id: props?.sheetId, title: props?.title ?? cfg.title };
+    } catch (err: any) {
+      return `sheets_add_sheet failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/batch-update-values.ts
+++ b/mcp/src/lab/sheets/steps/batch-update-values.ts
@@ -1,0 +1,197 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+/** 2D array of cell values; strings starting with '=' become live formulas under USER_ENTERED. */
+const valuesSchema = z
+  .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
+  .describe(
+    "2D array of rows. Strings starting with '=' are entered as live formulas (e.g. '=SUM(B2:B10)').",
+  );
+
+export default defineStep({
+  type: "sheets/batch-update-values",
+  description:
+    "Write multiple ranges of a spreadsheet in one call — use this instead of repeated " +
+    "sheets_update_values when laying out a model (e.g. headers, inputs, and a formula block at once). " +
+    "Same formula semantics as sheets_update_values.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id from sheets_create_spreadsheet."),
+    data: z
+      .array(z.object({ range: z.string(), values: valuesSchema }))
+      .describe("One entry per target range."),
+    raw: z
+      .boolean()
+      .optional()
+      .describe("Store strings literally instead of parsing formulas/numbers/dates (default false)."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const resp = await api(
+        "POST",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}/values:batchUpdate`,
+        { valueInputOption: cfg.raw ? "RAW" : "USER_ENTERED", data: cfg.data },
+      );
+      if (!resp.ok) return errorResult("sheets_batch_update_values", resp.status, resp.body);
+      return {
+        total_updated_cells: resp.body.totalUpdatedCells,
+        updated_ranges: (resp.body.responses ?? []).map((r: any) => r.updatedRange),
+      };
+    } catch (err: any) {
+      return `sheets_batch_update_values failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/create-spreadsheet.ts
+++ b/mcp/src/lab/sheets/steps/create-spreadsheet.ts
@@ -1,0 +1,239 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+const spreadsheetUrl = (id: string) => `https://docs.google.com/spreadsheets/d/${id}/edit`;
+
+export default defineStep({
+  type: "sheets/create-spreadsheet",
+  description:
+    "Create a new Google Spreadsheet and return its spreadsheet_id and url. " +
+    "When a shared Drive folder is configured (GOOGLE_DRIVE_FOLDER_ID), it is created inside " +
+    "that folder, so the user can open it immediately. " +
+    "Start here for any calculation task, then write inputs and formulas with sheets_update_values. " +
+    "Every spreadsheet starts with one tab named 'Sheet1'; pass extra_sheet_titles to add more tabs up front.",
+  input: z.object({
+    title: z.string().describe("Spreadsheet title shown in Drive."),
+    extra_sheet_titles: z
+      .array(z.string())
+      .optional()
+      .describe("Additional tabs to create beyond the default 'Sheet1'."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+    driveFolderId: z
+      .string()
+      .optional()
+      .describe(
+        "Drive folder to create the spreadsheet in (must be shared with the service account's " +
+          "client_email). Normally omitted — resolved from the GOOGLE_DRIVE_FOLDER_ID secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api, driveFolderId, clientEmail } = await sheetsCtx(
+      ctx as StepContext<VeinCapabilities>,
+      cfg,
+    );
+    // A 403/404 here almost always means the folder isn't shared with the SA.
+    const shareHint = driveFolderId
+      ? ` (if this is a permission error, share the Drive folder ${driveFolderId} with the service account's client_email ${clientEmail})`
+      : "";
+    try {
+      let spreadsheetId: string;
+      if (driveFolderId) {
+        // Creating through Drive places the file directly in the shared
+        // folder (a Sheets-API create would land in the service account's
+        // own root Drive, invisible to the user).
+        const resp = await api("POST", `${DRIVE_API}?supportsAllDrives=true`, {
+          name: cfg.title,
+          mimeType: "application/vnd.google-apps.spreadsheet",
+          parents: [driveFolderId],
+        });
+        if (!resp.ok) {
+          return errorResult("sheets_create_spreadsheet", resp.status, resp.body) + shareHint;
+        }
+        spreadsheetId = resp.body.id;
+      } else {
+        const resp = await api("POST", SHEETS_API, { properties: { title: cfg.title } });
+        if (!resp.ok) return errorResult("sheets_create_spreadsheet", resp.status, resp.body);
+        spreadsheetId = resp.body.spreadsheetId;
+      }
+
+      if (cfg.extra_sheet_titles && cfg.extra_sheet_titles.length > 0) {
+        const resp = await api(
+          "POST",
+          `${SHEETS_API}/${encodeURIComponent(spreadsheetId)}:batchUpdate`,
+          {
+            requests: cfg.extra_sheet_titles.map((t: string) => ({
+              addSheet: { properties: { title: t } },
+            })),
+          },
+        );
+        if (!resp.ok) {
+          return {
+            spreadsheet_id: spreadsheetId,
+            url: spreadsheetUrl(spreadsheetId),
+            warning: errorResult("adding extra sheets", resp.status, resp.body),
+          };
+        }
+      }
+
+      return {
+        spreadsheet_id: spreadsheetId,
+        url: spreadsheetUrl(spreadsheetId),
+        sheets: ["Sheet1", ...(cfg.extra_sheet_titles ?? [])],
+      };
+    } catch (err: any) {
+      return `sheets_create_spreadsheet failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/get-values.ts
+++ b/mcp/src/lab/sheets/steps/get-values.ts
@@ -1,0 +1,190 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+export default defineStep({
+  type: "sheets/get-values",
+  description:
+    "Read a range of a spreadsheet (A1 notation). render='computed' (default) returns calculated " +
+    "numbers — use it to read the results of formulas you wrote; 'formatted' returns display strings " +
+    "(currency symbols, rounding); 'formula' returns the formula text itself for auditing.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id."),
+    range: z.string().describe("A1-notation range to read, e.g. 'Sheet1!A1:D20'."),
+    render: z
+      .enum(["computed", "formatted", "formula"])
+      .optional()
+      .describe("How to render cell values (default 'computed')."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const renderOption =
+        cfg.render === "formatted"
+          ? "FORMATTED_VALUE"
+          : cfg.render === "formula"
+            ? "FORMULA"
+            : "UNFORMATTED_VALUE";
+      const resp = await api(
+        "GET",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}/values/${encodeURIComponent(cfg.range)}?valueRenderOption=${renderOption}`,
+      );
+      if (!resp.ok) return errorResult("sheets_get_values", resp.status, resp.body);
+      return { range: resp.body.range, values: resp.body.values ?? [] };
+    } catch (err: any) {
+      return `sheets_get_values failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/import-spreadsheet.ts
+++ b/mcp/src/lab/sheets/steps/import-spreadsheet.ts
@@ -1,0 +1,484 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+// ── Pure helpers (ported verbatim from the source tool) ────────────────────
+
+/**
+ * Resolve the label used in tab names.
+ * - An explicit `label` param always wins.
+ * - For converted (non-native) sources, fall back to the Drive filename.
+ * - For native Google Sheet sources, fall back to the spreadsheet's own title.
+ */
+function resolveLabel({
+  explicitLabel,
+  driveFileName,
+  sourceSpreadsheetTitle,
+  isNative,
+}: {
+  explicitLabel?: string;
+  driveFileName: string;
+  sourceSpreadsheetTitle: string;
+  isNative: boolean;
+}): string {
+  if (explicitLabel) return explicitLabel;
+  return isNative ? sourceSpreadsheetTitle : driveFileName;
+}
+
+/**
+ * Build the raw (pre-collision-check) tab name from label + sheet title.
+ * - Single-sheet source → `SOURCE: <label>`
+ * - Multi-sheet source  → `SOURCE: <label> — <sheet title>`
+ */
+function buildTabName(label: string, sheetTitle: string, totalSheets: number): string {
+  if (totalSheets === 1) return `SOURCE: ${label}`;
+  return `SOURCE: ${label} — ${sheetTitle}`;
+}
+
+/**
+ * Given a candidate tab name and a Set of already-taken names, return a
+ * non-colliding name. If the candidate is already taken, appends " (2)",
+ * " (3)", etc., incrementing past any existing suffixes.
+ */
+function resolveCollisionSuffix(candidate: string, existingNames: Set<string>): string {
+  if (!existingNames.has(candidate)) return candidate;
+  let n = 2;
+  while (existingNames.has(`${candidate} (${n})`)) n++;
+  return `${candidate} (${n})`;
+}
+
+/**
+ * Given a list of formula strings and a list of other sheet titles, returns
+ * the subset of titles that are literally referenced in at least one formula
+ * (heuristic: `'Title'!` or `Title!` — standard A1 cross-sheet syntax).
+ */
+function detectCrossSheetFormulaRefs(formulas: string[], sheetTitles: string[]): string[] {
+  const referenced: string[] = [];
+  for (const title of sheetTitles) {
+    const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`(?:'${escapedTitle}'|${escapedTitle})!`, "i");
+    if (formulas.some((f) => pattern.test(f))) {
+      referenced.push(title);
+    }
+  }
+  return referenced;
+}
+
+export default defineStep({
+  type: "sheets/import-spreadsheet",
+  description:
+    "Import every sheet of a source spreadsheet (uploaded .xlsx or existing Google Sheet) into a " +
+    "destination spreadsheet as correctly-named tabs. Source may be any Drive file id; non-native " +
+    "files (e.g. .xlsx) are converted to Google Sheets format automatically. Each imported tab is " +
+    "named 'SOURCE: <label>' (single-sheet source) or 'SOURCE: <label> — <sheet title>' (multi-sheet). " +
+    "Collisions with existing tab names are resolved by auto-appending ' (2)', ' (3)', etc. " +
+    "Import is best-effort: one sheet failing does not abort the rest. Returns per-sheet status " +
+    "(success / failed / copied_unrenamed) and any formula/range warnings.",
+  input: z.object({
+    destination_spreadsheet_id: z
+      .string()
+      .describe("Spreadsheet id of the destination to copy sheets into."),
+    source_file_id: z
+      .string()
+      .describe(
+        "Drive file id of the source — may be an uploaded .xlsx or an existing native Google Sheet.",
+      ),
+    label: z
+      .string()
+      .optional()
+      .describe(
+        "Override the label used in tab names. Defaults to the Drive filename (converted) or spreadsheet title (native).",
+      ),
+    keep_converted_copy: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, the intermediate converted-copy file (for non-native sources) is kept in Drive after import. Default false.",
+      ),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    const { destination_spreadsheet_id, source_file_id, label, keep_converted_copy } = cfg;
+    try {
+      // ── Step 1: Fetch Drive metadata for the source file ──────────────
+      const metaResp = await api(
+        "GET",
+        `${DRIVE_API}/${encodeURIComponent(source_file_id)}?supportsAllDrives=true&fields=name,mimeType,parents`,
+      );
+      if (!metaResp.ok) {
+        return `sheets_import_spreadsheet failed: could not fetch source file metadata: HTTP ${metaResp.status}: ${truncate(metaResp.body?.error?.message ?? metaResp.body, 300)}`;
+      }
+      const sourceMeta: { name: string; mimeType: string; parents?: string[] } = metaResp.body;
+
+      // ── Step 2: Convert if not already a native Google Sheet ──────────
+      // tempSpreadsheetId is ONLY the id of the converted copy — never
+      // aliased from source_file_id — so the later delete call is
+      // unambiguous.
+      let tempSpreadsheetId: string | undefined = undefined;
+      let workingId: string;
+
+      const SHEETS_MIME = "application/vnd.google-apps.spreadsheet";
+      if (sourceMeta.mimeType !== SHEETS_MIME) {
+        const parentFolder = sourceMeta.parents?.[0];
+        const copyBody: Record<string, unknown> = { mimeType: SHEETS_MIME };
+        if (parentFolder) copyBody.parents = [parentFolder];
+        const copyResp = await api(
+          "POST",
+          `${DRIVE_API}/${encodeURIComponent(source_file_id)}/copy?supportsAllDrives=true`,
+          copyBody,
+        );
+        if (!copyResp.ok) {
+          return `sheets_import_spreadsheet failed: could not convert source file to Google Sheets: HTTP ${copyResp.status}: ${truncate(copyResp.body?.error?.message ?? copyResp.body, 300)}`;
+        }
+        // Store in a dedicated variable; NEVER reuse source_file_id.
+        tempSpreadsheetId = copyResp.body.id as string;
+        workingId = tempSpreadsheetId;
+      } else {
+        workingId = source_file_id;
+      }
+
+      // ── Step 3: Enumerate source sheets ─────────────────────────────
+      const srcSheetsResp = await api(
+        "GET",
+        `${SHEETS_API}/${encodeURIComponent(workingId)}?fields=properties.title,sheets.properties`,
+      );
+      if (!srcSheetsResp.ok) {
+        return `sheets_import_spreadsheet failed: could not read source spreadsheet: HTTP ${srcSheetsResp.status}: ${truncate(srcSheetsResp.body?.error?.message ?? srcSheetsResp.body, 300)}`;
+      }
+      const sourceSheets: Array<{ sheetId: number; title: string }> = (
+        srcSheetsResp.body.sheets ?? []
+      ).map((s: any) => ({
+        sheetId: s.properties.sheetId as number,
+        title: s.properties.title as string,
+      }));
+      const sourceSpreadsheetTitle: string =
+        srcSheetsResp.body.properties?.title ?? sourceMeta.name;
+
+      // ── Step 4: Seed the live title Set from the destination ──────────
+      const dstSheetsResp = await api(
+        "GET",
+        `${SHEETS_API}/${encodeURIComponent(destination_spreadsheet_id)}?fields=sheets.properties.title`,
+      );
+      if (!dstSheetsResp.ok) {
+        return `sheets_import_spreadsheet failed: could not read destination spreadsheet: HTTP ${dstSheetsResp.status}: ${truncate(dstSheetsResp.body?.error?.message ?? dstSheetsResp.body, 300)}`;
+      }
+      // Single source of truth for collision detection — updated after each rename.
+      const existingTitles = new Set<string>(
+        (dstSheetsResp.body.sheets ?? []).map((s: any) => s.properties.title as string),
+      );
+
+      // ── Step 5: Per-sheet best-effort copy loop ───────────────────────
+      const resolvedLabel = resolveLabel({
+        explicitLabel: label,
+        driveFileName: sourceMeta.name,
+        sourceSpreadsheetTitle,
+        isNative: sourceMeta.mimeType === SHEETS_MIME,
+      });
+
+      const imported: Array<{
+        source_sheet: string;
+        tab_name: string | null;
+        sheet_id: number | null;
+        status: "success" | "failed" | "copied_unrenamed";
+        error?: string;
+      }> = [];
+
+      for (const sheet of sourceSheets) {
+        const targetTabName = resolveCollisionSuffix(
+          buildTabName(resolvedLabel, sheet.title, sourceSheets.length),
+          existingTitles,
+        );
+
+        // copyTo
+        let copiedSheetId: number;
+        try {
+          const copyToResp = await api(
+            "POST",
+            `${SHEETS_API}/${encodeURIComponent(workingId)}/sheets/${sheet.sheetId}:copyTo`,
+            { destinationSpreadsheetId: destination_spreadsheet_id },
+          );
+          if (!copyToResp.ok) {
+            imported.push({
+              source_sheet: sheet.title,
+              tab_name: null,
+              sheet_id: null,
+              status: "failed",
+              error: `copyTo failed: HTTP ${copyToResp.status}: ${truncate(copyToResp.body?.error?.message ?? copyToResp.body, 200)}`,
+            });
+            continue;
+          }
+          copiedSheetId = copyToResp.body.sheetId as number;
+        } catch (copyErr: any) {
+          imported.push({
+            source_sheet: sheet.title,
+            tab_name: null,
+            sheet_id: null,
+            status: "failed",
+            error: `copyTo threw: ${copyErr?.message ?? String(copyErr)}`,
+          });
+          continue;
+        }
+
+        // rename via batchUpdate
+        try {
+          const renameResp = await api(
+            "POST",
+            `${SHEETS_API}/${encodeURIComponent(destination_spreadsheet_id)}:batchUpdate`,
+            {
+              requests: [
+                {
+                  updateSheetProperties: {
+                    properties: { sheetId: copiedSheetId, title: targetTabName },
+                    fields: "title",
+                  },
+                },
+              ],
+            },
+          );
+          if (!renameResp.ok) {
+            // Google assigns a default name like "Copy of <original>"
+            imported.push({
+              source_sheet: sheet.title,
+              tab_name: `Copy of ${sheet.title}`,
+              sheet_id: copiedSheetId,
+              status: "copied_unrenamed",
+              error: `rename failed: HTTP ${renameResp.status}: ${truncate(renameResp.body?.error?.message ?? renameResp.body, 200)}`,
+            });
+            // Do NOT add to existingTitles — we don't know the actual Google-assigned name precisely.
+          } else {
+            imported.push({
+              source_sheet: sheet.title,
+              tab_name: targetTabName,
+              sheet_id: copiedSheetId,
+              status: "success",
+            });
+            // Update the live title Set immediately so subsequent sheets
+            // in this same run see this name as taken.
+            existingTitles.add(targetTabName);
+          }
+        } catch (renameErr: any) {
+          imported.push({
+            source_sheet: sheet.title,
+            tab_name: `Copy of ${sheet.title}`,
+            sheet_id: copiedSheetId,
+            status: "copied_unrenamed",
+            error: `rename threw: ${renameErr?.message ?? String(renameErr)}`,
+          });
+        }
+      }
+
+      // ── Step 6: Cross-sheet formula warnings ─────────────────────────
+      const warnings: string[] = [];
+      const sourceTitles = sourceSheets.map((s) => s.title);
+      const successfulSheets = imported.filter((r) => r.status === "success");
+
+      for (const result of successfulSheets) {
+        // Fetch formula cells for this destination sheet
+        const formulaResp = await api(
+          "GET",
+          `${SHEETS_API}/${encodeURIComponent(destination_spreadsheet_id)}/values/${encodeURIComponent(`'${result.tab_name}'`)}?valueRenderOption=FORMULA`,
+        );
+        if (formulaResp.ok) {
+          const cellValues: string[] = (formulaResp.body.values ?? [])
+            .flat()
+            .filter((v: unknown) => typeof v === "string" && v.startsWith("="));
+          // Check formulas against other source sheet titles (not its own)
+          const otherTitles = sourceTitles.filter((t) => t !== result.source_sheet);
+          const referenced = detectCrossSheetFormulaRefs(cellValues, otherTitles);
+          for (const ref of referenced) {
+            warnings.push(
+              `Tab "${result.tab_name}" contains formula references to source sheet "${ref}", which has been renamed in the destination — cross-sheet references may not resolve correctly.`,
+            );
+          }
+        }
+      }
+      // Always warn about named/protected range limitation.
+      warnings.push(
+        "Named ranges and protected ranges defined in the source workbook are not carried over by the Sheets API copyTo operation and are not recreated by this tool.",
+      );
+
+      // ── Step 7: Cleanup temp converted file ─────────────────────────
+      // converted_copy_deleted is null when no conversion occurred.
+      let converted_copy_deleted: boolean | null = null;
+      if (tempSpreadsheetId !== undefined) {
+        // Safety: tempSpreadsheetId must NEVER equal source_file_id or
+        // destination_spreadsheet_id — distinct variables by construction
+        // (see Step 2).
+        if (!keep_converted_copy) {
+          try {
+            const deleteResp = await api(
+              "DELETE",
+              `${DRIVE_API}/${encodeURIComponent(tempSpreadsheetId)}?supportsAllDrives=true`,
+            );
+            converted_copy_deleted = deleteResp.ok;
+          } catch {
+            converted_copy_deleted = false;
+          }
+        } else {
+          converted_copy_deleted = false;
+        }
+      }
+
+      return {
+        destination_spreadsheet_id,
+        imported,
+        converted_copy_deleted,
+        warnings,
+      };
+    } catch (err: any) {
+      return `sheets_import_spreadsheet failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/update-values.ts
+++ b/mcp/src/lab/sheets/steps/update-values.ts
@@ -1,0 +1,196 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+/** 2D array of cell values; strings starting with '=' become live formulas under USER_ENTERED. */
+const valuesSchema = z
+  .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
+  .describe(
+    "2D array of rows. Strings starting with '=' are entered as live formulas (e.g. '=SUM(B2:B10)').",
+  );
+
+export default defineStep({
+  type: "sheets/update-values",
+  description:
+    "Write a 2D array of values into a spreadsheet range (A1 notation, e.g. 'Sheet1!A1:C10'). " +
+    "Strings starting with '=' are entered as LIVE FORMULAS — prefer building calculations with " +
+    "formulas over precomputing numbers yourself, so the sheet stays auditable and recalculates " +
+    "when inputs change. Read computed results back with sheets_get_values.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id from sheets_create_spreadsheet."),
+    range: z.string().describe("A1-notation target range, e.g. 'Sheet1!A1' or 'Model!B2:D20'."),
+    values: valuesSchema,
+    raw: z
+      .boolean()
+      .optional()
+      .describe("Store strings literally instead of parsing formulas/numbers/dates (default false)."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const input = cfg.raw ? "RAW" : "USER_ENTERED";
+      const resp = await api(
+        "PUT",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}/values/${encodeURIComponent(cfg.range)}?valueInputOption=${input}`,
+        { values: cfg.values },
+      );
+      if (!resp.ok) return errorResult("sheets_update_values", resp.status, resp.body);
+      const { updatedRange, updatedCells } = resp.body;
+      return { updated_range: updatedRange, updated_cells: updatedCells };
+    } catch (err: any) {
+      return `sheets_update_values failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -109,7 +109,7 @@ cd vein && npm run dev        # serves API + UI on :3000
 | `VEIN_SECRET_KEY`   | (unset)        | Encryption key for the secret store (AES-256-GCM). Unset → a default dev key + one-time warning (obfuscated, not secure). See "Secrets". |
 | `VEIN_LLM_PROVIDER` | `anthropic`    | Default LLM provider for llm step    |
 | `VEIN_LLM_MODEL`    | (per-provider) | Override model name                  |
-| `VEIN_CHAT_MODEL`   | `claude-sonnet-4-20250514` | Anthropic model for the AI-builder chat agent |
+| `VEIN_CHAT_MODEL`   | `claude-sonnet-5` | Anthropic model for the AI-builder chat agent |
 | `VEIN_CHAT_MAX_STEPS` | `30`         | Max agent tool-call iterations per chat turn |
 
 ## Auth

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -201,6 +201,28 @@ const token = cfg.token ?? (await ctx?.services?.secrets?.get("GITHUB_TOKEN"));
   (`GOOGLE_ACCESS_TOKEN` or `GOOGLE_SERVICE_ACCOUNT_JSON`) are the reference
   examples.
 
+## Artifacts (per-run files)
+
+`ctx.services.artifacts` (`ArtifactsCapability`, `capabilities.ts`) is per-run
+file storage for the files a run produces that later steps — and humans —
+reference. Backed by `fileArtifactsCapability` rooted at
+`<workspace>/artifacts/<runId>/`, auto-injected by `createVein` (a consumer
+services bag can override it, same as `http`/`secrets`).
+
+- **Convention:** a step writes a file (`write(ctx.runId, relPath, content)`)
+  and puts the RELATIVE path in its output; downstream steps resolve it via
+  `read`/`dir`. Point an `agent` step's `cwd` at `dir(ctx.runId)` and the
+  built-in file tools (`str_replace_based_edit_tool`, `bash`) see the same
+  files — that's how agents in a workflow hand files to each other.
+- **Isolation:** paths are guarded per run — a relPath cannot escape its
+  run's directory (so one run can't reach another's files). Invalid runIds
+  (path separators, `..`) are rejected.
+- **Retention:** artifacts survive the run (they're part of its record);
+  `onRunEnd` does not touch them.
+- **HTTP:** `GET /artifacts/:runId` lists (recursive relative paths);
+  `GET /artifacts/:runId/<path>` serves the file (minimal content-type map).
+  Read-only — steps are the only writers.
+
 ## Key concepts
 
 - **`createVein()` is the primary entry point** (`src/createVein.ts`).
@@ -525,6 +547,11 @@ const token = cfg.token ?? (await ctx?.services?.secrets?.get("GITHUB_TOKEN"));
     `toolFilter`); unknown types are skipped. This is what lets mcp's `/lab`
     `gitsee-setup-and-run` drive a QA harness (boot/browser/observe/assess) as
     the core `agent` instead of a forked loop.
+    Entries may be **glob patterns** (`expandAgentTools`): `"jarvis/*"` grants
+    every registry step in that namespace (matches sorted, deduped; a pattern
+    matching nothing warns). `"agent"` itself is grantable — that's the
+    sub-agent primitive: recursion depth is controlled by whether the child's
+    own `agentTools` list includes `"agent"` again, not by a numeric cap.
   - **Every tool call emits a nested run event** (`wrapToolsWithEmit`, applied
     to built-ins AND `agentTools` with one shared counter): a
     `step.start`/`step.end` (or `step.error`) at `<agentPath>/NNN-<tool>` with

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -27,7 +27,7 @@ vein/
 ├── tsconfig.json          # strict, Node16 module, types: ["node"]
 ├── src/
 │   ├── core.ts            # flow(), step(), defineStep(), services bag, all types
-│   ├── expr.ts            # {{ }} template evaluator (~460 LOC recursive descent)
+│   ├── expr.ts            # {{ }} template evaluator (recursive descent; whitelisted array methods + arrow lambdas)
 │   ├── runner.ts          # execution engine: DAG (topological), retry, onError, control flow
 │   ├── store.ts           # RunStore interface + FileRunStore + MemoryRunStore + tailJsonl (shared append-only tail engine)
 │   ├── chat-store.ts      # ChatStore interface + FileChatStore + MemoryChatStore (chats/<id>/: meta.json + messages.jsonl + events.jsonl) + truncateToolMessages

--- a/vein/SPEC.md
+++ b/vein/SPEC.md
@@ -343,7 +343,13 @@ Available bindings inside a step config:
 - Literals: numbers, strings (single or double quotes), `true`, `false`, `null`.
 - Operators: `=== !== == != < <= > >= && || !  + - * / %`.
 - Ternary: `a ? b : c`.
-- Function calls: **none** in v1.
+- Array methods (whitelist): `map`, `filter`, `find`, `join`, `includes`,
+  `slice` — with **single-param arrow lambdas** whose body is one expression
+  (`items.map(x => x.ref_id)`). No statements, no user-defined functions, no
+  other methods — every expression still terminates by construction. The
+  whitelist matches the JS idiom because workflow authors are usually LLM
+  agents; errors for anything outside it name the supported surface. Grow it
+  only when a real agent misses.
 
 Examples:
 
@@ -352,6 +358,8 @@ Examples:
 {{ poll.body.status === "complete" }}
 {{ fan.left.count + fan.right.count }}
 {{ items[0].name }}
+{{ search.map(n => n.ref_id) }}
+{{ prs.filter(p => p.merged).map(p => p.title).join(", ") }}
 ```
 
 ### 5.4 Resolution

--- a/vein/package.json
+++ b/vein/package.json
@@ -22,7 +22,7 @@
     "build:web": "npm --prefix web run build",
     "dev": "npm run build:web && tsx --env-file=.env src/server.ts",
     "start": "node build/server.js",
-    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts src/slack.test.ts src/gdrive.test.ts"
+    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts src/artifacts.test.ts src/slack.test.ts src/gdrive.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.92",

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -50,6 +50,7 @@ Rules:
 - Use {{ }} templates to reference previous step outputs or the workflow's input payload, e.g. {{ fetch.body.name }} or {{ input.url }} (where "input" is the object passed to run_workflow; you choose its shape).
 - ALWAYS WRAP TEMPLATE VALUES IN QUOTES. A YAML value that starts with "{{" is otherwise parsed as an object, not a string — e.g. \`pull_number: {{ input.pull_number }}\` silently becomes an object and the step fails with "expected number, received object". Write \`pull_number: "{{ input.pull_number }}"\`. A sole \`"{{ expr }}"\` still preserves the value's real type (a number stays a number) — so quoting does NOT turn a number into a string.
 - Use === for equality in expressions, not ==.
+- Arrays support a WHITELIST of methods with single-param arrow lambdas: map, filter, find, join, includes, slice — e.g. \`"{{ search.map(n => n.ref_id) }}"\` or \`"{{ prs.filter(p => p.merged).map(p => p.title).join(', ') }}"\`. Lambda bodies are single expressions (no statements); no other methods exist (no reduce/sort/flatMap).
 
 Branching (if):
 - The "if" step is a GATE. It evaluates "cond" and returns a boolean.

--- a/vein/src/artifacts.test.ts
+++ b/vein/src/artifacts.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { fileArtifactsCapability } from "./capabilities.js";
+
+describe("fileArtifactsCapability (per-run artifact files)", () => {
+  let root: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "vein-artifacts-"));
+  });
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("dir() creates the run dir on demand and returns its absolute path", async () => {
+    const a = fileArtifactsCapability(root);
+    const d = await a.dir("run1");
+    assert.equal(d, join(root, "run1"));
+    // Idempotent.
+    assert.equal(await a.dir("run1"), d);
+  });
+
+  it("write → read round-trips text (and creates subdirectories)", async () => {
+    const a = fileArtifactsCapability(root);
+    const abs = await a.write("run1", "reports/summary.md", "# hello");
+    assert.equal(abs, join(root, "run1", "reports", "summary.md"));
+    const bytes = await a.read("run1", "reports/summary.md");
+    assert.equal(Buffer.from(bytes).toString(), "# hello");
+  });
+
+  it("write accepts binary content", async () => {
+    const a = fileArtifactsCapability(root);
+    const payload = new Uint8Array([0, 1, 2, 255]);
+    await a.write("run1", "blob.bin", payload);
+    assert.deepEqual(await a.read("run1", "blob.bin"), payload);
+  });
+
+  it("list() returns recursive relative paths, sorted; [] for an unknown run", async () => {
+    const a = fileArtifactsCapability(root);
+    await a.write("run1", "b.txt", "b");
+    await a.write("run1", "sub/a.txt", "a");
+    assert.deepEqual(await a.list("run1"), ["b.txt", join("sub", "a.txt")]);
+    assert.deepEqual(await a.list("never-ran"), []);
+  });
+
+  it("runs are isolated from each other", async () => {
+    const a = fileArtifactsCapability(root);
+    await a.write("run1", "x.txt", "one");
+    await a.write("run2", "x.txt", "two");
+    assert.equal(Buffer.from(await a.read("run2", "x.txt")).toString(), "two");
+    assert.deepEqual(await a.list("run1"), ["x.txt"]);
+  });
+
+  it("rejects runIds containing path separators or ..", async () => {
+    const a = fileArtifactsCapability(root);
+    for (const bad of ["", "a/b", "a\\b", "..", "x..y"]) {
+      await assert.rejects(() => a.dir(bad), /invalid runId/);
+    }
+  });
+
+  it("rejects relPaths that escape the run dir", async () => {
+    const a = fileArtifactsCapability(root);
+    await assert.rejects(
+      () => a.write("run1", "../elsewhere.txt", "nope"),
+      /escapes the artifact root/,
+    );
+    await assert.rejects(
+      () => a.read("run1", "../../etc/passwd"),
+      /escapes the artifact root/,
+    );
+  });
+});

--- a/vein/src/capabilities.ts
+++ b/vein/src/capabilities.ts
@@ -17,6 +17,15 @@
  * their own typed services bag.
  */
 
+import { mkdir, readFile, writeFile, readdir } from "node:fs/promises";
+import {
+  dirname as pathDirname,
+  join as pathJoin,
+  relative as pathRelative,
+  resolve as pathResolve,
+  sep as pathSep,
+} from "node:path";
+
 // ── secrets ────────────────────────────────────────────────────────────────
 
 /** Credential access. The single boundary through which adapters read secrets
@@ -184,6 +193,84 @@ function looksLikeJson(text: string): boolean {
   return t.startsWith("{") || t.startsWith("[");
 }
 
+// ── artifacts ──────────────────────────────────────────────────────────────
+
+/**
+ * Per-run artifact storage — files a run produces that later steps (and
+ * humans, via `GET /artifacts/:runId/…`) reference. The convention: a step
+ * writes a file and puts its RELATIVE path in its output; downstream steps
+ * resolve it through this capability (or point an `agent` step's `cwd` at
+ * `dir(ctx.runId)` so the built-in file tools see the same files).
+ *
+ * Artifacts are retained after the run ends — they're part of the run's
+ * record, not scratch space (`onRunEnd` does not touch them).
+ */
+export interface ArtifactsCapability {
+  /** Absolute path of the run's artifact directory, created on demand. */
+  dir(runId: string): Promise<string>;
+  /** Write `content` at `relPath` under the run's dir (subdirectories are
+   *  created). Returns the absolute path of the written file. */
+  write(runId: string, relPath: string, content: string | Uint8Array): Promise<string>;
+  /** Read the file at `relPath` under the run's dir, as bytes.
+   *  (`Buffer.from(bytes).toString()` for text.) */
+  read(runId: string, relPath: string): Promise<Uint8Array>;
+  /** Relative paths of every file under the run's dir (recursive, sorted).
+   *  `[]` when the run has no artifacts. */
+  list(runId: string): Promise<string[]>;
+}
+
+/** Reject run ids / relative paths that could escape the RUN's directory
+ *  (one run must not reach another run's files). Returns the resolved
+ *  absolute path when safe. */
+function artifactPath(root: string, runId: string, relPath = ""): string {
+  if (!runId || /[/\\]|\.\./.test(runId)) {
+    throw new Error(`artifacts: invalid runId "${runId}"`);
+  }
+  const runDir = pathResolve(root, runId);
+  const abs = pathResolve(runDir, relPath);
+  if (abs !== runDir && !abs.startsWith(runDir + pathSep)) {
+    throw new Error(`artifacts: path escapes the artifact root: ${relPath}`);
+  }
+  return abs;
+}
+
+/** Filesystem-backed artifacts capability rooted at `root`
+ *  (`<root>/<runId>/<relPath>`). The default the standard server injects,
+ *  rooted at `<workspace>/artifacts`. */
+export function fileArtifactsCapability(root: string): ArtifactsCapability {
+  return {
+    async dir(runId) {
+      const d = artifactPath(root, runId);
+      await mkdir(d, { recursive: true });
+      return d;
+    },
+    async write(runId, relPath, content) {
+      const abs = artifactPath(root, runId, relPath);
+      await mkdir(pathDirname(abs), { recursive: true });
+      await writeFile(abs, content);
+      return abs;
+    },
+    async read(runId, relPath) {
+      const abs = artifactPath(root, runId, relPath);
+      return new Uint8Array(await readFile(abs));
+    },
+    async list(runId) {
+      const d = artifactPath(root, runId);
+      let entries;
+      try {
+        entries = await readdir(d, { recursive: true, withFileTypes: true });
+      } catch (err: any) {
+        if (err?.code === "ENOENT") return [];
+        throw err;
+      }
+      return entries
+        .filter((e) => e.isFile())
+        .map((e) => pathRelative(d, pathJoin(e.parentPath, e.name)))
+        .sort();
+    },
+  };
+}
+
 // ── standard bag ───────────────────────────────────────────────────────────
 
 /** The standard capability shape adapters rely on. Consumers extend this with
@@ -191,6 +278,9 @@ function looksLikeJson(text: string): boolean {
 export interface VeinCapabilities {
   http: HttpCapability;
   secrets: SecretsCapability;
+  /** Per-run artifact files. Present on the standard server (rooted in the
+   *  workspace); optional because a bare in-code bag may not carry one. */
+  artifacts?: ArtifactsCapability;
 }
 
 /** The default standard services bag: global-fetch http + secrets. Secrets are

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -91,7 +91,7 @@ export interface VeinOptions<TServices = unknown> {
   chatMaxSteps?: number;
 
   /** Anthropic model id for the chat agent. Defaults to `VEIN_CHAT_MODEL` or
-   *  `claude-sonnet-4-20250514`. */
+   *  `claude-sonnet-5`. */
   chatModel?: string;
 
   /** Directory containing the built web UI (the `dist` folder). Defaults
@@ -309,7 +309,7 @@ export async function createVein<TServices = unknown>(
   const chatMaxSteps =
     opts.chatMaxSteps ?? Number(process.env["VEIN_CHAT_MAX_STEPS"] ?? 30);
   const chatModel =
-    opts.chatModel ?? process.env["VEIN_CHAT_MODEL"] ?? "claude-sonnet-4-20250514";
+    opts.chatModel ?? process.env["VEIN_CHAT_MODEL"] ?? "claude-sonnet-5";
   const webDist =
     opts.webDist ??
     resolve(dirname(fileURLToPath(import.meta.url)), "../web/dist");

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -23,7 +23,8 @@ import { buildRegistry, readStepSourceFromDisk } from "./steps/registry.js";
 import type { StepSources } from "./steps/registry.js";
 import { runWorkflow } from "./runner.js";
 import { requireApiKey, warnIfUnconfigured } from "./auth.js";
-import { standardServices } from "./capabilities.js";
+import { standardServices, fileArtifactsCapability } from "./capabilities.js";
+import type { ArtifactsCapability } from "./capabilities.js";
 import type { SecretStore } from "./secret-store.js";
 import {
   FileSecretStore,
@@ -290,8 +291,14 @@ export async function createVein<TServices = unknown>(
   // existing out of the box.
   const services = {
     ...(standardServices({ secretStore }) as unknown as Record<string, unknown>),
+    // Per-run artifact files, rooted in the workspace. A consumer bag can
+    // override with its own ArtifactsCapability (spread below wins).
+    artifacts: fileArtifactsCapability(join(workspace.path, "artifacts")),
     ...((opts.services ?? {}) as Record<string, unknown>),
   } as TServices;
+  const artifacts = (services as Record<string, unknown>)["artifacts"] as
+    | ArtifactsCapability
+    | undefined;
   const serveUi = opts.serveUi ?? true;
   const enableChat = opts.enableChat ?? true;
   const chatStore: ChatStore =
@@ -616,6 +623,38 @@ export async function createVein<TServices = unknown>(
       return c.json({ ok: true, workflow: name, active: body.version });
     } catch (err) {
       return c.json({ error: err instanceof Error ? err.message : String(err) }, 404);
+    }
+  });
+
+  // ── Artifacts ────────────────────────────────────────────────────────────
+  // Files a run wrote via `ctx.services.artifacts` (keyed by runId alone —
+  // artifacts are run-scoped, not workflow-scoped). Read-only: steps are the
+  // only writers.
+
+  app.get("/artifacts/:runId", async (c) => {
+    if (!artifacts) return c.json({ error: "artifacts capability not available" }, 501);
+    const runId = c.req.param("runId");
+    try {
+      return c.json({ runId, files: await artifacts.list(runId) });
+    } catch (err) {
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
+    }
+  });
+
+  app.get("/artifacts/:runId/:path{.+}", async (c) => {
+    if (!artifacts) return c.json({ error: "artifacts capability not available" }, 501);
+    const runId = c.req.param("runId");
+    const relPath = c.req.param("path");
+    try {
+      const bytes = await artifacts.read(runId, relPath);
+      return c.body(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength) as ArrayBuffer, 200, {
+        "content-type": contentTypeFor(relPath),
+      });
+    } catch (err: any) {
+      if (err?.code === "ENOENT") {
+        return c.json({ error: `artifact not found: ${relPath}` }, 404);
+      }
+      return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
     }
   });
 
@@ -1169,4 +1208,24 @@ export async function createVein<TServices = unknown>(
     run,
     listen,
   };
+}
+
+/** Minimal content-type map for serving artifacts; octet-stream otherwise. */
+function contentTypeFor(path: string): string {
+  const ext = path.slice(path.lastIndexOf(".") + 1).toLowerCase();
+  const map: Record<string, string> = {
+    json: "application/json",
+    txt: "text/plain; charset=utf-8",
+    md: "text/markdown; charset=utf-8",
+    csv: "text/csv; charset=utf-8",
+    html: "text/html; charset=utf-8",
+    yaml: "text/yaml; charset=utf-8",
+    yml: "text/yaml; charset=utf-8",
+    png: "image/png",
+    jpg: "image/jpeg",
+    jpeg: "image/jpeg",
+    svg: "image/svg+xml",
+    pdf: "application/pdf",
+  };
+  return map[ext] ?? "application/octet-stream";
 }

--- a/vein/src/expr.test.ts
+++ b/vein/src/expr.test.ts
@@ -523,3 +523,114 @@ describe("resolveConfig", () => {
     assert.deepEqual(result.body, { data: "done" });
   });
 });
+
+describe("array methods (whitelist + arrow lambdas)", () => {
+  const nodes = [
+    { ref_id: "r1", name: "Duty of Care", score: 0.9 },
+    { ref_id: "r2", name: "Negligence", score: 0.4 },
+    { ref_id: "r3", name: "Causation", score: 0.7 },
+  ];
+  const scope = { search: nodes, tags: ["legal", "tort"], input: { min: 0.5 } };
+
+  it("map plucks a field (the original agent failure)", () => {
+    assert.deepEqual(evaluateExpr('search.map(n => n.ref_id)', scope), ["r1", "r2", "r3"]);
+  });
+
+  it("filter with a comparison against outer scope", () => {
+    assert.deepEqual(
+      evaluateExpr('search.filter(n => n.score > input.min)', scope),
+      [nodes[0], nodes[2]],
+    );
+  });
+
+  it("find with equality", () => {
+    assert.deepEqual(
+      evaluateExpr('search.find(n => n.name === "Negligence")', scope),
+      nodes[1],
+    );
+  });
+
+  it("chains: filter then map then join", () => {
+    assert.equal(
+      evaluateExpr('search.filter(n => n.score > 0.5).map(n => n.name).join(", ")', scope),
+      "Duty of Care, Causation",
+    );
+  });
+
+  it("join defaults to comma; includes and slice take plain args", () => {
+    assert.equal(evaluateExpr("tags.join()", scope), "legal,tort");
+    assert.equal(evaluateExpr('tags.includes("legal")', scope), true);
+    assert.deepEqual(evaluateExpr("search.slice(0, 2).map(n => n.ref_id)", scope), ["r1", "r2"]);
+  });
+
+  it("lambda body may use ternary, nested access, and arithmetic", () => {
+    assert.deepEqual(
+      evaluateExpr('search.map(n => n.score > 0.5 ? n.name : "low")', scope),
+      ["Duty of Care", "low", "Causation"],
+    );
+    assert.deepEqual(evaluateExpr("search.map(n => n.score * 10)", scope), [9, 4, 7]);
+  });
+
+  it("nested lambdas: inner method call inside a lambda body", () => {
+    const s = { groups: [{ items: [{ v: 1 }, { v: 2 }] }, { items: [{ v: 3 }] }] };
+    assert.deepEqual(
+      evaluateExpr("groups.map(g => g.items.map(i => i.v))", s),
+      [[1, 2], [3]],
+    );
+  });
+
+  it("lambda param shadows an outer scope binding", () => {
+    const s = { n: "OUTER", search: nodes };
+    assert.deepEqual(evaluateExpr("search.map(n => n.ref_id)", s), ["r1", "r2", "r3"]);
+  });
+
+  it("unknown method error teaches the supported surface", () => {
+    assert.throws(
+      () => evaluateExpr("search.reduce(n => n)", scope),
+      /Unknown method 'reduce'.*map, filter, find, join, includes, slice.*arrow lambdas/s,
+    );
+  });
+
+  it("method on a non-array errors with the hint", () => {
+    assert.throws(
+      () => evaluateExpr("input.map(n => n)", scope),
+      /Cannot call 'map' on object — methods are supported on arrays/,
+    );
+  });
+
+  it("map without a lambda errors with an example", () => {
+    assert.throws(
+      () => evaluateExpr('search.map("ref_id")', scope),
+      /map\(\) requires a lambda argument.*items\.map\(x => x\.name\)/s,
+    );
+  });
+
+  it("method call on null/undefined errors clearly", () => {
+    assert.throws(
+      () => evaluateExpr("missing.map(n => n)", { missing: null }),
+      /Cannot call method 'map' of null/,
+    );
+  });
+
+  it("unterminated lambda body errors", () => {
+    assert.throws(() => evaluateExpr("search.map(n => ", scope), /Unterminated lambda body/);
+    assert.throws(() => evaluateExpr("search.map(n => )", scope), /Empty lambda body/);
+  });
+
+  it("property named like a method still resolves without a call", () => {
+    const s = { obj: { map: "a property, not a method" } };
+    assert.equal(evaluateExpr("obj.map", s), "a property, not a method");
+  });
+
+  it("works through resolveTemplate with type preservation", () => {
+    assert.deepEqual(
+      resolveTemplate("{{ search.map(n => n.ref_id) }}", scope),
+      ["r1", "r2", "r3"],
+    );
+    // embedded in a larger string → stringified
+    assert.equal(
+      resolveTemplate('ids: {{ search.map(n => n.ref_id).join("/") }}', scope),
+      "ids: r1/r2/r3",
+    );
+  });
+});

--- a/vein/src/expr.ts
+++ b/vein/src/expr.ts
@@ -6,7 +6,12 @@
  *  - Literals: numbers, strings ('...' or "..."), true, false, null
  *  - Operators: === !== == != < <= > >= && || ! + - * / %
  *  - Ternary: a ? b : c
- *  - No function calls in v1.
+ *  - Array methods (whitelist): map, filter, find, join, includes, slice —
+ *    with single-param arrow lambdas, e.g. {{ search.map(n => n.ref_id) }}.
+ *    Expression bodies only (no statements, no user-defined functions), so
+ *    every expression still terminates by construction. The whitelist exists
+ *    because the language's primary AUTHORS are LLM agents, whose first
+ *    attempt is always the JS idiom — grow it only when a real agent misses.
  */
 
 export class TemplateError extends Error {
@@ -31,6 +36,8 @@ type TokenType =
   | "question"
   | "colon"
   | "not"
+  | "comma"
+  | "arrow"
   | "eof";
 
 interface Token {
@@ -96,6 +103,14 @@ function tokenize(input: string): Token[] {
       continue;
     }
 
+    // Arrow (lambda) — before the operator loop so '=' never reaches the
+    // unexpected-character error.
+    if (input.slice(i, i + 2) === "=>") {
+      tokens.push({ type: "arrow", value: "=>" });
+      i += 2;
+      continue;
+    }
+
     // Multi-char operators
     let matched = false;
     for (const op of OPERATORS) {
@@ -133,6 +148,9 @@ function tokenize(input: string): Token[] {
     } else if (ch === "!") {
       tokens.push({ type: "not", value: "!" });
       i++;
+    } else if (ch === ",") {
+      tokens.push({ type: "comma", value: "," });
+      i++;
     } else if (/[a-zA-Z_$]/.test(ch)) {
       let ident = "";
       while (i < input.length && /[a-zA-Z0-9_$]/.test(input[i]!)) {
@@ -147,6 +165,68 @@ function tokenize(input: string): Token[] {
 
   tokens.push({ type: "eof", value: "" });
   return tokens;
+}
+
+// ── Array methods (whitelist) ──────────────────────────────────────────────
+
+const ARRAY_METHODS = ["map", "filter", "find", "join", "includes", "slice"] as const;
+
+/** The teaching suffix: every method error states the supported surface, so
+ *  an agent that steps outside it can self-correct from the error alone. */
+const METHODS_HINT =
+  `supported on arrays: ${ARRAY_METHODS.join(", ")} ` +
+  `(single-param arrow lambdas only, e.g. items.map(x => x.ref_id))`;
+
+function callMethod(obj: unknown, method: string, args: unknown[]): unknown {
+  if (obj === null || obj === undefined) {
+    throw new TemplateError(`Cannot call method '${method}' of ${obj}`);
+  }
+  if (!Array.isArray(obj)) {
+    throw new TemplateError(
+      `Cannot call '${method}' on ${typeof obj} — methods are ${METHODS_HINT}`,
+    );
+  }
+  const lambdaArg = (): ((el: unknown) => unknown) => {
+    const f = args[0];
+    if (typeof f !== "function") {
+      throw new TemplateError(
+        `${method}() requires a lambda argument, e.g. items.${method}(x => x.name)`,
+      );
+    }
+    return f as (el: unknown) => unknown;
+  };
+  const plainArgs = (): unknown[] => {
+    if (args.some((a) => typeof a === "function")) {
+      throw new TemplateError(`${method}() does not take a lambda argument`);
+    }
+    return args;
+  };
+  switch (method) {
+    case "map": {
+      const f = lambdaArg();
+      return obj.map((el) => f(el));
+    }
+    case "filter": {
+      const f = lambdaArg();
+      return obj.filter((el) => Boolean(f(el)));
+    }
+    case "find": {
+      const f = lambdaArg();
+      return obj.find((el) => Boolean(f(el)));
+    }
+    case "join": {
+      const [sep] = plainArgs();
+      return obj.join(sep === undefined ? "," : String(sep));
+    }
+    case "includes":
+      return obj.includes(plainArgs()[0]);
+    case "slice": {
+      const [a, b] = plainArgs();
+      return obj.slice(a as number | undefined, b as number | undefined);
+    }
+    default:
+      throw new TemplateError(`Unknown method '${method}' — ${METHODS_HINT}`);
+  }
 }
 
 // ── Parser (recursive descent, evaluates in one pass) ─────────────────────
@@ -296,6 +376,54 @@ function parse(
     return parseAccess();
   }
 
+  function peekAhead(): Token {
+    return tokens[pos + 1] ?? { type: "eof", value: "" };
+  }
+
+  /** Capture a lambda body's tokens (to the depth-0 `,` or `)` that ends the
+   *  argument) WITHOUT evaluating them — the parameter isn't bound yet.
+   *  Returns a closure that re-parses the slice per element with the
+   *  parameter bound in a child scope (shadowing any outer binding). */
+  function parseLambda(): (el: unknown) => unknown {
+    const param = expect("ident").value;
+    expect("arrow");
+    const body: Token[] = [];
+    let depth = 0;
+    while (true) {
+      const t = peek();
+      if (t.type === "eof") {
+        throw new TemplateError(`Unterminated lambda body for parameter '${param}'`);
+      }
+      if (depth === 0 && (t.type === "comma" || t.type === "rparen")) break;
+      if (t.type === "lparen" || t.type === "lbracket") depth++;
+      if (t.type === "rparen" || t.type === "rbracket") depth--;
+      body.push(advance());
+    }
+    if (body.length === 0) {
+      throw new TemplateError(`Empty lambda body for parameter '${param}'`);
+    }
+    const bodyTokens: Token[] = [...body, { type: "eof", value: "" }];
+    return (el: unknown) => parse(bodyTokens, { ...scope, [param]: el });
+  }
+
+  /** Parse a call's arguments: each is a single-param arrow lambda
+   *  (`x => expr`) or an ordinary expression. */
+  function parseCallArgs(): unknown[] {
+    expect("lparen");
+    const args: unknown[] = [];
+    while (peek().type !== "rparen") {
+      if (peek().type === "ident" && peekAhead().type === "arrow") {
+        args.push(parseLambda());
+      } else {
+        args.push(parseTernary());
+      }
+      if (peek().type === "comma") advance();
+      else break;
+    }
+    expect("rparen");
+    return args;
+  }
+
   function parseAccess(): unknown {
     let obj = parsePrimary();
 
@@ -303,6 +431,10 @@ function parse(
       if (peek().type === "dot") {
         advance();
         const prop = expect("ident").value;
+        if (peek().type === "lparen") {
+          obj = callMethod(obj, prop, parseCallArgs());
+          continue;
+        }
         if (obj === null || obj === undefined) {
           throw new TemplateError(
             `Cannot access property '${prop}' of ${obj}`,

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -99,11 +99,13 @@ export {
   computeCost,
 } from "./pricing.js";
 
-// Standard capabilities — the http + secrets services adapter steps build on.
+// Standard capabilities — the http + secrets + artifacts services adapter steps build on.
 export {
   standardServices,
   httpCapability,
   secretsCapability,
+  fileArtifactsCapability,
+  type ArtifactsCapability,
   type VeinCapabilities,
   type HttpCapability,
   type HttpRequestOptions,

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -158,6 +158,59 @@ describe("agentTools (buildRegistryTools — tools are steps)", () => {
     assert.ok(tools["agent"], "the core agent step is grantable as an agentTool");
     assert.equal((tools["agent"] as any).inputSchema, reg["agent"]!.input);
   });
+
+  it("nests a registry step's own emits under the tool-call span (child ctx path)", async () => {
+    // A step that emits an event itself — stands in for a nested agent whose
+    // own tool calls emit at `${ctx.path}/NNN-<tool>`.
+    const emittingStep = defineStep({
+      type: "demo/emitter",
+      input: z.object({}),
+      output: z.any(),
+      async run(_cfg, sctx) {
+        await (sctx.emit as any)({ type: "step.start", path: `${sctx.path}/001-inner`, stepType: "tool:inner" });
+        return "ok";
+      },
+    });
+    const reg = { "demo/emitter": emittingStep } as StepRegistry;
+    const events: any[] = [];
+    const ctx = {
+      runId: "r1", path: "wf/parent-agent", scope: {}, input: undefined,
+      emit: async (e: any) => { events.push(e); }, services: undefined, registry: reg,
+    } as unknown as StepContext;
+
+    const tools = buildRegistryTools(["demo/emitter"], reg, ctx, (d: any) => d);
+    wrapToolsWithEmit(tools, ctx);
+    await (tools["demo_emitter"] as any).execute({}, {});
+
+    const paths = events.map((e) => e.path);
+    // outer span from wrapToolsWithEmit…
+    assert.ok(paths.includes("wf/parent-agent/001-demo_emitter"), `outer span missing: ${paths}`);
+    // …and the step's own emit nests UNDER it (not as a flat sibling).
+    assert.ok(
+      paths.includes("wf/parent-agent/001-demo_emitter/001-inner"),
+      `inner emit not nested: ${paths}`,
+    );
+  });
+
+  it("registry tool keeps the parent ctx path when called without wrap options", async () => {
+    const events: any[] = [];
+    const probeStep = defineStep({
+      type: "demo/probe",
+      input: z.object({}),
+      output: z.any(),
+      async run(_cfg, sctx) {
+        return sctx.path;
+      },
+    });
+    const reg = { "demo/probe": probeStep } as StepRegistry;
+    const ctx = {
+      runId: "r1", path: "wf/agent", scope: {}, input: undefined,
+      emit: async (e: any) => { events.push(e); }, services: undefined, registry: reg,
+    } as unknown as StepContext;
+    const tools = buildRegistryTools(["demo/probe"], reg, ctx, (d: any) => d);
+    // Unwrapped (no wrapToolsWithEmit): no veinToolPath → parent path unchanged.
+    assert.equal(await (tools["demo_probe"] as any).execute({}), "wf/agent");
+  });
 });
 
 describe("wrapToolsWithEmit (per-call nested run events)", () => {

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -6,7 +6,7 @@ import { join } from "node:path";
 import { z } from "zod";
 import { coreRegistry } from "../registry.js";
 import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
-import agent, { repoTree, textEdit, buildRegistryTools, wrapToolsWithEmit } from "./agent.js";
+import agent, { repoTree, textEdit, buildRegistryTools, expandAgentTools, wrapToolsWithEmit } from "./agent.js";
 
 // These tests are OFFLINE: they exercise registration, the input schema, and the
 // config-validation guards in run() that fire BEFORE any model call. The actual
@@ -98,6 +98,65 @@ describe("agentTools (buildRegistryTools — tools are steps)", () => {
     const tools = buildRegistryTools(["demo/echo"], registry, undefined, fakeTool);
     const out = await (tools["demo_echo"] as any).execute({ wrong: 1 });
     assert.match(String(out), /Error: invalid input for "demo\/echo"/);
+  });
+
+  describe("glob expansion (expandAgentTools)", () => {
+    const shoutStep = defineStep({
+      type: "demo/shout",
+      input: z.object({ msg: z.string() }),
+      output: z.string(),
+      async run(cfg) {
+        return cfg.msg.toUpperCase();
+      },
+    });
+    const otherStep = defineStep({
+      type: "other/thing",
+      input: z.object({}),
+      output: z.any(),
+      async run() {
+        return null;
+      },
+    });
+    const globReg = {
+      "demo/echo": echoStep,
+      "demo/shout": shoutStep,
+      "other/thing": otherStep,
+    } as StepRegistry;
+
+    it("expands a namespace glob to every matching step type, sorted", () => {
+      assert.deepEqual(expandAgentTools(["demo/*"], globReg), ["demo/echo", "demo/shout"]);
+    });
+
+    it("mixes globs and plain names, deduping (first occurrence wins)", () => {
+      assert.deepEqual(
+        expandAgentTools(["demo/echo", "demo/*", "other/thing"], globReg),
+        ["demo/echo", "demo/shout", "other/thing"],
+      );
+    });
+
+    it("a glob matching nothing expands to nothing (no throw)", () => {
+      assert.deepEqual(expandAgentTools(["nope/*"], globReg), []);
+    });
+
+    it("does not treat regex metacharacters in the pattern as regex", () => {
+      // "demo/e.ho" must NOT match "demo/echo" — dots are literal.
+      assert.deepEqual(
+        expandAgentTools(["demo/e.ho"], globReg),
+        ["demo/e.ho"], // passes through as a plain (unknown) name
+      );
+    });
+
+    it("buildRegistryTools consumes globs end-to-end", () => {
+      const tools = buildRegistryTools(["demo/*"], globReg, undefined, fakeTool);
+      assert.deepEqual(Object.keys(tools).sort(), ["demo_echo", "demo_shout"]);
+    });
+  });
+
+  it("exposes the agent step itself as a tool (sub-agent recursion seam)", () => {
+    const reg = coreRegistry();
+    const tools = buildRegistryTools(["agent"], reg, undefined, fakeTool);
+    assert.ok(tools["agent"], "the core agent step is grantable as an agentTool");
+    assert.equal((tools["agent"] as any).inputSchema, reg["agent"]!.input);
   });
 });
 

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -466,7 +466,7 @@ export function buildRegistryTools(
     out[toolNameFor(stepType)] = toolFactory({
       description: def.description ?? `Run the "${stepType}" step.`,
       inputSchema: def.input,
-      execute: async (input: unknown) => {
+      execute: async (input: unknown, options?: { veinToolPath?: string }) => {
         let parsed: unknown;
         try {
           parsed = def.input.parse(input ?? {});
@@ -474,9 +474,16 @@ export function buildRegistryTools(
           return `Error: invalid input for "${stepType}": ${(e as Error).message}`;
         }
         // Run the step with the agent's ctx (leaf tool-steps reach
-        // ctx.services etc.). The nesting/emit is added by wrapToolsWithEmit.
-        const childCtx: StepContext = ctx ??
+        // ctx.services etc.). The nesting/emit is added by wrapToolsWithEmit,
+        // which also threads this call's event path in via `veinToolPath` —
+        // adopting it as the child ctx path makes any events the step itself
+        // emits (e.g. a nested `agent` step's own tool calls) nest UNDER this
+        // call's span instead of appearing as flat siblings of it.
+        const base: StepContext = ctx ??
           ({ runId: "", path: "", scope: {}, input: undefined, emit: (async () => {}) as any, services: undefined });
+        const childCtx: StepContext = options?.veinToolPath
+          ? { ...base, path: options.veinToolPath }
+          : base;
         return def.run(parsed, childCtx);
       },
     });
@@ -512,7 +519,13 @@ export function wrapToolsWithEmit(tools: Record<string, any>, ctx: StepContext |
       const startedAt = Date.now();
       await emit({ type: "step.start", path, stepType: `tool:${name}`, input });
       try {
-        const out = await (orig as (i: unknown, o: unknown) => Promise<unknown>)(input, opts);
+        // Thread this call's event path to the tool (registry tools adopt it
+        // as their child ctx path, so nested emits land under this span).
+        const optsWithPath =
+          typeof opts === "object" && opts !== null
+            ? { ...(opts as Record<string, unknown>), veinToolPath: path }
+            : { veinToolPath: path };
+        const out = await (orig as (i: unknown, o: unknown) => Promise<unknown>)(input, optsWithPath);
         await emit({
           type: "step.end",
           path,

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -580,7 +580,7 @@ export default defineStep({
   }),
   output: z.any(),
   async run(cfg, ctx) {
-    const { ToolLoopAgent, Output, tool, stepCountIs, hasToolCall, jsonSchema, generateText } = await import("ai");
+    const { ToolLoopAgent, Output, tool, stepCountIs, hasToolCall, jsonSchema, streamText } = await import("ai");
 
     const provider = cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? "anthropic";
     const modelName = cfg.model ?? process.env["VEIN_LLM_MODEL"];
@@ -760,9 +760,26 @@ export default defineStep({
 
     const preamble = buildPreamble(cfg.cwd);
     const startTime = Date.now();
-    const res = await agent.generate({
+    // STREAM, don't generate: a long drafting turn (multi-minute, many
+    // thousands of output tokens) produces zero bytes on a non-streaming
+    // connection until it completes, and intermediaries sever it as idle —
+    // seen live as "other side closed" at ~3min, killing whole runs.
+    // Streaming keeps bytes flowing; we drain the stream and then await the
+    // aggregate fields, which have the same shapes generate() returned.
+    const streamRes = await agent.stream({
       prompt: preamble ? `${preamble}\n\n${cfg.prompt}` : cfg.prompt,
     });
+    let streamError: unknown;
+    await streamRes.consumeStream({ onError: (e: unknown) => { streamError = e; } });
+    if (streamError) throw streamError;
+    const res = {
+      steps: await streamRes.steps,
+      response: await streamRes.response,
+      totalUsage: await streamRes.totalUsage,
+      usage: undefined as unknown,
+      text: await streamRes.text,
+      output: useSchema ? await (streamRes as any).output : undefined,
+    };
 
     const steps = res.steps ?? [];
     // The full session is HUGE and the runner persists every step's output, so we
@@ -811,7 +828,9 @@ export default defineStep({
       if (!final) {
         console.warn("[agent] No final_answer tool call; forcing a final-answer turn.");
         try {
-          const forced = await generateText({
+          // Streamed for the same severed-connection reason as the main loop —
+          // this single turn emits the ENTIRE final answer.
+          const forced = streamText({
             model,
             ...(providerOptions ? { providerOptions } : {}),
             messages: [
@@ -822,10 +841,13 @@ export default defineStep({
               },
             ],
           });
-          const ft = (forced.text ?? "").trim();
+          let forcedError: unknown;
+          await forced.consumeStream({ onError: (e: unknown) => { forcedError = e; } });
+          if (forcedError) throw forcedError;
+          const ft = ((await forced.text) ?? "").trim();
           if (ft) {
             final = ft;
-            const fu = usageFromResult(forced.totalUsage ?? forced.usage);
+            const fu = usageFromResult(await forced.totalUsage);
             usage = addUsage(usage, fu);
             cost += computeCost(provider, fu);
           }

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -389,6 +389,46 @@ function toolNameFor(stepType: string): string {
   return stepType.replace(/[^a-zA-Z0-9_]/g, "_");
 }
 
+/** Compile a glob pattern (`*` = any run of characters) to an anchored RegExp. */
+function globToRegExp(pattern: string): RegExp {
+  const escaped = pattern.replace(/[.*+?^${}()|[\]\\]/g, (c) =>
+    c === "*" ? ".*" : `\\${c}`,
+  );
+  return new RegExp(`^${escaped}$`);
+}
+
+/**
+ * Expand `agentTools` entries against the registry: a name containing `*` is a
+ * glob over registry step types (e.g. `"jarvis/*"` → every jarvis step), so a
+ * whole namespace can be granted in one entry and new steps in it are picked
+ * up automatically. Plain names pass through untouched (unknown ones still
+ * warn in the tool-build loop). Duplicates collapse (first occurrence wins);
+ * glob matches are sorted for a stable tool order.
+ */
+export function expandAgentTools(names: string[], registry: StepRegistry): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const name of names) {
+    let matches: string[];
+    if (name.includes("*")) {
+      const re = globToRegExp(name);
+      matches = Object.keys(registry).filter((t) => re.test(t)).sort();
+      if (matches.length === 0) {
+        console.warn(`[agent] agentTools: pattern "${name}" matched no step types`);
+      }
+    } else {
+      matches = [name];
+    }
+    for (const m of matches) {
+      if (!seen.has(m)) {
+        seen.add(m);
+        out.push(m);
+      }
+    }
+  }
+  return out;
+}
+
 /** Truncate a tool's I/O for the run-event log (the full thing lives in the
  *  model transcript; the event log only needs a readable preview). */
 function summarizeForEvent(v: unknown): string {
@@ -417,7 +457,7 @@ export function buildRegistryTools(
 ): Record<string, unknown> {
   const out: Record<string, unknown> = {};
   if (!names?.length || !registry) return out;
-  for (const stepType of names) {
+  for (const stepType of expandAgentTools(names, registry)) {
     const def = registry[stepType];
     if (!def) {
       console.warn(`[agent] agentTools: unknown step type "${stepType}" — skipping`);
@@ -513,7 +553,7 @@ export default defineStep({
       .array(z.string())
       .default([])
       .describe(
-        "registry step TYPES to expose as additional LLM tools (the 'tools are steps' model, e.g. ['gitsee/read-logs']). Each step's input schema becomes the tool schema and its run() is the executor, called with a nested ctx so every tool call emits a step.start/step.end run event (visible in the events panel). Merged ON TOP of the built-ins (not subject to toolFilter). Unknown types are skipped. Requires the runner-populated ctx.registry.",
+        "registry step TYPES to expose as additional LLM tools (the 'tools are steps' model, e.g. ['gitsee/read-logs']). Entries may be glob patterns over step types ('jarvis/*' grants the whole namespace; new steps in it are picked up automatically). Each step's input schema becomes the tool schema and its run() is the executor, called with a nested ctx so every tool call emits a step.start/step.end run event (visible in the events panel). Merged ON TOP of the built-ins (not subject to toolFilter). Unknown types are skipped. Requires the runner-populated ctx.registry.",
       ),
     model: z.string().optional(),
     provider: z.string().optional(),

--- a/vein/src/steps/core/llm.ts
+++ b/vein/src/steps/core/llm.ts
@@ -6,7 +6,7 @@ const EXAMPLE = `- id: summarize
   config:
     prompt: "Summarize this: {{ fetch.body }}"
     provider: anthropic
-    model: claude-sonnet-4-20250514`;
+    model: claude-sonnet-5`;
 
 export default defineStep({
   type: "llm",
@@ -31,7 +31,7 @@ export default defineStep({
     switch (provider) {
       case "anthropic": {
         const { anthropic } = await import("@ai-sdk/anthropic");
-        aiModel = anthropic(model ?? "claude-sonnet-4-20250514");
+        aiModel = anthropic(model ?? "claude-sonnet-5");
         break;
       }
       case "openai": {

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -173,8 +173,15 @@ export async function streamRun(
   name: string,
   runId: string,
   onEvent?: (event: RunEvent) => void,
+  signal?: AbortSignal,
 ): Promise<any> {
-  const res = await fetch(`${BASE}/workflows/${name}/runs/${runId}/stream`);
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}/workflows/${name}/runs/${runId}/stream`, { signal });
+  } catch (e) {
+    if ((e as Error)?.name === "AbortError") return null;
+    throw e;
+  }
   const reader = res.body?.getReader();
   if (!reader) throw new Error("No response body");
 
@@ -183,7 +190,14 @@ export async function streamRun(
   let result: any = null;
 
   while (true) {
-    const { done, value } = await reader.read();
+    let done: boolean, value: Uint8Array | undefined;
+    try {
+      ({ done, value } = await reader.read());
+    } catch (e) {
+      // Aborted mid-read (caller navigated away): return quietly.
+      if ((e as Error)?.name === "AbortError") return null;
+      throw e;
+    }
     if (done) break;
     buffer += decoder.decode(value, { stream: true });
 

--- a/vein/web/src/app.tsx
+++ b/vein/web/src/app.tsx
@@ -242,9 +242,26 @@ export function App() {
       setEvents([]);
       return;
     }
-    api.getRunEvents(selectedWf, selectedRun).then((evts) => {
-      setEvents(evts);
-    }).catch(console.error);
+    // TAIL the run rather than one-shot fetching its events: the SSE stream
+    // replays the full history, then follows live appends until the run
+    // completes — so selecting an IN-FLIGHT run (launched via curl, the chat
+    // agent, or another tab) updates the events panel in real time. For a
+    // completed run the stream drains and ends immediately (same behavior as
+    // the old fetch). Aborted on run-switch/unmount so pollers don't leak.
+    const ctrl = new AbortController();
+    const accumulated: api.RunEvent[] = [];
+    setEvents([]);
+    api.streamRun(selectedWf, selectedRun, (event) => {
+      if (ctrl.signal.aborted) return;
+      accumulated.push(event);
+      setEvents([...accumulated]);
+    }, ctrl.signal)
+      .then((result) => {
+        // A live-tailed run just finished → refresh the sidebar status.
+        if (result != null && !ctrl.signal.aborted) refreshRuns();
+      })
+      .catch(console.error);
+    return () => ctrl.abort();
   }, [selectedRun]);
 
   // Resolve the selected run's declared promotions (a winning value → a target


### PR DESCRIPTION
## Summary

Groundwork for authoring knowledge-graph workflows in vein/lab (toward porting the legal-benchmark workflows): the vein agent step gets namespace tool grants and sub-agent recursion, vein core gets per-run artifact files, and the lab gets the full Jarvis tool surface as seeded steps.

### vein core
- **`agentTools` glob patterns** (`expandAgentTools` in `steps/core/agent.ts`): `"jarvis/*"` grants every registry step in a namespace (sorted, deduped, warns on zero matches; regex metacharacters stay literal). `"agent"` itself is grantable — that's the sub-agent primitive: recursion depth is controlled by whether the child's own `agentTools` list includes `"agent"` again, not a numeric cap.
- **`ArtifactsCapability`** (`capabilities.ts`): per-run file storage at `<workspace>/artifacts/<runId>/`, auto-injected by `createVein` (consumer bag can override). Steps write files and put relative paths in outputs; point an agent step's `cwd` at `dir(ctx.runId)` to share files between agents. Per-run path isolation (a relPath cannot escape its run dir; bad runIds rejected). Artifacts are retained after the run. New read-only routes: `GET /artifacts/:runId` (recursive list) + `GET /artifacts/:runId/<path>` (serve, minimal content-type map).
- Tests: 441 passing (new `artifacts.test.ts` + glob/agent-recursion cases in `agent.test.ts`).

### mcp/src/lab/jarvis
Self-contained seeded steps porting the repo-agent Jarvis tools (`repo/toolsJarvis.ts`) — same endpoints, schemas, and LLM-facing descriptions:
- Reads: `jarvis/get-ontology`, `jarvis/get-ontology-type`, `jarvis/graph-search`, `jarvis/graph-get`, `jarvis/graph-get-batched`, `jarvis/graph-neighbors`
- Writes: `jarvis/create-node`, `jarvis/edit-node`, `jarvis/create-triplet`, `jarvis/create-batch-triplet`
- Config resolves through `ctx.services.secrets` (`JARVIS_URL` / `API_TOKEN` / optional `JARVIS_HTTP_TIMEOUT_MS`, secret store → env fallback) and all requests go through `ctx.services.http`, so runs are cassette-recordable and credentials scrubbed from fixtures.
- Always seeded (deterministic workspace/registry); without `JARVIS_URL` a step fails loudly per run rather than being silently absent. Ontology CRUD family deliberately not ported (schema editing stays a human/setup activity).
- Concepts need no dedicated steps — they're Jarvis nodes (`type: "Concept"`).

### Verification
- `vein`: `npm test` → 441 pass; `tsc --noEmit` clean
- `mcp`: `tsc --noEmit` clean; `yarn build` copies jarvis lab assets
- Offline smoke `npx tsx src/lab/jarvis/smoke.ts`: seeds into a temp workspace, verifies registry discovery of all 10 steps, runs every step against a fake Jarvis (auth headers, param encoding, connection-count collapsing, inline-node resolution + batch dedup, soft-error paths) — all passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

### mcp/src/lab/harvey — Harvey LAB verification (second commit)
The hardcoded grader for the legal benchmarks: an **in-code service** (`harvey/service.ts`) that subprocess-runs the **actual** harvey-labs eval (`uv run python -m evaluation.run_eval`) against the checkout at `HARVEY_LABS_DIR` — nothing ported, and deliberately NOT a seeded step, so the workflow-authoring agent can never edit its own grader.
- Integrity invariant enforced per grade: clean git tree required, optional `HARVEY_LABS_REV` pin must match HEAD, untracked `results/` (our staged runs) tolerated; every result carries `benchmarkRev`.
- Thin seeded steps: `harvey/get-task` (instructions + documents, **rubric stripped in the service**) and `harvey/evaluate` (stages this run's artifact deliverables into `results/vein-<runId>/output/`, runs the real eval, returns the harness's own `scores.json` + `benchmarkRev` + `reportPath`). Guardrail documented: grant `harvey/evaluate` only to harness workflows, never the producing agent.
- Offline smoke (`src/lab/harvey/smoke.ts`: fake checkout via real git + fake `uv` exec) covers integrity enforcement, rubric stripping, staging, CLI args, and step wiring; a live read-only check passed against the real checkout (rev `b58a28ae`).
