### PR TITLE
vein: meta/* steps + services.authoring — close the layer-3 gap

### DIFF
--- a/vein/EVOLVE_SPEC.md
+++ b/vein/EVOLVE_SPEC.md
@@ -22,7 +22,7 @@ one measured run and the next. The guiding idea:
 | --- | --- | --- | --- | --- |
 | **1. Prompt** | a `params` value | param default + new workflow version | minutes; fully autonomous | **built** (`eval/optimize`) |
 | **2. Environment** | an `env.manifest` diff | rebuilt image | days; human-reviewed | **todo** (§4) |
-| **3. Structure** | a workflow version + step sources | published version | hours; agent-interactive | **partial** (§5 — the `meta/*` gap) |
+| **3. Structure** | a workflow version + step sources | published version | hours; agent-interactive | **mechanism built** (§5 — `meta/*` + `services.authoring`; optimize generalization §5.3.3 todo) |
 
 The layers are ordered by how cheap they are to try and how safely they can
 be automated. Prompt tuning is mechanical and reversible. Environment changes
@@ -183,22 +183,51 @@ already frames a structural variant as "just a new workflow version," which
 versioning captures and the eval scores. What's missing is the ability for a
 workflow to author one **from inside a run**.
 
-### 5.1 The gap
+### 5.1 The gap (now closed)
 
 `agentTools` grants **registry step types** as LLM tools. The authoring
 tools — `create_step`, `edit_step`, `create_workflow`, `edit_workflow`,
-`run_workflow` — are bespoke AI SDK tools in `vein/src/ai/tools.ts`, bound to
-the workspace. They are not registry steps, so an in-workflow agent cannot
+`run_workflow` — were bespoke AI SDK tools in `vein/src/ai/tools.ts`, bound to
+the workspace. They are not registry steps, so an in-workflow agent could not
 reach them. That's why EVAL_SPEC §7 says structural evolution "stays
-agent-interactive for now."
+agent-interactive for now." §5.2 closes this.
 
-### 5.2 The fix: `meta/*` steps
+### 5.2 The fix: `meta/*` steps — **built**
 
-Wrap the workspace authoring ops as registry steps — `meta/create-step`,
-`meta/publish-workflow`, `meta/get-step`, `meta/list-steps`,
-`meta/run-workflow` — each thin plumbing over `workspace.*`. A leaf step has
-no workspace handle, so inject `services.authoring` exactly the way
-`createLabVein` already injects `services.optimizer` for the optimize loop.
+Implemented in vein core, benchmark-agnostic: `vein/src/authoring.ts` is the
+shared authoring core (the chat tools now sit on the same helpers), the steps
+live in `vein/src/steps/lib/meta/`, and `createVein` auto-provides
+`services.authoring` the way it already provides `http`/`secrets`/
+`artifacts` — so every vein deployment gets the surface, not just the lab.
+
+The roster mirrors the chat assistant's real authoring surface
+(`vein/src/ai/tools.ts`). The loop the assistant actually runs is
+create → test → edit → test; a roster missing the edit/test half strands an
+in-workflow author on iteration one:
+
+| Meta step | Wraps | Why |
+| --- | --- | --- |
+| `meta/list-steps`, `meta/search-steps`, `meta/get-step` | step discovery | read before authoring |
+| `meta/create-step`, `meta/edit-step` | `workspace.publishStep` | `create_step` refuses existing names — without edit, every iteration pollutes the registry (`my-fetcher-2`, `-3`, …) |
+| `meta/run-step` | `runSingleStep` + cassettes | the inner loop: test ONE step, offline via record/replay, without paying for a full candidate run |
+| `meta/list-workflows`, `meta/get-workflow` | workflow discovery | read current source before editing |
+| `meta/publish-workflow` | create/edit as an explicit upsert | the candidate artifact |
+| `meta/run-workflow` | `runWorkflow` | test the candidate end to end |
+| `meta/list-runs`, `meta/get-run` | run-store reads | debug a failed candidate — **provenance-scoped, see §6** |
+| `meta/list-secrets` | secret NAMES only | author steps that reference auth by name |
+
+Deliberately absent: `bash` and `web_search` — the agent step grants those
+itself, and §5.3.2 forbids `meta/*` + `bash` on one agent anyway — and
+`set_workflow_category` (UI cosmetics; and keeping it out means an in-run
+author cannot re-file a workflow into the candidate namespace, §6).
+
+The chat tools carry real logic worth not duplicating: name-conflict checks,
+JSON-string arg coercion (`coerceJsonArg`), and the load-verify-and-report
+behavior §5.3.4 demands. Both surfaces sit on the one shared core
+(`authoring.ts`); the capability adds the meta POLICY on top — everything it
+publishes is stamped `publisher: "ai"`, and its publish, run, and
+run-history operations are **closed over that stamped set** (§6).
+
 Then `agentTools: ["meta/*"]` closes the loop:
 
 ```
@@ -210,11 +239,17 @@ reflect (eval/reflect)                    → next candidate
 
 ### 5.3 Four things that will bite
 
-1. **Glob expansion is start-of-step.** `buildRegistryTools` resolves
-   `agentTools` once when the agent step begins, so a step authored mid-turn
-   is not in that agent's own toolset. Split authoring and execution into
-   separate steps rather than adding a reload escape hatch — it also makes
-   each candidate harness a diffable artifact.
+1. **The registry is a per-RUN snapshot, not just per-step.**
+   `buildRegistryTools` resolves `agentTools` once when the agent step
+   begins, so a step authored mid-turn is not in that agent's own toolset —
+   but it's worse than that: `runWorkflow` threads ONE registry through the
+   entire run, so a step published by `meta/create-step` at step N is
+   invisible to step N+1 too. Splitting authoring and execution into
+   separate steps is necessary but not sufficient: `meta/run-workflow` and
+   `meta/run-step` must build a fresh registry from the workspace at call
+   time (`services.authoring.getRegistry()`), never use the run's
+   `ctx.registry`. The chat tools already do the equivalent —
+   `deps.registry = await deps.getRegistry()` after every publish.
 2. **The authoring agent must never be the producing agent.** An agent with
    `meta/*` *and* `bash` can author a step that reads a rubric or shells into
    a benchmark checkout. Separate runs, disjoint grants (§6).
@@ -242,6 +277,29 @@ surface, permanently:
   own rubric trains against it.
 - **Grader grants.** `harvey/evaluate` / `gaia/evaluate` are harness-only,
   never in a producing agent's `agentTools`.
+- **The meta surface is closed over its own namespace** (*built* —
+  `authoring.ts`). A harness workflow's run log records what its grader
+  steps were handed — potentially gold and rubric text. So the capability
+  scopes by **workflow provenance**, not by actor: `meta/publish-workflow`
+  stamps everything it publishes `publisher: "ai"` (the capability sets the
+  stamp; the calling agent cannot override it), and `meta/run-workflow`,
+  `meta/list-runs`, and `meta/get-run` act on stamped workflows ONLY,
+  failing closed on everything else. Publishing over an existing unstamped
+  workflow is refused outright (so the loop also can't rewire the harness
+  that grades it), an identical-content republish never re-stamps (no
+  claiming a workflow by republishing its own YAML verbatim), and
+  `meta/edit-step` edits only steps published as `"ai"` (seeded harness
+  steps carry seeder publishers). Actor scoping ("runs this agent
+  started") would have broken iteration — generation N must inspect
+  generation N−1's candidate runs, which a different run started; the
+  stamp lives on the workflow record, so it survives sessions. This is
+  defense in depth, not the sole barrier: graders must also resolve gold
+  internally (by task id, from the services bag) and emit only verdicts,
+  so that NO run's event log carries answers even where scoping is
+  misconfigured — including a laundered candidate that embeds a grader
+  step directly. The residual channel — hill-climbing answers against
+  pass/fail verdicts as an oracle — is the train-set problem, and §7's
+  train/val split is what answers it, not scoping.
 - **Benchmark provenance.** Clean-tree checks, `benchmarkRev`,
   `scorerSha256`. A dirty checkout refuses to grade.
 - **Infra constants.** Values a workflow author has no basis for choosing and
@@ -311,7 +369,9 @@ possible version of "capture."
    have honest signal.
 3. **`env.manifest` + Dockerfile consumption** (§4.2) — makes layer 2 a
    proposable artifact.
-4. **`meta/*` steps + `services.authoring`** (§5.2) — closes layer 3.
+4. ~~**`meta/*` steps + `services.authoring`** (§5.2) — closes layer 3.~~
+   **Done** — `authoring.ts` + `steps/lib/meta/*`, auto-wired by
+   `createVein`; next is a first authoring-harness workflow that uses them.
 5. **Generalize `eval/optimize`'s candidate** from prompt string to workflow
    ref + version (§5.3.3) — the change that lets one loop drive all three
    layers.

--- a/vein/package.json
+++ b/vein/package.json
@@ -22,7 +22,7 @@
     "build:web": "npm --prefix web run build",
     "dev": "npm run build:web && tsx --env-file=.env src/server.ts",
     "start": "node build/server.js",
-    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts src/artifacts.test.ts src/slack.test.ts src/gdrive.test.ts src/html-extract.test.ts src/shell.test.ts"
+    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/authoring.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts src/artifacts.test.ts src/slack.test.ts src/gdrive.test.ts src/html-extract.test.ts src/shell.test.ts"
   },
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.92",

--- a/vein/src/ai/stepHelpers.ts
+++ b/vein/src/ai/stepHelpers.ts
@@ -2,7 +2,17 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { CORE_STEP_TYPES, LIB_DIR } from "../steps/registry.js";
-import { AiDeps } from "./prompts.js";
+import type { StepRegistry } from "../core.js";
+import type { WorkspaceManager } from "../workspace.js";
+
+/**
+ * The subset of dependencies the step-explorer helpers need. Both the chat
+ * builder's `AiDeps` and the authoring capability satisfy it structurally.
+ */
+export interface StepExplorerDeps {
+  workspace: WorkspaceManager;
+  registry: StepRegistry;
+}
 
 /**
  * Registry entries that don't come from any of the discoverable tiers
@@ -12,7 +22,7 @@ import { AiDeps } from "./prompts.js";
  * existing `list_steps` / pre-seeded prompt tree just sees them.
  */
 async function inCodeRegistryExtras(
-  deps: AiDeps,
+  deps: StepExplorerDeps,
 ): Promise<Array<{ type: string; description?: string }>> {
   const onDiskCustom = new Set(
     (await deps.workspace.listSteps()).map((s) => s.type),
@@ -69,7 +79,7 @@ function normalizeStepsPath(path: string): string[] {
   return parts;
 }
 
-export async function lsSteps(path: string, deps: AiDeps) {
+export async function lsSteps(path: string, deps: StepExplorerDeps) {
   const parts = normalizeStepsPath(path);
   if (parts[0] === "__invalid__") {
     return { error: `Invalid path "${path}". Paths must start with "steps".` };
@@ -164,7 +174,7 @@ async function listStepDir(dir: string): Promise<string[] | null> {
   return entries.sort();
 }
 
-export async function searchSteps(query: string, deps: AiDeps) {
+export async function searchSteps(query: string, deps: StepExplorerDeps) {
   const q = query.trim().toLowerCase();
   if (!q) return { matches: [] };
   const terms = q.split(/\s+/).filter(Boolean);
@@ -195,7 +205,7 @@ export async function searchSteps(query: string, deps: AiDeps) {
  */
 export async function readStepSource(
   type: string,
-  deps: AiDeps,
+  deps: StepExplorerDeps,
 ): Promise<string | undefined> {
   if (CORE_STEP_TYPES.includes(type)) return undefined;
 

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -2,63 +2,26 @@ import { z } from "zod";
 import { tool } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
 import { runWorkflow } from "../runner.js";
-import type { RunEvent, RunSummary } from "../core.js";
 import { AiDeps } from "./prompts.js";
 import { lsSteps, searchSteps, readStepSource } from "./stepHelpers.js";
 import { zodToFields } from "./schemaHelpers.js";
 import { runSingleStep, cassettePath } from "../run-step.js";
 import { generateRunId } from "../store.js";
-
-// The run-history read methods live on `FileRunStore`, not the base `RunStore`
-// interface (which is write-only: append/finalize). `MemoryRunStore` lacks them.
-// Feature-detect so the run-history tools degrade gracefully on stores that
-// can't read back (they return an error rather than throwing).
-interface RunReadStore {
-  listRuns(workflow: string): Promise<string[]>;
-  getRunSummary(workflow: string, runId: string): Promise<RunSummary | null>;
-  getRunEvents(workflow: string, runId: string): Promise<RunEvent[]>;
-}
-
-function asReadStore(store: unknown): RunReadStore | null {
-  const s = store as Partial<RunReadStore> | undefined;
-  return s &&
-    typeof s.listRuns === "function" &&
-    typeof s.getRunSummary === "function" &&
-    typeof s.getRunEvents === "function"
-    ? (s as RunReadStore)
-    : null;
-}
-
-/** Drop bulky input/output payloads from an event so a run's event list stays
- *  token-cheap; the agent can re-fetch a specific run's full events if needed. */
-function slimEvent(e: RunEvent) {
-  return {
-    type: e.type,
-    path: e.path,
-    ...(e.stepType ? { stepType: e.stepType } : {}),
-    ...(e.durationMs != null ? { durationMs: e.durationMs } : {}),
-    ...(e.iteration != null ? { iteration: e.iteration } : {}),
-    ...(e.error ? { error: e.error } : {}),
-  };
-}
+// The shared authoring core — the same mechanism the meta/* steps' capability
+// sits on (see authoring.ts): publish checks + strict load-verification, and
+// the run-history reads. The chat tools layer their own policy on top (no
+// ownership gating — this surface is human-supervised).
+import {
+  AI_PUBLISHER,
+  asReadStore,
+  coerceJsonArg,
+  listRunSummaries,
+  publishNewStep,
+  publishStepVersion,
+  readRun,
+} from "../authoring.js";
 
 // ── Tools ──────────────────────────────────────────────────────────────────
-
-/** LLMs sometimes pass an object-valued tool arg as a JSON *string* (e.g.
- *  run_workflow's `input`). The template engine then sees a string, so
- *  `{{ input.owner }}` resolves to undefined and every field fails validation.
- *  Defensively parse a JSON string back into the object/array it represents;
- *  leave anything else untouched. */
-function coerceJsonArg(v: unknown): unknown {
-  if (typeof v !== "string") return v;
-  const t = v.trim();
-  if (!(t.startsWith("{") || t.startsWith("["))) return v;
-  try {
-    return JSON.parse(t);
-  } catch {
-    return v;
-  }
-}
 
 export function buildTools(deps: AiDeps) {
   return {
@@ -137,36 +100,13 @@ export function buildTools(deps: AiDeps) {
         description: z.string().optional(),
       }),
       execute: async ({ name, code, description }) => {
-        if (deps.publishingEnabled === false) {
-          return { error: "Step publishing is disabled (the registry was injected at construction)." };
-        }
-        const customs = await deps.workspace.listSteps();
-        if (customs.some((s) => s.type === name)) {
-          return { error: `Step "${name}" already exists. Use edit_step to publish a new version.` };
-        }
-        if (deps.registry[name]) {
-          return { error: `"${name}" conflicts with a built-in (core/lib) step. Choose another name.` };
-        }
-        let result;
-        try {
-          result = await deps.workspace.publishStep(name, code, description, "ai");
-        } catch (err) {
-          return { error: err instanceof Error ? err.message : String(err) };
-        }
+        const result = await publishNewStep(deps, name, code, description, AI_PUBLISHER);
         deps.registry = await deps.getRegistry();
-        const loaded = Boolean(deps.registry[name]);
-        return {
-          ok: true,
-          type: name,
-          version: result.version,
-          loaded,
-          ...(loaded
-            ? {}
-            : {
-                warning:
-                  "Published but failed to load into the registry — check the source imports only 'vein' and has a valid defineStep default export.",
-              }),
-        };
+        if (result.ok && result.loaded === false) {
+          const { loadError, ...rest } = result;
+          return { ...rest, warning: `Published but failed to load into the registry: ${loadError}` };
+        }
+        return result;
       },
     }),
 
@@ -181,31 +121,13 @@ export function buildTools(deps: AiDeps) {
         description: z.string().optional(),
       }),
       execute: async ({ type, code, description }) => {
-        if (deps.publishingEnabled === false) {
-          return { error: "Step publishing is disabled (the registry was injected at construction)." };
-        }
-        const customs = await deps.workspace.listSteps();
-        if (!customs.some((s) => s.type === type)) {
-          return {
-            error: deps.registry[type]
-              ? `"${type}" is a built-in step and can't be edited. Use create_step with a new name.`
-              : `Step "${type}" not found. Use create_step to author a new step.`,
-          };
-        }
-        let result;
-        try {
-          result = await deps.workspace.publishStep(type, code, description);
-        } catch (err) {
-          return { error: err instanceof Error ? err.message : String(err) };
-        }
+        const result = await publishStepVersion(deps, type, code, description);
         deps.registry = await deps.getRegistry();
-        return {
-          ok: true,
-          type,
-          version: result.version,
-          changed: result.changed,
-          loaded: Boolean(deps.registry[type]),
-        };
+        if (result.ok && result.loaded === false) {
+          const { loadError, ...rest } = result;
+          return { ...rest, warning: `Published but failed to load into the registry: ${loadError}` };
+        }
+        return result;
       },
     }),
 
@@ -514,20 +436,7 @@ export function buildTools(deps: AiDeps) {
               "Run history is unavailable (the run store does not support reading back runs).",
           };
         }
-        const ids = (await store.listRuns(name)).slice(0, limit);
-        const runs = await Promise.all(
-          ids.map(async (runId) => {
-            const s = await store.getRunSummary(name, runId);
-            return {
-              runId,
-              status: s?.status,
-              startedAt: s?.startedAt,
-              durationMs: s?.durationMs,
-              ...(s?.error ? { error: s.error } : {}),
-            };
-          }),
-        );
-        return { workflow: name, runs };
+        return { workflow: name, runs: await listRunSummaries(store, name, limit) };
       },
     }),
 
@@ -550,19 +459,7 @@ export function buildTools(deps: AiDeps) {
               "Run history is unavailable (the run store does not support reading back runs).",
           };
         }
-        const [summary, rawEvents] = await Promise.all([
-          store.getRunSummary(name, runId),
-          store.getRunEvents(name, runId),
-        ]);
-        if (!summary && rawEvents.length === 0) {
-          return { error: `Run "${runId}" not found for workflow "${name}".` };
-        }
-        return {
-          workflow: name,
-          runId,
-          summary,
-          events: fullEvents ? rawEvents : rawEvents.map(slimEvent),
-        };
+        return readRun(store, name, runId, fullEvents);
       },
     }),
 

--- a/vein/src/authoring.test.ts
+++ b/vein/src/authoring.test.ts
@@ -1,0 +1,209 @@
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { randomUUID } from "node:crypto";
+import { z } from "zod";
+
+import { createVein, type Vein } from "./createVein.js";
+import { WorkspaceManager } from "./workspace.js";
+import type { AuthoringCapability } from "./authoring.js";
+
+/**
+ * The authoring capability (services.authoring) + the meta/* lib steps —
+ * EVOLVE_SPEC §5.2/§6: an in-workflow agent's author/test/inspect surface,
+ * closed over the artifacts it publishes (publisher "ai").
+ *
+ * Authored step sources deliberately avoid `import "vein"`: the temp
+ * workspace lives outside the package tree, where that specifier can't
+ * resolve at dynamic-import time. A duck-typed `{ parse }` schema exercises
+ * the same registry/load/run paths.
+ */
+
+// A loadable custom step with no imports (see note above).
+const echoStep = (type: string, n: number) => `export default {
+  type: ${JSON.stringify(type)},
+  description: "echoes its config",
+  input: { parse: (v) => v },
+  output: { parse: (v) => v },
+  run: async (cfg) => ({ echoed: cfg.msg, rev: ${n} }),
+};
+`;
+
+const logFlow = (name: string, msg: string) =>
+  `name: ${name}\nsteps:\n  - id: say\n    type: log\n    config:\n      message: "${msg}"\n`;
+
+describe("authoring capability (the meta surface)", () => {
+  let tempDir: string;
+  let vein: Vein<Record<string, unknown>>;
+  let authoring: AuthoringCapability;
+
+  before(async () => {
+    tempDir = join(tmpdir(), `vein-authoring-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+    vein = await createVein({
+      workspace: new WorkspaceManager(tempDir),
+      serveUi: false,
+    });
+    authoring = (vein.services as { authoring?: AuthoringCapability }).authoring!;
+  });
+
+  after(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("createVein auto-provides services.authoring and registers the meta/* lib steps", async () => {
+    assert.ok(authoring, "services.authoring should be auto-provided");
+    const registry = vein.getRegistry();
+    for (const type of [
+      "meta/list-steps",
+      "meta/search-steps",
+      "meta/get-step",
+      "meta/create-step",
+      "meta/edit-step",
+      "meta/run-step",
+      "meta/list-workflows",
+      "meta/get-workflow",
+      "meta/publish-workflow",
+      "meta/run-workflow",
+      "meta/list-runs",
+      "meta/get-run",
+      "meta/list-secrets",
+    ]) {
+      assert.ok(registry[type], `expected "${type}" in the registry`);
+    }
+    // The underscore helper is not a step.
+    assert.equal(registry["meta/_shared"], undefined);
+  });
+
+  it("createStep → runStep → editStep is the inner loop, load-verified", async () => {
+    const created = (await authoring.createStep("cand/echo", echoStep("cand/echo", 1))) as any;
+    assert.equal(created.ok, true, JSON.stringify(created));
+    assert.equal(created.version, "v1");
+    assert.equal(created.loaded, true);
+
+    const ran = (await authoring.runStep("cand/echo", { config: { msg: "hi" } })) as any;
+    assert.equal(ran.status, "success", JSON.stringify(ran.error));
+    assert.equal(ran.output.echoed, "hi");
+    assert.equal(ran.output.rev, 1);
+
+    const edited = (await authoring.editStep("cand/echo", echoStep("cand/echo", 2))) as any;
+    assert.equal(edited.ok, true);
+    assert.equal(edited.version, "v2");
+    assert.equal(edited.changed, true);
+
+    const ran2 = (await authoring.runStep("cand/echo", { config: { msg: "yo" } })) as any;
+    assert.equal(ran2.output.rev, 2);
+  });
+
+  it("createStep hands back the load error for broken source (§5.3.4)", async () => {
+    const broken = (await authoring.createStep("cand/broken", "export default { nope")) as any;
+    assert.ok(!broken.ok, "a step that doesn't load must not report ok");
+    assert.ok(broken.error, "the import failure must be handed back");
+    assert.equal(broken.loaded, false);
+  });
+
+  it("editStep refuses steps the agent surface did not author", async () => {
+    await vein.workspace.publishStep(
+      "seeded/tool",
+      echoStep("seeded/tool", 1),
+      undefined,
+      "harness-seed",
+    );
+    const res = (await authoring.editStep("seeded/tool", echoStep("seeded/tool", 2))) as any;
+    assert.ok(res.error && /only edits steps it authored/.test(res.error), res.error);
+  });
+
+  it("publishWorkflow stamps publisher 'ai'; run + run-history are closed over the stamped set", async () => {
+    // Candidate: published through the meta surface → stamped.
+    const pub = (await authoring.publishWorkflow("cand-flow", logFlow("cand-flow", "v1"))) as any;
+    assert.equal(pub.ok, true, JSON.stringify(pub));
+    assert.equal(pub.version, "v1");
+    assert.equal(pub.created, true);
+
+    const listed = (await authoring.listWorkflows()) as any;
+    const entry = listed.workflows.find((w: any) => w.name === "cand-flow");
+    assert.equal(entry.publisher, "ai");
+
+    // Idempotent republish; changed content bumps the version.
+    const same = (await authoring.publishWorkflow("cand-flow", logFlow("cand-flow", "v1"))) as any;
+    assert.equal(same.changed, false);
+    const bumped = (await authoring.publishWorkflow("cand-flow", logFlow("cand-flow", "v2"))) as any;
+    assert.equal(bumped.version, "v2");
+
+    // Harness: created outside the meta surface → unstamped.
+    await vein.workspace.createWorkflow("harness-flow", logFlow("harness-flow", "gold"));
+
+    const overwrite = (await authoring.publishWorkflow(
+      "harness-flow",
+      logFlow("harness-flow", "evil"),
+    )) as any;
+    assert.ok(overwrite.error && /not agent-authored/.test(overwrite.error), overwrite.error);
+
+    const runRefused = (await authoring.runWorkflow("harness-flow")) as any;
+    assert.ok(runRefused.error && /not agent-authored/.test(runRefused.error));
+
+    const historyRefused = (await authoring.listRuns("harness-flow")) as any;
+    assert.ok(historyRefused.error && /not agent-authored/.test(historyRefused.error));
+
+    // The stamped candidate runs, and its run history reads back.
+    const result = (await authoring.runWorkflow("cand-flow", {})) as any;
+    assert.equal(result.status, "success", JSON.stringify(result.error));
+    assert.ok(result.runId);
+
+    const runs = (await authoring.listRuns("cand-flow")) as any;
+    assert.equal(runs.workflow, "cand-flow");
+    assert.ok(runs.runs.length >= 1);
+
+    const run = (await authoring.getRun("cand-flow", result.runId)) as any;
+    assert.equal(run.summary.status, "success");
+    assert.ok(Array.isArray(run.events) && run.events.length > 0);
+    // Slim events carry no payloads by default.
+    assert.equal(run.events[0].input, undefined);
+  });
+
+  it("runWorkflow sees a step authored moments before (fresh registry, §5.3.1)", async () => {
+    const created = (await authoring.createStep("cand/echo2", echoStep("cand/echo2", 7))) as any;
+    assert.equal(created.ok, true);
+
+    const yaml = `name: cand-flow2\nsteps:\n  - id: e\n    type: cand/echo2\n    config:\n      msg: "fresh"\n`;
+    const pub = (await authoring.publishWorkflow("cand-flow2", yaml)) as any;
+    assert.equal(pub.ok, true);
+
+    const result = (await authoring.runWorkflow("cand-flow2", {})) as any;
+    assert.equal(result.status, "success", JSON.stringify(result.error));
+    assert.equal((result.output as any).echoed, "fresh");
+  });
+
+  it("meta/* steps reach the capability through ctx.services inside a real run", async () => {
+    const result = await vein.run({
+      name: "meta-wiring-test",
+      input: z.any(),
+      steps: [
+        { id: "pub", type: "meta/publish-workflow", config: {
+          name: "cand-inrun",
+          yaml: logFlow("cand-inrun", "from inside a run"),
+        } },
+        { id: "run", type: "meta/run-workflow", config: { name: "cand-inrun" }, depends: "pub" },
+        { id: "history", type: "meta/list-runs", config: { name: "cand-inrun" }, depends: "run" },
+      ],
+    });
+    assert.equal(result.status, "success", JSON.stringify(result.error));
+    const out = result.output as any;
+    assert.ok(out.runs.length >= 1, "the in-run candidate's run history should read back");
+
+    // ...and the workflow published from inside the run is stamped.
+    const listed = (await authoring.listWorkflows()) as any;
+    const entry = listed.workflows.find((w: any) => w.name === "cand-inrun");
+    assert.equal(entry.publisher, "ai");
+  });
+
+  it("listSecrets returns names only", async () => {
+    await vein.secretStore.set("MY_TOKEN", "shh");
+    const res = (await authoring.listSecrets()) as any;
+    const names = res.secrets.map((s: any) => s.name);
+    assert.ok(names.includes("MY_TOKEN"));
+    assert.ok(!JSON.stringify(res).includes("shh"), "secret values must never surface");
+  });
+});

--- a/vein/src/authoring.ts
+++ b/vein/src/authoring.ts
@@ -1,0 +1,501 @@
+import { join } from "node:path";
+import type { RunEvent, RunResult, RunSummary, StepRegistry } from "./core.js";
+import type { WorkspaceManager } from "./workspace.js";
+import type { RunStore } from "./store.js";
+import { generateRunId } from "./store.js";
+import { runWorkflow } from "./runner.js";
+import { runSingleStep, cassettePath, type RunStepResult } from "./run-step.js";
+import { stepLoadError } from "./steps/registry.js";
+import type { CassetteMode } from "./cassette.js";
+import type { SecretInfo } from "./secret-store.js";
+import { lsSteps, searchSteps, readStepSource } from "./ai/stepHelpers.js";
+import { zodToFields } from "./ai/schemaHelpers.js";
+
+/**
+ * The AUTHORING core — the workspace's author/test/inspect operations, shared
+ * by two consumers:
+ *
+ *   - the chat builder's AI tools (`ai/tools.ts`) — the human-supervised
+ *     authoring surface; and
+ *   - the `meta/*` lib steps — the same operations as REGISTRY STEPS, so an
+ *     in-workflow agent (`agentTools: ["meta/*"]`) can author, test, and
+ *     inspect candidate workflows from inside a run (EVOLVE_SPEC §5).
+ *
+ * The exported helpers are the shared MECHANISM (conflict checks, strict
+ * load-verification, run-history reads). `buildAuthoringCapability` bakes in
+ * the meta-surface POLICY on top (EVOLVE_SPEC §6): everything the capability
+ * publishes is stamped `publisher: "ai"`, and its publish / run /
+ * run-history operations are CLOSED over that stamped set — it refuses to
+ * touch, run, or read runs of workflows it didn't publish. A harness
+ * workflow's run log records what its grader steps were handed, so
+ * run-history reads on unstamped workflows fail closed.
+ */
+
+/** The provenance stamp for AI-authored artifacts (steps AND workflows). */
+export const AI_PUBLISHER = "ai";
+
+// ── Run-history reads (shared mechanism) ───────────────────────────────────
+
+// The run-history read methods live on `FileRunStore`, not the base `RunStore`
+// interface (which is write-only: append/finalize). `MemoryRunStore` lacks
+// them. Feature-detect so run-history reads degrade gracefully on stores that
+// can't read back (they return an error rather than throwing).
+export interface RunReadStore {
+  listRuns(workflow: string): Promise<string[]>;
+  getRunSummary(workflow: string, runId: string): Promise<RunSummary | null>;
+  getRunEvents(workflow: string, runId: string): Promise<RunEvent[]>;
+}
+
+export function asReadStore(store: unknown): RunReadStore | null {
+  const s = store as Partial<RunReadStore> | undefined;
+  return s &&
+    typeof s.listRuns === "function" &&
+    typeof s.getRunSummary === "function" &&
+    typeof s.getRunEvents === "function"
+    ? (s as RunReadStore)
+    : null;
+}
+
+/** Drop bulky input/output payloads from an event so a run's event list stays
+ *  token-cheap; the caller can re-fetch a specific run's full events if needed. */
+export function slimEvent(e: RunEvent) {
+  return {
+    type: e.type,
+    path: e.path,
+    ...(e.stepType ? { stepType: e.stepType } : {}),
+    ...(e.durationMs != null ? { durationMs: e.durationMs } : {}),
+    ...(e.iteration != null ? { iteration: e.iteration } : {}),
+    ...(e.error ? { error: e.error } : {}),
+  };
+}
+
+const NO_RUN_HISTORY_ERROR =
+  "Run history is unavailable (the run store does not support reading back runs).";
+
+/** List a workflow's recent runs (newest first) as slim summaries. */
+export async function listRunSummaries(
+  store: RunReadStore,
+  name: string,
+  limit: number,
+) {
+  const ids = (await store.listRuns(name)).slice(0, limit);
+  return Promise.all(
+    ids.map(async (runId) => {
+      const s = await store.getRunSummary(name, runId);
+      return {
+        runId,
+        status: s?.status,
+        startedAt: s?.startedAt,
+        durationMs: s?.durationMs,
+        ...(s?.error ? { error: s.error } : {}),
+      };
+    }),
+  );
+}
+
+/** Read one run's summary + events (slimmed unless `fullEvents`). */
+export async function readRun(
+  store: RunReadStore,
+  name: string,
+  runId: string,
+  fullEvents: boolean,
+) {
+  const [summary, rawEvents] = await Promise.all([
+    store.getRunSummary(name, runId),
+    store.getRunEvents(name, runId),
+  ]);
+  if (!summary && rawEvents.length === 0) {
+    return { error: `Run "${runId}" not found for workflow "${name}".` };
+  }
+  return {
+    workflow: name,
+    runId,
+    summary,
+    events: fullEvents ? rawEvents : rawEvents.map(slimEvent),
+  };
+}
+
+// ── Step publishing (shared mechanism) ─────────────────────────────────────
+
+/** LLMs sometimes pass an object-valued arg as a JSON *string* (e.g.
+ *  run_workflow's `input`). The template engine then sees a string, so
+ *  `{{ input.owner }}` resolves to undefined and every field fails validation.
+ *  Defensively parse a JSON string back into the object/array it represents;
+ *  leave anything else untouched. */
+export function coerceJsonArg(v: unknown): unknown {
+  if (typeof v !== "string") return v;
+  const t = v.trim();
+  if (!(t.startsWith("{") || t.startsWith("["))) return v;
+  try {
+    return JSON.parse(t);
+  } catch {
+    return v;
+  }
+}
+
+/** What both publish paths need. The chat builder's `AiDeps` satisfies it
+ *  structurally; the authoring capability builds its own. `getRegistry` must
+ *  return a FRESH registry (re-scanned from the workspace). */
+export interface StepPublishDeps {
+  workspace: WorkspaceManager;
+  getRegistry(): Promise<StepRegistry>;
+  publishingEnabled?: boolean;
+}
+
+export interface StepPublishResult {
+  ok?: true;
+  error?: string;
+  type?: string;
+  version?: string;
+  changed?: boolean;
+  /** Whether the published source actually loaded into the registry. */
+  loaded?: boolean;
+  /** The import/shape error when `loaded` is false (§5.3.4: a broken step
+   *  otherwise fails silently — `loadStepFile` warns and returns null, so the
+   *  step simply doesn't exist). */
+  loadError?: string;
+}
+
+/** Verify a just-published step actually loads; surface the error if not. */
+async function verifyLoaded(
+  deps: StepPublishDeps,
+  name: string,
+): Promise<{ loaded: boolean; loadError?: string }> {
+  const fresh = await deps.getRegistry();
+  if (fresh[name]) return { loaded: true };
+  const err = await stepLoadError(
+    join(deps.workspace.path, "steps", "custom", `${name}.ts`),
+  );
+  return {
+    loaded: false,
+    loadError:
+      err ??
+      "step did not appear in the registry — check the source imports only 'vein' and has a valid defineStep default export",
+  };
+}
+
+/** Author a NEW custom step (the chat `create_step` / `meta/create-step`
+ *  mechanism): refuses existing names and built-in collisions, publishes as
+ *  v1, then load-verifies the source and hands any import error back. */
+export async function publishNewStep(
+  deps: StepPublishDeps,
+  name: string,
+  code: string,
+  description?: string,
+  publisher?: string,
+): Promise<StepPublishResult> {
+  if (deps.publishingEnabled === false) {
+    return { error: "Step publishing is disabled (the registry was injected at construction)." };
+  }
+  const customs = await deps.workspace.listSteps();
+  if (customs.some((s) => s.type === name)) {
+    return { error: `Step "${name}" already exists. Use edit_step to publish a new version.` };
+  }
+  if ((await deps.getRegistry())[name]) {
+    return { error: `"${name}" conflicts with a built-in (core/lib) step. Choose another name.` };
+  }
+  let result;
+  try {
+    result = await deps.workspace.publishStep(name, code, description, publisher);
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+  return { ok: true, type: name, version: result.version, ...(await verifyLoaded(deps, name)) };
+}
+
+/** Publish a NEW VERSION of an existing custom step (the chat `edit_step` /
+ *  `meta/edit-step` mechanism). Pass `requirePublisher` to enforce the meta
+ *  ownership rule: only steps stamped with that publisher may be edited. */
+export async function publishStepVersion(
+  deps: StepPublishDeps,
+  type: string,
+  code: string,
+  description?: string,
+  opts: { requirePublisher?: string } = {},
+): Promise<StepPublishResult> {
+  if (deps.publishingEnabled === false) {
+    return { error: "Step publishing is disabled (the registry was injected at construction)." };
+  }
+  const customs = await deps.workspace.listSteps();
+  const existing = customs.find((s) => s.type === type);
+  if (!existing) {
+    return {
+      error: (await deps.getRegistry())[type]
+        ? `"${type}" is a built-in step and can't be edited. Use create_step with a new name.`
+        : `Step "${type}" not found. Use create_step to author a new step.`,
+    };
+  }
+  if (opts.requirePublisher && existing.publisher !== opts.requirePublisher) {
+    return {
+      error:
+        `Step "${type}" was not published by "${opts.requirePublisher}" (publisher: ` +
+        `${existing.publisher ?? "none"}) — the meta surface only edits steps it authored. ` +
+        `Author a new step under a different name instead.`,
+    };
+  }
+  let result;
+  try {
+    result = await deps.workspace.publishStep(type, code, description);
+  } catch (err) {
+    return { error: err instanceof Error ? err.message : String(err) };
+  }
+  return {
+    ok: true,
+    type,
+    version: result.version,
+    changed: result.changed,
+    ...(await verifyLoaded(deps, type)),
+  };
+}
+
+// ── The capability ─────────────────────────────────────────────────────────
+
+export interface RunStepArgs {
+  config?: Record<string, unknown>;
+  input?: unknown;
+  params?: Record<string, unknown>;
+  cassette?: CassetteMode;
+  cassetteName?: string;
+}
+
+/**
+ * The authoring capability injected as `services.authoring` — what the
+ * `meta/*` lib steps are thin plumbing over. Auto-provided by `createVein`
+ * (like `http` / `secrets` / `artifacts`); embedders can inject their own.
+ */
+export interface AuthoringCapability {
+  listSteps(path?: string): Promise<unknown>;
+  searchSteps(query: string): Promise<unknown>;
+  getStep(type: string): Promise<unknown>;
+  createStep(name: string, code: string, description?: string): Promise<StepPublishResult>;
+  editStep(type: string, code: string, description?: string): Promise<StepPublishResult>;
+  runStep(type: string, args?: RunStepArgs): Promise<RunStepResult | { error: string }>;
+  listWorkflows(): Promise<unknown>;
+  getWorkflow(name: string, version?: string): Promise<unknown>;
+  publishWorkflow(
+    name: string,
+    yaml: string,
+    description?: string,
+    category?: string,
+  ): Promise<unknown>;
+  runWorkflow(
+    name: string,
+    input?: unknown,
+    params?: Record<string, unknown>,
+    version?: string,
+  ): Promise<RunResult | { error: string }>;
+  listRuns(name: string, limit?: number): Promise<unknown>;
+  getRun(name: string, runId: string, fullEvents?: boolean): Promise<unknown>;
+  listSecrets(): Promise<unknown>;
+}
+
+export interface AuthoringDeps extends StepPublishDeps {
+  store: RunStore;
+  /** Capabilities bag threaded into `runWorkflow` / `runStep` so authored
+   *  steps reach `ctx.services` (http, secrets, and any consumer services). */
+  services?: unknown;
+  /** Read-only view of the deployment's secret store (NAMES only — never
+   *  values). Optional: `listSecrets` degrades gracefully when absent. */
+  secrets?: { list(): Promise<SecretInfo[]> };
+}
+
+export function buildAuthoringCapability(deps: AuthoringDeps): AuthoringCapability {
+  const { workspace, store } = deps;
+
+  const explorerDeps = async () => ({ workspace, registry: await deps.getRegistry() });
+
+  const findWorkflow = async (name: string) =>
+    (await workspace.listWorkflows()).find((w) => w.name === name);
+
+  /** The ownership gate: the meta surface acts only on workflows it
+   *  published (EVOLVE_SPEC §6). Returns an error message, or null when the
+   *  workflow exists and is stamped. */
+  const notOwned = async (name: string, verb: string): Promise<string | null> => {
+    const entry = await findWorkflow(name);
+    if (!entry) return `Workflow "${name}" not found`;
+    if (entry.publisher !== AI_PUBLISHER) {
+      return (
+        `Workflow "${name}" is not agent-authored (publisher: ${entry.publisher ?? "none"}) — ` +
+        `the meta surface only ${verb} workflows it published. ` +
+        `Author a candidate with meta/publish-workflow under a new name instead.`
+      );
+    }
+    return null;
+  };
+
+  return {
+    async listSteps(path = "steps") {
+      return lsSteps(path, await explorerDeps());
+    },
+
+    async searchSteps(query) {
+      return searchSteps(query, await explorerDeps());
+    },
+
+    async getStep(type) {
+      const d = await explorerDeps();
+      const def = d.registry[type];
+      if (!def) return { error: `Step type "${type}" not found` };
+      return {
+        type,
+        description: def.description,
+        fields: zodToFields(def.input),
+        source: await readStepSource(type, d),
+      };
+    },
+
+    async createStep(name, code, description) {
+      const result = await publishNewStep(deps, name, code, description, AI_PUBLISHER);
+      // For the in-workflow author a broken publish is a FAILURE, not a
+      // warning — §5.3.4: hand the import error back loudly.
+      if (result.ok && result.loaded === false) {
+        return {
+          ...result,
+          ok: undefined,
+          error: `Published as ${result.version} but the step failed to load: ${result.loadError}`,
+        };
+      }
+      return result;
+    },
+
+    async editStep(type, code, description) {
+      const result = await publishStepVersion(deps, type, code, description, {
+        requirePublisher: AI_PUBLISHER,
+      });
+      if (result.ok && result.loaded === false) {
+        return {
+          ...result,
+          ok: undefined,
+          error: `Published as ${result.version} but the step failed to load: ${result.loadError}. Prior versions are retained — fix and edit again, or roll back.`,
+        };
+      }
+      return result;
+    },
+
+    async runStep(type, args = {}) {
+      // FRESH registry: a step authored earlier in this same run must be
+      // runnable here — the run's own `ctx.registry` is a start-of-run
+      // snapshot and would not contain it (EVOLVE_SPEC §5.3.1).
+      const registry = await deps.getRegistry();
+      if (!registry[type]) return { error: `Step type "${type}" not found` };
+      return runSingleStep(type, registry, deps.services, {
+        config: coerceJsonArg(args.config) as Record<string, unknown> | undefined,
+        input: coerceJsonArg(args.input),
+        params: coerceJsonArg(args.params) as Record<string, unknown> | undefined,
+        workspace,
+        ...(args.cassette
+          ? {
+              cassette: {
+                mode: args.cassette,
+                path: cassettePath(workspace.path, args.cassetteName ?? type),
+              },
+            }
+          : {}),
+      });
+    },
+
+    async listWorkflows() {
+      return { workflows: await workspace.listWorkflows() };
+    },
+
+    async getWorkflow(name, version) {
+      const entry = await findWorkflow(name);
+      if (!entry) return { error: `Workflow "${name}" not found` };
+      const resolved = version ?? entry.activeVersion;
+      let yaml;
+      try {
+        yaml = await workspace.getWorkflowSource(name, resolved);
+      } catch {
+        return {
+          error: `Version "${resolved}" not found for "${name}". Available: ${entry.versions.join(", ")}`,
+        };
+      }
+      return {
+        name,
+        version: resolved,
+        activeVersion: entry.activeVersion,
+        versions: entry.versions,
+        description: entry.description,
+        publisher: entry.publisher,
+        yaml,
+      };
+    },
+
+    async publishWorkflow(name, yaml, description, category) {
+      const entry = await findWorkflow(name);
+      if (entry && entry.publisher !== AI_PUBLISHER) {
+        return {
+          error:
+            `Workflow "${name}" exists and is not agent-authored (publisher: ` +
+            `${entry.publisher ?? "none"}). The meta surface never edits workflows it ` +
+            `didn't publish — choose a new name to author a candidate.`,
+        };
+      }
+      try {
+        const result = await workspace.publishWorkflowByContent(
+          name,
+          yaml,
+          description,
+          category,
+          AI_PUBLISHER,
+        );
+        return {
+          ok: true,
+          name,
+          version: result.version,
+          changed: result.changed,
+          created: !entry,
+        };
+      } catch (err) {
+        return { error: err instanceof Error ? err.message : String(err) };
+      }
+    },
+
+    async runWorkflow(name, input, params, version) {
+      const gate = await notOwned(name, "runs");
+      if (gate) return { error: gate };
+      let flow;
+      try {
+        flow = version
+          ? await workspace.getWorkflowVersion(name, version)
+          : await workspace.getWorkflow(name);
+      } catch (err) {
+        return { error: err instanceof Error ? err.message : String(err) };
+      }
+      // FRESH registry, same reason as runStep: steps published mid-run are
+      // invisible to the enclosing run's registry snapshot.
+      const registry = await deps.getRegistry();
+      return runWorkflow(flow, coerceJsonArg(input) ?? {}, registry, {
+        runId: generateRunId(),
+        store,
+        workspace,
+        services: deps.services,
+        params: coerceJsonArg(params) as Record<string, unknown> | undefined,
+      });
+    },
+
+    async listRuns(name, limit = 20) {
+      const gate = await notOwned(name, "reads run history of");
+      if (gate) return { error: gate };
+      const read = asReadStore(store);
+      if (!read) return { error: NO_RUN_HISTORY_ERROR };
+      return { workflow: name, runs: await listRunSummaries(read, name, limit) };
+    },
+
+    async getRun(name, runId, fullEvents = false) {
+      const gate = await notOwned(name, "reads run history of");
+      if (gate) return { error: gate };
+      const read = asReadStore(store);
+      if (!read) return { error: NO_RUN_HISTORY_ERROR };
+      return readRun(read, name, runId, fullEvents);
+    },
+
+    async listSecrets() {
+      if (!deps.secrets) {
+        return { error: "Secret store is not available in this deployment." };
+      }
+      const secrets = await deps.secrets.list();
+      return { secrets: secrets.map((s) => ({ name: s.name, updatedAt: s.updatedAt })) };
+    },
+  };
+}

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -33,6 +33,7 @@ import {
   isValidSecretName,
 } from "./secret-store.js";
 import { runSingleStep, cassettePath } from "./run-step.js";
+import { buildAuthoringCapability } from "./authoring.js";
 import type { CassetteMode } from "./cassette.js";
 // Static import is safe: notifier depends only on chat-store, never the AI
 // SDK (which stays lazy-loaded inside launchChatTurn).
@@ -356,6 +357,28 @@ export async function createVein<TServices = unknown>(
 
   if (!registryWasInjected) {
     await rebuildRegistry();
+  }
+
+  // Auto-provide the AUTHORING capability (the workspace's author/test/inspect
+  // operations as one service) unless the consumer injected their own — same
+  // spirit as http/secrets/artifacts above, added here because it closes over
+  // the registry state initialized just before. This is what the meta/* lib
+  // steps reach via ctx.services.authoring, letting an in-workflow agent
+  // (agentTools: ["meta/*"]) author and evaluate candidate workflows
+  // (EVOLVE_SPEC §5). Everything it publishes is stamped publisher "ai", and
+  // its publish/run/run-history operations are closed over that stamped set.
+  if (!(services as Record<string, unknown>)["authoring"]) {
+    (services as Record<string, unknown>)["authoring"] = buildAuthoringCapability({
+      workspace,
+      store,
+      services,
+      publishingEnabled: !registryWasInjected,
+      getRegistry: async () => {
+        await rebuildRegistry();
+        return registry;
+      },
+      ...(secretsInjected ? {} : { secrets: secretStore }),
+    });
   }
 
   const app = new Hono();

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -145,6 +145,19 @@ export {
   type RunStepResult,
 } from "./run-step.js";
 
+// Authoring — the workspace's author/test/inspect operations as one
+// injectable service: what the meta/* steps are plumbing over. Auto-provided
+// by createVein as `services.authoring`; embedders can build their own.
+export {
+  buildAuthoringCapability,
+  AI_PUBLISHER,
+  type AuthoringCapability,
+  type AuthoringDeps,
+  type StepPublishDeps,
+  type StepPublishResult,
+  type RunStepArgs,
+} from "./authoring.js";
+
 // Vein factory — the primary entry point for library usage.
 export {
   createVein,

--- a/vein/src/steps/lib/meta/_shared.ts
+++ b/vein/src/steps/lib/meta/_shared.ts
@@ -1,0 +1,29 @@
+import type { AuthoringCapability } from "../../../authoring.js";
+
+/**
+ * The `meta/*` steps are thin plumbing over the authoring capability
+ * (`services.authoring`, auto-provided by `createVein`) — the workspace's
+ * author/test/inspect operations as REGISTRY STEPS, so an in-workflow agent
+ * (`agentTools: ["meta/*"]`) can author, test, and inspect candidate
+ * workflows from inside a run. See EVOLVE_SPEC §5.2, and authoring.ts for
+ * the ownership rule the capability enforces (§6).
+ *
+ * GRANT DISCIPLINE (§5.3.2): an authoring agent gets `meta/*` and nothing
+ * else — never `bash` alongside it, and never grader steps. The producing
+ * agent (the one whose output is graded) gets no `meta/*` at all.
+ */
+export interface AuthoringServices {
+  authoring?: AuthoringCapability;
+}
+
+export function requireAuthoring(services: unknown): AuthoringCapability {
+  const authoring = (services as AuthoringServices | undefined)?.authoring;
+  if (!authoring) {
+    throw new Error(
+      "meta/* steps require the authoring capability (ctx.services.authoring). " +
+        "The standard vein server provides it automatically; embedders can inject one " +
+        "via buildAuthoringCapability (import from 'vein').",
+    );
+  }
+  return authoring;
+}

--- a/vein/src/steps/lib/meta/create-step.ts
+++ b/vein/src/steps/lib/meta/create-step.ts
@@ -1,0 +1,24 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/create-step",
+  description:
+    "Author a NEW custom step type from TypeScript source. The code is a self-contained vein step: `import { z, defineStep } from \"vein\"` and `export default defineStep({ type, input, output, async run(cfg, ctx) {...} })`. Reach external capabilities through `ctx.services` — `ctx.services.http(url, opts)` for network calls, `ctx.services.secrets.get(name)` for credentials (NOT global fetch / process.env), so the step is recordable/replayable by meta/run-step's cassette. The source is load-verified before returning: a broken step comes back as an error with the import failure, not a silent no-op. Use meta/edit-step to change an existing step. Publishing creates version v1.",
+  input: z.object({
+    name: z
+      .string()
+      .describe("Step type name. Slashes nest it (e.g. 'candidates/my-fetcher') and become the registry type."),
+    code: z
+      .string()
+      .describe(
+        'Full TypeScript source. Shape: import { z, defineStep } from "vein"; export default defineStep({ type: "<name>", input: z.object({...}), output: z.any(), async run(cfg, ctx) {...} });',
+      ),
+    description: z.string().optional(),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).createStep(cfg.name, cfg.code, cfg.description);
+  },
+});

--- a/vein/src/steps/lib/meta/edit-step.ts
+++ b/vein/src/steps/lib/meta/edit-step.ts
@@ -1,0 +1,18 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/edit-step",
+  description:
+    "Publish a NEW VERSION of an EXISTING agent-authored custom step. Same self-contained source rules as meta/create-step; call meta/get-step first to read the current source. Identical content is a no-op; a change increments the version (v1 → v2 → …) with prior versions kept for rollback. Only steps the agent surface authored can be edited — built-ins and seeded steps are refused.",
+  input: z.object({
+    type: z.string().describe("Existing custom step type to edit, e.g. 'candidates/my-fetcher'."),
+    code: z.string().describe("Full updated TypeScript source (same self-contained shape as meta/create-step)."),
+    description: z.string().optional(),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).editStep(cfg.type, cfg.code, cfg.description);
+  },
+});

--- a/vein/src/steps/lib/meta/get-run.ts
+++ b/vein/src/steps/lib/meta/get-run.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/get-run",
+  description:
+    "Get one run of an agent-authored workflow: its summary (input, output, status, error, duration) and event log. Events are slimmed by default (no payloads) to stay token-cheap; set fullEvents:true for each step's input/output. Use to debug why a candidate run failed. Runs of workflows the agent surface did not author are refused.",
+  input: z.object({
+    name: z.string().describe("Workflow name (must be agent-authored)"),
+    runId: z.string().describe("Run id (from meta/list-runs or a meta/run-workflow result)"),
+    fullEvents: z
+      .boolean()
+      .default(false)
+      .describe("Include full per-step input/output payloads in events (default false: slimmed)."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).getRun(cfg.name, cfg.runId, cfg.fullEvents);
+  },
+});

--- a/vein/src/steps/lib/meta/get-step.ts
+++ b/vein/src/steps/lib/meta/get-step.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/get-step",
+  description:
+    "Get a step type's details: input schema fields, description, and (for lib/custom steps) source code. Read before editing a step or wiring it into a workflow.",
+  input: z.object({
+    type: z.string().describe("Step type, e.g. 'http' or 'github/fetch-pr'"),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).getStep(cfg.type);
+  },
+});

--- a/vein/src/steps/lib/meta/get-workflow.ts
+++ b/vein/src/steps/lib/meta/get-workflow.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/get-workflow",
+  description:
+    "Get a published workflow's full YAML source plus version metadata. Defaults to the active version; pass `version` for a specific one. Read before republishing a candidate with meta/publish-workflow.",
+  input: z.object({
+    name: z.string().describe("Workflow name"),
+    version: z.string().optional().describe("Optional specific version. Defaults to the active version."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).getWorkflow(cfg.name, cfg.version);
+  },
+});

--- a/vein/src/steps/lib/meta/list-runs.ts
+++ b/vein/src/steps/lib/meta/list-runs.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/list-runs",
+  description:
+    "List past runs of an agent-authored workflow (newest first) with status, duration, and timestamps — across ALL sessions, so earlier generations' candidate runs are inspectable. Then call meta/get-run for a specific run's detail. Run history of workflows the agent surface did not author is refused (their logs can record what graders were handed).",
+  input: z.object({
+    name: z.string().describe("Workflow name whose runs to list (must be agent-authored)"),
+    limit: z.number().int().positive().default(20).describe("Max number of recent runs to return (default 20)."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).listRuns(cfg.name, cfg.limit);
+  },
+});

--- a/vein/src/steps/lib/meta/list-secrets.ts
+++ b/vein/src/steps/lib/meta/list-secrets.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/list-secrets",
+  description:
+    "List the NAMES of credentials in the deployment's secret store (never the values). Use before authoring a step that needs auth: reference an existing name via ctx.services.secrets.get(\"NAME\") in the step source.",
+  input: z.object({}),
+  output: z.any(),
+  async run(_cfg, ctx) {
+    return requireAuthoring(ctx.services).listSecrets();
+  },
+});

--- a/vein/src/steps/lib/meta/list-steps.ts
+++ b/vein/src/steps/lib/meta/list-steps.ts
@@ -1,0 +1,21 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/list-steps",
+  description:
+    "List available step types like a filesystem. Valid paths: 'steps' (shows core/, lib/, custom/), 'steps/core', 'steps/lib', 'steps/lib/<namespace>', 'steps/custom'. Use before authoring to see what already exists.",
+  input: z.object({
+    path: z
+      .string()
+      .default("steps")
+      .describe(
+        "Path to list. Defaults to 'steps' (the root). Use 'steps/lib' to see lib namespaces, 'steps/custom' for workspace custom steps.",
+      ),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).listSteps(cfg.path);
+  },
+});

--- a/vein/src/steps/lib/meta/list-workflows.ts
+++ b/vein/src/steps/lib/meta/list-workflows.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/list-workflows",
+  description:
+    "List all published workflows with each one's active version, versions, description, and publisher stamp. Use to discover what exists before authoring — only workflows stamped publisher 'ai' can be republished, run, or have their run history read through the meta surface.",
+  input: z.object({}),
+  output: z.any(),
+  async run(_cfg, ctx) {
+    return requireAuthoring(ctx.services).listWorkflows();
+  },
+});

--- a/vein/src/steps/lib/meta/publish-workflow.ts
+++ b/vein/src/steps/lib/meta/publish-workflow.ts
@@ -1,0 +1,27 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/publish-workflow",
+  description:
+    "Publish a workflow from YAML — an explicit UPSERT: a new name creates v1, an existing agent-authored name gets the next version (identical content is a no-op; prior versions are kept for rollback). Everything published here is stamped publisher 'ai' — that stamp is what later allows meta/run-workflow and meta/get-run on it. Publishing over a workflow the agent surface did NOT author is refused: author candidates under new names.",
+  input: z.object({
+    name: z.string().describe("Workflow name (kebab-case)"),
+    yaml: z.string().describe("Full workflow YAML"),
+    description: z.string().optional(),
+    category: z
+      .string()
+      .optional()
+      .describe("Optional sidebar grouping label (e.g. an experiment name). Omit to leave unchanged."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).publishWorkflow(
+      cfg.name,
+      cfg.yaml,
+      cfg.description,
+      cfg.category,
+    );
+  },
+});

--- a/vein/src/steps/lib/meta/run-step.ts
+++ b/vein/src/steps/lib/meta/run-step.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/run-step",
+  description:
+    "Run a SINGLE step in isolation with a given config + input and return its output + events — the inner loop for authoring: meta/create-step → meta/run-step → meta/edit-step → meta/run-step until the output is right. Set cassette:'record' to run live AND capture the step's external service calls to a reusable fixture (secrets scrubbed); then cassette:'replay' to iterate OFFLINE against it — deterministic, no rate limits, no cost, no side effects. Sees steps published earlier in this same run (the registry is re-read fresh). Returns { status, output?, error?, events, recorded? }.",
+  input: z.object({
+    type: z.string().describe("Step type to run, e.g. 'candidates/my-fetcher' or 'http'."),
+    config: z
+      .record(z.any())
+      .optional()
+      .describe("The step's config (same shape as in a workflow). Templates like {{ input.* }} / {{ params.* }} are resolved."),
+    input: z.any().optional().describe("Workflow input object, referenced in config via {{ input.* }}."),
+    params: z.record(z.any()).optional().describe("Params knobs, referenced via {{ params.* }}."),
+    cassette: z
+      .enum(["record", "replay"])
+      .optional()
+      .describe("record: run live + capture external calls to a fixture. replay: serve them from the fixture (offline). Omit for a plain live run."),
+    cassetteName: z
+      .string()
+      .optional()
+      .describe("Fixture name (defaults to the step type). Use distinct names to keep multiple scenarios per step."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).runStep(cfg.type, {
+      config: cfg.config,
+      input: cfg.input,
+      params: cfg.params,
+      cassette: cfg.cassette,
+      cassetteName: cfg.cassetteName,
+    });
+  },
+});

--- a/vein/src/steps/lib/meta/run-workflow.ts
+++ b/vein/src/steps/lib/meta/run-workflow.ts
@@ -1,0 +1,29 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/run-workflow",
+  description:
+    "Run an agent-authored workflow (publisher 'ai' — i.e. published via meta/publish-workflow) with a given input, awaiting the result: { runId, status, output?, error? }. The candidate runs as its OWN persisted run (inspect it with meta/get-run). Sees steps and workflows published earlier in this same run (the registry is re-read fresh). Workflows the agent surface did not author are refused.",
+  input: z.object({
+    name: z.string().describe("Workflow name to run"),
+    input: z
+      .any()
+      .optional()
+      .describe(
+        "Input passed to the workflow as a JSON OBJECT (not a string), referenced in its steps via {{ input.* }}. Use {} if none.",
+      ),
+    params: z
+      .record(z.any())
+      .optional()
+      .describe(
+        "Optional overrides for the workflow's `params` knobs (prompts, thresholds), shallow-merged over its defaults — those are runs, not versions.",
+      ),
+    version: z.string().optional().describe("Optional specific version. Defaults to the active version."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).runWorkflow(cfg.name, cfg.input, cfg.params, cfg.version);
+  },
+});

--- a/vein/src/steps/lib/meta/search-steps.ts
+++ b/vein/src/steps/lib/meta/search-steps.ts
@@ -1,0 +1,16 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/search-steps",
+  description:
+    "Search step types by keyword — matches type names and descriptions across core, lib, and custom steps. Returns ranked matches. Use to check whether a step already exists before authoring one.",
+  input: z.object({
+    query: z.string().describe("Search keywords, e.g. 'github pr' or 'http request'"),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).searchSteps(cfg.query);
+  },
+});

--- a/vein/src/steps/registry.ts
+++ b/vein/src/steps/registry.ts
@@ -171,6 +171,33 @@ async function loadStepFile(filePath: string): Promise<AnyStepDef | null> {
 }
 
 /**
+ * Import a step file the way registry discovery does, but return the failure
+ * as a MESSAGE instead of a console warning. `null` means the file imports
+ * cleanly and default-exports a valid step def. This is the authoring loop's
+ * §5.3.4 guard: `loadStepFile` fails silently (a broken step simply doesn't
+ * exist), so publish paths call this to hand the error back to the author.
+ */
+export async function stepLoadError(filePath: string): Promise<string | null> {
+  try {
+    let suffix = "?strict";
+    try {
+      const { mtimeMs } = await stat(filePath);
+      suffix = `?v=${mtimeMs}-strict`;
+    } catch {
+      // stat failed — fall back to a static cache-bust
+    }
+    const mod = await import(pathToFileURL(filePath).href + suffix);
+    const def = mod.default ?? mod;
+    if (def && typeof def === "object" && "type" in def && "run" in def) {
+      return null;
+    }
+    return `no valid default export — expected \`export default defineStep({ type, input, output, run })\``;
+  } catch (err) {
+    return err instanceof Error ? err.message : String(err);
+  }
+}
+
+/**
  * Build the complete step registry by merging core steps (statically
  * imported) with lib steps (dynamically imported from `src/steps/lib/`)
  * and custom steps (dynamically imported from `<workspace>/steps/custom/`).

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -99,6 +99,12 @@ export interface WorkflowMetadata {
    *  version-level: it survives publishes and can be changed at any time via
    *  `setWorkflowCategory`. */
   category?: string;
+  /** Optional identifier of the service that published this workflow
+   *  (parallels `StepInfo.publisher`). Workflow-level provenance: the
+   *  authoring capability stamps everything it publishes `"ai"` and its
+   *  publish/run/run-history operations are closed over that stamped set —
+   *  see `authoring.ts` and EVOLVE_SPEC §6 (run-history scoping). */
+  publisher?: string;
 }
 
 export interface StepVersionInfo {
@@ -138,6 +144,8 @@ export interface WorkflowListEntry {
   description?: string;
   /** Grouping label, if the workflow has one (see WorkflowMetadata.category). */
   category?: string;
+  /** Provenance stamp, if any (see WorkflowMetadata.publisher). */
+  publisher?: string;
   /** Start time (epoch ms) of the most recent run, if any. Run ids are
    *  millisecond timestamps (FileRunStore), so this is just the max entry
    *  in the workflow's `runs/` dir — no run.json reads. */
@@ -183,6 +191,7 @@ export class WorkspaceManager {
           versions: Object.keys(meta.versions),
           description: activeDesc,
           ...(meta.category ? { category: meta.category } : {}),
+          ...(meta.publisher ? { publisher: meta.publisher } : {}),
           ...(lastRunAt != null ? { lastRunAt } : {}),
         });
       }
@@ -259,6 +268,7 @@ export class WorkspaceManager {
     content: { steps: any[]; params?: Record<string, unknown> } | string,
     description?: string,
     category?: string,
+    publisher?: string,
   ): Promise<{ name: string; version: string }> {
     const workflowsDir = join(this.root, "workflows");
     let finalName = name;
@@ -278,18 +288,20 @@ export class WorkspaceManager {
       }
     }
 
-    await this.publishWorkflow(finalName, "v1", resolvedContent, description, category);
+    await this.publishWorkflow(finalName, "v1", resolvedContent, description, category, publisher);
     return { name: finalName, version: "v1" };
   }
 
   /** Publish a new workflow version. Accepts steps array or raw YAML string.
-   *  `category` (when provided) updates the workflow-level grouping label. */
+   *  `category` (when provided) updates the workflow-level grouping label;
+   *  `publisher` (when provided) sets the workflow-level provenance stamp. */
   async publishWorkflow(
     name: string,
     version: string,
     content: { steps: any[]; params?: Record<string, unknown>; promotes?: unknown[] } | string,
     description?: string,
     category?: string,
+    publisher?: string,
   ): Promise<void> {
     const dir = join(this.root, "workflows", name);
     await mkdir(dir, { recursive: true });
@@ -325,6 +337,7 @@ export class WorkspaceManager {
     };
     meta.active = version;
     if (category !== undefined) meta.category = category;
+    if (publisher !== undefined) meta.publisher = publisher;
 
     await writeFile(
       join(dir, "_metadata.json"),
@@ -417,6 +430,7 @@ export class WorkspaceManager {
     yamlStr: string,
     description?: string,
     category?: string,
+    publisher?: string,
   ): Promise<{ version: string; changed: boolean }> {
     const hash = contentHash(yamlStr);
     const meta = await this.readWorkflowMetadata(name);
@@ -440,7 +454,11 @@ export class WorkspaceManager {
     }
 
     const next = nextVersionLabel(meta ? Object.keys(meta.versions) : []);
-    await this.publishWorkflow(name, next, yamlStr, description, category);
+    // `publisher` is only ever applied when a version is actually written —
+    // never reconciled on the identical-content no-op path above, so
+    // republishing a workflow's existing content verbatim cannot re-stamp
+    // (and thereby claim) a workflow someone else published.
+    await this.publishWorkflow(name, next, yamlStr, description, category, publisher);
     return { version: next, changed: true };
   }
 


### PR DESCRIPTION
## What

Implements EVOLVE_SPEC §5.2: the workspace's author/test/inspect operations as **registry steps**, so an in-workflow agent (`agentTools: ["meta/*"]`) can author, test, and evaluate candidate workflows from inside a run — the missing mechanism for layer-3 (structural) self-evolution. Generalized: it lives in vein core and works for any benchmark, not just GAIA.

## How

- **`authoring.ts`** — one shared authoring core. The mechanism (name-conflict checks, JSON-string arg coercion, strict load-verification, run-history reads) is exported as helpers; the chat builder's tools (`ai/tools.ts`) were refactored to sit on the same helpers, and `buildAuthoringCapability` layers the meta policy on top. One implementation, two policies.
- **13 `meta/*` lib steps** (`steps/lib/meta/`) — list/search/get/create/edit/run step, list/get/publish/run workflow, list-runs/get-run, list-secrets — thin plumbing over `ctx.services.authoring`, auto-discovered like any lib step.
- **`createVein` auto-provides `services.authoring`** the same way it provides `http`/`secrets`/`artifacts`, so every vein deployment gets the surface with zero wiring; embedders can inject their own.

## The ownership rule (EVOLVE_SPEC §6)

A harness workflow's run log records what its grader steps were handed — potentially gold and rubric text. So the capability scopes by **workflow provenance, not actor**:

- `WorkflowMetadata` gains a `publisher` field (mirroring the step-level one). Everything the capability publishes is stamped `"ai"` — the capability sets the stamp, the calling agent can't override it.
- `meta/publish-workflow`, `meta/run-workflow`, `meta/list-runs`, `meta/get-run` act on **stamped workflows only**, failing closed on everything else — the loop can't read harness runs and can't rewire the harness that grades it.
- An identical-content republish never re-stamps, so a workflow can't be claimed by republishing its own YAML verbatim.
- `meta/edit-step` edits only steps published as `"ai"`; seeded harness steps carry seeder publishers (`harvey-seed`, `eval-seed`, …).
- Provenance lives on the workflow record, so generation N can inspect generation N−1's candidate runs across sessions — actor scoping would have broken iteration.

## Also fixed along the way

- **§5.3.1 was understated**: `runWorkflow` threads one registry snapshot through the *entire run*, not just per agent step — so `meta/run-workflow` / `meta/run-step` re-read a fresh registry at call time; a step authored mid-run is runnable moments later (covered by a test).
- **§5.3.4 silent failures**: publishes are import-verified via a new `stepLoadError` in `steps/registry.ts` — a broken step comes back as an error carrying the actual import failure instead of silently not existing. (Import check, not a full `tsc` typecheck — catches syntax/bad-import/missing-export flailing cheaply.)

## Testing

- 8 new tests in `authoring.test.ts`: capability auto-provision + meta step registration, the create→run→edit inner loop with load-verification, broken-source error handoff, edit-ownership refusal, the full provenance closure (stamp, refuse unstamped publish/run/history, idempotent republish), fresh-registry mid-run authoring, meta steps wired through `ctx.services` in a real run, and secrets names-only.
- Full vein suite: 488/488 pass. vein `tsc`, web `tsc`, and mcp `tsc` all clean; `EVOLVE_SPEC.md` updated to reflect built status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)