### PR TITLE
gaia: create the cache parent before the git-lfs probe (cold-start ENOENT)

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -433,7 +433,7 @@ on the `LabServices` bag), never in a seeded/authored step. `gaia/*` steps
   yields a checkout the grader cannot read. Bootstrap therefore does
   init → `fetch --depth 1 <pinned sha>` → `checkout FETCH_HEAD` against
   `897f2dfb`, the last revision with the full benchmark (165 validation +
-  300 test rows), which is also what every score so far was graded against.
+  301 test rows), which is also what every score so far was graded against.
 - **`HF_TOKEN` is REQUIRED for a cold bootstrap.** The dataset is gated:
   anonymous `ls-remote` answers (which makes the repo look open), but the
   actual `git-upload-pack` fetch is refused without credentials. Bootstrap

--- a/mcp/src/lab/gaia/bootstrap.ts
+++ b/mcp/src/lab/gaia/bootstrap.ts
@@ -81,7 +81,7 @@ const DATASET_REPO = "https://huggingface.co/datasets/gaia-benchmark/GAIA";
  * later and confusingly at `loadMeta`.
  *
  * This SHA is the last revision carrying the full benchmark: 165 validation
- * rows + 300 test rows, matching the published split sizes. It is also the
+ * rows + 301 test rows, matching the published split sizes. It is also the
  * revision every score this lab has produced so far was graded against, so
  * pinning it keeps new numbers comparable to the existing ones.
  *
@@ -425,6 +425,10 @@ export async function ensureGaiaDataset(
       );
     }
 
+    // On a truly cold cache the parent dir does not exist yet — and a spawn
+    // with a missing cwd rejects with ENOENT, which the probe's catch-all
+    // would misreport as "git-lfs not on PATH". Create it before probing.
+    await mkdir(dirname(root), { recursive: true });
     await assertGitLfs(exec, dirname(root));
 
     // A checkout can be present-but-incomplete (interrupted clone, or a dir

--- a/mcp/src/lab/gaia/smoke.ts
+++ b/mcp/src/lab/gaia/smoke.ts
@@ -171,6 +171,10 @@ async function bootstrapSmoke(): Promise<void> {
         } = {},
       ): BootstrapExecFn =>
       async (_cmd, args, o) => {
+        // Real spawn REJECTS with ENOENT when cwd does not exist — it does
+        // not return a nonzero exit. Model that, so a probe run from a
+        // not-yet-created directory fails here the way it fails in prod.
+        if (!existsSync(o.cwd)) throw new Error(`spawn git ENOENT (cwd ${o.cwd})`);
         if (args[0] === "lfs") {
           return opts.lfs === false
             ? { code: 1, stdout: "", stderr: "git: 'lfs' is not a git command" }
@@ -299,6 +303,17 @@ async function bootstrapSmoke(): Promise<void> {
         }),
       /unresolved git-lfs pointers/,
     );
+
+    // ── a COLD cache (parent dirs don't exist yet) still bootstraps: the
+    //    git-lfs probe must not spawn from a not-yet-created directory ──
+    resetGaiaBootstrap();
+    const cold = join(box, "deep", "nested", "gaia");
+    const coldRes = await ensureGaiaDataset({
+      dir: cold, hfToken: "hf_xxx", exec: fakeExec(), fetchText: fetchStub,
+      scorerSha256: STUB_SHA, log,
+    });
+    assert.equal(coldRes.root, cold);
+    assert.ok(existsSync(join(cold, "2023", "validation", "metadata.jsonl")));
 
     // ── happy path: checkout + scorer installed, verified against the pin ──
     resetGaiaBootstrap();


### PR DESCRIPTION
The first genuinely cold-container run of the bootstrap — v0.4.226 image, `HF_TOKEN` supplied — failed with:

```
gaia: git-lfs is required — GAIA's attachments (xlsx/pdf/mp3/png) are LFS-backed…
```

in an image where git-lfs is installed, system-configured, and demonstrably working. The real cause: `assertGitLfs` spawns `git lfs version` with `cwd` set to the cache parent (`/root/.cache/vein`), which **does not exist yet on a cold cache**. Node's `spawn` rejects a missing cwd with `ENOENT` (`spawn git ENOENT`), and the probe's catch-all converts any rejection into "git-lfs not on PATH". Confirmed by reproducing the bare spawn in the container.

Latent since #1599: every prior run — host runs, the `~/data/gaia` fast path, fixture smokes — happened to have the parent directory already present. Prod's cold start (fresh volume) is precisely the case that doesn't.

## Fix

`mkdir -p` the cache parent before probing (one line; `cloneDataset` needed it created moments later anyway).

## Tests

The smoke `fakeExec` now models spawn's real missing-cwd semantics — reject, not a nonzero exit — for **every** scenario, so no bootstrap test can silently run from a directory that wouldn't exist in prod. A new cold-cache scenario targets `<box>/deep/nested/gaia` with no pre-created parents; it fails without the fix and passes with it.

## Verified

- `npx tsx src/lab/gaia/smoke.ts` all pass, `tsc --noEmit` clean.
- Shipped `v0.4.226-arm64` image with the fixed compiled module mounted, real `HF_TOKEN`, empty cache: **cold bootstrap 5.3s**, `rev == DATASET_REV`, 165 validation + 301 test metadata rows, 109 attachments checked with **zero** LFS pointer stubs, and a known-answer pair graded at the expected **0.5** through the real `scorer.py`, with `benchmarkRev`/`scorerSha256` attribution intact.
- Negative control on the same image: no token → the #1601 fail-fast fires with the `HF_TOKEN` remediation text.

Also corrects "300 test rows" → **301** in the `DATASET_REV` comment and `AGENTS.md` (GAIA is 466 = 165 validation + 301 test; measured from the pinned checkout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)