### PR TITLE
reflect: file concept proposals from session reflection, one evolving draft per target

### DIFF
--- a/mcp/src/gitree/__tests__/concept-proposals.test.ts
+++ b/mcp/src/gitree/__tests__/concept-proposals.test.ts
@@ -16,7 +16,7 @@
  */
 import { test, expect } from "../../testkit.js";
 import { applyProposal } from "../proposals.js";
-import { createProposal, HttpError } from "../service.js";
+import { createProposal, reviseProposal, HttpError } from "../service.js";
 import type { Concept, ConceptProposal } from "../types.js";
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
@@ -55,14 +55,24 @@ function makeStorage(seed: Concept[] = []) {
   const savedDocs: Array<{ conceptId: string; documentation: string }> = [];
   const savedConcepts: Concept[] = [];
   const savedProposals: ConceptProposal[] = [];
+  const proposalsById: Record<string, ConceptProposal> = {};
 
   const storage: any = {
     _store: store,
     _savedDocs: savedDocs,
     _savedConcepts: savedConcepts,
     _savedProposals: savedProposals,
+    _proposalsById: proposalsById,
     saveProposal: async (proposal: ConceptProposal) => {
       savedProposals.push(proposal);
+      proposalsById[proposal.id] = proposal;
+    },
+    getProposal: async (id: string) => proposalsById[id] ?? null,
+    updateProposal: async (proposal: ConceptProposal) => {
+      const existing = proposalsById[proposal.id];
+      if (!existing || existing.status !== "pending") return false;
+      proposalsById[proposal.id] = { ...proposal, status: existing.status };
+      return true;
     },
     initialize: async () => {},
     getConcept: async (id: string, repo?: string) => {
@@ -219,6 +229,140 @@ test.describe("createProposal", () => {
         }),
       400
     );
+  });
+});
+
+// ─── reviseProposal (revise-in-place for session reflection) ────────────────
+
+test.describe("reviseProposal", () => {
+  async function seedDraft(storage: any) {
+    return createProposal(storage, {
+      action: "update",
+      conceptId: "owner/repo/auth",
+      documentation: "turn-1 docs",
+      rationale: "first pass",
+      sessionIds: ["sess-1"],
+      source: "reflection",
+    });
+  }
+
+  test("replaces content, keeps identity, re-snapshots baseDocs", async () => {
+    const concept = makeConcept({
+      id: "owner/repo/auth",
+      name: "Auth",
+      repo: "owner/repo",
+      documentation: "docs v1",
+    });
+    const storage = makeStorage([concept]);
+    const draft = await seedDraft(storage);
+    expect(draft.baseDocs).toBe("docs v1");
+
+    // The target drifts while the draft is pending.
+    concept.documentation = "docs v2";
+
+    const revised = await reviseProposal(storage, draft.id, {
+      action: "update",
+      conceptId: "owner/repo/auth",
+      documentation: "turn-2 docs",
+      rationale: "requirements changed",
+      sessionIds: ["sess-1"],
+    });
+
+    expect(revised.id).toBe(draft.id);
+    expect(revised.createdAt).toBe(draft.createdAt);
+    expect(revised.documentation).toBe("turn-2 docs");
+    // Fresh snapshot: an accepted revision must diff against docs v2, not v1.
+    expect(revised.baseDocs).toBe("docs v2");
+    expect(storage._proposalsById[draft.id].documentation).toBe("turn-2 docs");
+  });
+
+  test("evidence accumulates across revisions", async () => {
+    const storage = makeStorage([
+      makeConcept({ id: "owner/repo/auth", name: "Auth", repo: "owner/repo" }),
+    ]);
+    const draft = await seedDraft(storage);
+    const revised = await reviseProposal(storage, draft.id, {
+      action: "update",
+      conceptId: "owner/repo/auth",
+      documentation: "x",
+      sessionIds: ["sess-2"],
+    });
+    expect(revised.sessionIds).toEqual(["sess-1", "sess-2"]);
+  });
+
+  test("a revision can retarget the action for the same concept", async () => {
+    const storage = makeStorage([
+      makeConcept({ id: "owner/repo/auth", name: "Auth", repo: "owner/repo" }),
+    ]);
+    const draft = await seedDraft(storage);
+    const revised = await reviseProposal(storage, draft.id, {
+      action: "delete",
+      conceptId: "owner/repo/auth",
+      rationale: "turned out to be obsolete",
+    });
+    expect(revised.action).toBe("delete");
+    expect(revised.documentation).toBeUndefined();
+  });
+
+  test("404 for a proposal that does not exist", async () => {
+    const storage = makeStorage();
+    await expectHttpError(
+      () => reviseProposal(storage, "nope", { action: "create", name: "x", documentation: "d" }),
+      404
+    );
+  });
+
+  test("409 for a proposal that was already decided", async () => {
+    const storage = makeStorage([
+      makeConcept({ id: "owner/repo/auth", name: "Auth", repo: "owner/repo" }),
+    ]);
+    const draft = await seedDraft(storage);
+    storage._proposalsById[draft.id].status = "accepted";
+    const err = await expectHttpError(
+      () =>
+        reviseProposal(storage, draft.id, {
+          action: "update",
+          conceptId: "owner/repo/auth",
+          documentation: "x",
+        }),
+      409
+    );
+    expect(err.extra?.status).toBe("accepted");
+  });
+
+  test("409 when the reviewer decides it mid-revision (atomic guard)", async () => {
+    const storage = makeStorage([
+      makeConcept({ id: "owner/repo/auth", name: "Auth", repo: "owner/repo" }),
+    ]);
+    const draft = await seedDraft(storage);
+    // Pending at the early check, decided by the time the write lands.
+    storage.updateProposal = async () => false;
+    await expectHttpError(
+      () =>
+        reviseProposal(storage, draft.id, {
+          action: "update",
+          conceptId: "owner/repo/auth",
+          documentation: "x",
+        }),
+      409
+    );
+  });
+
+  test("revision re-validates: bad target fails without writing", async () => {
+    const storage = makeStorage([
+      makeConcept({ id: "owner/repo/auth", name: "Auth", repo: "owner/repo" }),
+    ]);
+    const draft = await seedDraft(storage);
+    await expectHttpError(
+      () =>
+        reviseProposal(storage, draft.id, {
+          action: "update",
+          conceptId: "owner/repo/vanished",
+          documentation: "x",
+        }),
+      404
+    );
+    expect(storage._proposalsById[draft.id].documentation).toBe("turn-1 docs");
   });
 });
 

--- a/mcp/src/gitree/service.ts
+++ b/mcp/src/gitree/service.ts
@@ -164,15 +164,7 @@ export async function requireConcept(
   return concept;
 }
 
-/**
- * Validate and persist a ConceptProposal. Shared by POST /gitree/proposals
- * and the propose_concept_change agent tool. Snapshots the target's current
- * docs (baseDocs/absorbedDocs) server-side so accept can detect drift.
- */
-export async function createProposal(
-  storage: GraphStorage,
-  input: CreateProposalInput
-): Promise<ConceptProposal> {
+function newProposalShell(input: CreateProposalInput): ConceptProposal {
   const action = input.action;
   if (!VALID_PROPOSAL_ACTIONS.includes(action)) {
     throw new HttpError(
@@ -180,8 +172,7 @@ export async function createProposal(
       `action must be one of: ${VALID_PROPOSAL_ACTIONS.join(", ")}`
     );
   }
-
-  const proposal: ConceptProposal = {
+  return {
     id: randomUUID(),
     action,
     status: "pending",
@@ -196,6 +187,21 @@ export async function createProposal(
       : undefined,
     createdAt: new Date(),
   };
+}
+
+/**
+ * Per-action validation and target snapshotting, shared by create and revise.
+ * Fills the proposal's content fields in place, re-reading the target so
+ * baseDocs/absorbedDocs always reflect the target's docs AT THIS MOMENT —
+ * which is what lets a revised proposal pass the accept-time staleness check
+ * even when the target drifted while an earlier version sat in the queue.
+ */
+async function validateAndFillProposal(
+  storage: GraphStorage,
+  proposal: ConceptProposal,
+  input: CreateProposalInput
+): Promise<void> {
+  const action = proposal.action;
 
   if (action === "create") {
     const name = optionalString(input.name);
@@ -291,9 +297,70 @@ export async function createProposal(
     proposal.documentation = input.documentation;
     proposal.description = optionalString(input.description);
   }
+}
 
+/**
+ * Validate and persist a ConceptProposal. Shared by POST /gitree/proposals
+ * and the propose_concept_change agent tool. Snapshots the target's current
+ * docs (baseDocs/absorbedDocs) server-side so accept can detect drift.
+ */
+export async function createProposal(
+  storage: GraphStorage,
+  input: CreateProposalInput
+): Promise<ConceptProposal> {
+  const proposal = newProposalShell(input);
+  await validateAndFillProposal(storage, proposal, input);
   await storage.saveProposal(proposal);
   return proposal;
+}
+
+/**
+ * Replace a PENDING proposal's content in place — same validation and target
+ * snapshotting as createProposal, keeping the proposal's id and createdAt.
+ * Used by session reflection to keep one evolving draft per (session, target)
+ * instead of filing a sibling every turn.
+ *
+ * Evidence accumulates: prNumbers and sessionIds are unioned with what the
+ * proposal already carries. The pending-only guard is enforced twice — an
+ * early check for a friendly error, and atomically in storage.updateProposal
+ * so a reviewer deciding the proposal mid-revision always wins.
+ */
+export async function reviseProposal(
+  storage: GraphStorage,
+  id: string,
+  input: CreateProposalInput
+): Promise<ConceptProposal> {
+  const existing = await storage.getProposal(id);
+  if (!existing) {
+    throw new HttpError(404, `Proposal ${id} not found`);
+  }
+  if (existing.status !== "pending") {
+    throw new HttpError(409, `Proposal ${id} was already ${existing.status}`, {
+      status: existing.status,
+    });
+  }
+
+  const shell = newProposalShell(input);
+  const proposal: ConceptProposal = {
+    ...shell,
+    id: existing.id,
+    createdAt: existing.createdAt,
+    source: shell.source ?? existing.source,
+    prNumbers: unionEvidence(existing.prNumbers, shell.prNumbers),
+    sessionIds: unionEvidence(existing.sessionIds, shell.sessionIds),
+  };
+  await validateAndFillProposal(storage, proposal, input);
+
+  const updated = await storage.updateProposal(proposal);
+  if (!updated) {
+    throw new HttpError(409, `Proposal ${id} was decided while being revised`);
+  }
+  return proposal;
+}
+
+function unionEvidence<T>(a?: T[], b?: T[]): T[] | undefined {
+  if (!a?.length && !b?.length) return undefined;
+  return Array.from(new Set([...(a ?? []), ...(b ?? [])]));
 }
 
 export async function listProposals(

--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -2656,53 +2656,127 @@ export class GraphStorage extends Storage {
         }
       );
 
-      // TARGETS edges to the concept(s) this proposal wants to change. For
-      // merge, both targets get an edge with a role so the UI can tell which
-      // concept survives.
-      const targets: Array<{ conceptId: string; role: string | null }> = [];
-      if (proposal.conceptId) {
-        targets.push({
-          conceptId: proposal.conceptId,
-          role: proposal.action === "merge" ? "absorb" : null,
-        });
-      }
-      if (proposal.mergeIntoConceptId) {
-        targets.push({ conceptId: proposal.mergeIntoConceptId, role: "into" });
-      }
-      for (const target of targets) {
-        await session.run(
-          `
-          MATCH (p:ConceptProposal {id: $id})
-          MATCH (c:Concept {id: $conceptId})
-          MERGE (p)-[r:TARGETS]->(c)
-          ON CREATE SET r.ref_id = randomUUID()
-          SET r.role = $role
-          `,
-          { id: proposal.id, conceptId: target.conceptId, role: target.role }
-        );
-      }
-
-      // EVIDENCE edges to the PRs that motivated this proposal (same matching
-      // pattern as the TOUCHES edges in saveConcept).
-      if (proposal.prNumbers && proposal.prNumbers.length > 0 && proposal.repo) {
-        await session.run(
-          `
-          MATCH (p:ConceptProposal {id: $id})
-          UNWIND $prNumbers as prNumber
-          MATCH (pr:PullRequest)
-          WHERE (pr.repo = $repo AND pr.number = prNumber) OR pr.id = $repo + '/pr-' + toString(prNumber)
-          MERGE (p)-[r:EVIDENCE]->(pr)
-          ON CREATE SET r.ref_id = randomUUID()
-          `,
-          {
-            id: proposal.id,
-            prNumbers: proposal.prNumbers,
-            repo: proposal.repo,
-          }
-        );
-      }
+      await this.writeProposalEdges(session, proposal);
     } finally {
       await session.close();
+    }
+  }
+
+  /**
+   * Revise a PENDING proposal's content in place. Deliberately never touches
+   * status/decision fields, and the pending guard is part of the match — so a
+   * reviewer deciding the proposal concurrently wins and this returns false.
+   */
+  async updateProposal(proposal: ConceptProposal): Promise<boolean> {
+    const session = this.resilientSession();
+    try {
+      const result = await session.run(
+        `
+        MATCH (p:ConceptProposal {id: $id, status: 'pending'})
+        SET p.action = $action,
+            p.repo = $repo,
+            p.conceptId = $conceptId,
+            p.mergeIntoConceptId = $mergeIntoConceptId,
+            p.name = $name,
+            p.description = $description,
+            p.documentation = $documentation,
+            p.parent = $parent,
+            p.baseDocs = $baseDocs,
+            p.absorbedDocs = $absorbedDocs,
+            p.rationale = $rationale,
+            p.source = $source,
+            p.prNumbers = $prNumbers,
+            p.sessionIds = $sessionIds
+        RETURN p
+        `,
+        {
+          id: proposal.id,
+          action: proposal.action,
+          repo: proposal.repo || null,
+          conceptId: proposal.conceptId || null,
+          mergeIntoConceptId: proposal.mergeIntoConceptId || null,
+          name: proposal.name || null,
+          description: proposal.description ?? null,
+          documentation: proposal.documentation ?? null,
+          parent: proposal.parent || null,
+          baseDocs: proposal.baseDocs ?? null,
+          absorbedDocs: proposal.absorbedDocs ?? null,
+          rationale: proposal.rationale || null,
+          source: proposal.source || null,
+          prNumbers: proposal.prNumbers || [],
+          sessionIds: proposal.sessionIds || [],
+        }
+      );
+      if (result.records.length === 0) return false;
+
+      // A revision can retarget (create -> update, or a different concept), so
+      // rebuild the evidence edges from scratch.
+      await session.run(
+        `
+        MATCH (p:ConceptProposal {id: $id})-[r:TARGETS|EVIDENCE]->()
+        DELETE r
+        `,
+        { id: proposal.id }
+      );
+      await this.writeProposalEdges(session, proposal);
+      return true;
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * TARGETS + EVIDENCE edges for a proposal. Shared by saveProposal and
+   * updateProposal; assumes the ConceptProposal node already exists.
+   */
+  private async writeProposalEdges(
+    session: any,
+    proposal: ConceptProposal
+  ): Promise<void> {
+    // TARGETS edges to the concept(s) this proposal wants to change. For
+    // merge, both targets get an edge with a role so the UI can tell which
+    // concept survives.
+    const targets: Array<{ conceptId: string; role: string | null }> = [];
+    if (proposal.conceptId) {
+      targets.push({
+        conceptId: proposal.conceptId,
+        role: proposal.action === "merge" ? "absorb" : null,
+      });
+    }
+    if (proposal.mergeIntoConceptId) {
+      targets.push({ conceptId: proposal.mergeIntoConceptId, role: "into" });
+    }
+    for (const target of targets) {
+      await session.run(
+        `
+        MATCH (p:ConceptProposal {id: $id})
+        MATCH (c:Concept {id: $conceptId})
+        MERGE (p)-[r:TARGETS]->(c)
+        ON CREATE SET r.ref_id = randomUUID()
+        SET r.role = $role
+        `,
+        { id: proposal.id, conceptId: target.conceptId, role: target.role }
+      );
+    }
+
+    // EVIDENCE edges to the PRs that motivated this proposal (same matching
+    // pattern as the TOUCHES edges in saveConcept).
+    if (proposal.prNumbers && proposal.prNumbers.length > 0 && proposal.repo) {
+      await session.run(
+        `
+        MATCH (p:ConceptProposal {id: $id})
+        UNWIND $prNumbers as prNumber
+        MATCH (pr:PullRequest)
+        WHERE (pr.repo = $repo AND pr.number = prNumber) OR pr.id = $repo + '/pr-' + toString(prNumber)
+        MERGE (p)-[r:EVIDENCE]->(pr)
+        ON CREATE SET r.ref_id = randomUUID()
+        `,
+        {
+          id: proposal.id,
+          prNumbers: proposal.prNumbers,
+          repo: proposal.repo,
+        }
+      );
     }
   }
 

--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -1145,9 +1145,10 @@ class Db {
       await session.run(Q.FULLTEXT_NAME_INDEX_QUERY);
       await session.run(Q.FULLTEXT_COMPOSITE_INDEX_QUERY);
       await session.run(Q.VECTOR_INDEX_QUERY);
-      await session.run(
-        "CREATE INDEX agent_session_id_index IF NOT EXISTS FOR (n:AgentSession) ON (n.node_key)",
-      );
+      // No standalone index on (:AgentSession).node_key — the uniqueness
+      // constraint created below is backed by its own index, and Neo4j
+      // refuses to create the constraint while a separate index covers the
+      // same label/property.
       // Turn.session_id backs the polling endpoint's flat per-session lookup.
       await session.run(
         "CREATE INDEX turn_session_id_index IF NOT EXISTS FOR (n:Turn) ON (n.session_id)",
@@ -1175,6 +1176,14 @@ class Db {
    * to stop the service from booting.
    */
   private async ensureAgentSessionUnique(session: ResilientSession): Promise<void> {
+    try {
+      // Migration: earlier versions created a standalone index on this exact
+      // label/property. Neo4j will not create the constraint while it exists,
+      // so drop it first — a no-op on graphs that never had it.
+      await session.run("DROP INDEX agent_session_id_index IF EXISTS");
+    } catch (e) {
+      console.warn("[neo4j] could not drop legacy agent_session_id_index:", e);
+    }
     try {
       await session.run(Q.AGENT_SESSION_KEY_CONSTRAINT_QUERY);
       return;

--- a/mcp/src/repo/__tests__/concepts.test.ts
+++ b/mcp/src/repo/__tests__/concepts.test.ts
@@ -40,6 +40,8 @@ const {
   buildReflectTurn,
   reflectEnabled,
   reflectPromptOverride,
+  proposalTargetKey,
+  applyReflectionProposals,
 } = await import("../concepts.js");
 
 /** A graph_get result for a Concept node, as the tool actually returns it. */
@@ -192,23 +194,58 @@ test.describe("parsing the reflect turn", () => {
           { id: "c_4f2a", rank: 1, evidence: "used for the sidecar answer" },
           { id: "c_91bd", rank: 2, evidence: "opened on a wrong guess", contradicts: "says X; source says Y" },
         ],
-        gap: "provenance sidecar format",
       }),
       concepts,
     );
     expect(out.concepts[0].rank).toBe(1);
     expect(out.concepts[1].contradicts).toBe("says X; source says Y");
-    expect(out.gap).toBe("provenance sidecar format");
+    expect(out.proposals).toEqual([]);
   });
 
   test("a concept the model skipped stays unranked rather than disappearing", () => {
     const out = parseReflection(
-      JSON.stringify({ ranking: [{ id: "c_4f2a", rank: 1 }], gap: null }),
+      JSON.stringify({ ranking: [{ id: "c_4f2a", rank: 1 }] }),
       concepts,
     );
     expect(out.concepts).toHaveLength(2);
     expect(out.concepts[1].rank).toBeNull();
-    expect(out.gap).toBeNull();
+  });
+
+  test("parses proposals, dropping malformed entries", () => {
+    const out = parseReflection(
+      JSON.stringify({
+        ranking: [],
+        proposals: [
+          {
+            action: "update",
+            concept_id: "c_4f2a",
+            documentation: "# Auth\nrevised",
+            rationale: "source contradicts the docs",
+          },
+          { action: "explode", concept_id: "c_4f2a" }, // invalid action
+          "not an object",
+          { action: "create", name: "session-reflection", documentation: "# New", rationale: "missing" },
+        ],
+      }),
+      concepts,
+    );
+    expect(out.proposals).toHaveLength(2);
+    expect(out.proposals[0].action).toBe("update");
+    expect(out.proposals[0].concept_id).toBe("c_4f2a");
+    expect(out.proposals[1].action).toBe("create");
+    expect(out.proposals[1].name).toBe("session-reflection");
+  });
+
+  test("proposals survive a reply with no ranking", () => {
+    const out = parseReflection(
+      JSON.stringify({
+        proposals: [{ action: "delete", concept_id: "c_91bd", rationale: "obsolete" }],
+      }),
+      concepts,
+    );
+    expect(out.proposals).toHaveLength(1);
+    // The ranking half still degrades the same way it always did.
+    expect(out.concepts.every((c) => c.rank === null)).toBe(true);
   });
 
   test("ids the model invented are dropped", () => {
@@ -247,6 +284,30 @@ test.describe("the reflect turn itself", () => {
     expect(turn.content).not.toContain("REFLECTION");
   });
 
+  test("standing drafts are embedded with their full documentation", () => {
+    const turn = buildReflectTurn(
+      [{ id: "c_4f2a", name: "auth", via: "learn_concept" }],
+      undefined,
+      [
+        {
+          id: "prop-1",
+          action: "update",
+          status: "pending",
+          conceptId: "c_4f2a",
+          documentation: "# Auth\ndraft body from turn 1",
+          rationale: "docs were stale",
+          createdAt: new Date(),
+        },
+      ],
+    );
+    expect(turn.content).toContain("pending human review");
+    expect(turn.content).toContain("draft body from turn 1");
+    // No drafts -> no draft block at all (the prompt's own mention of
+    // standing drafts remains, but no block header or content).
+    const bare = buildReflectTurn([{ id: "c_4f2a", name: "auth", via: "learn_concept" }]);
+    expect(bare.content).not.toContain("pending human review");
+  });
+
   test("reflect config accepts true or an object", () => {
     expect(reflectEnabled(true)).toBe(true);
     expect(reflectEnabled({ prompt: "hi" })).toBe(true);
@@ -268,7 +329,6 @@ test.describe("the reflection sidecar", () => {
         { id: "c_4f2a", name: "auth", rank: 1, evidence: "load-bearing" },
         { id: "c_91bd", name: "runs", rank: 2 },
       ],
-      gap: "sidecar format",
     });
 
     // A later turn reads a third concept, but its reflect call fails — the
@@ -289,7 +349,6 @@ test.describe("the reflection sidecar", () => {
     expect(byId["c_02e1"].rank).toBeNull();
     // Unranked concepts sort after ranked ones.
     expect(saved?.concepts[2].id).toBe("c_02e1");
-    expect(saved?.gap).toBe("sidecar format");
   });
 
   test("a ref_id-only record and a fuller one are the same concept", async () => {
@@ -384,7 +443,6 @@ test.describe("the reflection sidecar", () => {
     const sessionId = `sess-${randomUUID()}`;
     const returned = mergeReflection(sessionId, {
       concepts: [{ ref_id: "ref-abc", name: "auth", rank: 1 }],
-      gap: null,
     });
     expect(returned.session_id).toBe(sessionId);
     expect(returned.concepts).toHaveLength(1);
@@ -394,5 +452,163 @@ test.describe("the reflection sidecar", () => {
   test("no sidecar for a session that read nothing", async () => {
     const { loadReflection } = await import("../session.js");
     expect(loadReflection(`sess-${randomUUID()}`)).toBeNull();
+  });
+});
+
+// ─── Filing reflection proposals (create-or-revise per (session, target)) ────
+
+function makeConcept(id: string, documentation: string) {
+  const now = new Date();
+  return {
+    id,
+    name: id,
+    description: "",
+    prNumbers: [],
+    commitShas: [],
+    createdAt: now,
+    lastUpdated: now,
+    documentation,
+  };
+}
+
+/** In-memory mock of the GraphStorage surface the proposal service touches. */
+function makeProposalStorage(seedConcepts: any[] = [], seedProposals: any[] = []) {
+  const concepts: Record<string, any> = {};
+  for (const c of seedConcepts) concepts[c.id] = c;
+  const proposals: Record<string, any> = {};
+  for (const p of seedProposals) proposals[p.id] = p;
+
+  return {
+    _proposals: proposals,
+    initialize: async () => {},
+    getConcept: async (id: string) => concepts[id] ?? null,
+    saveProposal: async (p: any) => {
+      proposals[p.id] = p;
+    },
+    getProposal: async (id: string) => proposals[id] ?? null,
+    updateProposal: async (p: any) => {
+      const existing = proposals[p.id];
+      if (!existing || existing.status !== "pending") return false;
+      proposals[p.id] = { ...p, status: existing.status };
+      return true;
+    },
+    claimProposal: async (id: string, status: string, decidedBy?: string) => {
+      const existing = proposals[id];
+      if (!existing || existing.status !== "pending") return false;
+      existing.status = status;
+      existing.decidedBy = decidedBy;
+      return true;
+    },
+  } as any;
+}
+
+test.describe("applying reflection proposals", () => {
+  test("target keys: creates by name, everything else by concept", () => {
+    expect(proposalTargetKey({ action: "create", name: "Session Reflection" })).toBe(
+      proposalTargetKey({ action: "create", name: "session reflection" }),
+    );
+    expect(proposalTargetKey({ action: "update", conceptId: "c_1" })).toBe(
+      proposalTargetKey({ action: "delete", conceptId: "c_1" }),
+    );
+    expect(proposalTargetKey({ action: "update", conceptId: "c_1" })).not.toBe(
+      proposalTargetKey({ action: "update", conceptId: "c_2" }),
+    );
+  });
+
+  test("files a fresh proposal stamped with the session and reflection source", async () => {
+    const storage = makeProposalStorage([makeConcept("c_1", "old docs")]);
+    const result = await applyReflectionProposals(storage, {
+      sessionId: "sess-1",
+      proposals: [
+        { action: "update", concept_id: "c_1", documentation: "new docs", rationale: "stale" },
+      ],
+      drafts: [],
+    });
+    expect(result.filed).toHaveLength(1);
+    expect(result.filed[0].source).toBe("reflection");
+    expect(result.filed[0].sessionIds).toEqual(["sess-1"]);
+    expect(result.filed[0].baseDocs).toBe("old docs");
+  });
+
+  test("revises the session's standing draft instead of filing a sibling", async () => {
+    const draft = {
+      id: "prop-1",
+      action: "update",
+      status: "pending",
+      conceptId: "c_1",
+      documentation: "turn-1 docs",
+      baseDocs: "docs as of turn 1",
+      sessionIds: ["sess-1"],
+      source: "reflection",
+      createdAt: new Date(),
+    };
+    // The concept drifted while the draft sat in the queue.
+    const storage = makeProposalStorage([makeConcept("c_1", "current docs")], [draft]);
+
+    const result = await applyReflectionProposals(storage, {
+      sessionId: "sess-1",
+      proposals: [
+        { action: "update", concept_id: "c_1", documentation: "turn-2 docs", rationale: "requirements changed" },
+      ],
+      drafts: [draft as any],
+    });
+
+    expect(result.filed).toHaveLength(0);
+    expect(result.revised).toHaveLength(1);
+    expect(result.revised[0].id).toBe("prop-1");
+    expect(result.revised[0].documentation).toBe("turn-2 docs");
+    // baseDocs re-snapshots at revision time, so accept-time staleness checks
+    // compare against what the reflection actually saw.
+    expect(result.revised[0].baseDocs).toBe("current docs");
+    expect(Object.keys(storage._proposals)).toHaveLength(1);
+  });
+
+  test("withdraw rejects the standing draft and files nothing", async () => {
+    const draft = {
+      id: "prop-1",
+      action: "create",
+      status: "pending",
+      name: "obsolete-idea",
+      documentation: "x",
+      sessionIds: ["sess-1"],
+      createdAt: new Date(),
+    };
+    const storage = makeProposalStorage([], [draft]);
+    const result = await applyReflectionProposals(storage, {
+      sessionId: "sess-1",
+      proposals: [{ action: "create", name: "obsolete-idea", withdraw: true }],
+      drafts: [draft as any],
+    });
+    expect(result.withdrawn).toEqual(["prop-1"]);
+    expect(result.filed).toHaveLength(0);
+    expect(storage._proposals["prop-1"].status).toBe("rejected");
+  });
+
+  test("a ref_id the model echoed back resolves to the gitree concept id", async () => {
+    const storage = makeProposalStorage([makeConcept("c_1", "docs")]);
+    const result = await applyReflectionProposals(storage, {
+      sessionId: "sess-1",
+      proposals: [
+        { action: "update", concept_id: "ref-abc", documentation: "revised", rationale: "r" },
+      ],
+      drafts: [],
+      known: [{ id: "c_1", ref_id: "ref-abc", via: "graph_get" }],
+    });
+    expect(result.filed).toHaveLength(1);
+    expect(result.filed[0].conceptId).toBe("c_1");
+  });
+
+  test("one bad proposal never blocks the rest", async () => {
+    const storage = makeProposalStorage([makeConcept("c_1", "docs")]);
+    const result = await applyReflectionProposals(storage, {
+      sessionId: "sess-1",
+      proposals: [
+        { action: "update", concept_id: "c_missing", documentation: "x", rationale: "r" },
+        { action: "update", concept_id: "c_1", documentation: "y", rationale: "r" },
+      ],
+      drafts: [],
+    });
+    expect(result.filed).toHaveLength(1);
+    expect(result.filed[0].conceptId).toBe("c_1");
   });
 });

--- a/mcp/src/repo/agent.ts
+++ b/mcp/src/repo/agent.ts
@@ -25,9 +25,12 @@ import {
   runReflection,
   reflectEnabled,
   reflectPromptOverride,
+  sessionPendingProposals,
+  fileReflectionProposals,
   type ConceptCollector,
   type ReflectConfig,
 } from "./concepts.js";
+import type { ConceptProposal } from "../gitree/types.js";
 import { SKILLS, enabledEntries, renderSkillIndex } from "./skills.js";
 import { type SubAgent, subAgentRepoNames } from "./subagent.js";
 import { ContextResult } from "../tools/types.js";
@@ -1047,7 +1050,9 @@ If the user's prompt mentions a sub-agent with an @mention (e.g. "@${validSubAge
 
 /**
  * Record which gitree Concepts this run read, and — when `reflect` is on —
- * ask the agent to rank them.
+ * ask the agent to rank them and to propose knowledge-base changes its work
+ * supports (filed as human-reviewed ConceptProposals, one evolving draft per
+ * (session, target)).
  *
  * Called after the session has been persisted, so it is the last thing a run
  * does. Two properties it must keep:
@@ -1102,6 +1107,16 @@ async function reflectOnConcepts(
 
   if (!reflectEnabled(opts.reflect)) return recordReadsOnly();
 
+  // The session's standing draft proposals from earlier turns, shown to the
+  // model so it revises them instead of re-filing. Best-effort: reflection
+  // still runs (and files fresh proposals) when the lookup fails.
+  let drafts: ConceptProposal[] = [];
+  try {
+    drafts = await sessionPendingProposals(sessionId, repo);
+  } catch (e) {
+    console.error("[concepts] could not load session proposal drafts:", e);
+  }
+
   try {
     console.log(`===> reflecting on ${concepts.length} concept(s) for session ${sessionId}`);
     const result = await runReflection({
@@ -1112,9 +1127,34 @@ async function reflectOnConcepts(
       tools: prepared.tools as Record<string, any>,
       messages,
       concepts,
+      drafts,
       promptOverride: reflectPromptOverride(opts.reflect),
     });
-    return mergeReflection(sessionId, result);
+
+    // Proposals are the side-channel half: file them create-or-revise keyed on
+    // (session, target), and never let a filing failure cost the ranking.
+    if (result.proposals.length > 0) {
+      try {
+        const applied = await fileReflectionProposals({
+          sessionId,
+          repo,
+          proposals: result.proposals,
+          drafts,
+          known: concepts,
+        });
+        console.log(
+          `===> reflection proposals for session ${sessionId}: ` +
+            `${applied.filed.length} filed, ${applied.revised.length} revised, ${applied.withdrawn.length} withdrawn`,
+        );
+      } catch (e) {
+        console.error("[concepts] could not file reflection proposals:", e);
+      }
+    }
+
+    return mergeReflection(sessionId, {
+      concepts: result.concepts,
+      raw: result.raw,
+    });
   } catch (e) {
     console.error("[concepts] reflection failed:", e);
     // The ranking is the optional half — keep the read record regardless.

--- a/mcp/src/repo/concepts.ts
+++ b/mcp/src/repo/concepts.ts
@@ -1,5 +1,13 @@
 import { generateText, ModelMessage, LanguageModel, type Tool } from "ai";
-import { listConcepts } from "../gitree/service.js";
+import {
+  listConcepts,
+  listProposals,
+  createProposal,
+  reviseProposal,
+  type CreateProposalInput,
+} from "../gitree/service.js";
+import { GraphStorage } from "../gitree/store/index.js";
+import type { ConceptProposal, ConceptProposalAction } from "../gitree/types.js";
 import { getProviderOptions } from "../aieo/src/index.js";
 import { extractLeadingJsonObject, maxOutputTokensFor } from "./utils.js";
 import type { ReflectedConcept } from "./session.js";
@@ -14,9 +22,13 @@ import type { ReflectedConcept } from "./session.js";
  *     READ during a run. Recorded from tool results, not from the model.
  *  2. Reflection (opt-in, `reflect`) — one extra call appended to the finished
  *     transcript asking the agent to rank those concepts by how load-bearing
- *     they were. Runs immediately after the run ends, while the provider's
+ *     they were, and to propose changes to the Concept knowledge base its work
+ *     supports. Runs immediately after the run ends, while the provider's
  *     prompt cache is still warm, so the transcript re-read is ~0.1x input
- *     price.
+ *     price. Proposals are filed by deterministic code (never a tool call —
+ *     that would either break the cached prefix or trust the model with the
+ *     upsert), keyed on (session, target) so a multi-turn session revises its
+ *     one standing draft per topic instead of filing a sibling each turn.
  */
 
 /** Caller config for the `reflect` request field: `true` or an object. */
@@ -259,11 +271,20 @@ export async function normalizeConceptReads(
 const DEFAULT_REFLECT_PROMPT = `REFLECTION — a review turn on the work you just finished. Do not call any tools. Answer with JSON only.
 
 1. Rank the concepts listed below from most to least load-bearing for the answer you gave, and for each give one line of evidence: where you used it and what it changed. A concept you read and never ended up using is a useful answer, not a failure — say so plainly.
-2. Did anything you read in those concepts contradict what you found in the source? If so, quote both sides in \`contradicts\`. Omit the field when nothing did.
-3. Was there anything you had to work out from the source that one of these concepts should have covered? Put it in \`gap\` as one sentence, or null.
+2. Did anything you read in those concepts contradict what you found in the source? If so, quote both sides in \`contradicts\`. If you verified the source is right and the concept is wrong, that is grounds for an "update" proposal below.
+3. \`proposals\` — optional, and empty on most runs. The Concept knowledge base exists to orient FUTURE sessions, so the test for filing one is: did this session uncover knowledge the next agent could NOT cheaply re-derive by reading the code? A pattern, best practice, or gotcha — a convention that spans files, a constraint the code doesn't make obvious, a mistake the code invites — is worth remembering. Feature-level and implementation-level detail is not: the next agent can always read the code itself for low-level specifics.
+
+File a proposal only when this session produced that kind of evidence:
+- You had to work out a pattern, convention, or gotcha from source that a concept should have covered → "create" a new concept (or "update" the nearest existing one).
+- A concept's documentation contradicted the source and you verified it → "update" with the FULL revised documentation (it replaces the whole body).
+- Two concepts turned out to cover the same ground → "merge". A concept describes something that no longer exists → "delete".
+
+Do NOT propose: knowledge specific to this one question, feature-level details readable from the code, minor wording preferences, suspicions you didn't verify, or reorganizations of concepts you only skimmed. Every proposal needs a rationale citing what happened this session — a human reviews it before anything takes effect.
+
+If a STANDING DRAFT proposal from this session is shown below, do NOT file a second proposal for the same target. Either return a revised full version of it (same target), leave it out of \`proposals\` to keep it unchanged, or return it with "withdraw": true if it no longer meets the bar above (the conversation moved on, or the learning turned out to be feature-specific after all).
 
 Respond with JSON and nothing else:
-{"ranking":[{"id":"<id>","rank":1,"evidence":"...","contradicts":"..."}],"gap":"..." or null}`;
+{"ranking":[{"id":"<id>","rank":1,"evidence":"...","contradicts":"..."}],"proposals":[{"action":"create|update|delete|merge","concept_id":"<target concept id; omit for create>","merge_into_concept_id":"<merge only: surviving concept>","name":"<create only>","description":"...","documentation":"...","rationale":"...","withdraw":false}]}`;
 
 /**
  * The identifier to show the model for one concept.
@@ -279,21 +300,96 @@ function displayId(c: ConceptRead): string {
 }
 
 /**
+ * A standing draft, rendered for the model in the same field names the
+ * response schema uses, so revising is a copy-and-edit rather than a mapping
+ * exercise. Full documentation included — a revision replaces the whole body,
+ * so the model must see what it is revising.
+ */
+function renderDraft(p: ConceptProposal): string {
+  return JSON.stringify({
+    action: p.action,
+    concept_id: p.conceptId,
+    merge_into_concept_id: p.mergeIntoConceptId,
+    name: p.name,
+    description: p.description,
+    documentation: p.documentation,
+    rationale: p.rationale,
+  });
+}
+
+/**
  * Build the single user turn appended to the finished transcript.
  *
- * The concept list is always appended by us, including under a caller-supplied
- * prompt: the caller has no way of knowing which concepts a run read, so it
- * can't supply this part itself.
+ * The concept list and the session's standing draft proposals are always
+ * appended by us, including under a caller-supplied prompt: the caller has no
+ * way of knowing which concepts a run read or what it proposed on an earlier
+ * turn, so it can't supply this part itself.
  */
 export function buildReflectTurn(
   concepts: ConceptRead[],
   promptOverride?: string,
+  drafts?: ConceptProposal[],
 ): ModelMessage {
   const list = concepts.map((c) => `  ${displayId(c)}  ${c.name ?? "(unnamed)"}`).join("\n");
+  const draftBlock =
+    drafts && drafts.length > 0
+      ? `\n\nSTANDING DRAFT proposals from this session (pending human review):\n${drafts
+          .map(renderDraft)
+          .join("\n")}`
+      : "";
   return {
     role: "user",
-    content: `${promptOverride ?? DEFAULT_REFLECT_PROMPT}\n\nConcepts you read this session:\n${list}`,
+    content: `${promptOverride ?? DEFAULT_REFLECT_PROMPT}\n\nConcepts you read this session:\n${list}${draftBlock}`,
   };
+}
+
+/**
+ * One proposed change parsed from the reflect turn, in the response schema's
+ * own field names. Mapped onto CreateProposalInput at apply time.
+ */
+export interface ReflectionProposal {
+  action: ConceptProposalAction;
+  concept_id?: string;
+  merge_into_concept_id?: string;
+  name?: string;
+  description?: string;
+  documentation?: string;
+  rationale?: string;
+  /** True = withdraw this session's standing draft for the same target. */
+  withdraw?: boolean;
+}
+
+const REFLECT_PROPOSAL_ACTIONS = new Set<ConceptProposalAction>([
+  "create",
+  "update",
+  "delete",
+  "merge",
+]);
+
+function cleanString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+/** Lenient parse of the `proposals` array; malformed entries are dropped. */
+function parseReflectionProposals(parsed: any): ReflectionProposal[] {
+  if (!Array.isArray(parsed?.proposals)) return [];
+  const out: ReflectionProposal[] = [];
+  for (const entry of parsed.proposals) {
+    if (!entry || typeof entry !== "object") continue;
+    if (!REFLECT_PROPOSAL_ACTIONS.has(entry.action)) continue;
+    out.push({
+      action: entry.action,
+      concept_id: cleanString(entry.concept_id),
+      merge_into_concept_id: cleanString(entry.merge_into_concept_id),
+      name: cleanString(entry.name),
+      description: cleanString(entry.description),
+      documentation:
+        typeof entry.documentation === "string" ? entry.documentation : undefined,
+      rationale: cleanString(entry.rationale),
+      withdraw: entry.withdraw === true,
+    });
+  }
+  return out;
 }
 
 /**
@@ -302,12 +398,14 @@ export function buildReflectTurn(
  * Lenient by design. The ranking is only ever an overlay on the deterministic
  * read list: ids the model invented are dropped, ids it omitted stay with
  * `rank: null`, and text that isn't JSON at all (likely under a custom prompt)
- * is preserved as `raw` instead of being thrown away.
+ * is preserved as `raw` instead of being thrown away. Proposals are parsed
+ * independently of the ranking, so a turn that answers only one half still
+ * yields the other.
  */
 export function parseReflection(
   text: string,
   concepts: ConceptRead[],
-): { concepts: ReflectedConcept[]; gap: string | null; raw?: string } {
+): { concepts: ReflectedConcept[]; proposals: ReflectionProposal[]; raw?: string } {
   const base: ReflectedConcept[] = concepts.map((c) => ({
     id: c.id,
     ref_id: c.ref_id,
@@ -317,9 +415,10 @@ export function parseReflection(
   }));
 
   const parsed = extractLeadingJsonObject(text);
+  const proposals = parseReflectionProposals(parsed);
   const ranking = Array.isArray(parsed?.ranking) ? parsed.ranking : null;
   if (!ranking) {
-    return { concepts: base, gap: null, raw: text.trim() || undefined };
+    return { concepts: base, proposals, raw: text.trim() || undefined };
   }
 
   const byKey = new Map<string, ReflectedConcept>();
@@ -338,8 +437,7 @@ export function parseReflection(
     }
   }
 
-  const gap = typeof parsed?.gap === "string" && parsed.gap.trim() ? parsed.gap : null;
-  return { concepts: base, gap };
+  return { concepts: base, proposals };
 }
 
 export interface ReflectRunArgs {
@@ -353,6 +451,8 @@ export interface ReflectRunArgs {
   /** The full model-facing transcript of the finished run. */
   messages: ModelMessage[];
   concepts: ConceptRead[];
+  /** This session's standing pending proposals, shown for revise-not-refile. */
+  drafts?: ConceptProposal[];
   promptOverride?: string;
 }
 
@@ -370,7 +470,7 @@ export interface ReflectRunArgs {
  */
 export async function runReflection(args: ReflectRunArgs): Promise<{
   concepts: ReflectedConcept[];
-  gap: string | null;
+  proposals: ReflectionProposal[];
   raw?: string;
 }> {
   const { model, modelId, provider, system, tools, messages, concepts } = args;
@@ -378,10 +478,160 @@ export async function runReflection(args: ReflectRunArgs): Promise<{
   const result = await generateText({
     model,
     ...(system ? { system } : {}),
-    messages: [...messages, buildReflectTurn(concepts, args.promptOverride)],
+    messages: [
+      ...messages,
+      buildReflectTurn(concepts, args.promptOverride, args.drafts),
+    ],
     tools,
     providerOptions: providerOptions as any,
     maxOutputTokens: maxOutputTokensFor(provider),
   });
   return parseReflection(result.text ?? "", concepts);
+}
+
+// ─── Reflection proposals (create-or-revise, one draft per target) ──────────
+
+/**
+ * The standing pending proposals attributable to a session — the drafts the
+ * reflect turn shows the model, and the upsert targets at apply time. Only
+ * reflection stamps sessionIds today, but the filter deliberately doesn't
+ * check `source`: any future producer that stamps the session gets revised
+ * rather than duplicated.
+ */
+export async function sessionPendingProposals(
+  sessionId: string,
+  repo?: string,
+): Promise<ConceptProposal[]> {
+  const all = await listProposals(repo, "pending");
+  return all.filter((p) => p.sessionIds?.includes(sessionId));
+}
+
+/**
+ * Upsert identity for a proposal within a session: the concept it targets, or
+ * for creates the proposed name. This is what makes a session revise its one
+ * draft per topic instead of filing a sibling each turn — and what keeps two
+ * genuinely unrelated proposals from clobbering each other.
+ */
+export function proposalTargetKey(p: {
+  action: string;
+  conceptId?: string;
+  name?: string;
+}): string {
+  if (p.action === "create") {
+    return `create:${(p.name ?? "").trim().toLowerCase()}`;
+  }
+  return `concept:${p.conceptId ?? ""}`;
+}
+
+/**
+ * The graph tools show the model ref_ids, but the proposal service resolves
+ * targets by gitree concept id — so map a ref_id back through what this run
+ * actually read before treating it as a target.
+ */
+function resolveConceptId(
+  raw: string | undefined,
+  known: ConceptRead[],
+): string | undefined {
+  if (!raw) return undefined;
+  const match = known.find((c) => c.ref_id === raw || c.id === raw);
+  return match?.id ?? raw;
+}
+
+export interface ApplyReflectionResult {
+  filed: ConceptProposal[];
+  revised: ConceptProposal[];
+  withdrawn: string[];
+}
+
+/**
+ * File the reflect turn's proposals: create-or-revise keyed on
+ * (session, target), withdraw on request.
+ *
+ * The model half is already over by the time this runs — everything here is
+ * deterministic code, which is the point: session-stamping, dedup against the
+ * standing drafts, and the pending-only revision guard are enforced rather
+ * than asked of the model. Per-proposal failures are logged and skipped so one
+ * bad entry never blocks the rest, and the caller treats the whole thing as
+ * best-effort.
+ */
+export async function applyReflectionProposals(
+  storage: GraphStorage,
+  args: {
+    sessionId: string;
+    repo?: string;
+    proposals: ReflectionProposal[];
+    drafts: ConceptProposal[];
+    /** This run's concept reads, for ref_id -> gitree id translation. */
+    known?: ConceptRead[];
+  },
+): Promise<ApplyReflectionResult> {
+  const { sessionId, repo, proposals, drafts } = args;
+  const known = args.known ?? [];
+  const result: ApplyReflectionResult = { filed: [], revised: [], withdrawn: [] };
+
+  const draftByTarget = new Map<string, ConceptProposal>();
+  for (const d of drafts) draftByTarget.set(proposalTargetKey(d), d);
+
+  for (const p of proposals) {
+    try {
+      const conceptId = resolveConceptId(p.concept_id, known);
+      const targetKey = proposalTargetKey({
+        action: p.action,
+        conceptId,
+        name: p.name,
+      });
+      const draft = draftByTarget.get(targetKey);
+
+      if (p.withdraw) {
+        if (draft) {
+          await storage.claimProposal(
+            draft.id,
+            "rejected",
+            "reflection",
+            "Withdrawn by session reflection",
+          );
+          result.withdrawn.push(draft.id);
+        }
+        continue;
+      }
+
+      const input: CreateProposalInput = {
+        action: p.action,
+        repo,
+        conceptId,
+        mergeIntoConceptId: resolveConceptId(p.merge_into_concept_id, known),
+        name: p.name,
+        description: p.description,
+        documentation: p.documentation,
+        rationale: p.rationale,
+        source: "reflection",
+        sessionIds: [sessionId],
+      };
+
+      if (draft) {
+        result.revised.push(await reviseProposal(storage, draft.id, input));
+      } else {
+        result.filed.push(await createProposal(storage, input));
+      }
+    } catch (e) {
+      console.error(
+        `[concepts] could not apply reflection proposal (${p.action} ${p.concept_id ?? p.name ?? ""}):`,
+        e,
+      );
+    }
+  }
+  return result;
+}
+
+/** applyReflectionProposals against the live graph. */
+export async function fileReflectionProposals(args: {
+  sessionId: string;
+  repo?: string;
+  proposals: ReflectionProposal[];
+  drafts: ConceptProposal[];
+  known?: ConceptRead[];
+}): Promise<ApplyReflectionResult> {
+  const storage = new GraphStorage();
+  await storage.initialize();
+  return applyReflectionProposals(storage, args);
 }

--- a/mcp/src/repo/session.ts
+++ b/mcp/src/repo/session.ts
@@ -509,8 +509,6 @@ export interface SessionReflection {
   session_id: string;
   updated_at: string;
   concepts: ReflectedConcept[];
-  /** Something the agent had to work out from source that no concept covered. */
-  gap?: string | null;
   /** Raw model output, kept only when it didn't parse into the shape above. */
   raw?: string;
 }
@@ -549,7 +547,6 @@ export function mergeReflection(
   sessionId: string,
   incoming: {
     concepts: ReflectedConcept[];
-    gap?: string | null;
     raw?: string;
   },
 ): SessionReflection {
@@ -603,7 +600,6 @@ export function mergeReflection(
     session_id: sessionId,
     updated_at: new Date().toISOString(),
     concepts,
-    gap: incoming.gap ?? existing?.gap ?? null,
   };
   if (incoming.raw) reflection.raw = incoming.raw;
 


### PR DESCRIPTION
## What

The `reflect=true` post-run step now proposes changes to the Concept knowledge base, replacing the dead-end `gap` field (which was written to the reflection sidecar and consumed by nothing). Proposals land in the existing human-review queue as `ConceptProposal` nodes, stamped `source: "reflection"` and `sessionIds`.

## Design

**No tool call — proposals are parsed from the reflection JSON and filed by deterministic code.** Giving the reflect call a `propose_concept_change` tool would either invalidate the whole cached prompt prefix (tool definitions serialize ahead of everything) or require trusting the model with multi-step dedup. Instead the reflect call stays exactly as it was — single step, "do not call any tools", byte-identical prefix — and everything with side effects is code.

**One evolving draft per (session, target).** Sessions are multi-turn and reflection runs after every turn, so naive filing would produce a sibling proposal per turn. Instead:
- The session's standing pending proposals are embedded in the reflect turn (full documentation included) with revise / keep / withdraw semantics — the conversation has amnesia about prior reflections, so the proposal queue *is* the memory.
- Filing is a create-or-revise upsert keyed on the target concept id (or proposed name, for creates).
- `withdraw: true` rejects the draft with "Withdrawn by session reflection".

**Revision safety.** New `reviseProposal` service path re-validates like `createProposal` and re-snapshots `baseDocs` from the target's *current* docs, so the accept-time staleness check compares against what the revision actually saw. `storage.updateProposal` puts the pending-only guard in the Cypher match and never touches status/decision fields — a reviewer deciding the proposal concurrently always wins (the revision 409s). Evidence (`sessionIds`, `prNumbers`) unions across revisions; TARGETS/EVIDENCE edges are rebuilt since revisions can retarget.

**Prompt gates on durable knowledge.** The bar for filing: knowledge the next agent could NOT cheaply re-derive by reading the code — patterns, best practices, gotchas (conventions spanning files, constraints the code doesn't make obvious). Feature-level detail is explicitly excluded, an empty list is called the expected answer, and every rationale must cite what happened in the session. A verified `contradicts` finding is named as grounds for an update proposal.

`reflect` stays opt-in and its request shape is unchanged. Filing failures are logged and swallowed — they never cost the ranking or the run.

## Changes

- `mcp/src/gitree/service.ts` — extract shared per-action validation; add `reviseProposal` (404 missing / 409 decided / 409 on losing the atomic race)
- `mcp/src/gitree/store/graphStorage.ts` — `updateProposal` (atomic pending-only content revision), shared `writeProposalEdges`
- `mcp/src/repo/concepts.ts` — prompt rewrite; `proposals` parsing; drafts embed in `buildReflectTurn`; `applyReflectionProposals` upsert (with ref_id→gitree-id translation via the run's own reads); `gap` removed
- `mcp/src/repo/agent.ts` — fetch standing drafts before the reflect call, file results after
- `mcp/src/repo/session.ts` — `gap` removed from `SessionReflection` (old sidecar files are ignored, not migrated)
- Tests: proposal parsing, upsert keys, revise/withdraw/session-stamping, baseDocs re-snapshot, atomic mid-revision race, revalidation-without-write

## Testing

- `npm run test:node`: 731 pass
- `tsc --noEmit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)