### PR TITLE
aieo: raise default LLM first-response timeout to 5 minutes

### DIFF
--- a/mcp/src/aieo/src/provider.ts
+++ b/mcp/src/aieo/src/provider.ts
@@ -349,11 +349,14 @@ export interface GetModelOptions {
  * with HTTP headers before giving up. The timer is disarmed once headers
  * arrive, so only the connect/stall phase is bounded — not the stream body.
  *
- * 120 s is generous enough for slow gateways but still well below the 2-hour
- * busy watchdog. Ops can tune via `LLM_HTTP_TIMEOUT_MS`.
+ * 5 min covers slow gateways and — crucially — non-streaming `generateText`
+ * calls, where the provider sends nothing (headers included) until the whole
+ * message is generated, so an adaptive-thinking call can legitimately need
+ * minutes. Still well below the 2-hour busy watchdog. Ops can tune via
+ * `LLM_HTTP_TIMEOUT_MS`.
  */
 const DEFAULT_LLM_HTTP_TIMEOUT_MS =
-  parseInt(process.env.LLM_HTTP_TIMEOUT_MS || "", 10) || 120_000;
+  parseInt(process.env.LLM_HTTP_TIMEOUT_MS || "", 10) || 300_000;
 
 /**
  * Extra attempts after a connect-phase timeout. The timeout aborts via an


### PR DESCRIPTION
## What changed

`DEFAULT_LLM_HTTP_TIMEOUT_MS` goes from 120s to 300s (still overridable via `LLM_HTTP_TIMEOUT_MS`).

## Why

For **non-streaming** `generateText` calls, the provider sends nothing — headers included — until the entire message is generated, so the "first-response" timeout is effectively a total-generation cap. Several call sites (`repo/concepts.ts`, `repo/docs.ts`, `repo/workflows.ts`, `repo/descriptions.ts`) run with adaptive thinking on Anthropic models and can legitimately need more than 2 minutes; at 120s they'd be killed and then futilely re-run by the retry logic from #1588 (a slow generation is deterministic, not transient).

**Streaming** calls (the main agent loop and subagents) are unaffected either way: headers arrive within seconds and disarm the timer before thinking starts.

## Trade-off

A genuinely stalled connect now waits 5 min per attempt instead of 2 — worst case ~15 min across the 3 attempts from #1588 — still far under the 2-hour busy watchdog.

Follows up on #1588. `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)