### PR TITLE
neo4j: share one bolt pool process-wide instead of one per request

### DIFF
--- a/ast/src/lang/graphs/neo4j/connection.rs
+++ b/ast/src/lang/graphs/neo4j/connection.rs
@@ -11,18 +11,76 @@ use crate::lang::graphs::{
 use crate::lang::Neo4jGraph;
 pub struct Neo4jConnectionManager;
 
+/// Cache key for the shared pool. If a caller ever passes a `Neo4jConfig`
+/// pointing at a different server/db, it gets a fresh pool (replacing the
+/// cached one) instead of silently reusing the wrong connection.
+type PoolKey = (String, String, String);
+
+struct CachedPool {
+    key: PoolKey,
+    pool: Neo4jConnection,
+}
+
+/// Process-wide shared pool. `neo4rs::Graph` is an Arc'd pool handle, so
+/// cloning it is cheap and every clone talks to the same set of bolt sockets.
+/// The tokio Mutex is held across the connect await on purpose: concurrent
+/// first callers serialize, a FAILED connect is never cached, and the next
+/// caller retries.
+static SHARED_POOL: tokio::sync::Mutex<Option<CachedPool>> = tokio::sync::Mutex::const_new(None);
+
+#[cfg(test)]
+pub static POOL_BUILDS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
 impl Neo4jConnectionManager {
-    /// Build a `neo4rs::Graph` (a pooled bolt connection handle).
+    /// Return the process-wide `neo4rs::Graph` (a pooled bolt connection
+    /// handle), building it on first use.
     ///
-    /// IMPORTANT: previously this ignored `Neo4jConfig::max_connections` and
-    /// `fetch_size`, so the entire service ran on neo4rs's default pool. In
-    /// production this manifested as a single long-lived bolt socket carrying
-    /// every query — when that socket got into a bad state (idle middlebox,
-    /// server-side bolt thread stuck, etc.) every subsequent query hung until
-    /// our tokio per-attempt timeout fired, and retries reused the same wedged
-    /// socket. Configuring an explicit pool size means a wedged socket can't
-    /// take down the whole service.
+    /// Every `Neo4jGraph`/`GraphOps` in the process shares this one pool:
+    /// previously each call built a brand-new pool, so per-request
+    /// `GraphOps::new().connect()` callers opened `max_connections` fresh bolt
+    /// sockets per operation and concurrent load could hold ~70 connections
+    /// against a single Neo4j instance (enough to OOM a small swarm node).
+    ///
+    /// IMPORTANT: this must keep configuring the pool explicitly. At one point
+    /// it ignored `Neo4jConfig::max_connections` and `fetch_size`, so the
+    /// service ran on neo4rs's default pool. In production this manifested as
+    /// a single long-lived bolt socket carrying every query — when that socket
+    /// got into a bad state (idle middlebox, server-side bolt thread stuck,
+    /// etc.) every subsequent query hung until our tokio per-attempt timeout
+    /// fired, and retries reused the same wedged socket. Configuring an
+    /// explicit pool size means a wedged socket can't take down the whole
+    /// service. (`Neo4jGraph::force_reconnect` handles the wedged case for the
+    /// shared pool by calling `invalidate` below.)
     pub async fn initialize(cfg: &Neo4jConfig) -> Result<Neo4jConnection> {
+        let key: PoolKey = (cfg.uri.clone(), cfg.username.clone(), cfg.database.clone());
+
+        let mut cached = SHARED_POOL.lock().await;
+        if let Some(c) = cached.as_ref() {
+            if c.key == key {
+                return Ok(c.pool.clone());
+            }
+        }
+
+        let pool = Self::build_pool(cfg).await?;
+        *cached = Some(CachedPool {
+            key,
+            pool: pool.clone(),
+        });
+        Ok(pool)
+    }
+
+    /// Drop the cached shared pool so the next `initialize` builds a fresh
+    /// one. Used by `Neo4jGraph::force_reconnect` when the pool's bolt
+    /// socket(s) may be wedged — without this, re-connecting would just hand
+    /// back the same stuck pool.
+    pub async fn invalidate() {
+        *SHARED_POOL.lock().await = None;
+    }
+
+    async fn build_pool(cfg: &Neo4jConfig) -> Result<Neo4jConnection> {
+        #[cfg(test)]
+        POOL_BUILDS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+
         let max_connections = std::env::var("NEO4J_MAX_CONNECTIONS")
             .ok()
             .and_then(|s| s.parse::<usize>().ok())
@@ -45,6 +103,38 @@ impl Neo4jConnectionManager {
         Neo4jConnection::connect(config)
             .await
             .map_err(|e| Error::dependency(format!("Failed to connect to Neo4j: {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::Ordering;
+
+    #[tokio::test]
+    async fn initialize_reuses_shared_pool() {
+        let cfg = Neo4jConfig::default();
+        if Neo4jConnectionManager::initialize(&cfg).await.is_err() {
+            eprintln!("skipping initialize_reuses_shared_pool: no Neo4j reachable");
+            return;
+        }
+        let builds = POOL_BUILDS.load(Ordering::SeqCst);
+        for _ in 0..3 {
+            Neo4jConnectionManager::initialize(&cfg).await.unwrap();
+        }
+        assert_eq!(
+            POOL_BUILDS.load(Ordering::SeqCst),
+            builds,
+            "repeated initialize() calls must reuse the cached pool"
+        );
+
+        Neo4jConnectionManager::invalidate().await;
+        Neo4jConnectionManager::initialize(&cfg).await.unwrap();
+        assert_eq!(
+            POOL_BUILDS.load(Ordering::SeqCst),
+            builds + 1,
+            "invalidate() must force the next initialize() to build a fresh pool"
+        );
     }
 }
 

--- a/ast/src/lang/graphs/neo4j/graph.rs
+++ b/ast/src/lang/graphs/neo4j/graph.rs
@@ -125,8 +125,11 @@ impl Neo4jGraph {
     /// Drop the cached `neo4rs::Graph` and rebuild it. Used by the retry layer
     /// when an attempt times out — the underlying bolt socket(s) may be wedged,
     /// so reusing the same `Graph` would make every retry hang the same way.
+    /// The pool is shared process-wide, so also invalidate the manager's cache;
+    /// otherwise reconnecting would hand back the same wedged pool.
     pub async fn force_reconnect(&self) -> Result<Neo4jConnection> {
         warn!("[neo4j] forcing reconnect (cached Graph will be dropped)");
+        Neo4jConnectionManager::invalidate().await;
         *self.connection.lock().await = None;
         self.ensure_connected().await
     }

--- a/standalone/src/handlers/hive_query.rs
+++ b/standalone/src/handlers/hive_query.rs
@@ -142,7 +142,7 @@ pub async fn hive_query_handler(
     let stripped = LIMIT_STRIP_RE.replace_all(&body.query, "");
     let modified_query = format!("{} LIMIT {}", stripped.trim_end(), effective_limit);
 
-    // Per-request bolt pool — consistent with vector_search_handler and all other handlers.
+    // Cheap per-request handle — connect() reuses the process-wide shared bolt pool.
     let mut graph_ops = GraphOps::new();
     if let Err(e) = graph_ops.connect().await {
         tracing::error!(error = %e, "hive_query: failed to connect to Neo4j");


### PR DESCRIPTION
## What

`Neo4jConnectionManager::initialize` claimed to be a "global connection manager" but built a brand-new `neo4rs::Graph` bolt pool on every call. Since handlers and services construct a throwaway `GraphOps::new().connect()` per operation (hive_query, query, vector, coverage ×3, graph_service ×4, repo_service ×2, main.rs), each operation opened up to `max_connections` (default 10) fresh bolt sockets. Under concurrent ingest + query load this held ~70 connections against a single shared Neo4j on a swarm instance and contributed to OOM-killing it.

This change caches the pool handle process-wide, so every `Neo4jGraph`/`GraphOps` in the process shares one pool:

- The `neo4rs::Graph` (an Arc'd, cheaply-cloneable pool handle) is cached in a `static tokio::sync::Mutex<Option<CachedPool>>` keyed by `(uri, username, database)`. The lock is held across the connect await deliberately: concurrent first callers serialize, a **failed** connect is never cached, and the next caller retries.
- `Neo4jGraph::force_reconnect()` now calls `Neo4jConnectionManager::invalidate()` before rebuilding — the wedged-socket retry path in `executor.rs` still gets fresh sockets instead of being handed back the same stuck shared pool.
- `NEO4J_MAX_CONNECTIONS` / `NEO4J_FETCH_SIZE` env overrides and `Neo4jConfig` fields still apply to the pool that actually gets built; the explicit-pool-sizing doc comment (wedged-socket rationale) is preserved.

## Notes for review

- **Config audit:** `Neo4jGraph::with_config` has zero callers anywhere in the repo — every construction site uses `Neo4jGraph::default()` with the env-derived config — so a single cached handle suffices. If a caller ever passes a config for a different server/db, the keyed cache builds a fresh pool and replaces the cached one rather than silently reusing the wrong connection.
- **`disconnect()`:** has zero callers, and it only dropped a local clone of the Arc'd handle anyway — dropping local handles never closes the shared pool.
- **Call sites unchanged:** the per-request `GraphOps::new().connect()` pattern is left as-is; with the cached pool those are now cheap clone-of-Arc operations. (A follow-up could share a `GraphOps`, but this keeps the change minimal.)

## Testing

- New unit test `initialize_reuses_shared_pool` (skips gracefully if no Neo4j is reachable): verified against a live local Neo4j that repeated `initialize()` calls reuse one pool (build counter unchanged) and `invalidate()` forces exactly one rebuild.
- `cargo build` (workspace) and `cargo build -p ast --features neo4j` pass.
- `cargo test -p ast --lib` (no neo4j feature, CI rust-test.yml mode): 100/100 pass.
- `cargo test -p ast --features neo4j --lib -- --test-threads=1`: 324/328 pass. The 4 failures (`test_{react,rust,typescript,nextjs}_graph_upload`) fail **identically on main** with the same node counts (e.g. 625 vs expected 321 — a constant +304 leftover nodes in the local dev Neo4j that the fixture `clear()` does not remove), so they are pre-existing/environmental, not caused by this change. Note this suite is not run by CI (rust-test workflows run without the `neo4j` feature; standalone-test runs the standalone crate).
- End-to-end ingest via the standalone service was not exercised locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
