### PR TITLE
mcp: optional allow_scratchpad on create_node, create_triplet, create_batch_triplet

### DIFF
--- a/mcp/src/repo/toolsJarvis.ts
+++ b/mcp/src/repo/toolsJarvis.ts
@@ -1338,6 +1338,14 @@ function registerGraphWriteTools(
         .describe(
           "Jarvis namespace (data partition) for inline node creation. Not an access-control boundary.",
         ),
+      allow_scratchpad: z
+        .boolean()
+        .optional()
+        .describe(
+          "Opt in to Jarvis's scratchpad fallback: when a node write is rejected (unknown node type, " +
+          "data that fails schema validation) the payload is preserved as a ScratchpadEntry instead of " +
+          "returning a 400, and the response comes back with status \"scratchpad\". Off by default.",
+        ),
     }),
     execute: async (input: {
       source_ref_id?: string;
@@ -1351,6 +1359,7 @@ function registerGraphWriteTools(
       weight?: number;
       create_schema_if_missing?: boolean;
       namespace?: string;
+      allow_scratchpad?: boolean;
     }) => {
       const {
         source_ref_id,
@@ -1364,6 +1373,7 @@ function registerGraphWriteTools(
         weight,
         create_schema_if_missing = false,
         namespace,
+        allow_scratchpad,
       } = input;
 
       for (const err of [
@@ -1394,6 +1404,7 @@ function registerGraphWriteTools(
         const res = await jarvisMutate("post", url, jarvisHeaders, {
           node_type: nodeType,
           node_data: nodeData,
+          ...(allow_scratchpad ? { allow_scratchpad: true } : {}),
         }, reqOpts);
         let body: any;
         try {
@@ -1424,6 +1435,7 @@ function registerGraphWriteTools(
           source: { ref_id: sourceRef },
           target: { ref_id: targetRef },
           create_schema_if_missing,
+          ...(allow_scratchpad ? { allow_scratchpad: true } : {}),
         }, reqOpts);
         let body: any;
         try {
@@ -1551,6 +1563,14 @@ function registerGraphWriteTools(
           "later in this session (e.g. to update or delete an individual edge). Leaving it off " +
           "keeps results small, which matters because every tool result stays in context.",
         ),
+      allow_scratchpad: z
+        .boolean()
+        .optional()
+        .describe(
+          "Opt in to Jarvis's scratchpad fallback: when a node write is rejected (unknown node type, " +
+          "data that fails schema validation) the payload is preserved as a ScratchpadEntry instead of " +
+          "returning a 400, and the response comes back with status \"scratchpad\". Off by default.",
+        ),
     }),
     execute: async (input: {
       triplets: Array<{
@@ -1567,8 +1587,9 @@ function registerGraphWriteTools(
       }>;
       namespace?: string;
       return_edge_ids?: boolean;
+      allow_scratchpad?: boolean;
     }) => {
-      const { triplets, namespace, return_edge_ids = false } = input;
+      const { triplets, namespace, return_edge_ids = false, allow_scratchpad } = input;
       console.log(
         `[create_batch_triplet] count=${triplets.length} namespace=${namespace ?? "-"}`,
       );
@@ -1632,6 +1653,7 @@ function registerGraphWriteTools(
           const res = await jarvisMutate("post", url, jarvisHeaders, {
             node_type: nodeType,
             node_data: nodeData,
+            ...(allow_scratchpad ? { allow_scratchpad: true } : {}),
           }, reqOpts);
           let body: any;
           try {
@@ -1732,6 +1754,7 @@ function registerGraphWriteTools(
           source: { ref_id: rt.source_ref_id },
           target: { ref_id: rt.target_ref_id },
           create_schema_if_missing: rt.create_schema_if_missing,
+          ...(allow_scratchpad ? { allow_scratchpad: true } : {}),
         }));
 
         const edgeParams = new URLSearchParams();
@@ -1781,6 +1804,7 @@ function registerGraphWriteTools(
               source: { ref_id: rt.source_ref_id },
               target: { ref_id: rt.target_ref_id },
               create_schema_if_missing: rt.create_schema_if_missing,
+              ...(allow_scratchpad ? { allow_scratchpad: true } : {}),
             }, reqOpts);
             let body: any;
             try {
@@ -1883,13 +1907,22 @@ function registerGraphWriteTools(
         .describe(
           "Jarvis namespace (data partition) to create the node in. Not an access-control boundary.",
         ),
+      allow_scratchpad: z
+        .boolean()
+        .optional()
+        .describe(
+          "Opt in to Jarvis's scratchpad fallback: when a node write is rejected (unknown node type, " +
+          "data that fails schema validation) the payload is preserved as a ScratchpadEntry instead of " +
+          "returning a 400, and the response comes back with status \"scratchpad\". Off by default.",
+        ),
     }),
     execute: async (input: {
       node_type: string;
       node_data: Record<string, any>;
       namespace?: string;
+      allow_scratchpad?: boolean;
     }) => {
-      const { node_type, node_data, namespace } = input;
+      const { node_type, node_data, namespace, allow_scratchpad } = input;
       console.log(`[create_node] type=${node_type} namespace=${namespace ?? "-"}`);
       try {
         const params = new URLSearchParams();
@@ -1899,6 +1932,7 @@ function registerGraphWriteTools(
         const res = await jarvisMutate("post", url, jarvisHeaders, {
           node_type,
           node_data,
+          ...(allow_scratchpad ? { allow_scratchpad: true } : {}),
         }, reqOpts);
         let body: any;
         try {


### PR DESCRIPTION
Threads Jarvis's existing per-request `allow_scratchpad` opt-in through the three graph write tools in `mcp/src/repo/toolsJarvis.ts`, so a write Jarvis would reject (unknown node type, data that fails schema validation) is preserved as a `ScratchpadEntry` instead of returning a plain 400.

Minimal replacement for #1597, which rewrote result assembly, logging and edge matching for behavior Jarvis already governs server-side.

## Where the flag goes (per the Jarvis source)

- **Nodes** — `api/helper/schema_node_helper.py`: `allow_scratchpad = bool(data.get("allow_scratchpad", False))`, read at the **top level** of the `POST /v2/nodes` body (sibling of `node_data`). It gates only the two reject paths. On fallback Jarvis returns HTTP 200 with `status: "scratchpad"` and `data.ref_id` set to the entry's ref_id.
- **Edges** — `api/service/node_service.py`: `data.get("allow_scratchpad") or data["edge"].get("allow_scratchpad")` on `POST /v2/edges`; same read per item in `node_service_v2.bulk_create_edges_v2`. Only relevant to entry→entry edges — a canonical node pointing at an entry is refused either way.

## What changed

One optional `allow_scratchpad: z.boolean().optional()` input on `create_node`, `create_triplet` and `create_batch_triplet` (a single top-level flag for the batch, applying to all items), spread as `...(allow_scratchpad ? { allow_scratchpad: true } : {})` into the six request bodies:

- the node create in each of the three tools
- the `/v2/edges` body in `create_triplet`
- both batch edge-write sites — bulk `edgeList` items and the single-object fallback loop

No helper rewrites, no response reshaping, no new logging. `create_node` already returns `status: body?.status ?? "Success"`, so `"scratchpad"` surfaces on its own; edge legality stays Jarvis's call. With the flag absent, every request body is byte-identical to today.

## Tests

`tsc --noEmit` clean. `mcp/src/repo/__tests__/toolsJarvis.test.ts` — 110/110 pass, unmodified.

Not yet exercised against a live Jarvis; worth one probe post-merge to confirm the ScratchpadEntry schema is seeded in the target environment (migration 099):

```bash
curl -sS -X POST "$JARVIS_URL/v2/nodes" -H "Content-Type: application/json" -H "X-Api-Token: $API_TOKEN" \
  -d '{"node_type":"DefinitelyNotARealNodeType","node_data":{"name":"probe"},"allow_scratchpad":true}'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)