### PR TITLE
mcp: make gitree Concepts visible to jarvis search

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -81,6 +81,7 @@
     "neo4j-driver": "5.28.3",
     "node-cache": "5.1.2",
     "p-queue": "^6.6.2",
+    "redis": "^6.2.1",
     "simple-git": "3.30.0",
     "tsx": "4.21.0",
     "uuid": "11.1.0",

--- a/mcp/src/gitree/store/graphStorage.ts
+++ b/mcp/src/gitree/store/graphStorage.ts
@@ -13,8 +13,9 @@ import {
   ChronologicalCheckpoint,
   Usage,
 } from "../types.js";
-import { formatPRMarkdown, formatCommitMarkdown, parseRepoFromUrl, computeConceptEmbedding } from "./utils.js";
+import { formatPRMarkdown, formatCommitMarkdown, parseRepoFromUrl, computeConceptEmbedding, conceptEmbeddingText } from "./utils.js";
 import { addUsage, normalizeUsage } from "../../aieo/src/usage.js";
+import { jarvisRedisEnabled, pushJarvisEmbeddingJob } from "./jarvis.js";
 
 const Data_Bank = "Data_Bank";
 
@@ -201,6 +202,10 @@ export class GraphStorage extends Storage {
 
     // Backfill embeddings for concepts created before semantic search existed.
     await this.backfillConceptEmbeddings();
+
+    // Label + queue jarvis text_embeddings for concepts written before the
+    // jarvis interop existed (see jarvis.ts).
+    await this.backfillJarvisConceptInterop();
   }
 
   /**
@@ -272,6 +277,59 @@ export class GraphStorage extends Storage {
       console.log(`[gitree] Backfilled embeddings for ${updated} concept(s).`);
     } catch (error) {
       console.error("[gitree] Error backfilling concept embeddings:", error);
+    } finally {
+      await session.close();
+    }
+  }
+
+  /**
+   * Make pre-existing Concepts visible to jarvis (see jarvis.ts):
+   * apply the Domain_general label so they fall inside jarvis's domain-scoped
+   * vector index, and queue text_embeddings jobs for concepts that lack them.
+   * Runs on every `initialize()`; both steps short-circuit to no-op scans
+   * once the graph is caught up (the embedding step re-queues until jarvis's
+   * worker writes text_embeddings back, which is idempotent).
+   */
+  private async backfillJarvisConceptInterop(): Promise<void> {
+    const session = this.resilientSession();
+    try {
+      const labelResult = await session.run(`
+        MATCH (c:${Data_Bank}:Concept)
+        WHERE NOT c:Domain_general
+        SET c:Domain_general
+      `);
+      const labelsAdded =
+        labelResult.summary.counters.updates().labelsAdded || 0;
+      if (labelsAdded > 0) {
+        console.log(
+          `[gitree] Applied Domain_general label to ${labelsAdded} concept(s).`
+        );
+      }
+
+      if (!jarvisRedisEnabled()) return;
+
+      const pending = await session.run(`
+        MATCH (c:${Data_Bank}:Concept)
+        WHERE c.text_embeddings IS NULL AND c.ref_id IS NOT NULL
+        RETURN c.ref_id AS refId, c.name AS name, c.description AS description
+      `);
+      let queued = 0;
+      for (const record of pending.records) {
+        const text = conceptEmbeddingText({
+          name: record.get("name") || "",
+          description: record.get("description") || "",
+        });
+        if (await pushJarvisEmbeddingJob(record.get("refId"), text)) {
+          queued++;
+        }
+      }
+      if (queued > 0) {
+        console.log(
+          `[gitree] Queued jarvis text_embeddings for ${queued} concept(s).`
+        );
+      }
+    } catch (error) {
+      console.error("[gitree] Error backfilling jarvis concept interop:", error);
     } finally {
       await session.close();
     }
@@ -562,10 +620,11 @@ export class GraphStorage extends Storage {
         );
       }
 
-      await session.run(
+      const result = await session.run(
         `
         MERGE (f:${Data_Bank}:Concept {id: $id})
-        SET f.name = $name,
+        SET f:Domain_general,
+            f.name = $name,
             f.repo = $repo,
             f.description = $description,
             f.embeddings = $embeddings,
@@ -606,6 +665,12 @@ export class GraphStorage extends Storage {
           dateAddedToGraph: now,
         }
       );
+
+      // jarvis's vector search reads text_embeddings, which only its Redis
+      // embedding worker writes — queue a job so this concept shows up there.
+      const savedRefId =
+        result.records[0]?.get("f")?.properties?.ref_id ?? null;
+      await pushJarvisEmbeddingJob(savedRefId, conceptEmbeddingText(concept));
 
       // Create TOUCHES relationships from PRs to this Concept
       // Match PRs by repo-prefixed id or by number+repo combo

--- a/mcp/src/gitree/store/jarvis.ts
+++ b/mcp/src/gitree/store/jarvis.ts
@@ -1,0 +1,88 @@
+import { createClient, RedisClientType } from "redis";
+
+/**
+ * Jarvis interop for Concept nodes.
+ *
+ * Jarvis fetches Concepts through domain-scoped vector indexes
+ * (`FOR (n:Domain_general) ON n.text_embeddings`), while this pipeline writes
+ * `:Data_Bank:Concept` nodes over bolt with its own `embeddings` property.
+ * Two things bridge the gap:
+ *
+ * 1. The `Domain_general` label (applied in saveConcept / backfilled at init)
+ *    puts Concepts inside jarvis's `domain_general_vector_index`.
+ * 2. Jarvis populates `text_embeddings` only via its Redis embedding queue
+ *    (`jarvis:embedding_queue`, drained by run_embedding_worker), so we push
+ *    a job there after each Concept write. The worker matches nodes by
+ *    `(n:Data_Bank {ref_id})` and writes `n.text_embeddings` back.
+ *
+ * `embeddings` (BGE, used by list_concepts / local semantic search) is
+ * untouched — the two embedding spaces coexist on the node.
+ */
+
+export const JARVIS_EMBEDDING_QUEUE = "jarvis:embedding_queue";
+
+// Same shape jarvis's push_embedding_job produces; kind "data_bank" makes the
+// worker write back to n.text_embeddings.
+interface JarvisEmbeddingJob {
+  ref_id: string;
+  text: string;
+  kind: "data_bank";
+}
+
+let clientPromise: Promise<RedisClientType | null> | null = null;
+
+export function jarvisRedisEnabled(): boolean {
+  return !!process.env.REDIS_URL;
+}
+
+async function getClient(): Promise<RedisClientType | null> {
+  if (!jarvisRedisEnabled()) return null;
+  if (!clientPromise) {
+    clientPromise = (async () => {
+      const client: RedisClientType = createClient({
+        url: process.env.REDIS_URL,
+      });
+      // Without a listener, a dropped connection emits an unhandled 'error'
+      // event and crashes the process; reconnects are automatic.
+      client.on("error", (err) =>
+        console.error("[jarvis] Redis client error:", err.message || err)
+      );
+      await client.connect();
+      return client;
+    })().catch((error) => {
+      clientPromise = null; // allow a retry on the next push
+      throw error;
+    });
+  }
+  return clientPromise;
+}
+
+/**
+ * Queue text_embeddings generation for a Concept in jarvis's embedding
+ * worker. Fire-and-forget semantics: never throws, no-ops when REDIS_URL is
+ * unset, logs and moves on when Redis is unreachable.
+ */
+export async function pushJarvisEmbeddingJob(
+  refId: string | null | undefined,
+  text: string
+): Promise<boolean> {
+  if (!jarvisRedisEnabled()) return false;
+  if (!refId || !text.trim()) return false;
+  try {
+    const client = await getClient();
+    if (!client) return false;
+    const job: JarvisEmbeddingJob = {
+      ref_id: refId,
+      text,
+      kind: "data_bank",
+    };
+    await client.rPush(JARVIS_EMBEDDING_QUEUE, JSON.stringify(job));
+    return true;
+  } catch (error: any) {
+    console.error(
+      `[jarvis] Failed to queue embedding job for ref_id=${refId}:`,
+      error.message || error
+    );
+    return false;
+  }
+}

--- a/mcp/yarn.lock
+++ b/mcp/yarn.lock
@@ -1723,6 +1723,33 @@
     unbzip2-stream "^1.4.3"
     yargs "^17.7.2"
 
+"@redis/bloom@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@redis/bloom/-/bloom-6.2.1.tgz#9aaffd5f51595fc4ff5bcd62ce9a31da82ce5cf4"
+  integrity sha512-huQgNLaCIZfQ9SeLn4q9124uOUd8HbZDYHwwUzNcRgHqCHiHKl2dDxMqJCeWh8cMqZAoWuHR8XnWbDMIf+o7ag==
+
+"@redis/client@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@redis/client/-/client-6.2.1.tgz#202d6c6bc88f1ed791fc50604d6d792ddf75438b"
+  integrity sha512-LzxBY7SIBvvJiyCgcaJZZakE3fJrZZ++i24+EDW9fKpCl68D35uJcKFpZZwCfOoG9WZTbyZlMzMeM0gtOAMU9Q==
+  dependencies:
+    cluster-key-slot "1.1.2"
+
+"@redis/json@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@redis/json/-/json-6.2.1.tgz#1861fe4b3522b845fd29094f40e0bbb5907bcb00"
+  integrity sha512-AFIUJ8Gj0DaaSBHYuSt8+O0oYWM+50OK1c0OmodB7XERIA8+BbyV3O4v76f9iccWasd1/7qjfZTpuzexUaZtrQ==
+
+"@redis/search@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@redis/search/-/search-6.2.1.tgz#0c83c6611dc387fde102828bd200cd5d459f4be9"
+  integrity sha512-2vfOAOyYFE7UUw3sBBlkqqruBtOUS4HRY5MtW4hp83llrwvtrTE4r22CEqXddlV+54zkLxBE4nmsIJ/dpezQrQ==
+
+"@redis/time-series@6.2.1":
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/@redis/time-series/-/time-series-6.2.1.tgz#0e3d9ae4563714491e7a6516165f037833f3cd36"
+  integrity sha512-kiYniph04dJOole+L359B6C9E+jYS2uDP7hca6Onj0xF38ZIpyxARO0Iq0W4ZRn1e8Q6vqW00QFZVSMRA/2Ijw==
+
 "@rollup/rollup-android-arm-eabi@4.57.1":
   version "4.57.1"
   resolved "https://registry.yarnpkg.com/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.57.1.tgz#add5e608d4e7be55bc3ca3d962490b8b1890e088"
@@ -2986,6 +3013,11 @@ clone@2.x:
   version "2.1.2"
   resolved "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz"
   integrity sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w==
+
+cluster-key-slot@1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/cluster-key-slot/-/cluster-key-slot-1.1.2.tgz#88ddaa46906e303b5de30d3153b7d9fe0a0c19ac"
+  integrity sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==
 
 color-convert@^2.0.1:
   version "2.0.1"
@@ -5434,6 +5466,17 @@ real-require@^0.2.0:
   version "0.2.0"
   resolved "https://registry.npmjs.org/real-require/-/real-require-0.2.0.tgz"
   integrity sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==
+
+redis@^6.2.1:
+  version "6.2.1"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-6.2.1.tgz#8f5f2aff8e59b57d169a6a03416cc90a1f0a9a5c"
+  integrity sha512-Z9VHtgYs48PiQC77X9O2Er8Hj4T+5BtFjT91/vi5Is1D04N72cA946ZslM1ImJw8ZctFBZWAVjM7S5wJNeHMpg==
+  dependencies:
+    "@redis/bloom" "6.2.1"
+    "@redis/client" "6.2.1"
+    "@redis/json" "6.2.1"
+    "@redis/search" "6.2.1"
+    "@redis/time-series" "6.2.1"
 
 require-directory@^2.1.1:
   version "2.1.1"


### PR DESCRIPTION
## Problem

Jarvis fetches Concepts through domain-scoped vector indexes (`FOR (n:Domain_general) ON n.text_embeddings`), but gitree writes bare `:Data_Bank:Concept` nodes directly over bolt. Jarvis's own migration 108 docs call this out as known drift:

- **No domain label** — concepts are invisible to jarvis's domain-scoped search until its next boot, when `ensure_concept_domain_labels_on_startup` re-labels them.
- **No `text_embeddings`** — jarvis only populates that property via its Redis embedding queue, which gitree never fed. Stakgraph-written concepts were *never* semantically searchable in jarvis (only fulltext).

## Fix (at the GraphStorage choke point, so every writer gets it)

- `saveConcept` applies the `Domain_general` label in the same MERGE, so new/updated concepts land inside `domain_general_vector_index` immediately.
- After each save, a `{ref_id, text, kind: "data_bank"}` job is pushed onto `jarvis:embedding_queue` (new `mcp/src/gitree/store/jarvis.ts`, guarded by `REDIS_URL`) — jarvis's worker MiniLM-encodes it and writes `text_embeddings` back matching `(n:Data_Bank {ref_id})`. The text is the same name + description gitree embeds locally. Fire-and-forget: no `REDIS_URL` or Redis down just logs and moves on; concept writes can't fail on jarvis plumbing.
- `initialize()` gains `backfillJarvisConceptInterop()`: labels existing concepts missing `Domain_general`, and queues embedding jobs for concepts where `text_embeddings IS NULL`. Both are no-op scans once caught up.

The local BGE `embeddings` property (used by `list_concepts` / local semantic search) is untouched — the two embedding spaces coexist on the node.

## Notes

- `REDIS_URL` must point at the same Redis jarvis uses (plain host/port, db 0, e.g. `redis://localhost:6379`). Without it the label fix still applies; only the embedding push is skipped.
- Adds `redis@^6` to mcp dependencies (lockfile additions only).
- The lab copy at `mcp/src/lab/concepts/store/graphStorage.ts` was intentionally left alone.

## Testing

- `tsc --noEmit` clean
- All 37 gitree tests pass (`NO_DB=true tsx --test "src/gitree/**/*.test.ts"`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)