### PR TITLE
gaia: HF_TOKEN is required — drop the anonymous bootstrap pathway

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -68,13 +68,14 @@ ENV PATH="/usr/src/agent-venv/bin:$PATH"
 # NOTE (lab / GAIA): the dataset is deliberately NOT baked into the image —
 # GAIA's terms forbid resharing it outside a gated/private repo, and a
 # published image is neither. It is fetched at runtime by
-# src/lab/gaia/bootstrap.ts, which needs NO required env vars.
+# src/lab/gaia/bootstrap.ts.
 #
-# HF_TOKEN is OPTIONAL: HF currently serves this repo's git endpoints
-# anonymously, so a cold bootstrap works with no credentials. Set it anyway if
-# you have one (no username needed — HF takes the token as the password with
-# any username); bootstrap attaches it when present and the failure path names
-# it if access is ever refused.
+# HF_TOKEN is REQUIRED at runtime: the dataset is gated and the fetch is
+# refused without credentials (anonymous `git ls-remote` succeeding against
+# the repo is a red herring — `git-upload-pack` is what's gated). Supply a
+# READ token from an account that has accepted GAIA's terms; no username is
+# needed (HF takes the token as the password with any username). Only a
+# pre-populated checkout mounted at GAIA_DIR removes the need for it.
 #
 # GAIA_PYTHON is unnecessary here: the agent venv above is first on PATH and
 # carries the numpy the scorer needs. GAIA_SCORER_SHA256 is unnecessary too —

--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -422,8 +422,8 @@ grader AND the gold live in the in-code `gaia` service (`gaia/service.ts`,
 on the `LabServices` bag), never in a seeded/authored step. `gaia/*` steps
 (authored by the assistant) are thin plumbing over `ctx.services.gaia.*`.
 
-- **Setup**: automatic (`gaia/bootstrap.ts`) — **zero required env vars**.
-  First use materialises the dataset into `<cache>/vein/gaia`, installs the
+- **Setup**: automatic (`gaia/bootstrap.ts`) — the one required env var is
+  **`HF_TOKEN`**. First use materialises the dataset into `<cache>/vein/gaia`, installs the
   leaderboard Space's `scorer.py` (verified against the in-repo
   `SCORER_SHA256`), and resolves a numpy-capable python: `python3` in the prod
   image (the agent venv is on PATH), else a cached venv built on demand.
@@ -434,18 +434,17 @@ on the `LabServices` bag), never in a seeded/authored step. `gaia/*` steps
   init → `fetch --depth 1 <pinned sha>` → `checkout FETCH_HEAD` against
   `897f2dfb`, the last revision with the full benchmark (165 validation +
   300 test rows), which is also what every score so far was graded against.
-- **`HF_TOKEN` is OPTIONAL.** HF currently serves this repo's git endpoints
-  anonymously (its `resolve` HTTP endpoint returns 401, but git-upload-pack
-  and LFS do not) — a cold bootstrap succeeds with no credentials at all. A
-  token is attached whenever one is set, since that can change; no username is
-  needed (HF takes the token as the password with any username). If access is
-  ever refused the error names `HF_TOKEN` and the un-automatable
-  accept-the-terms click-through.
+- **`HF_TOKEN` is REQUIRED for a cold bootstrap.** The dataset is gated:
+  anonymous `ls-remote` answers (which makes the repo look open), but the
+  actual `git-upload-pack` fetch is refused without credentials. Bootstrap
+  fails fast — before any subprocess — when no token is set. No username is
+  needed (HF takes the token as the password with any username); the token
+  reaches git via an env-reading credential helper, never `.git/config` or
+  argv. An already-populated checkout needs no token.
 - **git-lfs is required**: GAIA's attachments are LFS-backed and a checkout
   without it silently yields ~130-byte pointer stubs. Checked before fetching
   and detected after.
-- Overrides, all optional: `GAIA_DIR`, `VEIN_CACHE_DIR`, `HF_TOKEN`,
-  `GAIA_PYTHON`, `GAIA_SCORER_SHA256`, `GAIA_AUTO_SETUP=0`. The dataset is NOT
+- Overrides, all optional: `GAIA_DIR`, `VEIN_CACHE_DIR`, `GAIA_PYTHON`, `GAIA_SCORER_SHA256`, `GAIA_AUTO_SETUP=0`. The dataset is NOT
   baked into the image (the terms forbid resharing outside a gated/private
   repo); mount a volume at the cache dir in prod.
 - **Integrity invariant** (per grade): dataset checkout must be a CLEAN git
@@ -460,7 +459,8 @@ on the `LabServices` bag), never in a seeded/authored step. `gaia/*` steps
   `score()` subprocess reads it. Never grant a scoring step to the
   producing agent's `agentTools`.
 - `smoke.ts` — offline integrity paths + the real python driver against a
-  stub scorer, plus the bootstrap paths (no token / no git-lfs / gated 403 /
+  stub scorer, plus the bootstrap paths (missing-token fail-fast / no
+  git-lfs / gated 403 /
   scorer-hash mismatch / LFS pointer stubs / idempotent re-entry / half-written
   checkout) with `exec` and `fetchText` faked (`npx tsx src/lab/gaia/smoke.ts`).
 

--- a/mcp/src/lab/gaia/bootstrap.ts
+++ b/mcp/src/lab/gaia/bootstrap.ts
@@ -44,13 +44,16 @@ import { join, resolve, dirname } from "node:path";
  * has already accepted; a 403 on clone means it has not, and the error below
  * says exactly that.
  *
- * Config (env), all optional:
- *   HF_TOKEN            — (or HUGGING_FACE_HUB_TOKEN / HF_API_TOKEN) a READ
- *                         token. Optional in practice — HF currently serves
- *                         this repo's git endpoints anonymously — but used
- *                         whenever set, since that can change. No username
- *                         is needed: HF takes the token as the password
- *                         with any username.
+ * Config (env):
+ *   HF_TOKEN            — REQUIRED for a cold bootstrap (or
+ *                         HUGGING_FACE_HUB_TOKEN / HF_API_TOKEN): a READ
+ *                         token from an account that has accepted GAIA's
+ *                         terms. No username is needed — HF takes the token
+ *                         as the password with any username. An
+ *                         already-populated checkout is used as-is, no
+ *                         token needed.
+ *
+ *   The rest, all optional:
  *   GAIA_DIR            — pin the checkout location; defaults to
  *                         <cache>/vein/gaia
  *   VEIN_CACHE_DIR      — cache root override (else XDG_CACHE_HOME, else
@@ -127,7 +130,8 @@ export type FetchTextFn = (url: string) => Promise<string>;
 export interface EnsureGaiaOptions {
   /** Target checkout dir. Defaults to env GAIA_DIR, else <cache>/vein/gaia. */
   dir?: string;
-  /** HF token. Defaults to HF_TOKEN / HUGGING_FACE_HUB_TOKEN / HF_API_TOKEN. */
+  /** HF token; REQUIRED whenever a clone is needed. Defaults to HF_TOKEN /
+   *  HUGGING_FACE_HUB_TOKEN / HF_API_TOKEN. */
   hfToken?: string;
   /** Set false (or GAIA_AUTO_SETUP=0) to require a pre-populated GAIA_DIR. */
   autoSetup?: boolean;
@@ -288,20 +292,20 @@ async function installScorer(
  * `checkout FETCH_HEAD`. HF's git server allows fetching an arbitrary SHA,
  * and the shallow fetch keeps this to one revision (~210MB with LFS).
  *
- * The token, WHEN PRESENT, reaches git through a one-shot inline credential
- * helper reading it from the CHILD ENV: it is never written to `.git/config`
+ * The token reaches git through a one-shot inline credential helper
+ * reading it from the CHILD ENV: it is never written to `.git/config`
  * (which a plain `https://user:token@…` remote would do, persisting a live
  * credential inside the checkout) and never appears in argv (visible to any
  * `ps` on the host). HF accepts any username with the token as the password,
  * so the username is a constant.
  *
- * The token is OPTIONAL: this repo's git endpoints currently serve anonymous
- * fetches even though its `resolve` HTTP endpoint returns 401. That may
- * change without notice, so a token is used whenever one is configured.
+ * The token is REQUIRED: the dataset is gated. Do not be fooled by anonymous
+ * `git ls-remote` succeeding against this repo — HF answers `info/refs`
+ * without credentials, but refuses the actual `git-upload-pack` fetch.
  */
 async function cloneDataset(
   target: string,
-  token: string | undefined,
+  token: string,
   exec: BootstrapExecFn,
   log: (m: string) => void,
 ): Promise<void> {
@@ -310,21 +314,17 @@ async function cloneDataset(
   const staging = `${target}.partial`;
   await rm(staging, { recursive: true, force: true });
 
-  log(
-    `gaia: fetching ${DATASET_REPO} @ ${DATASET_REV.slice(0, 12)} (~210MB with LFS) → ${target}` +
-      (token ? "" : " [anonymous — no HF token configured]"),
-  );
+  log(`gaia: fetching ${DATASET_REPO} @ ${DATASET_REV.slice(0, 12)} (~210MB with LFS) → ${target}`);
   await mkdir(staging, { recursive: true });
 
-  // Token, when present, is supplied by an env-reading helper; no token means
-  // a plain anonymous fetch. GIT_TERMINAL_PROMPT=0 keeps a credential prompt
-  // from hanging a headless container forever.
+  // The token is supplied by an env-reading helper. GIT_TERMINAL_PROMPT=0
+  // keeps a credential prompt from hanging a headless container forever.
   const helper = '!f() { echo "username=hf"; echo "password=$GAIA_HF_TOKEN"; }; f';
-  const auth = token ? ["-c", `credential.helper=${helper}`] : [];
+  const auth = ["-c", `credential.helper=${helper}`];
   const env: NodeJS.ProcessEnv = {
     ...process.env,
     GIT_TERMINAL_PROMPT: "0",
-    ...(token ? { GAIA_HF_TOKEN: token } : {}),
+    GAIA_HF_TOKEN: token,
   };
 
   const steps: Array<{ args: string[]; timeoutMs: number }> = [
@@ -348,17 +348,14 @@ async function cloneDataset(
     // "expected 'packfile'". Match all of them, or a gated failure gets
     // reported as a generic git error and the operator has nothing to act on.
     const denied =
-      /40[13]|forbidden|unauthor|restricted|gated|please log in|expected 'packfile'|could not fetch/i.test(
+      /40[13]|forbidden|unauthor|restricted|gated|please log in|expected 'packfile'|could not read username|could not fetch/i.test(
         tail,
       );
     throw new Error(
       denied
-        ? `gaia: access to the dataset was refused${token ? " with the configured HF token" : " (no HF token configured)"}. ` +
-          (token
-            ? `The owning account has probably not accepted GAIA's terms — that click-through cannot be automated. ` +
-              `Visit ${DATASET_REPO}, accept, then retry.`
-            : `Set HF_TOKEN to a read token from an account that has accepted GAIA's terms at ${DATASET_REPO}.`) +
-          `\n${tail}`
+        ? `gaia: access to the dataset was refused with the configured HF token. Either it is not a valid ` +
+          `READ token, or its account has not accepted GAIA's terms — that click-through cannot be ` +
+          `automated. Visit ${DATASET_REPO}, accept, then retry.\n${tail}`
         : `gaia: git ${step.args.filter((a) => a !== "-c" && !a.startsWith("credential.")).join(" ")} failed (exit ${res.code}).\n${tail}`,
     );
   }
@@ -417,10 +414,16 @@ export async function ensureGaiaDataset(
       );
     }
 
-    // Optional: HF currently serves this repo's git endpoints anonymously.
-    // Used when configured, and the failure path above tells the operator to
-    // set it if access is ever refused.
+    // Required: the dataset is gated. Fail here — before any subprocess —
+    // with the fix in hand, rather than letting git discover it obliquely.
     const token = resolveToken(opts.hfToken);
+    if (!token) {
+      throw new Error(
+        `gaia: HF_TOKEN is not set, and ${root} holds no GAIA checkout to fall back on. The dataset ` +
+          `is gated — set HF_TOKEN (or HUGGING_FACE_HUB_TOKEN / HF_API_TOKEN) to a READ token from ` +
+          `an account that has accepted GAIA's terms at ${DATASET_REPO}.`,
+      );
+    }
 
     await assertGitLfs(exec, dirname(root));
 

--- a/mcp/src/lab/gaia/service.ts
+++ b/mcp/src/lab/gaia/service.ts
@@ -33,11 +33,13 @@ import { ensureGaiaDataset, ensureGaiaPython, SCORER_SHA256 } from "./bootstrap.
  * image numpy is already on PATH via /usr/src/agent-venv, so a deployment
  * needs exactly one variable — HF_TOKEN.
  *
- * Config (env), all optional:
- *   HF_TOKEN           — read access to the gated dataset (or
- *                        HUGGING_FACE_HUB_TOKEN / HF_API_TOKEN). The owning
- *                        account must have accepted GAIA's terms on the HF
- *                        website; that click-through cannot be automated.
+ * Config (env):
+ *   HF_TOKEN           — REQUIRED for a cold start (or HUGGING_FACE_HUB_TOKEN
+ *                        / HF_API_TOKEN): read access to the gated dataset.
+ *                        The owning account must have accepted GAIA's terms on
+ *                        the HF website; that click-through cannot be
+ *                        automated. Only an already-populated checkout
+ *                        removes the need for it. The rest are optional:
  *   GAIA_DIR           — pin the checkout location (default <cache>/vein/gaia)
  *   GAIA_SCORER_SHA256 — override the in-repo scorer pin (SCORER_SHA256)
  *   GAIA_PYTHON        — python interpreter (default "python3"; needs numpy)

--- a/mcp/src/lab/gaia/smoke.ts
+++ b/mcp/src/lab/gaia/smoke.ts
@@ -176,8 +176,8 @@ async function bootstrapSmoke(): Promise<void> {
             ? { code: 1, stdout: "", stderr: "git: 'lfs' is not a git command" }
             : { code: 0, stdout: "git-lfs/3.4.0\n", stderr: "" };
         }
-        // Record whether a credential helper was attached, so the token-optional
-        // behaviour is asserted rather than assumed.
+        // Record whether a credential helper was attached, so the token's
+        // delivery to git is asserted rather than assumed.
         if (opts.seenAuth && args.includes("fetch")) {
           opts.seenAuth.push(args.some((a) => a.startsWith("credential.helper=")) ? "auth" : "anon");
         }
@@ -202,18 +202,22 @@ async function bootstrapSmoke(): Promise<void> {
       };
     const fetchStub = async () => STUB_SCORER;
 
-    // ── NO token is fine: HF serves this repo's git endpoints anonymously ──
+    // ── NO token fails FAST, before any subprocess: the dataset is gated.
+    //    (hfToken: "" pins the no-token path even when HF_TOKEN is in env.) ──
     resetGaiaBootstrap();
-    const anon: string[] = [];
-    const anonDir = join(box, "anon");
-    const okAnon = await ensureGaiaDataset({
-      dir: anonDir, hfToken: "", exec: fakeExec({ seenAuth: anon }),
-      fetchText: fetchStub, scorerSha256: STUB_SHA, log,
-    });
-    assert.equal(okAnon.root, anonDir);
-    assert.deepEqual(anon, ["anon"], "fetched with a credential helper despite no token");
+    let sawExec = 0;
+    await assert.rejects(
+      () =>
+        ensureGaiaDataset({
+          dir: join(box, "anon"), hfToken: "",
+          exec: async () => { sawExec += 1; return { code: 0, stdout: "", stderr: "" }; },
+          fetchText: fetchStub, scorerSha256: STUB_SHA, log,
+        }),
+      /HF_TOKEN is not set[\s\S]*accepted GAIA's terms/,
+    );
+    assert.equal(sawExec, 0, "missing-token fail-fast still shelled out");
 
-    // ── a token, when present, IS attached to the fetch ──
+    // ── the token reaches the fetch via the credential helper ──
     resetGaiaBootstrap();
     const withTok: string[] = [];
     await ensureGaiaDataset({
@@ -227,27 +231,27 @@ async function bootstrapSmoke(): Promise<void> {
     await assert.rejects(
       () =>
         ensureGaiaDataset({
-          dir: join(box, "b"), exec: fakeExec({ lfs: false }), fetchText: fetchStub, log,
+          dir: join(box, "b"), hfToken: "hf_xxx", exec: fakeExec({ lfs: false }), fetchText: fetchStub, log,
         }),
       /git-lfs is required/,
     );
 
-    // ── HF's opaque gated failure ("expected 'packfile'") is recognised and,
-    //    with no token configured, the message points at HF_TOKEN ──
+    // ── HF's opaque gated failure ("expected 'packfile'") is recognised as
+    //    a refusal and blames the un-automatable click-through ──
     resetGaiaBootstrap();
     const gated = join(box, "c");
     await assert.rejects(
       () =>
         ensureGaiaDataset({
-          dir: gated, hfToken: "",
+          dir: gated, hfToken: "hf_xxx",
           exec: fakeExec({ fetchErr: "fatal: expected 'packfile'" }),
           fetchText: fetchStub, log,
         }),
-      /refused \(no HF token configured\)[\s\S]*Set HF_TOKEN/,
+      /refused with the configured HF token[\s\S]*accepted GAIA's terms/,
     );
     assert.ok(!existsSync(`${gated}.partial`), "staging dir left behind after a failed fetch");
 
-    // ── same failure WITH a token blames the un-automatable click-through ──
+    // ── the prose variant of the same refusal is recognised too ──
     resetGaiaBootstrap();
     await assert.rejects(
       () =>
@@ -266,7 +270,7 @@ async function bootstrapSmoke(): Promise<void> {
     await assert.rejects(
       () =>
         ensureGaiaDataset({
-          dir: nometa, exec: fakeExec({ noMeta: true }), fetchText: fetchStub,
+          dir: nometa, hfToken: "hf_xxx", exec: fakeExec({ noMeta: true }), fetchText: fetchStub,
           scorerSha256: STUB_SHA, log,
         }),
       /no 2023.*metadata\.jsonl[\s\S]*DATASET_REV/,
@@ -279,7 +283,7 @@ async function bootstrapSmoke(): Promise<void> {
     await assert.rejects(
       () =>
         ensureGaiaDataset({
-          dir: mism, exec: fakeExec(), fetchText: fetchStub, scorerSha256: "a".repeat(64), log,
+          dir: mism, hfToken: "hf_xxx", exec: fakeExec(), fetchText: fetchStub, scorerSha256: "a".repeat(64), log,
         }),
       /refusing to install/,
     );
@@ -290,7 +294,7 @@ async function bootstrapSmoke(): Promise<void> {
     await assert.rejects(
       () =>
         ensureGaiaDataset({
-          dir: join(box, "e"), exec: fakeExec({ lfsPointers: true }),
+          dir: join(box, "e"), hfToken: "hf_xxx", exec: fakeExec({ lfsPointers: true }),
           fetchText: fetchStub, scorerSha256: STUB_SHA, log,
         }),
       /unresolved git-lfs pointers/,
@@ -300,14 +304,15 @@ async function bootstrapSmoke(): Promise<void> {
     resetGaiaBootstrap();
     const ok = join(box, "f");
     const res = await ensureGaiaDataset({
-      dir: ok, exec: fakeExec(), fetchText: fetchStub, scorerSha256: STUB_SHA, log,
+      dir: ok, hfToken: "hf_xxx", exec: fakeExec(), fetchText: fetchStub, scorerSha256: STUB_SHA, log,
     });
     assert.equal(res.root, ok);
     assert.ok(existsSync(join(ok, "2023", "validation", "metadata.jsonl")));
     assert.equal(readFileSync(join(ok, "scorer.py"), "utf-8"), STUB_SCORER);
     assert.ok(!existsSync(`${ok}.partial`), "staging dir survived a successful fetch");
 
-    // ── idempotent: a populated dir short-circuits without touching git ──
+    // ── idempotent: a populated dir short-circuits without touching git —
+    //    and needs NO token (hfToken: "" proves the tokenless hot path) ──
     resetGaiaBootstrap();
     let execCalls = 0;
     const counting: BootstrapExecFn = async () => {
@@ -315,7 +320,7 @@ async function bootstrapSmoke(): Promise<void> {
       return { code: 0, stdout: "", stderr: "" };
     };
     const again = await ensureGaiaDataset({
-      dir: ok, exec: counting,
+      dir: ok, hfToken: "", exec: counting,
       fetchText: async () => { throw new Error("must not refetch scorer"); },
       scorerSha256: STUB_SHA, log,
     });
@@ -328,7 +333,7 @@ async function bootstrapSmoke(): Promise<void> {
     mkdirSync(partial, { recursive: true });
     writeFileSync(join(partial, "scorer.py"), STUB_SCORER); // scorer but no .git/meta
     const healed = await ensureGaiaDataset({
-      dir: partial, exec: fakeExec(), fetchText: fetchStub, scorerSha256: STUB_SHA, log,
+      dir: partial, hfToken: "hf_xxx", exec: fakeExec(), fetchText: fetchStub, scorerSha256: STUB_SHA, log,
     });
     assert.equal(healed.root, partial);
     assert.ok(existsSync(join(partial, "2023", "validation", "metadata.jsonl")));


### PR DESCRIPTION
Corrects the central claim of #1599: **"HF_TOKEN is optional" was wrong.** The dataset is gated, and a cold bootstrap without a token fails.

## How the false negative happened

The verification for #1599 ran on a dev machine with `credential.helper=osxkeychain` holding a saved `huggingface.co` credential. git consulted it silently, so "cold bootstrap with `HF_TOKEN` unset" was in fact an authenticated fetch. Reproduced both ways on the same host: default helpers → fetch succeeds; `git -c credential.helper=` → `fatal: could not read Username for 'https://huggingface.co'`.

What made it believable: anonymous `git ls-remote` genuinely works against this repo (`info/refs` is served without credentials, and `resolve/...` 401s — the endpoint inconsistency is real). But `git-upload-pack`, the actual fetch, is gated.

Verified in a clean container (published `v0.4.225-arm64` image):

| | result |
| --- | --- |
| pinned fetch of gated GAIA, no token | ❌ `could not read Username` |
| clone of a public HF LFS repo, no token | ✅ real bytes, no pointer stubs |

The public-repo control rules out network/egress — it is the gating. (That run also closed #1599's one open item: `git lfs install --system` is wired in the shipped image and the smudge filter resolves real files.)

## What changed

One pathway, as small as it can be:

- **Missing token fails fast** — before any subprocess — naming `HF_TOKEN` (and its aliases) and the un-automatable accept-the-terms click-through. Previously this exact case fell through to the *generic* git-error branch: `could not read Username` matched nothing in the denied-regex, so the one failure the guidance was written for never showed it.
- **The conditional-auth machinery is gone**: the credential helper is always attached (unchanged mechanism — token via child env, never `.git/config`, never argv), the refusal message has a single branch, and the `[anonymous — no HF token configured]` log suffix is deleted.
- The denied-regex learns `could not read username`, so even a future regression in token plumbing reports as a refusal instead of a generic git error.
- An **already-populated checkout still needs no token** — the hot path returns before the check, so a mounted `GAIA_DIR` volume works credential-less as before.
- Docs (`Dockerfile`, `AGENTS.md`, `service.ts`, `bootstrap.ts` headers) all now say REQUIRED, with a note about the `ls-remote` red herring so the next person isn't fooled the same way.

## Smokes

`npx tsx src/lab/gaia/smoke.ts` — all pass, `tsc --noEmit` clean.

- The anonymous-success scenario is replaced by a fail-fast assertion: no token → rejects naming `HF_TOKEN`, with **zero** subprocesses spawned.
- Both gated-refusal scenarios (`expected 'packfile'` and the `restricted… Please log in` prose) now run with a token and assert the click-through guidance; the staging-dir-cleanup assertion is kept.
- The idempotent scenario passes `hfToken: ""` explicitly, proving the tokenless populated-checkout path.
- All scenarios that reach the clone path supply a token, as reality now demands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)