### PR TITLE
docgen: constrain generated paraIds to the OOXML-valid range

### DIFF
--- a/mcp/src/repo/__tests__/docgen.test.ts
+++ b/mcp/src/repo/__tests__/docgen.test.ts
@@ -745,6 +745,22 @@ describe("injectParaIds — unit tests", () => {
     }
   });
 
+  it("generates IDs within the OOXML-valid range (nonzero, high bit clear)", async () => {
+    const { injectParaIds } = await import("../docgen.js");
+    // 50 paragraphs × 2 IDs = 100 samples; under the old unmasked generator
+    // each had a ~50% chance of an out-of-range value, so all passing by luck
+    // is astronomically unlikely
+    const paras = Array(50).fill("<w:p/>").join("\n");
+    const xml = `<w:document xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main"><w:body>${paras}</w:body></w:document>`;
+    const { xml: out } = injectParaIds(xml);
+    const ids = [...out.matchAll(/w14:(?:paraId|textId)="([0-9A-F]{8})"/g)].map(m => m[1]);
+    assert.ok(ids.length >= 100, "50 paragraphs × 2 IDs each = at least 100");
+    for (const id of ids) {
+      const n = parseInt(id, 16);
+      assert.ok(n >= 0x00000001 && n <= 0x7fffffff, `ID "${id}" must be in 0x00000001–0x7FFFFFFF`);
+    }
+  });
+
   it("generates unique IDs across multiple paragraphs", async () => {
     const { injectParaIds } = await import("../docgen.js");
     // Generate 20 paragraphs to surface collision issues

--- a/mcp/src/repo/docgen.ts
+++ b/mcp/src/repo/docgen.ts
@@ -75,14 +75,15 @@ export interface XlsxInput {
 /**
  * Generate a unique 8-digit uppercase hex ID, avoiding the reserved value
  * "00000000" and any IDs already in the `used` set. Adds the new ID to `used`.
+ * OOXML requires paraId/textId values to be nonzero with the high bit clear,
+ * so IDs are constrained to 0x00000001–0x7FFFFFFF.
  */
 function genParaId(used: Set<string>): string {
   while (true) {
-    const id = Math.floor(Math.random() * 0xffffffff + 1)
-      .toString(16)
-      .toUpperCase()
-      .padStart(8, "0");
-    if (id !== "00000000" && !used.has(id)) {
+    const n = Math.floor(Math.random() * 0x100000000) & 0x7fffffff;
+    if (n === 0) continue;
+    const id = n.toString(16).toUpperCase().padStart(8, "0");
+    if (!used.has(id)) {
       used.add(id);
       return id;
     }


### PR DESCRIPTION
## What changed

`genParaId` in `mcp/src/repo/docgen.ts` generated `w14:paraId`/`w14:textId` values from the full 32-bit range (`Math.random() * 0xffffffff + 1`), so roughly half of the IDs stamped onto pandoc-generated documents had the high bit set. The OOXML spec requires these IDs to be nonzero and below `0x80000000`, so the bundled docx-mcp-server's `audit_document` tool reported `paraids.valid=false` with a long `out_of_range` list on every `generate_docx` output (all flagged IDs started with hex 8–F).

The generator now masks the sample with `0x7FFFFFFF` and re-rolls on zero, constraining IDs to `0x00000001`–`0x7FFFFFFF`. The 8-hex-uppercase zero-padded format and the uniqueness check against the `used` set are unchanged.

## Tests

Added a test that stamps 50 paragraphs (100 IDs) and asserts every ID parses into the valid range — the old generator fails it with near-certainty. Existing coverage already checked format, uniqueness, and the `00000000` reservation, but not the upper bound.

All 59 tests in the docgen suite pass, including the `runDocx` integration tests over real pandoc output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)