### PR TITLE
lab/sheets: port the Google Sheets toolset to seeded vein steps

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -331,6 +331,51 @@ read/write the Jarvis knowledge graph. **Concepts are Jarvis nodes** (filter
   workspace, verifies registry discovery, and runs every step against a fake
   `ctx.services.http` Jarvis.
 
+### `sheets/` — Google Sheets steps (NOT an experiment)
+
+Self-contained ports of the mcp repo-agent's Google Sheets tools
+(`mcp/src/repo/toolsGoogleSheets.ts` — untouched; it stays the production
+repo-agent implementation) as seeded vein steps — same Sheets/Drive REST
+endpoints, same schemas, same LLM-facing descriptions — so workflows (and
+agent steps) can create spreadsheets and read/write cell values and live
+formulas.
+
+- **Steps:** `sheets/create-spreadsheet`, `sheets/update-values`,
+  `sheets/batch-update-values`, `sheets/get-values`, `sheets/add-sheet`,
+  `sheets/import-spreadsheet` (best-effort per-sheet import of an .xlsx or
+  native Sheet into a destination spreadsheet, with auto-conversion,
+  collision-suffixed tab names, and cross-sheet-formula warnings).
+- **Config resolution:** `cfg.serviceAccount` (explicit step config — parsed
+  JSON, JSON string, or base64 JSON) wins, else the
+  `GOOGLE_SERVICE_ACCOUNT_JSON` secret (secret store → env fallback); same
+  for `cfg.driveFolderId` / `GOOGLE_DRIVE_FOLDER_ID` (spreadsheets are
+  created inside that folder — share it with the service account's
+  client_email so humans can see agent-created sheets). Auth is a plain
+  service-account JWT flow: an RS256 assertion built with `node:crypto` (no
+  jsonwebtoken/axios deps), exchanged at the SA's `token_uri` for a bearer
+  token (scopes `spreadsheets` + `drive`), cached per step module with 60s
+  expiry slack. Everything goes through `ctx.services.http` +
+  `ctx.services.secrets`, so runs are cassette-recordable and credentials
+  are scrubbed from fixtures. Steps are ALWAYS seeded; without
+  `GOOGLE_SERVICE_ACCOUNT_JSON` they fail loudly per run rather than
+  silently missing. API errors come back as teaching strings (e.g. a 403 on
+  create names the folder and client_email to share it with), never throws
+  at the LLM.
+- **Granting to agents:** `agentTools: ["sheets/*"]` (glob, vein-core
+  `expandAgentTools`) for everything, or an explicit subset — e.g. a
+  read-only child gets just `sheets/get-values`.
+- **Self-contained duplication is deliberate:** each step file inlines its
+  `sheetsCtx` auth/request preamble (seeded steps may only value-import
+  `"vein"` + node builtins); the contract is documented once in
+  `sheets/steps/_shared.ts` — change it there AND in every step.
+- **Smoke:** `npx tsx src/lab/sheets/smoke.ts` — offline; seeds into a temp
+  workspace, verifies registry discovery, then runs every step against a
+  fake `ctx.services.http` Google (real RSA keypair so the JWT signature is
+  verified; covers token caching, bearer headers, round-trip shapes, the
+  loud missing-credentials error, and a teaching-error case). No live
+  Google call has been made yet — end-to-end verification with a real
+  service account is pending.
+
 ### `harvey/` — Harvey LAB verification (the hardcoded grader)
 
 Runs the **actual** Harvey LAB legal-benchmark eval (the

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -13,6 +13,7 @@ import { seedConceptWorkflows, seedConceptSteps } from "./concepts/seed.js";
 import { seedEvalSteps } from "./eval/seed.js";
 import { seedGitseeWorkflows, seedGitseeSteps } from "./gitsee/seed.js";
 import { seedJarvisSteps } from "./jarvis/seed.js";
+import { seedSheetsSteps } from "./sheets/seed.js";
 import { seedHarveySteps, seedHarveyWorkflows } from "./harvey/seed.js";
 import { seedArtifactSteps } from "./artifacts/seed.js";
 import { buildHarveyServices, type HarveyServices } from "./harvey/service.js";
@@ -131,6 +132,11 @@ export async function createLabVein(
   // ctx.services.http with JARVIS_URL/API_TOKEN from ctx.services.secrets).
   // Grantable to agents via agentTools: ["jarvis/*"].
   await seedJarvisSteps(workspace);
+  // google sheets steps (self-contained; reach the Sheets/Drive REST APIs
+  // over ctx.services.http with GOOGLE_SERVICE_ACCOUNT_JSON /
+  // GOOGLE_DRIVE_FOLDER_ID from ctx.services.secrets). Grantable to agents
+  // via agentTools: ["sheets/*"].
+  await seedSheetsSteps(workspace);
   // harvey verification steps (thin plumbing over services.harvey; grant
   // harvey/evaluate only to harness workflows, never the producing agent).
   await seedHarveySteps(workspace);

--- a/mcp/src/lab/sheets/seed.ts
+++ b/mcp/src/lab/sheets/seed.ts
@@ -1,0 +1,47 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { WorkspaceManager } from "vein";
+
+/**
+ * Google Sheets steps, seeded into the vein workspace. Each is a
+ * self-contained port of the matching mcp repo-agent tool
+ * (`mcp/src/repo/toolsGoogleSheets.ts`) speaking the same Sheets/Drive REST
+ * contract — but routed through `ctx.services.http` + `ctx.services.secrets`
+ * (GOOGLE_SERVICE_ACCOUNT_JSON / GOOGLE_DRIVE_FOLDER_ID, env-backed) so runs
+ * are cassette-recordable and credentials stay scrubbed. Reconciled by
+ * content hash on boot (edits via the vein UI publish a new active version).
+ *
+ * Grant them to an agent step with `agentTools: ["sheets/*"]` (glob), or an
+ * explicit subset (e.g. a read-only child gets just `sheets/get-values`).
+ *
+ * Steps are ALWAYS seeded (deterministic workspace, deterministic registry);
+ * a deployment without GOOGLE_SERVICE_ACCOUNT_JSON gets a loud per-run error
+ * instead of a silently missing tool.
+ */
+const SEED_STEPS: Array<{ file: string; type: string }> = [
+  { file: "create-spreadsheet.ts", type: "sheets/create-spreadsheet" },
+  { file: "update-values.ts", type: "sheets/update-values" },
+  { file: "batch-update-values.ts", type: "sheets/batch-update-values" },
+  { file: "get-values.ts", type: "sheets/get-values" },
+  { file: "add-sheet.ts", type: "sheets/add-sheet" },
+  { file: "import-spreadsheet.ts", type: "sheets/import-spreadsheet" },
+];
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+export async function seedSheetsSteps(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "steps");
+  for (const { file, type } of SEED_STEPS) {
+    try {
+      const code = await readFile(join(dir, file), "utf-8");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "sheets-seed");
+      if (changed) console.log(`[sheets] seeded step: ${type} @ ${version}`);
+    } catch (err) {
+      console.warn(
+        `[sheets] could not seed step "${type}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/mcp/src/lab/sheets/smoke.ts
+++ b/mcp/src/lab/sheets/smoke.ts
@@ -1,0 +1,347 @@
+/**
+ * Offline smoke test for the sheets/* steps — no vein server, no live Google.
+ * Verifies:
+ *   1. seeding: seedSheetsSteps publishes into a temp workspace and
+ *      buildRegistry discovers every step from disk;
+ *   2. auth: the RS256 service-account JWT is built correctly (signature
+ *      verifies against the keypair), exchanged once, then cached;
+ *   3. step logic: each step runs against a FAKE `ctx.services.http` that
+ *      replays canned Google API responses (correct Authorization headers,
+ *      create→update→get round trip shapes, the loud missing-credentials
+ *      error, an HTTP-error → teaching string case).
+ *
+ * Run: npx tsx src/lab/sheets/smoke.ts
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { generateKeyPairSync, createVerify } from "node:crypto";
+import { WorkspaceManager, buildRegistry, type StepContext, type HttpResponse } from "vein";
+import { seedSheetsSteps } from "./seed.js";
+
+const TOKEN_URI = "https://oauth2.googleapis.com/token";
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+
+// ── service-account keypair (real RSA so the JWT signature is verifiable) ──
+const { publicKey, privateKey } = generateKeyPairSync("rsa", { modulusLength: 2048 });
+const privPem = privateKey.export({ type: "pkcs8", format: "pem" }) as string;
+const SA = { client_email: "sa@test.iam.gserviceaccount.com", private_key: privPem };
+const SA_JSON = JSON.stringify(SA);
+
+// ── fake ctx: canned Google APIs over ctx.services.http ────────────────────
+type Call = { url: string; opts: any };
+const calls: Call[] = [];
+
+type Route = { match: (url: string, opts: any) => boolean; body: unknown; status?: number };
+
+/** Every ctx serves the token endpoint plus the given routes. */
+const tokenRoute: Route = {
+  match: (u, o) => u === TOKEN_URI && o.method === "POST",
+  body: { access_token: "tok-abc", expires_in: 3600, token_type: "Bearer" },
+};
+
+function fakeHttp(routes: Route[]) {
+  return async (url: string, opts: any = {}): Promise<HttpResponse> => {
+    calls.push({ url, opts });
+    for (const r of [tokenRoute, ...routes]) {
+      if (r.match(url, opts)) {
+        return { status: r.status ?? 200, ok: (r.status ?? 200) < 300, headers: {}, body: r.body };
+      }
+    }
+    return { status: 404, ok: false, headers: {}, body: `no fake route for ${opts.method ?? "GET"} ${url}` };
+  };
+}
+
+function makeCtx(routes: Route[], secrets?: Record<string, string>): StepContext {
+  const bag = secrets ?? { GOOGLE_SERVICE_ACCOUNT_JSON: SA_JSON };
+  return {
+    runId: "smoke",
+    path: "smoke",
+    scope: {},
+    input: undefined,
+    emit: async () => {},
+    services: {
+      http: fakeHttp(routes),
+      secrets: { get: async (name: string) => bag[name] },
+    },
+  } as unknown as StepContext;
+}
+
+const tokenCalls = () => calls.filter((c) => c.url === TOKEN_URI);
+
+async function main() {
+  // ── 1. seed + discover ───────────────────────────────────────────────────
+  // Under the mcp dir (not os tmpdir) so the seeded steps' dynamic
+  // `import "vein"` resolves via mcp/node_modules — same as the real
+  // lab-workspace location.
+  const dir = mkdtempSync(join(process.cwd(), ".sheets-smoke-"));
+  try {
+    const workspace = new WorkspaceManager(dir);
+    await seedSheetsSteps(workspace);
+    const { registry } = await buildRegistry(workspace.path);
+    const expected = [
+      "sheets/create-spreadsheet", "sheets/update-values", "sheets/batch-update-values",
+      "sheets/get-values", "sheets/add-sheet", "sheets/import-spreadsheet",
+    ];
+    for (const t of expected) assert.ok(registry[t], `registry missing ${t}`);
+    console.log(`✔ seeded + discovered ${expected.length} sheets steps`);
+
+    // ── 2. missing credentials is a loud error ─────────────────────────────
+    await assert.rejects(
+      () =>
+        registry["sheets/get-values"].run(
+          registry["sheets/get-values"].input.parse({ spreadsheet_id: "s1", range: "Sheet1!A1" }),
+          makeCtx([], {}),
+        ),
+      /GOOGLE_SERVICE_ACCOUNT_JSON not configured/,
+    );
+    console.log("✔ loud error without GOOGLE_SERVICE_ACCOUNT_JSON");
+
+    // ── 3. JWT exchange happens once, then the token is cached ─────────────
+    const getRoutes: Route[] = [
+      {
+        match: (u) => u.includes("/values/") && u.includes("valueRenderOption=UNFORMATTED_VALUE"),
+        body: { range: "Sheet1!A1:B2", values: [[1, 2], [3, "=SUM(A1:B1)"]] },
+      },
+    ];
+    let out: any = await registry["sheets/get-values"].run(
+      registry["sheets/get-values"].input.parse({ spreadsheet_id: "s1", range: "Sheet1!A1:B2" }),
+      makeCtx(getRoutes),
+    );
+    assert.deepEqual(out, { range: "Sheet1!A1:B2", values: [[1, 2], [3, "=SUM(A1:B1)"]] });
+    assert.equal(tokenCalls().length, 1, "expected exactly one token exchange");
+
+    // the assertion is a valid RS256 JWT signed with the SA key
+    const tokenCall = tokenCalls()[0];
+    assert.equal(tokenCall.opts.headers["Content-Type"], "application/x-www-form-urlencoded");
+    const assertion = new URLSearchParams(tokenCall.opts.body as string).get("assertion")!;
+    const [h, c, s] = assertion.split(".");
+    assert.deepEqual(JSON.parse(Buffer.from(h, "base64url").toString()), { alg: "RS256", typ: "JWT" });
+    const claims = JSON.parse(Buffer.from(c, "base64url").toString());
+    assert.equal(claims.iss, SA.client_email);
+    assert.equal(claims.aud, TOKEN_URI);
+    assert.match(claims.scope, /spreadsheets/);
+    assert.match(claims.scope, /drive/);
+    assert.equal(claims.exp - claims.iat, 3600);
+    assert.ok(
+      createVerify("RSA-SHA256").update(`${h}.${c}`).verify(publicKey, Buffer.from(s, "base64url")),
+      "JWT signature must verify against the SA public key",
+    );
+    // the API call carried the exchanged bearer token
+    const apiCall = calls[calls.length - 1];
+    assert.equal(apiCall.opts.headers.Authorization, "Bearer tok-abc");
+    console.log("✔ RS256 JWT exchange (header/claims/signature + bearer header)");
+
+    // second run: cached token, no new exchange
+    out = await registry["sheets/get-values"].run(
+      registry["sheets/get-values"].input.parse({ spreadsheet_id: "s1", range: "Sheet1!A1:B2", render: "formula" }),
+      makeCtx([
+        { match: (u) => u.includes("valueRenderOption=FORMULA"), body: { range: "Sheet1!A1:B2", values: [["=A1"]] } },
+      ]),
+    );
+    assert.deepEqual(out.values, [["=A1"]]);
+    assert.equal(tokenCalls().length, 1, "token must be cached across calls");
+    console.log("✔ token cached (no second exchange)");
+
+    // base64 serviceAccount via explicit cfg wins over (absent) secrets
+    out = await registry["sheets/get-values"].run(
+      registry["sheets/get-values"].input.parse({
+        spreadsheet_id: "s1",
+        range: "Sheet1!A1",
+        serviceAccount: Buffer.from(SA_JSON).toString("base64"),
+      }),
+      makeCtx(
+        [{ match: (u) => u.includes("/values/"), body: { range: "Sheet1!A1", values: [] } }],
+        {},
+      ),
+    );
+    assert.deepEqual(out, { range: "Sheet1!A1", values: [] });
+    console.log("✔ cfg.serviceAccount (base64) wins over secrets");
+
+    // ── 4. create → update → get round trip shapes ─────────────────────────
+    // create without a folder: Sheets API create + extra tabs
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model", extra_sheet_titles: ["Scenarios"] }),
+      makeCtx([
+        { match: (u, o) => u === SHEETS_API && o.method === "POST", body: { spreadsheetId: "ss1" } },
+        { match: (u, o) => u.includes("ss1:batchUpdate") && o.method === "POST", body: { replies: [{}] } },
+      ]),
+    );
+    assert.deepEqual(out, {
+      spreadsheet_id: "ss1",
+      url: "https://docs.google.com/spreadsheets/d/ss1/edit",
+      sheets: ["Sheet1", "Scenarios"],
+    });
+    let last = calls[calls.length - 1]; // the extra-tabs batchUpdate
+    assert.equal(last.opts.body.requests[0].addSheet.properties.title, "Scenarios");
+    console.log("✔ create-spreadsheet (Sheets API + extra tabs)");
+
+    // create WITH a drive folder (cfg override): goes through Drive
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model", driveFolderId: "folder1" }),
+      makeCtx([
+        { match: (u, o) => u.startsWith(DRIVE_API) && o.method === "POST", body: { id: "ss2" } },
+      ]),
+    );
+    assert.equal(out.spreadsheet_id, "ss2");
+    last = calls[calls.length - 1];
+    assert.ok(last.url.includes("supportsAllDrives=true"));
+    assert.deepEqual(last.opts.body.parents, ["folder1"]);
+    assert.equal(last.opts.body.mimeType, "application/vnd.google-apps.spreadsheet");
+    console.log("✔ create-spreadsheet (Drive folder path)");
+
+    // GOOGLE_DRIVE_FOLDER_ID secret is picked up when cfg has no folder
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model" }),
+      makeCtx(
+        [{ match: (u, o) => u.startsWith(DRIVE_API) && o.method === "POST", body: { id: "ss3" } }],
+        { GOOGLE_SERVICE_ACCOUNT_JSON: SA_JSON, GOOGLE_DRIVE_FOLDER_ID: "folder-env" },
+      ),
+    );
+    assert.equal(out.spreadsheet_id, "ss3");
+    assert.deepEqual(calls[calls.length - 1].opts.body.parents, ["folder-env"]);
+    console.log("✔ GOOGLE_DRIVE_FOLDER_ID secret fallback");
+
+    // update-values (USER_ENTERED default, PUT)
+    out = await registry["sheets/update-values"].run(
+      registry["sheets/update-values"].input.parse({
+        spreadsheet_id: "ss1",
+        range: "Sheet1!A1:B2",
+        values: [["Revenue", 100], ["Total", "=SUM(B1:B1)"]],
+      }),
+      makeCtx([
+        {
+          match: (u, o) => u.includes("valueInputOption=USER_ENTERED") && o.method === "PUT",
+          body: { updatedRange: "Sheet1!A1:B2", updatedCells: 4 },
+        },
+      ]),
+    );
+    assert.deepEqual(out, { updated_range: "Sheet1!A1:B2", updated_cells: 4 });
+    assert.deepEqual(calls[calls.length - 1].opts.body, {
+      values: [["Revenue", 100], ["Total", "=SUM(B1:B1)"]],
+    });
+    console.log("✔ update-values");
+
+    // raw:true → RAW
+    out = await registry["sheets/update-values"].run(
+      registry["sheets/update-values"].input.parse({
+        spreadsheet_id: "ss1", range: "Sheet1!A1", values: [["=literal"]], raw: true,
+      }),
+      makeCtx([
+        { match: (u, o) => u.includes("valueInputOption=RAW") && o.method === "PUT", body: { updatedRange: "Sheet1!A1", updatedCells: 1 } },
+      ]),
+    );
+    assert.equal(out.updated_cells, 1);
+    console.log("✔ update-values raw mode");
+
+    // batch-update-values
+    out = await registry["sheets/batch-update-values"].run(
+      registry["sheets/batch-update-values"].input.parse({
+        spreadsheet_id: "ss1",
+        data: [
+          { range: "Sheet1!A1", values: [["h1"]] },
+          { range: "Sheet1!B1", values: [["=A1"]] },
+        ],
+      }),
+      makeCtx([
+        {
+          match: (u, o) => u.includes("values:batchUpdate") && o.method === "POST",
+          body: { totalUpdatedCells: 2, responses: [{ updatedRange: "Sheet1!A1" }, { updatedRange: "Sheet1!B1" }] },
+        },
+      ]),
+    );
+    assert.deepEqual(out, { total_updated_cells: 2, updated_ranges: ["Sheet1!A1", "Sheet1!B1"] });
+    assert.equal(calls[calls.length - 1].opts.body.valueInputOption, "USER_ENTERED");
+    console.log("✔ batch-update-values");
+
+    // add-sheet
+    out = await registry["sheets/add-sheet"].run(
+      registry["sheets/add-sheet"].input.parse({ spreadsheet_id: "ss1", title: "Scenarios" }),
+      makeCtx([
+        {
+          match: (u, o) => u.includes("ss1:batchUpdate") && o.method === "POST",
+          body: { replies: [{ addSheet: { properties: { sheetId: 42, title: "Scenarios" } } }] },
+        },
+      ]),
+    );
+    assert.deepEqual(out, { sheet_id: 42, title: "Scenarios" });
+    console.log("✔ add-sheet");
+
+    // ── 5. HTTP error → teaching string ────────────────────────────────────
+    out = await registry["sheets/create-spreadsheet"].run(
+      registry["sheets/create-spreadsheet"].input.parse({ title: "Model", driveFolderId: "folderX" }),
+      makeCtx([
+        {
+          match: (u, o) => u.startsWith(DRIVE_API) && o.method === "POST",
+          status: 403,
+          body: { error: { message: "The caller does not have permission" } },
+        },
+      ]),
+    );
+    assert.equal(typeof out, "string");
+    assert.match(out, /HTTP 403/);
+    assert.match(out, /share the Drive folder folderX/);
+    assert.ok(out.includes(SA.client_email), "teaching error must name the SA client_email");
+    console.log("✔ 403 create → teaching string (share the folder with client_email)");
+
+    // ── 6. import-spreadsheet (xlsx conversion path, 2 sheets) ─────────────
+    const dash = "—";
+    out = await registry["sheets/import-spreadsheet"].run(
+      registry["sheets/import-spreadsheet"].input.parse({
+        destination_spreadsheet_id: "dst1",
+        source_file_id: "src1",
+      }),
+      makeCtx([
+        {
+          match: (u, o) => u.startsWith(`${DRIVE_API}/src1?`) && (o.method ?? "GET") === "GET",
+          body: { name: "budget.xlsx", mimeType: "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet", parents: ["p1"] },
+        },
+        { match: (u, o) => u.includes("/src1/copy") && o.method === "POST", body: { id: "conv1" } },
+        {
+          match: (u) => u.includes("/conv1?fields=properties.title"),
+          body: {
+            properties: { title: "budget" },
+            sheets: [
+              { properties: { sheetId: 11, title: "Data" } },
+              { properties: { sheetId: 12, title: "Summary" } },
+            ],
+          },
+        },
+        {
+          match: (u) => u.includes("/dst1?fields=sheets.properties.title"),
+          body: { sheets: [{ properties: { title: "Sheet1" } }] },
+        },
+        { match: (u, o) => u.includes("/sheets/11:copyTo") && o.method === "POST", body: { sheetId: 101 } },
+        { match: (u, o) => u.includes("/sheets/12:copyTo") && o.method === "POST", body: { sheetId: 102 } },
+        { match: (u, o) => u.includes("dst1:batchUpdate") && o.method === "POST", body: { replies: [{}] } },
+        {
+          match: (u) => u.includes("valueRenderOption=FORMULA") && decodeURIComponent(u).includes("Data"),
+          body: { values: [["=Summary!B2", 1]] },
+        },
+        { match: (u) => u.includes("valueRenderOption=FORMULA"), body: { values: [] } },
+        { match: (u, o) => u.includes("/conv1?supportsAllDrives") && o.method === "DELETE", body: "" },
+      ]),
+    );
+    assert.equal(out.destination_spreadsheet_id, "dst1");
+    assert.equal(out.imported.length, 2);
+    assert.deepEqual(
+      out.imported.map((r: any) => r.tab_name),
+      [`SOURCE: budget.xlsx ${dash} Data`, `SOURCE: budget.xlsx ${dash} Summary`],
+    );
+    assert.ok(out.imported.every((r: any) => r.status === "success"));
+    assert.equal(out.converted_copy_deleted, true);
+    assert.equal(out.warnings.length, 2); // cross-sheet formula ref + the standing named-ranges warning
+    assert.match(out.warnings[0], /formula references to source sheet "Summary"/);
+    console.log("✔ import-spreadsheet (convert → copy → rename → warnings → cleanup)");
+
+    console.log("\nALL SHEETS SMOKE CHECKS PASSED");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp/src/lab/sheets/steps/_shared.ts
+++ b/mcp/src/lab/sheets/steps/_shared.ts
@@ -1,0 +1,33 @@
+/**
+ * NOT a seeded step — the canonical description of the per-step preamble for
+ * the sheets/* steps.
+ *
+ * Seeded steps must be SELF-CONTAINED (value-imports from "vein" and node
+ * builtins only), so each step file inlines its own copy of the auth/request
+ * preamble (`sheetsCtx` + helpers below). If you change the contract, update
+ * every step in this directory — they are deliberately duplicated, not shared.
+ *
+ * Contract (ported from `mcp/src/repo/toolsGoogleSheets.ts` — do not modify
+ * that file; it stays the production repo-agent implementation):
+ *   - Credentials: `cfg.serviceAccount` (explicit step config — parsed JSON
+ *     object, JSON string, or base64 JSON) wins, else
+ *     `ctx.services.secrets.get("GOOGLE_SERVICE_ACCOUNT_JSON")` (secret store
+ *     → env fallback). Missing credentials THROW a loud per-run error — the
+ *     steps are always seeded, never silently absent.
+ *   - `cfg.driveFolderId` wins, else the `GOOGLE_DRIVE_FOLDER_ID` secret.
+ *     Spreadsheets are created inside that folder (share it with the service
+ *     account's client_email so humans can see agent-created sheets).
+ *   - Auth: plain service-account JWT flow — RS256 assertion built with
+ *     `node:crypto` (`createSign("RSA-SHA256")`, base64url header+claims; no
+ *     jsonwebtoken dep), exchanged at the SA's `token_uri` (default
+ *     `https://oauth2.googleapis.com/token`) for a bearer token with the
+ *     `spreadsheets` + `drive` scopes. The access token is cached at module
+ *     level per step file, keyed by client_email, with 60s expiry slack.
+ *   - Every request (token exchange included) goes through
+ *     `ctx.services.http` and credentials resolve through
+ *     `ctx.services.secrets`, so runs are cassette-recordable with secret
+ *     values scrubbed from fixtures.
+ *   - API errors are returned as readable "teaching" strings (`errorResult`),
+ *     never thrown at the LLM; only missing/invalid credentials throw.
+ */
+export {};

--- a/mcp/src/lab/sheets/steps/add-sheet.ts
+++ b/mcp/src/lab/sheets/steps/add-sheet.ts
@@ -1,0 +1,181 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+export default defineStep({
+  type: "sheets/add-sheet",
+  description:
+    "Add a new tab to an existing spreadsheet (e.g. a 'Scenarios' tab next to 'Model'). " +
+    "Reference its cells from other tabs as 'TabName!A1'.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id."),
+    title: z.string().describe("Title of the new tab."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const resp = await api(
+        "POST",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}:batchUpdate`,
+        { requests: [{ addSheet: { properties: { title: cfg.title } } }] },
+      );
+      if (!resp.ok) return errorResult("sheets_add_sheet", resp.status, resp.body);
+      const props = resp.body.replies?.[0]?.addSheet?.properties;
+      return { sheet_id: props?.sheetId, title: props?.title ?? cfg.title };
+    } catch (err: any) {
+      return `sheets_add_sheet failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/batch-update-values.ts
+++ b/mcp/src/lab/sheets/steps/batch-update-values.ts
@@ -1,0 +1,197 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+/** 2D array of cell values; strings starting with '=' become live formulas under USER_ENTERED. */
+const valuesSchema = z
+  .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
+  .describe(
+    "2D array of rows. Strings starting with '=' are entered as live formulas (e.g. '=SUM(B2:B10)').",
+  );
+
+export default defineStep({
+  type: "sheets/batch-update-values",
+  description:
+    "Write multiple ranges of a spreadsheet in one call — use this instead of repeated " +
+    "sheets_update_values when laying out a model (e.g. headers, inputs, and a formula block at once). " +
+    "Same formula semantics as sheets_update_values.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id from sheets_create_spreadsheet."),
+    data: z
+      .array(z.object({ range: z.string(), values: valuesSchema }))
+      .describe("One entry per target range."),
+    raw: z
+      .boolean()
+      .optional()
+      .describe("Store strings literally instead of parsing formulas/numbers/dates (default false)."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const resp = await api(
+        "POST",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}/values:batchUpdate`,
+        { valueInputOption: cfg.raw ? "RAW" : "USER_ENTERED", data: cfg.data },
+      );
+      if (!resp.ok) return errorResult("sheets_batch_update_values", resp.status, resp.body);
+      return {
+        total_updated_cells: resp.body.totalUpdatedCells,
+        updated_ranges: (resp.body.responses ?? []).map((r: any) => r.updatedRange),
+      };
+    } catch (err: any) {
+      return `sheets_batch_update_values failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/create-spreadsheet.ts
+++ b/mcp/src/lab/sheets/steps/create-spreadsheet.ts
@@ -1,0 +1,239 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+const spreadsheetUrl = (id: string) => `https://docs.google.com/spreadsheets/d/${id}/edit`;
+
+export default defineStep({
+  type: "sheets/create-spreadsheet",
+  description:
+    "Create a new Google Spreadsheet and return its spreadsheet_id and url. " +
+    "When a shared Drive folder is configured (GOOGLE_DRIVE_FOLDER_ID), it is created inside " +
+    "that folder, so the user can open it immediately. " +
+    "Start here for any calculation task, then write inputs and formulas with sheets_update_values. " +
+    "Every spreadsheet starts with one tab named 'Sheet1'; pass extra_sheet_titles to add more tabs up front.",
+  input: z.object({
+    title: z.string().describe("Spreadsheet title shown in Drive."),
+    extra_sheet_titles: z
+      .array(z.string())
+      .optional()
+      .describe("Additional tabs to create beyond the default 'Sheet1'."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+    driveFolderId: z
+      .string()
+      .optional()
+      .describe(
+        "Drive folder to create the spreadsheet in (must be shared with the service account's " +
+          "client_email). Normally omitted — resolved from the GOOGLE_DRIVE_FOLDER_ID secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api, driveFolderId, clientEmail } = await sheetsCtx(
+      ctx as StepContext<VeinCapabilities>,
+      cfg,
+    );
+    // A 403/404 here almost always means the folder isn't shared with the SA.
+    const shareHint = driveFolderId
+      ? ` (if this is a permission error, share the Drive folder ${driveFolderId} with the service account's client_email ${clientEmail})`
+      : "";
+    try {
+      let spreadsheetId: string;
+      if (driveFolderId) {
+        // Creating through Drive places the file directly in the shared
+        // folder (a Sheets-API create would land in the service account's
+        // own root Drive, invisible to the user).
+        const resp = await api("POST", `${DRIVE_API}?supportsAllDrives=true`, {
+          name: cfg.title,
+          mimeType: "application/vnd.google-apps.spreadsheet",
+          parents: [driveFolderId],
+        });
+        if (!resp.ok) {
+          return errorResult("sheets_create_spreadsheet", resp.status, resp.body) + shareHint;
+        }
+        spreadsheetId = resp.body.id;
+      } else {
+        const resp = await api("POST", SHEETS_API, { properties: { title: cfg.title } });
+        if (!resp.ok) return errorResult("sheets_create_spreadsheet", resp.status, resp.body);
+        spreadsheetId = resp.body.spreadsheetId;
+      }
+
+      if (cfg.extra_sheet_titles && cfg.extra_sheet_titles.length > 0) {
+        const resp = await api(
+          "POST",
+          `${SHEETS_API}/${encodeURIComponent(spreadsheetId)}:batchUpdate`,
+          {
+            requests: cfg.extra_sheet_titles.map((t: string) => ({
+              addSheet: { properties: { title: t } },
+            })),
+          },
+        );
+        if (!resp.ok) {
+          return {
+            spreadsheet_id: spreadsheetId,
+            url: spreadsheetUrl(spreadsheetId),
+            warning: errorResult("adding extra sheets", resp.status, resp.body),
+          };
+        }
+      }
+
+      return {
+        spreadsheet_id: spreadsheetId,
+        url: spreadsheetUrl(spreadsheetId),
+        sheets: ["Sheet1", ...(cfg.extra_sheet_titles ?? [])],
+      };
+    } catch (err: any) {
+      return `sheets_create_spreadsheet failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/get-values.ts
+++ b/mcp/src/lab/sheets/steps/get-values.ts
@@ -1,0 +1,190 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+export default defineStep({
+  type: "sheets/get-values",
+  description:
+    "Read a range of a spreadsheet (A1 notation). render='computed' (default) returns calculated " +
+    "numbers — use it to read the results of formulas you wrote; 'formatted' returns display strings " +
+    "(currency symbols, rounding); 'formula' returns the formula text itself for auditing.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id."),
+    range: z.string().describe("A1-notation range to read, e.g. 'Sheet1!A1:D20'."),
+    render: z
+      .enum(["computed", "formatted", "formula"])
+      .optional()
+      .describe("How to render cell values (default 'computed')."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const renderOption =
+        cfg.render === "formatted"
+          ? "FORMATTED_VALUE"
+          : cfg.render === "formula"
+            ? "FORMULA"
+            : "UNFORMATTED_VALUE";
+      const resp = await api(
+        "GET",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}/values/${encodeURIComponent(cfg.range)}?valueRenderOption=${renderOption}`,
+      );
+      if (!resp.ok) return errorResult("sheets_get_values", resp.status, resp.body);
+      return { range: resp.body.range, values: resp.body.values ?? [] };
+    } catch (err: any) {
+      return `sheets_get_values failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/import-spreadsheet.ts
+++ b/mcp/src/lab/sheets/steps/import-spreadsheet.ts
@@ -1,0 +1,484 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+// ── Pure helpers (ported verbatim from the source tool) ────────────────────
+
+/**
+ * Resolve the label used in tab names.
+ * - An explicit `label` param always wins.
+ * - For converted (non-native) sources, fall back to the Drive filename.
+ * - For native Google Sheet sources, fall back to the spreadsheet's own title.
+ */
+function resolveLabel({
+  explicitLabel,
+  driveFileName,
+  sourceSpreadsheetTitle,
+  isNative,
+}: {
+  explicitLabel?: string;
+  driveFileName: string;
+  sourceSpreadsheetTitle: string;
+  isNative: boolean;
+}): string {
+  if (explicitLabel) return explicitLabel;
+  return isNative ? sourceSpreadsheetTitle : driveFileName;
+}
+
+/**
+ * Build the raw (pre-collision-check) tab name from label + sheet title.
+ * - Single-sheet source → `SOURCE: <label>`
+ * - Multi-sheet source  → `SOURCE: <label> — <sheet title>`
+ */
+function buildTabName(label: string, sheetTitle: string, totalSheets: number): string {
+  if (totalSheets === 1) return `SOURCE: ${label}`;
+  return `SOURCE: ${label} — ${sheetTitle}`;
+}
+
+/**
+ * Given a candidate tab name and a Set of already-taken names, return a
+ * non-colliding name. If the candidate is already taken, appends " (2)",
+ * " (3)", etc., incrementing past any existing suffixes.
+ */
+function resolveCollisionSuffix(candidate: string, existingNames: Set<string>): string {
+  if (!existingNames.has(candidate)) return candidate;
+  let n = 2;
+  while (existingNames.has(`${candidate} (${n})`)) n++;
+  return `${candidate} (${n})`;
+}
+
+/**
+ * Given a list of formula strings and a list of other sheet titles, returns
+ * the subset of titles that are literally referenced in at least one formula
+ * (heuristic: `'Title'!` or `Title!` — standard A1 cross-sheet syntax).
+ */
+function detectCrossSheetFormulaRefs(formulas: string[], sheetTitles: string[]): string[] {
+  const referenced: string[] = [];
+  for (const title of sheetTitles) {
+    const escapedTitle = title.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const pattern = new RegExp(`(?:'${escapedTitle}'|${escapedTitle})!`, "i");
+    if (formulas.some((f) => pattern.test(f))) {
+      referenced.push(title);
+    }
+  }
+  return referenced;
+}
+
+export default defineStep({
+  type: "sheets/import-spreadsheet",
+  description:
+    "Import every sheet of a source spreadsheet (uploaded .xlsx or existing Google Sheet) into a " +
+    "destination spreadsheet as correctly-named tabs. Source may be any Drive file id; non-native " +
+    "files (e.g. .xlsx) are converted to Google Sheets format automatically. Each imported tab is " +
+    "named 'SOURCE: <label>' (single-sheet source) or 'SOURCE: <label> — <sheet title>' (multi-sheet). " +
+    "Collisions with existing tab names are resolved by auto-appending ' (2)', ' (3)', etc. " +
+    "Import is best-effort: one sheet failing does not abort the rest. Returns per-sheet status " +
+    "(success / failed / copied_unrenamed) and any formula/range warnings.",
+  input: z.object({
+    destination_spreadsheet_id: z
+      .string()
+      .describe("Spreadsheet id of the destination to copy sheets into."),
+    source_file_id: z
+      .string()
+      .describe(
+        "Drive file id of the source — may be an uploaded .xlsx or an existing native Google Sheet.",
+      ),
+    label: z
+      .string()
+      .optional()
+      .describe(
+        "Override the label used in tab names. Defaults to the Drive filename (converted) or spreadsheet title (native).",
+      ),
+    keep_converted_copy: z
+      .boolean()
+      .optional()
+      .describe(
+        "When true, the intermediate converted-copy file (for non-native sources) is kept in Drive after import. Default false.",
+      ),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    const { destination_spreadsheet_id, source_file_id, label, keep_converted_copy } = cfg;
+    try {
+      // ── Step 1: Fetch Drive metadata for the source file ──────────────
+      const metaResp = await api(
+        "GET",
+        `${DRIVE_API}/${encodeURIComponent(source_file_id)}?supportsAllDrives=true&fields=name,mimeType,parents`,
+      );
+      if (!metaResp.ok) {
+        return `sheets_import_spreadsheet failed: could not fetch source file metadata: HTTP ${metaResp.status}: ${truncate(metaResp.body?.error?.message ?? metaResp.body, 300)}`;
+      }
+      const sourceMeta: { name: string; mimeType: string; parents?: string[] } = metaResp.body;
+
+      // ── Step 2: Convert if not already a native Google Sheet ──────────
+      // tempSpreadsheetId is ONLY the id of the converted copy — never
+      // aliased from source_file_id — so the later delete call is
+      // unambiguous.
+      let tempSpreadsheetId: string | undefined = undefined;
+      let workingId: string;
+
+      const SHEETS_MIME = "application/vnd.google-apps.spreadsheet";
+      if (sourceMeta.mimeType !== SHEETS_MIME) {
+        const parentFolder = sourceMeta.parents?.[0];
+        const copyBody: Record<string, unknown> = { mimeType: SHEETS_MIME };
+        if (parentFolder) copyBody.parents = [parentFolder];
+        const copyResp = await api(
+          "POST",
+          `${DRIVE_API}/${encodeURIComponent(source_file_id)}/copy?supportsAllDrives=true`,
+          copyBody,
+        );
+        if (!copyResp.ok) {
+          return `sheets_import_spreadsheet failed: could not convert source file to Google Sheets: HTTP ${copyResp.status}: ${truncate(copyResp.body?.error?.message ?? copyResp.body, 300)}`;
+        }
+        // Store in a dedicated variable; NEVER reuse source_file_id.
+        tempSpreadsheetId = copyResp.body.id as string;
+        workingId = tempSpreadsheetId;
+      } else {
+        workingId = source_file_id;
+      }
+
+      // ── Step 3: Enumerate source sheets ─────────────────────────────
+      const srcSheetsResp = await api(
+        "GET",
+        `${SHEETS_API}/${encodeURIComponent(workingId)}?fields=properties.title,sheets.properties`,
+      );
+      if (!srcSheetsResp.ok) {
+        return `sheets_import_spreadsheet failed: could not read source spreadsheet: HTTP ${srcSheetsResp.status}: ${truncate(srcSheetsResp.body?.error?.message ?? srcSheetsResp.body, 300)}`;
+      }
+      const sourceSheets: Array<{ sheetId: number; title: string }> = (
+        srcSheetsResp.body.sheets ?? []
+      ).map((s: any) => ({
+        sheetId: s.properties.sheetId as number,
+        title: s.properties.title as string,
+      }));
+      const sourceSpreadsheetTitle: string =
+        srcSheetsResp.body.properties?.title ?? sourceMeta.name;
+
+      // ── Step 4: Seed the live title Set from the destination ──────────
+      const dstSheetsResp = await api(
+        "GET",
+        `${SHEETS_API}/${encodeURIComponent(destination_spreadsheet_id)}?fields=sheets.properties.title`,
+      );
+      if (!dstSheetsResp.ok) {
+        return `sheets_import_spreadsheet failed: could not read destination spreadsheet: HTTP ${dstSheetsResp.status}: ${truncate(dstSheetsResp.body?.error?.message ?? dstSheetsResp.body, 300)}`;
+      }
+      // Single source of truth for collision detection — updated after each rename.
+      const existingTitles = new Set<string>(
+        (dstSheetsResp.body.sheets ?? []).map((s: any) => s.properties.title as string),
+      );
+
+      // ── Step 5: Per-sheet best-effort copy loop ───────────────────────
+      const resolvedLabel = resolveLabel({
+        explicitLabel: label,
+        driveFileName: sourceMeta.name,
+        sourceSpreadsheetTitle,
+        isNative: sourceMeta.mimeType === SHEETS_MIME,
+      });
+
+      const imported: Array<{
+        source_sheet: string;
+        tab_name: string | null;
+        sheet_id: number | null;
+        status: "success" | "failed" | "copied_unrenamed";
+        error?: string;
+      }> = [];
+
+      for (const sheet of sourceSheets) {
+        const targetTabName = resolveCollisionSuffix(
+          buildTabName(resolvedLabel, sheet.title, sourceSheets.length),
+          existingTitles,
+        );
+
+        // copyTo
+        let copiedSheetId: number;
+        try {
+          const copyToResp = await api(
+            "POST",
+            `${SHEETS_API}/${encodeURIComponent(workingId)}/sheets/${sheet.sheetId}:copyTo`,
+            { destinationSpreadsheetId: destination_spreadsheet_id },
+          );
+          if (!copyToResp.ok) {
+            imported.push({
+              source_sheet: sheet.title,
+              tab_name: null,
+              sheet_id: null,
+              status: "failed",
+              error: `copyTo failed: HTTP ${copyToResp.status}: ${truncate(copyToResp.body?.error?.message ?? copyToResp.body, 200)}`,
+            });
+            continue;
+          }
+          copiedSheetId = copyToResp.body.sheetId as number;
+        } catch (copyErr: any) {
+          imported.push({
+            source_sheet: sheet.title,
+            tab_name: null,
+            sheet_id: null,
+            status: "failed",
+            error: `copyTo threw: ${copyErr?.message ?? String(copyErr)}`,
+          });
+          continue;
+        }
+
+        // rename via batchUpdate
+        try {
+          const renameResp = await api(
+            "POST",
+            `${SHEETS_API}/${encodeURIComponent(destination_spreadsheet_id)}:batchUpdate`,
+            {
+              requests: [
+                {
+                  updateSheetProperties: {
+                    properties: { sheetId: copiedSheetId, title: targetTabName },
+                    fields: "title",
+                  },
+                },
+              ],
+            },
+          );
+          if (!renameResp.ok) {
+            // Google assigns a default name like "Copy of <original>"
+            imported.push({
+              source_sheet: sheet.title,
+              tab_name: `Copy of ${sheet.title}`,
+              sheet_id: copiedSheetId,
+              status: "copied_unrenamed",
+              error: `rename failed: HTTP ${renameResp.status}: ${truncate(renameResp.body?.error?.message ?? renameResp.body, 200)}`,
+            });
+            // Do NOT add to existingTitles — we don't know the actual Google-assigned name precisely.
+          } else {
+            imported.push({
+              source_sheet: sheet.title,
+              tab_name: targetTabName,
+              sheet_id: copiedSheetId,
+              status: "success",
+            });
+            // Update the live title Set immediately so subsequent sheets
+            // in this same run see this name as taken.
+            existingTitles.add(targetTabName);
+          }
+        } catch (renameErr: any) {
+          imported.push({
+            source_sheet: sheet.title,
+            tab_name: `Copy of ${sheet.title}`,
+            sheet_id: copiedSheetId,
+            status: "copied_unrenamed",
+            error: `rename threw: ${renameErr?.message ?? String(renameErr)}`,
+          });
+        }
+      }
+
+      // ── Step 6: Cross-sheet formula warnings ─────────────────────────
+      const warnings: string[] = [];
+      const sourceTitles = sourceSheets.map((s) => s.title);
+      const successfulSheets = imported.filter((r) => r.status === "success");
+
+      for (const result of successfulSheets) {
+        // Fetch formula cells for this destination sheet
+        const formulaResp = await api(
+          "GET",
+          `${SHEETS_API}/${encodeURIComponent(destination_spreadsheet_id)}/values/${encodeURIComponent(`'${result.tab_name}'`)}?valueRenderOption=FORMULA`,
+        );
+        if (formulaResp.ok) {
+          const cellValues: string[] = (formulaResp.body.values ?? [])
+            .flat()
+            .filter((v: unknown) => typeof v === "string" && v.startsWith("="));
+          // Check formulas against other source sheet titles (not its own)
+          const otherTitles = sourceTitles.filter((t) => t !== result.source_sheet);
+          const referenced = detectCrossSheetFormulaRefs(cellValues, otherTitles);
+          for (const ref of referenced) {
+            warnings.push(
+              `Tab "${result.tab_name}" contains formula references to source sheet "${ref}", which has been renamed in the destination — cross-sheet references may not resolve correctly.`,
+            );
+          }
+        }
+      }
+      // Always warn about named/protected range limitation.
+      warnings.push(
+        "Named ranges and protected ranges defined in the source workbook are not carried over by the Sheets API copyTo operation and are not recreated by this tool.",
+      );
+
+      // ── Step 7: Cleanup temp converted file ─────────────────────────
+      // converted_copy_deleted is null when no conversion occurred.
+      let converted_copy_deleted: boolean | null = null;
+      if (tempSpreadsheetId !== undefined) {
+        // Safety: tempSpreadsheetId must NEVER equal source_file_id or
+        // destination_spreadsheet_id — distinct variables by construction
+        // (see Step 2).
+        if (!keep_converted_copy) {
+          try {
+            const deleteResp = await api(
+              "DELETE",
+              `${DRIVE_API}/${encodeURIComponent(tempSpreadsheetId)}?supportsAllDrives=true`,
+            );
+            converted_copy_deleted = deleteResp.ok;
+          } catch {
+            converted_copy_deleted = false;
+          }
+        } else {
+          converted_copy_deleted = false;
+        }
+      }
+
+      return {
+        destination_spreadsheet_id,
+        imported,
+        converted_copy_deleted,
+        warnings,
+      };
+    } catch (err: any) {
+      return `sheets_import_spreadsheet failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});

--- a/mcp/src/lab/sheets/steps/update-values.ts
+++ b/mcp/src/lab/sheets/steps/update-values.ts
@@ -1,0 +1,196 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { createSign } from "node:crypto";
+
+// ── sheets/* preamble — duplicated in every sheets/* step; see _shared.ts ──
+const SHEETS_API = "https://sheets.googleapis.com/v4/spreadsheets";
+const DRIVE_API = "https://www.googleapis.com/drive/v3/files";
+const OAUTH_SCOPES =
+  "https://www.googleapis.com/auth/spreadsheets https://www.googleapis.com/auth/drive";
+const DEFAULT_TOKEN_URI = "https://oauth2.googleapis.com/token";
+/** Refresh the cached access token this many seconds before it expires. */
+const TOKEN_EXPIRY_SLACK_S = 60;
+
+interface ServiceAccount {
+  client_email: string;
+  private_key: string;
+  token_uri?: string;
+}
+
+/** Accept a service account as an object, a JSON string, or base64-encoded JSON. */
+function parseServiceAccount(input: unknown): ServiceAccount {
+  let obj: any = input;
+  if (typeof input === "string") {
+    const trimmed = input.trim();
+    const json = trimmed.startsWith("{")
+      ? trimmed
+      : Buffer.from(trimmed, "base64").toString("utf-8");
+    obj = JSON.parse(json);
+  }
+  if (
+    !obj ||
+    typeof obj !== "object" ||
+    typeof obj.client_email !== "string" ||
+    typeof obj.private_key !== "string"
+  ) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON must be service-account JSON with client_email and private_key",
+    );
+  }
+  return {
+    client_email: obj.client_email,
+    // Keys pasted through env/JSON sometimes carry literal "\n" sequences.
+    private_key: obj.private_key.replace(/\\n/g, "\n"),
+    token_uri: typeof obj.token_uri === "string" ? obj.token_uri : undefined,
+  };
+}
+
+function truncate(value: unknown, maxChars: number): string {
+  const str = typeof value === "string" ? value : JSON.stringify(value);
+  if (str.length <= maxChars) return str;
+  return `${str.slice(0, maxChars)}…[truncated, ${str.length} chars total]`;
+}
+
+function errorResult(label: string, status: number, body: any): string {
+  const message = body?.error?.message ?? body;
+  return `${label} failed: HTTP ${status}: ${truncate(message, 500)}`;
+}
+
+/** Access token cached per step module (Google tokens last ~1h), keyed by
+ *  client_email so different credentials can never mix. */
+let cachedToken: { email: string; value: string; exp: number } | null = null;
+
+/** Resolve credentials (cfg wins → secret store → env) and return an
+ *  authenticated Sheets/Drive request helper over ctx.services.http. */
+async function sheetsCtx(
+  ctx: StepContext<VeinCapabilities> | undefined,
+  cfg: { serviceAccount?: unknown; driveFolderId?: string },
+) {
+  const httpMaybe = ctx?.services?.http;
+  if (!httpMaybe) {
+    throw new Error("sheets: ctx.services.http unavailable — run with a services bag");
+  }
+  const http = httpMaybe;
+  const secrets = ctx?.services?.secrets;
+  const rawSa = cfg.serviceAccount ?? (await secrets?.get("GOOGLE_SERVICE_ACCOUNT_JSON"));
+  if (!rawSa) {
+    throw new Error(
+      "GOOGLE_SERVICE_ACCOUNT_JSON not configured — paste the service-account JSON into the vein secrets UI or mcp env",
+    );
+  }
+  const sa = parseServiceAccount(rawSa);
+  const driveFolderId =
+    cfg.driveFolderId ?? (await secrets?.get("GOOGLE_DRIVE_FOLDER_ID")) ?? undefined;
+
+  async function getToken(): Promise<string> {
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      cachedToken &&
+      cachedToken.email === sa.client_email &&
+      cachedToken.exp - TOKEN_EXPIRY_SLACK_S > now
+    ) {
+      return cachedToken.value;
+    }
+    const tokenUri = sa.token_uri || DEFAULT_TOKEN_URI;
+    // RS256 service-account JWT built with node:crypto (no jsonwebtoken dep).
+    const enc = (o: unknown) => Buffer.from(JSON.stringify(o)).toString("base64url");
+    const signingInput = `${enc({ alg: "RS256", typ: "JWT" })}.${enc({
+      iss: sa.client_email,
+      scope: OAUTH_SCOPES,
+      aud: tokenUri,
+      iat: now,
+      exp: now + 3600,
+    })}`;
+    const signature = createSign("RSA-SHA256")
+      .update(signingInput)
+      .sign(sa.private_key)
+      .toString("base64url");
+    const res = await http(tokenUri, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: new URLSearchParams({
+        grant_type: "urn:ietf:params:oauth:grant-type:jwt-bearer",
+        assertion: `${signingInput}.${signature}`,
+      }).toString(),
+      timeout: 30_000,
+    });
+    const body = res.body as any;
+    if (!res.ok || !body?.access_token) {
+      throw new Error(
+        `Google OAuth token exchange failed: HTTP ${res.status}: ${truncate(res.body, 300)}`,
+      );
+    }
+    cachedToken = {
+      email: sa.client_email,
+      value: body.access_token,
+      exp: now + (Number(body.expires_in) || 3600),
+    };
+    return cachedToken.value;
+  }
+
+  async function api(
+    method: "GET" | "POST" | "PUT" | "DELETE",
+    url: string,
+    payload?: unknown,
+  ): Promise<{ ok: boolean; status: number; body: any }> {
+    const token = await getToken();
+    const res = await http(url, {
+      method,
+      headers: { Authorization: `Bearer ${token}` },
+      ...(payload !== undefined ? { body: payload } : {}),
+      timeout: 60_000,
+    });
+    return { ok: res.ok, status: res.status, body: res.body as any };
+  }
+
+  return { api, driveFolderId, clientEmail: sa.client_email };
+}
+// ── end preamble ───────────────────────────────────────────────────────────
+
+/** 2D array of cell values; strings starting with '=' become live formulas under USER_ENTERED. */
+const valuesSchema = z
+  .array(z.array(z.union([z.string(), z.number(), z.boolean(), z.null()])))
+  .describe(
+    "2D array of rows. Strings starting with '=' are entered as live formulas (e.g. '=SUM(B2:B10)').",
+  );
+
+export default defineStep({
+  type: "sheets/update-values",
+  description:
+    "Write a 2D array of values into a spreadsheet range (A1 notation, e.g. 'Sheet1!A1:C10'). " +
+    "Strings starting with '=' are entered as LIVE FORMULAS — prefer building calculations with " +
+    "formulas over precomputing numbers yourself, so the sheet stays auditable and recalculates " +
+    "when inputs change. Read computed results back with sheets_get_values.",
+  input: z.object({
+    spreadsheet_id: z.string().describe("Spreadsheet id from sheets_create_spreadsheet."),
+    range: z.string().describe("A1-notation target range, e.g. 'Sheet1!A1' or 'Model!B2:D20'."),
+    values: valuesSchema,
+    raw: z
+      .boolean()
+      .optional()
+      .describe("Store strings literally instead of parsing formulas/numbers/dates (default false)."),
+    serviceAccount: z
+      .any()
+      .optional()
+      .describe(
+        "Service-account credentials override (JSON object, JSON string, or base64 JSON). " +
+          "Normally omitted — resolved from the GOOGLE_SERVICE_ACCOUNT_JSON secret.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const { api } = await sheetsCtx(ctx as StepContext<VeinCapabilities>, cfg);
+    try {
+      const input = cfg.raw ? "RAW" : "USER_ENTERED";
+      const resp = await api(
+        "PUT",
+        `${SHEETS_API}/${encodeURIComponent(cfg.spreadsheet_id)}/values/${encodeURIComponent(cfg.range)}?valueInputOption=${input}`,
+        { values: cfg.values },
+      );
+      if (!resp.ok) return errorResult("sheets_update_values", resp.status, resp.body);
+      const { updatedRange, updatedCells } = resp.body;
+      return { updated_range: updatedRange, updated_cells: updatedCells };
+    } catch (err: any) {
+      return `sheets_update_values failed: ${err?.message ?? String(err)}`;
+    }
+  },
+});


### PR DESCRIPTION
Ports the six repo-agent Google Sheets tools (`mcp/src/repo/toolsGoogleSheets.ts`, untouched) to self-contained seeded vein steps, following the `jarvis/` port conventions. Stacked on #1581.

## Steps

`sheets/create-spreadsheet`, `sheets/update-values`, `sheets/batch-update-values`, `sheets/get-values`, `sheets/add-sheet`, `sheets/import-spreadsheet` — same Sheets/Drive REST endpoints, input schemas, and LLM-facing descriptions as the source tools. Grant to agents via `agentTools: ["sheets/*"]` (glob) or an explicit subset (e.g. a read-only child gets just `sheets/get-values`).

## Port notes

- **Self-contained**: `axios` → `ctx.services.http`; `jsonwebtoken` → a `node:crypto` RS256 service-account JWT (base64url header+claims, `createSign("RSA-SHA256")`), exchanged at the SA's `token_uri`. Token cached per step module with 60s expiry slack, keyed by `client_email`.
- **Credentials**: `cfg.serviceAccount` wins, else the `GOOGLE_SERVICE_ACCOUNT_JSON` secret (store → env fallback); same for `driveFolderId` / `GOOGLE_DRIVE_FOLDER_ID`. Steps are always seeded; missing credentials fail loudly per run.
- **Teaching errors**: API errors return readable strings; a 403/404 on create with a Drive folder configured names the folder and the SA's `client_email` to share it with.
- **Duplicated preamble** (deliberate, per jarvis convention): each step inlines an identical `sheetsCtx` copy (verified byte-identical); the contract is documented once in `sheets/steps/_shared.ts`.

## Verification

- `yarn tsc --noEmit` clean
- `npx tsx src/lab/sheets/smoke.ts` — offline smoke: seeds a temp workspace, verifies registry discovery of all six steps, drives each against a fake `ctx.services.http` Google. JWT signature verified against a real generated RSA keypair; one token exchange then cache hits; bearer headers; both create paths; create→update→get round-trip shapes; full import flow (convert → copyTo → rename → cross-sheet-formula warnings → temp cleanup); loud missing-credentials error; 403 teaching string.
- `yarn build` — `build/lab/sheets/steps/*.ts` picked up by the existing copy-lab-assets script.
- `mcp/src/lab/AGENTS.md` gained a `sheets/` section (tool list, config resolution, grant guidance).

**Live end-to-end Google verification (real service-account key) is pending** — the offline smoke is the bar for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)