### PR TITLE
gaia: commit + seed the 5/5 harness (steps, workflows, seed.ts)

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -420,7 +420,23 @@ quasi-exact match with type-aware normalization) as a `python3 -c` subprocess
 against the validation split's gold answers. Same discipline as harvey: the
 grader AND the gold live in the in-code `gaia` service (`gaia/service.ts`,
 on the `LabServices` bag), never in a seeded/authored step. `gaia/*` steps
-(authored by the assistant) are thin plumbing over `ctx.services.gaia.*`.
+are thin plumbing over `ctx.services.gaia.*`.
+
+- **Committed harness** (`gaia/seed.ts`, seeded at boot like harvey's):
+  steps `gaia/list-tasks`, `gaia/get-task` (stages a task's attached file
+  into the run's artifacts dir), `gaia/evaluate` (HARNESS-ONLY), and the
+  combiners `gaia/pack-result` + `gaia/summarize-batch`; workflows
+  `gaia-produce` (agent step; the produce system prompt, model, maxSteps: 50
+  and agentTools live in `params`; an `onError` fallback scores a blown-up
+  agent as an empty wrong answer instead of killing the batch), `gaia-run`
+  (single task: produce → score) and `gaia-batch` ({ level, limit }: one
+  score call for the whole batch). This is the harness that went 1/5 → 5/5
+  on the level-1 batch (EVOLVE_SPEC §1), promoted from the workspace where
+  the assistant authored it. Seeding is content-hash reconciled — the
+  committed copy is authoritative at boot, so a workspace-side evolution
+  survives restarts only once it's ported back here. The from-scratch
+  authoring recipe is kept in `notes/GAIA.md` as an authoring eval; it is no
+  longer the path to a working harness.
 
 - **Setup**: automatic (`gaia/bootstrap.ts`) — the one required env var is
   **`HF_TOKEN`**. First use materialises the dataset into `<cache>/vein/gaia`, installs the

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -15,6 +15,7 @@ import { seedGitseeWorkflows, seedGitseeSteps } from "./gitsee/seed.js";
 import { seedJarvisSteps } from "./jarvis/seed.js";
 import { seedSheetsSteps } from "./sheets/seed.js";
 import { seedHarveySteps, seedHarveyWorkflows } from "./harvey/seed.js";
+import { seedGaiaSteps, seedGaiaWorkflows } from "./gaia/seed.js";
 import { seedArtifactSteps } from "./artifacts/seed.js";
 import { buildHarveyServices, type HarveyServices } from "./harvey/service.js";
 import { buildGaiaServices, type GaiaServices } from "./gaia/service.js";
@@ -153,6 +154,10 @@ export async function createLabVein(
   // harvey/evaluate only to harness workflows, never the producing agent).
   await seedHarveySteps(workspace);
   await seedHarveyWorkflows(workspace);
+  // gaia harness (thin plumbing over services.gaia; grant gaia/evaluate —
+  // and every gaia/* — only to harness workflows, never the producing agent).
+  await seedGaiaSteps(workspace);
+  await seedGaiaWorkflows(workspace);
   // generic artifact plumbing (artifacts/dir — bridge runId → path for cwd).
   await seedArtifactSteps(workspace);
 

--- a/mcp/src/lab/gaia/seed.ts
+++ b/mcp/src/lab/gaia/seed.ts
@@ -1,0 +1,81 @@
+import { readFile } from "node:fs/promises";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import type { WorkspaceManager } from "vein";
+
+/**
+ * GAIA LAB steps + workflows — the harness that scored 5/5 on the first
+ * level-1 batch, promoted from the workspace where the assistant authored it
+ * (EVOLVE_SPEC §promote: winners become committed, diffable artifacts).
+ * The grader itself stays in the in-code `gaia` service (`service.ts`, on
+ * the LabServices bag) — these steps are THIN plumbing over
+ * `ctx.services.gaia.*`; editing them can only break plumbing, never change
+ * how scoring works.
+ *
+ * - `gaia/list-tasks`, `gaia/get-task` — task plumbing (gold stripped by the
+ *   service). get-task stages a task's attached file into the run's
+ *   artifacts dir so agent steps (cwd = artifacts dir) can read it.
+ * - `gaia/evaluate` — the real leaderboard scorer. HARNESS-ONLY: grant only
+ *   to harness workflows, never to a producing agent's `agentTools`.
+ * - `gaia/pack-result`, `gaia/summarize-batch` — pure combiners.
+ *
+ * Seeding is content-hash reconciled: the committed copy is authoritative at
+ * boot. A workspace-side evolution of these survives restarts only once it's
+ * ported back here.
+ */
+const SEED_STEPS: Array<{ file: string; type: string }> = [
+  { file: "list-tasks.ts", type: "gaia/list-tasks" },
+  { file: "get-task.ts", type: "gaia/get-task" },
+  { file: "evaluate.ts", type: "gaia/evaluate" },
+  { file: "pack-result.ts", type: "gaia/pack-result" },
+  { file: "summarize-batch.ts", type: "gaia/summarize-batch" },
+];
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+const SEED_WORKFLOWS: Array<{ name: string; description: string }> = [
+  {
+    name: "gaia-produce",
+    description:
+      "Helper: stage a GAIA task's file (if any) into a fresh artifacts dir, run a tool-using agent to answer it, and pack the result. A failed agent (rare no-object-generated error, etc.) falls back to an empty answer instead of aborting the caller. Input: { taskId }. Output: { taskId, question, level, hasFile, stagedPath, answer, cost, steps, produceError }.",
+  },
+  {
+    name: "gaia-run",
+    description:
+      "GAIA single-task harness: get-task -> agent produce -> real scorer. Input { taskId }. Output combines score + the produced answer/cost/steps.",
+  },
+  {
+    name: "gaia-batch",
+    description:
+      "GAIA batch harness: list-tasks (by level) -> first `limit` -> produce per task via gaia-produce -> one gaia/evaluate call -> merged report {accuracy, byLevel, perTask, totalCost, totalSteps}.",
+  },
+];
+
+export async function seedGaiaWorkflows(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "workflows");
+  for (const { name, description } of SEED_WORKFLOWS) {
+    try {
+      const yaml = await readFile(join(dir, `${name}.yaml`), "utf-8");
+      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, description, "gaia");
+      if (changed) console.log(`[gaia] seeded workflow: ${name} @ ${version}`);
+    } catch (err) {
+      console.warn(`[gaia] could not seed workflow "${name}":`, err instanceof Error ? err.message : err);
+    }
+  }
+}
+
+export async function seedGaiaSteps(workspace: WorkspaceManager): Promise<void> {
+  const dir = join(HERE, "steps");
+  for (const { file, type } of SEED_STEPS) {
+    try {
+      const code = await readFile(join(dir, file), "utf-8");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "gaia-seed");
+      if (changed) console.log(`[gaia] seeded step: ${type} @ ${version}`);
+    } catch (err) {
+      console.warn(
+        `[gaia] could not seed step "${type}":`,
+        err instanceof Error ? err.message : err,
+      );
+    }
+  }
+}

--- a/mcp/src/lab/gaia/steps/evaluate.ts
+++ b/mcp/src/lab/gaia/steps/evaluate.ts
@@ -1,0 +1,29 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/**
+ * HARNESS-ONLY plumbing over ctx.services.gaia.score. Never expose this
+ * step (or any gaia/*) as an agentTool to a producing agent — it would let
+ * the agent see grading/scoring internals or self-grade.
+ */
+export default defineStep({
+  type: "gaia/evaluate",
+  description:
+    "Score answer pairs against the GAIA gold set via ctx.services.gaia.score(pairs). HARNESS-ONLY — never grant to a producing agent's agentTools. Config: pairs [{ taskId, answer }]. Output: { accuracy, correct, total, byLevel, results, benchmarkRev, scorerSha256 }.",
+  input: z.object({
+    pairs: z
+      .array(
+        z.object({
+          taskId: z.string(),
+          answer: z.string(),
+        }),
+      )
+      .min(1),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const c = ctx as StepContext<VeinCapabilities & { gaia?: any }>;
+    const gaia = c.services?.gaia;
+    if (!gaia) throw new Error("gaia capability unavailable in this deployment");
+    return await gaia.score(cfg.pairs);
+  },
+});

--- a/mcp/src/lab/gaia/steps/get-task.ts
+++ b/mcp/src/lab/gaia/steps/get-task.ts
@@ -1,0 +1,57 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { readFile } from "node:fs/promises";
+import { basename } from "node:path";
+
+/**
+ * Plumbing over ctx.services.gaia.getTask, PLUS: when the task ships a
+ * file, copy it (from the read-only filePath) into this run's artifacts
+ * dir so agent steps (cwd = artifacts dir) can see it. Output adds
+ * `stagedPath` (relative path under the run's artifacts dir, or null).
+ */
+export default defineStep({
+  type: "gaia/get-task",
+  description:
+    "Fetch one GAIA task via ctx.services.gaia.getTask(taskId). If the task has an attached file, copies it into this run's artifacts dir (ctx.services.artifacts) and returns the staged RELATIVE path. Config: taskId. Output: { taskId, question, level, fileName, hasFile, stagedPath }.",
+  input: z.object({
+    taskId: z.string(),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const c = ctx as StepContext<VeinCapabilities & { gaia?: any }>;
+    const gaia = c.services?.gaia;
+    const artifacts = c.services?.artifacts;
+    if (!gaia) throw new Error("gaia capability unavailable in this deployment");
+    if (!artifacts) throw new Error("artifacts capability unavailable in this deployment");
+
+    const task = await gaia.getTask(cfg.taskId);
+    if (!task) {
+      throw new Error(
+        `gaia.getTask(${cfg.taskId}) returned nothing — likely a bad taskId (check gaia/list-tasks for valid ids)`,
+      );
+    }
+
+    let stagedPath: string | null = null;
+    if (task.filePath) {
+      let bytes: Buffer;
+      try {
+        bytes = await readFile(task.filePath);
+      } catch (err: any) {
+        throw new Error(
+          `Task ${cfg.taskId} declares filePath "${task.filePath}" but it could not be read (${err.message}) — the file may have moved or permissions are wrong`,
+        );
+      }
+      const name: string = task.fileName || basename(task.filePath);
+      stagedPath = name;
+      await artifacts.write(c.runId, name, bytes);
+    }
+
+    return {
+      taskId: task.taskId,
+      question: task.question,
+      level: task.level,
+      fileName: task.fileName ?? null,
+      hasFile: Boolean(task.filePath),
+      stagedPath,
+    };
+  },
+});

--- a/mcp/src/lab/gaia/steps/list-tasks.ts
+++ b/mcp/src/lab/gaia/steps/list-tasks.ts
@@ -1,0 +1,28 @@
+import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+
+/**
+ * Plumbing over ctx.services.gaia.listTasks. Optionally filter by level
+ * (1|2|3). Output: { tasks: [{ taskId, level, hasFile }], count, byLevel }.
+ */
+export default defineStep({
+  type: "gaia/list-tasks",
+  description:
+    "List GAIA benchmark tasks via ctx.services.gaia.listTasks({ level? }). Config: level? (1|2|3, omit for all). Output: { tasks: [{ taskId, level, hasFile }], count, byLevel: { '1': n, '2': n, '3': n } }.",
+  input: z.object({
+    level: z.union([z.literal(1), z.literal(2), z.literal(3)]).optional(),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const c = ctx as StepContext<VeinCapabilities & { gaia?: any }>;
+    const gaia = c.services?.gaia;
+    if (!gaia) throw new Error("gaia capability unavailable in this deployment");
+
+    const tasks = await gaia.listTasks(cfg.level ? { level: cfg.level } : {});
+    const byLevel: Record<string, number> = {};
+    for (const t of tasks) {
+      const key = String(t.level);
+      byLevel[key] = (byLevel[key] || 0) + 1;
+    }
+    return { tasks, count: tasks.length, byLevel };
+  },
+});

--- a/mcp/src/lab/gaia/steps/pack-result.ts
+++ b/mcp/src/lab/gaia/steps/pack-result.ts
@@ -1,0 +1,18 @@
+import { z, defineStep } from "vein";
+
+/**
+ * Trivial combiner: echoes its (already-template-resolved) config back as
+ * the step output. Used as the final step of a small workflow that needs
+ * to assemble fields from several earlier steps (task + agent output) into
+ * one object, since workflow output = the last step's output.
+ */
+export default defineStep({
+  type: "gaia/pack-result",
+  description:
+    "Echo the resolved config object back as output — a combiner for assembling fields from earlier steps into one object (workflow output = last step's output). Config: any JSON object. Output: the same object.",
+  input: z.record(z.any()),
+  output: z.any(),
+  async run(cfg) {
+    return cfg;
+  },
+});

--- a/mcp/src/lab/gaia/steps/summarize-batch.ts
+++ b/mcp/src/lab/gaia/steps/summarize-batch.ts
@@ -1,0 +1,51 @@
+import { z, defineStep } from "vein";
+
+/**
+ * Combine per-task produce results (taskId, question, level, answer, cost,
+ * steps) with the ONE gaia/evaluate score call's results (matched correctness
+ * per taskId) into the batch's final report shape.
+ */
+export default defineStep({
+  type: "gaia/summarize-batch",
+  description:
+    "Merge per-task produce results with a gaia/evaluate score response into a batch report. Config: produced (array of {taskId, question, level, answer, cost, steps, hasFile}), score (gaia/evaluate output). Output: { accuracy, correct, total, byLevel, totalCost, totalSteps, perTask: [{taskId, level, question, answer, correct, cost, steps}] }.",
+  input: z.object({
+    produced: z.array(z.any()),
+    score: z.any(),
+  }),
+  output: z.any(),
+  async run(cfg) {
+    const resultsByTask = new Map<string, any>();
+    for (const r of cfg.score?.results ?? []) resultsByTask.set(r.taskId, r);
+
+    let totalCost = 0;
+    let totalSteps = 0;
+    const perTask = cfg.produced.map((p: any) => {
+      const graded = resultsByTask.get(p.taskId);
+      const cost = typeof p.cost === "number" ? p.cost : 0;
+      const steps = typeof p.steps === "number" ? p.steps : 0;
+      totalCost += cost;
+      totalSteps += steps;
+      return {
+        taskId: p.taskId,
+        level: p.level,
+        question: p.question,
+        answer: p.answer,
+        correct: graded ? graded.correct : null,
+        cost: p.cost,
+        steps: p.steps,
+      };
+    });
+
+    return {
+      accuracy: cfg.score?.accuracy ?? null,
+      correct: cfg.score?.correct ?? null,
+      total: cfg.score?.total ?? null,
+      byLevel: cfg.score?.byLevel ?? null,
+      totalCost,
+      totalSteps,
+      benchmarkRev: cfg.score?.benchmarkRev,
+      perTask,
+    };
+  },
+});

--- a/mcp/src/lab/gaia/workflows/gaia-batch.yaml
+++ b/mcp/src/lab/gaia/workflows/gaia-batch.yaml
@@ -1,0 +1,36 @@
+name: gaia-batch
+# Batch harness: list tasks at a level -> take the first `limit` -> produce
+# an answer per task (agent, no gaia/* tools) -> ONE score call with every
+# pair -> merge into a report.
+# Input:  { level, limit }
+# Output: { accuracy, correct, total, byLevel, totalCost, totalSteps,
+#           benchmarkRev, perTask: [{taskId, level, question, answer,
+#           correct, cost, steps}] }
+steps:
+  - id: list
+    type: gaia/list-tasks
+    config:
+      level: "{{ input.level }}"
+
+  - id: produced
+    type: foreach
+    config:
+      items: "{{ list.tasks.slice(0, input.limit) }}"
+      body:
+        id: one
+        type: subflow
+        config:
+          workflow: gaia-produce
+          input:
+            taskId: "{{ $current.taskId }}"
+
+  - id: score
+    type: gaia/evaluate
+    config:
+      pairs: "{{ produced }}"
+
+  - id: result
+    type: gaia/summarize-batch
+    config:
+      produced: "{{ produced }}"
+      score: "{{ score }}"

--- a/mcp/src/lab/gaia/workflows/gaia-produce.yaml
+++ b/mcp/src/lab/gaia/workflows/gaia-produce.yaml
@@ -1,0 +1,126 @@
+name: gaia-produce
+steps:
+  - id: dir
+    type: artifacts/dir
+
+  - id: task
+    type: gaia/get-task
+    config:
+      taskId: "{{ input.taskId }}"
+
+  - id: produce
+    type: agent
+    options:
+      retry: { max: 1, delayMs: 5000 }
+      # A single task's agent blowing up (rare AI_NoObjectGeneratedError on
+      # the forced final turn, a dead tool, etc.) must NOT kill an entire
+      # batch run. Fall back to an empty (certainly-wrong) answer so this
+      # task is simply scored incorrect instead of aborting every other task.
+      onError:
+        id: produce_failed
+        type: gaia/pack-result
+        config:
+          object: { answer: "" }
+          cost: 0
+          steps: 0
+          error: "{{ $error.message }}"
+    config:
+      cwd: "{{ dir.path }}"
+      system: "{{ params.system }}"
+      prompt: |
+        QUESTION (level {{ task.level }}):
+        {{ task.question }}
+
+        hasFile: {{ task.hasFile }}
+        stagedPath: {{ task.stagedPath }}
+        (If hasFile is true, that file is already sitting in your current
+        working directory under that exact relative filename — read it
+        directly, no download needed. If hasFile is false, there is no
+        attached file; answer from reasoning/web research only.)
+      model: "{{ params.model }}"
+      maxSteps: "{{ params.maxSteps }}"
+      agentTools: "{{ params.agentTools }}"
+      schema:
+        type: object
+        properties:
+          answer:
+            type: string
+            description: "The bare final answer only. No units unless the question asks for them. No explanation."
+        required: ["answer"]
+        additionalProperties: false
+
+  - id: result
+    type: gaia/pack-result
+    config:
+      taskId: "{{ task.taskId }}"
+      question: "{{ task.question }}"
+      level: "{{ task.level }}"
+      hasFile: "{{ task.hasFile }}"
+      stagedPath: "{{ task.stagedPath }}"
+      answer: "{{ produce.object.answer }}"
+      cost: "{{ produce.cost }}"
+      steps: "{{ produce.steps }}"
+      produceError: "{{ produce.error }}"
+
+params:
+  model: claude-sonnet-4-6
+  # Generous budget — some GAIA tasks need many bash calls (pandas/pdftotext
+  # loops, retries after a failed extraction). Too tight a budget is what
+  # forces a premature/garbled final turn (AI_NoObjectGeneratedError).
+  maxSteps: 50
+  # Registry step types exposed as extra agent tools, beyond the agent's
+  # built-ins (bash, str_replace_based_edit_tool, web_search, repo_overview,
+  # fulltext_search). NEVER include gaia/* here (harness-only; would let the
+  # agent see grading/self-grade).
+  agentTools: ["html/extract"]
+  system: |
+    You are answering ONE question from the GAIA benchmark. Grading is EXACT
+    STRING MATCH against a gold answer — there is zero tolerance for extra
+    words, wrong units, or the wrong form of a number.
+
+    FINAL ANSWER FORMAT (non-negotiable):
+    - Output ONLY the bare answer: a number, a word, a short phrase, or a
+      comma-separated list — whatever the question's expected answer type is.
+    - No units unless the question explicitly asks for a value in that unit.
+    - No leading "The answer is", no trailing period/explanation, no markdown.
+    - Numbers: use digits, not words, unless the question asks you to spell
+      it out. Do not add thousands separators unless asked.
+    - If the question asks for a list, comma-separate it in the order asked.
+
+    BEFORE YOU FINALIZE:
+    - Re-read the ORIGINAL question text again, word for word. Check your
+      answer against its exact ask: right units (or explicitly no units),
+      "how many THOUSAND/MILLION" scaling, singular vs plural, which entity
+      it's asking about (first vs last, largest vs smallest), any rounding
+      instruction, and ordering if a list is asked for.
+    - If a tool or approach fails (missing binary, HTTP 404, empty/garbled
+      extraction, page paywalled), do NOT give up and guess — try at least
+      one genuinely different approach (a different search query, a
+      different site, a different extraction tool, or reasoning from
+      other found facts) before answering. Only answer from a guess if you
+      have truly exhausted your available approaches AND steps are running
+      out.
+    - For logic puzzles, counting problems, scheduling, or anything with
+      combinatorial/careful-bookkeeping structure: WRITE AND RUN a small
+      Python script via bash to simulate/compute it. Do not just reason it
+      out in your head — verify with code.
+    - Budget your steps: you have a limited number of tool calls. Once you
+      have enough evidence to answer confidently, STOP investigating and
+      call the final answer — don't keep polishing once you're sure.
+
+    TOOLING NOTES for this sandboxed environment (python3 venv has numpy,
+    pandas, openpyxl, pypdf, pdfplumber, pillow, requests, beautifulsoup4;
+    plus pdftotext, yt-dlp, ffmpeg, pandoc on PATH):
+    - PDFs: extract text with `pdftotext file.pdf -` or pdfplumber (needed for
+      tables); fall back to pypdf.
+    - Spreadsheets (.xlsx/.csv): use pandas or openpyxl — print every sheet,
+      every row/column you need, don't guess at structure.
+    - Audio/video: use yt-dlp to fetch, ffmpeg to extract/convert audio, then
+      transcribe/inspect as needed.
+    - Word docs (.docx): `pandoc file.docx -t markdown` or python-docx-style
+      extraction via bash if pandoc isn't enough.
+    - Web pages: prefer the html/extract tool for clean text (tables kept
+      readable); use web_search to find the right page first.
+
+    When you are fully confident, call the final-answer output with just the
+    bare answer string in the `answer` field.

--- a/mcp/src/lab/gaia/workflows/gaia-run.yaml
+++ b/mcp/src/lab/gaia/workflows/gaia-run.yaml
@@ -1,0 +1,36 @@
+name: gaia-run
+# Single-task harness: get-task -> produce (agent) -> evaluate (REAL scorer).
+# The producing agent NEVER gets gaia/* tools (see gaia-produce's params).
+# Input:  { taskId }
+# Output: { accuracy, correct, total, byLevel, results, benchmarkRev,
+#           scorerSha256, taskId, question, level, answer, cost, steps }
+steps:
+  - id: produced
+    type: subflow
+    config:
+      workflow: gaia-produce
+      input:
+        taskId: "{{ input.taskId }}"
+
+  - id: score
+    type: gaia/evaluate
+    config:
+      pairs:
+        - taskId: "{{ produced.taskId }}"
+          answer: "{{ produced.answer }}"
+
+  - id: result
+    type: gaia/pack-result
+    config:
+      accuracy: "{{ score.accuracy }}"
+      correct: "{{ score.correct }}"
+      total: "{{ score.total }}"
+      byLevel: "{{ score.byLevel }}"
+      results: "{{ score.results }}"
+      benchmarkRev: "{{ score.benchmarkRev }}"
+      taskId: "{{ produced.taskId }}"
+      question: "{{ produced.question }}"
+      level: "{{ produced.level }}"
+      answer: "{{ produced.answer }}"
+      cost: "{{ produced.cost }}"
+      steps: "{{ produced.steps }}"


### PR DESCRIPTION
## What

Promotes the workspace-authored GAIA harness into the repo as committed, boot-seeded artifacts — the EVOLVE_SPEC promote beat, following the exact harvey pattern:

- **`mcp/src/lab/gaia/steps/`** — the five `gaia/*` plumbing steps: `list-tasks`, `get-task` (stages a task's attached file into the run's artifacts dir), `evaluate` (HARNESS-ONLY — never granted to a producing agent), and the `pack-result` / `summarize-batch` combiners.
- **`mcp/src/lab/gaia/workflows/`** — the latest active versions: `gaia-produce` v2 (agent step; prompt/model/maxSteps/agentTools in `params`; `onError` fallback scores a blown-up agent as an empty wrong answer instead of killing the batch), `gaia-run` v1, `gaia-batch` v1.
- **`mcp/src/lab/gaia/seed.ts`** — content-hash-reconciled seeding at boot, wired into `createLabVein.ts` after harvey.
- **AGENTS.md** — documents the committed harness and the seed-is-authoritative-at-boot semantics.

## Why

This is the harness that went 1/5 → 5/5 on the level-1 batch (EVOLVE_SPEC §1). It previously lived only in the gitignored `lab-workspace/`, with the from-scratch authoring prompt in `notes/GAIA.md` as the only durable artifact — meaning every batch re-rolled the harness as a hidden variable, and the measured winner was one `rm -rf` from gone. Committing it makes GAIA numbers comparable across runs; `notes/GAIA.md` stays as an *authoring eval*, no longer the path to a working harness.

The grader and gold remain in the in-code `gaia` service — nothing agent-editable can touch scoring.

## One code delta from the workspace

`get-task.ts` needed a `name: string` annotation to pass this repo's stricter tsc (narrowing lost through the untyped task object) — identical runtime behavior. Seeding against the live workspace reconciled it as `gaia/get-task` v2; everything else was a byte-identical no-op, confirming the committed copy is exactly what scored 5/5.

## Verification

- `npm run build` clean; yaml + step sources copied into `build/lab/gaia/` by `copy-lab-assets.mjs` (no script changes needed).
- Seeding into a fresh temp workspace publishes all 5 steps + 3 workflows.
- Seeding against the live workspace: no-op except the `get-task` reconcile above.
- `npx tsx src/lab/gaia/smoke.ts` — ALL PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)