### PR TITLE
vein: meta/search-runs — cross-run grep over event logs

### DIFF
--- a/vein/EVOLVE_SPEC.md
+++ b/vein/EVOLVE_SPEC.md
@@ -147,16 +147,27 @@ becomes a manifest proposal, not an assumption that the install persists.
 
 ### 4.2 The mechanism
 
-**Capture — `env/missing-tools`.** Missing tooling has machine-detectable
-signatures: `command not found: yt-dlp`, `ModuleNotFoundError: No module
-named 'fitz'`, `pdftotext: not found`. Every bash call already emits a nested
-run event (`wrapToolsWithEmit`, `agent.ts`), so a post-run step can scan a
-run's events and emit a structured gap list. Small (~40 lines) and it is the
-difference between a gap being noticed in prose and a gap being *data*.
+**Capture — `meta/search-runs` + `env/missing-tools`.** Every bash call
+already emits a nested run event (`wrapToolsWithEmit`, `agent.ts`), so the
+evidence is on disk; the question is how it gets read. The general
+instrument is **`meta/search-runs`** (done — `searchRunEvents`,
+`authoring.ts`): grep a regex across a workflow's recent run event logs →
+matching (runId, event path, snippet) tuples plus a per-run frequency
+summary, behind the same agent-authored gate as `meta/get-run` (raw
+filesystem grep over the workspace would read grader logs — §6). That's
+what lets a propose agent hunt *flexibly* — signatures nobody enumerated,
+a tool that exists but is too old — instead of being limited to a fixed
+parser. One caveat: events hold ~1500-char output previews
+(`summarizeForEvent`), not full transcripts, so a signature buried deep in
+long output can be missed. On top of it, a deterministic `env/missing-tools`
+scan for the known signatures (`command not found: yt-dlp`,
+`ModuleNotFoundError: No module named 'fitz'`) is the free always-on
+tripwire: zero tokens per batch, and its misses just mean a gap surfaces a
+batch later through the agent's own search.
 
 **Propose.** Aggregate across a batch → a frequency-ranked list
 (`pdftotext: 12 runs, yt-dlp: 3, tesseract: 2`). This is `eval/reflect`
-pointed at the environment.
+pointed at the environment, with `meta/search-runs` as its instrument.
 
 **Promote — `env.manifest`.** A versioned file (apt packages + pip packages,
 **pinned**) that the Dockerfile installs from at build time. The agent
@@ -362,8 +373,10 @@ possible version of "capture."
 
 ## 9. What's next
 
-1. **`env/missing-tools`** (§4.2) — the smallest high-value piece. Turns
-   tooling gaps into structured data instead of prose.
+1. **Environment capture** (§4.2) — ~~`meta/search-runs`~~ **done**
+   (cross-run grep over event logs, gated like `meta/get-run`; also a
+   `search_runs` chat tool). Next: the deterministic `env/missing-tools`
+   tripwire on top.
 2. **Full level-1 GAIA sweep** (53 tasks, ~$25) — a real baseline on 48
    unseen tasks, and the first dataset big enough for layer-1 optimize to
    have honest signal.

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -169,6 +169,7 @@ Tools:
 - run_workflow("<name>", input?, params?, version?): run a published workflow and return its result. LONG RUNS AUTO-DETACH: if the run is still executing after the wait window (~a minute), the call returns { status: "running", detached: true, runId } and the run continues in the background. When it finishes, a "[run-notification]" user message will automatically start your next turn with the outcome (several runs finishing while you work arrive batched in one message). Do NOT poll get_run in a loop while waiting — finish your turn normally, stating what you launched and what you plan to do when the result arrives.
 - list_runs("<name>", limit?): a workflow's past runs (newest first) with status/duration — for inspecting history or comparing experiment runs.
 - get_run("<name>", "<runId>", fullEvents?): one run's summary (input/output/error) + event log (slimmed by default; fullEvents:true for per-step payloads) — for debugging a failed run.
+- search_runs("<name>", "<pattern>", runIds?/runLimit?/maxMatches?/ignoreCase?): grep a regex across recent runs' event logs (inputs/outputs/errors) → matching (runId, path, snippet) tuples + per-run counts — for cross-run questions ("which runs hit this error, and how often?"); then get_run on a hit.
 
 Workflow:
 1. Available step types are listed at the end of this prompt. Use search_steps only if you need to find something by keyword; use list_steps only to re-list after creating new custom steps.

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -19,6 +19,7 @@ import {
   publishNewStep,
   publishStepVersion,
   readRun,
+  searchRunEvents,
 } from "../authoring.js";
 
 // ── Tools ──────────────────────────────────────────────────────────────────
@@ -460,6 +461,48 @@ export function buildTools(deps: AiDeps) {
           };
         }
         return readRun(store, name, runId, fullEvents);
+      },
+    }),
+
+    search_runs: tool({
+      description:
+        "Grep across a workflow's recent runs: match a regex against every event's JSON (inputs, outputs, errors) and get back (runId, event path, snippet) tuples plus a per-run frequency summary. The cross-run complement to get_run — use it to answer 'which runs hit this, and how often?' (e.g. a recurring error signature across a batch), then get_run to investigate one run. Note: tool outputs are truncated in the event log (~1500 chars), so a signature deep in long output can be missed.",
+      inputSchema: z.object({
+        name: z.string().describe("Workflow name whose runs to search"),
+        pattern: z
+          .string()
+          .describe(
+            "JavaScript regular expression matched against each event's JSON line, e.g. \"command not found|ModuleNotFoundError\".",
+          ),
+        runIds: z
+          .array(z.string())
+          .optional()
+          .describe("Explicit run ids to search. Default: the newest runLimit runs."),
+        runLimit: z
+          .number()
+          .int()
+          .positive()
+          .default(20)
+          .describe("How many recent runs to scan when runIds is absent (default 20)."),
+        maxMatches: z
+          .number()
+          .int()
+          .positive()
+          .default(50)
+          .describe(
+            "Cap on returned matches; scanning stops once reached (truncated: true). Narrow the pattern or run window rather than raising this (default 50).",
+          ),
+        ignoreCase: z.boolean().default(true).describe("Case-insensitive matching (default true)."),
+      }),
+      execute: async ({ name, pattern, runIds, runLimit, maxMatches, ignoreCase }) => {
+        const store = asReadStore(deps.store);
+        if (!store) {
+          return {
+            error:
+              "Run history is unavailable (the run store does not support reading back runs).",
+          };
+        }
+        return searchRunEvents(store, name, pattern, { runIds, runLimit, maxMatches, ignoreCase });
       },
     }),
 

--- a/vein/src/authoring.test.ts
+++ b/vein/src/authoring.test.ts
@@ -69,6 +69,7 @@ describe("authoring capability (the meta surface)", () => {
       "meta/run-workflow",
       "meta/list-runs",
       "meta/get-run",
+      "meta/search-runs",
       "meta/list-secrets",
     ]) {
       assert.ok(registry[type], `expected "${type}" in the registry`);
@@ -161,6 +162,55 @@ describe("authoring capability (the meta surface)", () => {
     assert.ok(Array.isArray(run.events) && run.events.length > 0);
     // Slim events carry no payloads by default.
     assert.equal(run.events[0].input, undefined);
+  });
+
+  it("searchRuns greps event logs across runs, gated to the stamped set", async () => {
+    // Two runs of a stamped candidate: one carries an env-gap signature, one is clean.
+    const yaml = `name: cand-search\nsteps:\n  - id: say\n    type: log\n    config:\n      message: "{{ input.msg }}"\n`;
+    const pub = (await authoring.publishWorkflow("cand-search", yaml)) as any;
+    assert.equal(pub.ok, true, JSON.stringify(pub));
+    const bad = (await authoring.runWorkflow("cand-search", {
+      msg: "ModuleNotFoundError: No module named 'fitz'",
+    })) as any;
+    assert.equal(bad.status, "success");
+    const good = (await authoring.runWorkflow("cand-search", { msg: "all good" })) as any;
+    assert.equal(good.status, "success");
+
+    // The cross-run question: which runs hit the signature?
+    const res = (await authoring.searchRuns("cand-search", "ModuleNotFoundError")) as any;
+    assert.equal(res.runsScanned, 2);
+    assert.deepEqual(
+      res.runsWithMatches.map((r: any) => r.runId),
+      [bad.runId],
+    );
+    assert.ok(res.matches.length >= 1);
+    assert.equal(res.matches[0].runId, bad.runId);
+    assert.ok(res.matches[0].snippet.includes("fitz"), res.matches[0].snippet);
+    assert.ok(res.matches[0].path, "matches carry the event path for get-run drill-down");
+
+    // Case-insensitive by default; a maxMatches cap truncates rather than growing.
+    const ci = (await authoring.searchRuns("cand-search", "modulenotfound")) as any;
+    assert.ok(ci.matches.length >= 1);
+    const capped = (await authoring.searchRuns("cand-search", "ModuleNotFoundError", {
+      maxMatches: 1,
+    })) as any;
+    assert.equal(capped.matches.length, 1);
+    assert.equal(capped.truncated, true);
+
+    // An explicit runIds window restricts the scan.
+    const windowed = (await authoring.searchRuns("cand-search", "ModuleNotFoundError", {
+      runIds: [good.runId],
+    })) as any;
+    assert.equal(windowed.runsScanned, 1);
+    assert.equal(windowed.matches.length, 0);
+
+    // Bad regex → a handed-back error, not a throw.
+    const invalid = (await authoring.searchRuns("cand-search", "(unclosed")) as any;
+    assert.ok(invalid.error && /Invalid pattern/.test(invalid.error), invalid.error);
+
+    // The ownership gate holds: unstamped workflows' logs are not searchable.
+    const refused = (await authoring.searchRuns("harness-flow", "gold")) as any;
+    assert.ok(refused.error && /not agent-authored/.test(refused.error), refused.error);
   });
 
   it("runWorkflow sees a step authored moments before (fresh registry, §5.3.1)", async () => {

--- a/vein/src/authoring.ts
+++ b/vein/src/authoring.ts
@@ -115,6 +115,111 @@ export async function readRun(
   };
 }
 
+// ── Run search (shared mechanism) ──────────────────────────────────────────
+
+export interface RunSearchOptions {
+  /** Explicit run ids to search (e.g. one eval batch). Default: newest `runLimit` runs. */
+  runIds?: string[];
+  /** How many recent runs to scan when `runIds` is absent. Default 20. */
+  runLimit?: number;
+  /** Cap on returned match entries; scanning stops once reached. Default 50. */
+  maxMatches?: number;
+  /** Case-insensitive matching. Default true (signature hunting favors recall). */
+  ignoreCase?: boolean;
+}
+
+/** One matching event from a run search. */
+export interface RunSearchMatch {
+  runId: string;
+  path: string;
+  type: string;
+  stepType?: string;
+  /** Matches within this one event (the snippet shows the first). */
+  count: number;
+  /** The matched text with surrounding context from the event's JSON. */
+  snippet: string;
+}
+
+const SNIPPET_BEFORE = 80;
+const SNIPPET_AFTER = 160;
+
+/**
+ * Grep across a workflow's run event logs — the cross-run question the
+ * per-run `readRun` can't answer without N calls and N payloads ("which runs
+ * hit `ModuleNotFoundError`, and how often?" — EVOLVE_SPEC §4.2 capture).
+ * Each event is matched as its JSON line (the same shape events.jsonl holds),
+ * so input/output/error payloads are all searchable; matches come back as
+ * (runId, event path, snippet) tuples plus a per-run frequency summary.
+ * Scanning stops at `maxMatches` (`truncated: true`) — narrow the pattern or
+ * the run window rather than raising the cap.
+ */
+export async function searchRunEvents(
+  store: RunReadStore,
+  name: string,
+  pattern: string,
+  opts: RunSearchOptions = {},
+) {
+  const { runLimit = 20, maxMatches = 50, ignoreCase = true } = opts;
+  let re: RegExp;
+  try {
+    re = new RegExp(pattern, ignoreCase ? "gi" : "g");
+  } catch (err) {
+    return { error: `Invalid pattern: ${err instanceof Error ? err.message : String(err)}` };
+  }
+
+  const runIds = opts.runIds?.length
+    ? opts.runIds
+    : (await store.listRuns(name)).slice(0, runLimit);
+
+  const matches: RunSearchMatch[] = [];
+  const perRun: { runId: string; matchingEvents: number }[] = [];
+  let runsScanned = 0;
+  let truncated = false;
+
+  for (const runId of runIds) {
+    if (truncated) break;
+    const events = await store.getRunEvents(name, runId);
+    runsScanned++;
+    let matchingEvents = 0;
+    for (const e of events) {
+      const line = JSON.stringify(e);
+      re.lastIndex = 0;
+      const first = re.exec(line);
+      if (!first) continue;
+      matchingEvents++;
+      let count = 1;
+      while (re.exec(line) !== null) count++;
+      matches.push({
+        runId,
+        path: e.path,
+        type: e.type,
+        ...(e.stepType ? { stepType: e.stepType } : {}),
+        count,
+        snippet: line.slice(
+          Math.max(0, first.index - SNIPPET_BEFORE),
+          first.index + first[0].length + SNIPPET_AFTER,
+        ),
+      });
+      if (matches.length >= maxMatches) {
+        truncated = true;
+        break;
+      }
+    }
+    if (matchingEvents > 0) perRun.push({ runId, matchingEvents });
+  }
+
+  return {
+    workflow: name,
+    pattern,
+    runsScanned,
+    runsWithMatches: perRun,
+    matches,
+    ...(truncated
+      ? { truncated: true, note: "Match cap reached — narrow the pattern or run window." }
+      : {}),
+  };
+}
+
 // ── Step publishing (shared mechanism) ─────────────────────────────────────
 
 /** LLMs sometimes pass an object-valued arg as a JSON *string* (e.g.
@@ -286,6 +391,7 @@ export interface AuthoringCapability {
   ): Promise<RunResult | { error: string }>;
   listRuns(name: string, limit?: number): Promise<unknown>;
   getRun(name: string, runId: string, fullEvents?: boolean): Promise<unknown>;
+  searchRuns(name: string, pattern: string, opts?: RunSearchOptions): Promise<unknown>;
   listSecrets(): Promise<unknown>;
 }
 
@@ -488,6 +594,14 @@ export function buildAuthoringCapability(deps: AuthoringDeps): AuthoringCapabili
       const read = asReadStore(store);
       if (!read) return { error: NO_RUN_HISTORY_ERROR };
       return readRun(read, name, runId, fullEvents);
+    },
+
+    async searchRuns(name, pattern, opts) {
+      const gate = await notOwned(name, "reads run history of");
+      if (gate) return { error: gate };
+      const read = asReadStore(store);
+      if (!read) return { error: NO_RUN_HISTORY_ERROR };
+      return searchRunEvents(read, name, pattern, opts);
     },
 
     async listSecrets() {

--- a/vein/src/steps/lib/meta/search-runs.ts
+++ b/vein/src/steps/lib/meta/search-runs.ts
@@ -1,0 +1,45 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/search-runs",
+  description:
+    "Grep across the recent runs of an agent-authored workflow: match a regex against every event's JSON (inputs, outputs, errors) and get back (runId, event path, snippet) tuples plus a per-run frequency summary. The cross-run complement to meta/get-run — use it to answer 'which runs hit this, and how often?' (e.g. environment-gap signatures like 'command not found' or 'ModuleNotFoundError' — EVOLVE_SPEC §4.2), then meta/get-run to investigate one run. Note: tool outputs are truncated in the event log (~1500 chars), so a signature deep in long output can be missed. Run history of workflows the agent surface did not author is refused.",
+  input: z.object({
+    name: z.string().describe("Workflow name whose runs to search (must be agent-authored)"),
+    pattern: z
+      .string()
+      .describe(
+        "JavaScript regular expression to match against each event's JSON line, e.g. \"command not found|ModuleNotFoundError\".",
+      ),
+    runIds: z
+      .array(z.string())
+      .optional()
+      .describe("Explicit run ids to search (e.g. one eval batch). Default: the newest runLimit runs."),
+    runLimit: z
+      .number()
+      .int()
+      .positive()
+      .default(20)
+      .describe("How many recent runs to scan when runIds is absent (default 20)."),
+    maxMatches: z
+      .number()
+      .int()
+      .positive()
+      .default(50)
+      .describe(
+        "Cap on returned matches; scanning stops once reached (truncated: true). Narrow the pattern or run window rather than raising this (default 50).",
+      ),
+    ignoreCase: z.boolean().default(true).describe("Case-insensitive matching (default true)."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).searchRuns(cfg.name, cfg.pattern, {
+      runIds: cfg.runIds,
+      runLimit: cfg.runLimit,
+      maxMatches: cfg.maxMatches,
+      ignoreCase: cfg.ignoreCase,
+    });
+  },
+});


### PR DESCRIPTION
## What

Adds `meta/search-runs`: grep a regex across the recent runs of an agent-authored workflow's event logs and get back `(runId, event path, snippet, count)` tuples plus a per-run frequency summary — the cross-run capture instrument EVOLVE_SPEC §4.2 needs ("which runs hit `ModuleNotFoundError`, and how often?").

## Why not just get-run / raw grep

- `meta/get-run` is addressed by a single runId — answering a cross-run question meant `list-runs` + N × `get-run(fullEvents)`, N calls and N payloads for one answer. Here the run ids are the *output* of the search, not the input.
- The events already sit on disk (`events.jsonl`) on the same filesystem as an agent's bash, but raw workspace grep would walk through the ownership boundary: grader workflows' logs can record what the graders were handed. `meta/search-runs` sits behind the same agent-authored gate as `meta/get-run`, so the sanctioned path stays closed over the stamped set.

## How

- **`searchRunEvents`** (`authoring.ts`, shared mechanism): each event matched as its JSON line (inputs/outputs/errors all searchable), bounded by `runLimit` (default 20, newest first) or an explicit `runIds` window, capped at `maxMatches` (default 50, `truncated: true` when hit), case-insensitive by default; invalid regexes return `{ error }`.
- **`meta/search-runs`** lib step — thin plumbing over the capability, gated by `requireAuthoring` + the `notOwned` check. Description warns that event logs hold ~1500-char output previews (`summarizeForEvent`), so a signature deep in long output can be missed.
- **`search_runs`** chat-builder tool (ungated — human-supervised surface) + a line in the system prompt's tool list, keeping the two consumers of the authoring core in parity.
- **EVOLVE_SPEC §4.2** rewritten: `meta/search-runs` is the general capture instrument; the deterministic `env/missing-tools` signature scan is demoted to the free always-on tripwire. Roadmap §9 item 1 updated.

## Tests

New block in `authoring.test.ts`: two runs of a stamped candidate (one carrying `ModuleNotFoundError: No module named 'fitz'`, one clean) → only the bad run in `runsWithMatches`, snippet + event path on matches, case-insensitivity, `maxMatches` truncation, `runIds` windowing, invalid-regex error, and the ownership gate refusing unstamped workflows. Full suite: 489 pass, 0 fail; `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)