### PR TITLE
aieo: fix stale model context limits (gpt-5.x, ox-alpha, provider defaults)

### DIFF
--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -714,10 +714,20 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
   "gemini-3-pro-preview": 1_000_000,
   "gemini-2.0-flash": 1_000_000,
   // OpenAI
-  "gpt-5": 128_000,
+  "gpt-5": 400_000,
+  "gpt-5.5": 1_050_000,
+  "gpt-5.6-terra": 1_050_000,
+  "gpt-5.6-luna": 1_050_000,
+  "gpt-5.6-sol": 1_050_000,
   "gpt-4.1-mini": 1_000_000,
   // OpenRouter — values from the OpenRouter model catalog
   // (https://openrouter.ai/api/v1/models, context_length).
+  "stealth/ox-alpha": 1_048_576,
+  "openai/gpt-5": 400_000,
+  "openai/gpt-5.5": 1_050_000,
+  "openai/gpt-5.6-terra": 1_050_000,
+  "openai/gpt-5.6-luna": 1_050_000,
+  "openai/gpt-5.6-sol": 1_050_000,
   "moonshotai/kimi-k3": 1_048_576,
   "moonshotai/kimi-k2.7-code": 262_144,
   "moonshotai/kimi-k2.6": 262_144,
@@ -741,8 +751,9 @@ const MODEL_CONTEXT_LIMITS: Record<string, number> = {
 const DEFAULT_CONTEXT_LIMITS: Record<Provider, number> = {
   anthropic: 1_000_000,
   google: 1_000_000,
-  openai: 128_000,
-  openrouter: 128_000,
+  // gpt-5.x models are all 400k+; only legacy chat models are smaller
+  openai: 400_000,
+  openrouter: 256_000,
   xai: 256_000,
 };
 


### PR DESCRIPTION
## What changed

`truncateOldToolResults` was prematurely truncating `gpt-5.6-terra` runs at ~115k tokens because the model had no `MODEL_CONTEXT_LIMITS` entry and fell through to the stale openai provider default of 128k:

```
[truncate] providerTokens=85076 estimated=123844 threshold=115200 contextLimit=128000
[truncate] OVER LIMIT. worstCase=123844 excess=8644 tokensToFree=9509
```

Premature truncation is worse than it looks — it rewrites old messages, which invalidates provider prefix caches on every subsequent step.

Fixes in `mcp/src/aieo/src/provider.ts`:

- **`gpt-5` entry corrected**: 128k → 400k (verified against the OpenRouter catalog — GPT-5's window has been 400k all along)
- **gpt-5.5 / gpt-5.6-{terra,luna,sol} added** at 1,050,000 — both as bare ids (openai provider) and `openai/`-prefixed (OpenRouter), matching the existing xai duplication pattern
- **`stealth/ox-alpha` added** at 1,048,576 (from OpenRouter's `/api/v1/models` `context_length`)
- **Provider defaults bumped**: openai 128k → 400k, openrouter 128k → 256k

## Why not just default everything to 1M?

The failure modes are asymmetric. Underestimating the window causes early truncation — wasteful and cache-busting, but the run survives. Overestimating causes a hard context-exceeded 400 once the real limit is passed, and `runWithBadRequestRetry` resends the same payload, so the run dies unrecoverably. Defaults are therefore raised to modern-but-conservative values rather than 1M; models known to be large get explicit entries.

## Reviewer notes

- All numbers verified against `https://openrouter.ai/api/v1/models` (`context_length`)
- `npx tsc --noEmit` passes in `mcp/`
- Follow-up idea if unknown-model logs keep appearing: parse the real limit out of context-exceeded 400 error messages and retry with truncation, which would make a generous fallback safe and remove the need for this table

🤖 Generated with [Claude Code](https://claude.com/claude-code)