### PR TITLE
harvey: produce/grade split + harvey-evolve authoring harness (EVOLVE_SPEC §5.2/§9.4)

### DIFF
--- a/mcp/src/lab/artifacts/steps/dir.ts
+++ b/mcp/src/lab/artifacts/steps/dir.ts
@@ -1,4 +1,6 @@
 import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { mkdir } from "node:fs/promises";
+import { isAbsolute, join, resolve, sep } from "node:path";
 
 /**
  * Resolve THIS run's artifacts directory (creating it) and return its
@@ -6,19 +8,45 @@ import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
  * ctx.runId, which workflow expressions can't see) and steps that take a
  * path — point an `agent` step's `cwd` at `{{ dir.path }}` so its file tools
  * write into the run's artifact store, servable at GET /artifacts/:runId.
+ *
+ * Optional `sub`: a RELATIVE subdirectory to create under the run's dir and
+ * return instead. Subflows share their parent's runId (one run = one
+ * artifacts dir), so several produce subflows in one batch run would
+ * otherwise collide on `./output/` — a per-item `sub` (e.g. the task id)
+ * keeps them apart.
  */
 export default defineStep({
   type: "artifacts/dir",
   description:
     "Return this run's artifacts directory (absolute path, created on demand). " +
     "Use as an early workflow step and point an agent step's cwd at its `path` output " +
-    "so produced files land in the run's artifact store (browsable at GET /artifacts/:runId).",
-  input: z.object({}),
+    "so produced files land in the run's artifact store (browsable at GET /artifacts/:runId). " +
+    "Optional `sub`: relative subdirectory to create under the run's dir and return instead — " +
+    "use a per-item value (e.g. the task id) when several produce subflows share one parent " +
+    "run (same runId → same artifacts dir) so they don't collide on ./output/.",
+  input: z.object({
+    sub: z
+      .string()
+      .optional()
+      .describe(
+        "Relative subdirectory of the run's artifacts dir to create and return (nested paths ok). Absolute paths and '..' segments are rejected.",
+      ),
+  }),
   output: z.any(),
-  async run(_cfg, ctx) {
+  async run(cfg, ctx) {
     const c = ctx as StepContext<VeinCapabilities>;
     const artifacts = c.services?.artifacts;
     if (!artifacts) throw new Error("artifacts capability unavailable");
-    return { path: await artifacts.dir(c.runId), runId: c.runId };
+    const base = await artifacts.dir(c.runId);
+    if (!cfg.sub) return { path: base, runId: c.runId };
+    if (isAbsolute(cfg.sub) || cfg.sub.split(/[\\/]/).includes("..")) {
+      throw new Error(`artifacts/dir: sub must be a relative path without '..': "${cfg.sub}"`);
+    }
+    const path = resolve(join(base, cfg.sub));
+    if (path !== base && !path.startsWith(base + sep)) {
+      throw new Error(`artifacts/dir: sub escapes the run's artifacts dir: "${cfg.sub}"`);
+    }
+    await mkdir(path, { recursive: true });
+    return { path, runId: c.runId, sub: cfg.sub };
   },
 });

--- a/mcp/src/lab/harvey/evolve-smoke.ts
+++ b/mcp/src/lab/harvey/evolve-smoke.ts
@@ -1,0 +1,137 @@
+/**
+ * Offline validation for the harvey produce/grade split + evolve harness:
+ *  1. all four workflows seed + parse into Flows (YAML → Flow schema)
+ *  2. the template expressions used in them resolve as intended
+ *  3. harvey/digest-results aggregates fixture score reports correctly
+ *  4. artifacts/dir `sub` creates/guards subdirs
+ * No uv/python, no LLM, no network.
+ * Run: npx tsx src/lab/harvey/evolve-smoke.ts
+ */
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { WorkspaceManager, buildRegistry, fileArtifactsCapability, resolveConfig } from "vein";
+import { seedHarveySteps, seedHarveyWorkflows } from "./seed.js";
+import { seedArtifactSteps } from "../artifacts/seed.js";
+
+async function main() {
+  const base = mkdtempSync(join(process.cwd(), ".evolve-validate-"));
+  try {
+    const workspace = new WorkspaceManager(join(base, "ws"));
+    await seedHarveySteps(workspace);
+    await seedArtifactSteps(workspace);
+    await seedHarveyWorkflows(workspace);
+
+    // 1. every seeded workflow parses into a Flow
+    for (const name of ["harvey-produce", "harvey-run", "harvey-candidate-run", "harvey-evolve"]) {
+      const flow = await workspace.getWorkflow(name);
+      assert.equal(flow.name, name);
+      assert.ok(Array.isArray(flow.steps) && flow.steps.length > 0, `${name} has steps`);
+      console.log(`✔ workflow parses: ${name} (${flow.steps.length} steps)`);
+    }
+
+    // step types referenced by the workflows all exist in the registry
+    const { registry } = await buildRegistry(workspace.path);
+    const wanted = [
+      "harvey/get-task", "harvey/evaluate", "harvey/pack-result", "harvey/digest-results",
+      "artifacts/dir", "meta/run-workflow", "agent", "subflow", "foreach",
+    ];
+    for (const t of wanted) assert.ok(registry[t], `registry has ${t}`);
+    console.log("✔ all referenced step types resolve");
+
+    // 2. template expressions used in the new workflows
+    const scope: Record<string, unknown> = {
+      input: { task: "a/b", tasks: ["a/b", "c/d"] },
+      produced: { outputDir: "/x/output", cost: 1.2, steps: 7, usage: { inputTokens: 100, outputTokens: 50 } },
+      run: { runId: "r1", status: "success", output: { outputDir: "/y/output", cost: 0.5, steps: 3 } },
+      grade: { score: 0.5 },
+      author: { object: { candidate: "harvey-produce-ai", version: "v3" }, cost: 2, steps: 9 },
+      basedigest: { meanScore: 0.4, text: "digest" },
+      canddigest: { meanScore: 0.7 },
+      params: {},
+    };
+    const r = (s: string) => (resolveConfig as any)(s, scope);
+    assert.equal(r("{{ input.produceWorkflow || 'harvey-produce' }}"), "harvey-produce");
+    // The evaluator does NOT short-circuit (ternary/&&/|| still evaluate both
+    // sides), so the workflows never deep-access possibly-undefined objects.
+    const failedScope = { ...scope, run: { runId: "r2", status: "failed", error: { message: "boom" } } };
+    assert.throws(
+      () => (resolveConfig as any)("{{ run.output ? run.output.outputDir : undefined }}", failedScope),
+      /Cannot access/,
+    );
+    // Instead: whole objects are passed and unpacked in step code…
+    assert.deepEqual((resolveConfig as any)("{{ run }}", failedScope), failedScope.run);
+    assert.deepEqual((resolveConfig as any)("{{ run.error }}", failedScope), { message: "boom" });
+    // …and error-path packs keep usage always-present ({}), so one-level-deep
+    // access on it stays safe:
+    const onErrorScope = { ...scope, produced: { usage: {}, cost: 0, steps: 0 } };
+    assert.equal((resolveConfig as any)("{{ produced.usage.inputTokens }}", onErrorScope), undefined);
+    assert.equal(r("{{ produced.usage.inputTokens }}"), 100);
+    assert.equal(r("{{ canddigest.meanScore - basedigest.meanScore }}"), 0.7 - 0.4);
+    assert.equal(r("{{ input.tasks.length }}"), 2);
+    console.log("✔ template expressions resolve (fallback, whole-object pass, arithmetic; no-short-circuit guarded)");
+
+    // 3. digest step over fixture score reports (incl. onError shapes)
+    const digest = registry["harvey/digest-results"]!;
+    const ctxStub = { runId: "r", path: "p", scope: {}, input: undefined, emit: async () => {}, services: {}, registry } as any;
+    const out: any = await digest.run(
+      digest.input.parse({
+        results: [
+          {
+            task: "a/b", score: 0.5, all_pass: false,
+            criteria_results: [
+              { id: "c1", verdict: "pass", reasoning: "ok" },
+              { id: "c2", verdict: "fail", reasoning: "missed the HSR threshold update" },
+              { id: "c3", verdict: "fail" },
+            ],
+            produceCost: 1.1,
+          },
+          { task: "c/d", score: 1, all_pass: true, criteria_results: [{ id: "c1", verdict: "pass" }] },
+          {
+            task: "e/f", score: 0, all_pass: false,
+            // object-shaped RunResult error + cost only inside runResult —
+            // the harvey-candidate-run failure shape
+            error: { message: "candidate run failed" },
+            gradeError: "eval failed (exit 1)",
+            runResult: { runId: "x", status: "failed", output: { cost: 0.33 } },
+          },
+        ],
+        maxCriteria: 1,
+      }),
+      ctxStub,
+    );
+    assert.equal(out.n, 3);
+    assert.equal(out.meanScore, 0.5);
+    assert.equal(out.allPassCount, 1);
+    assert.equal(out.results[0].nFailed, 2);
+    assert.equal(out.results[0].failed.length, 1);
+    assert.equal(out.results[0].failedOmitted, 1);
+    assert.equal(out.results[0].cost, 1.1);
+    assert.equal(out.results[2].error, "candidate run failed");
+    assert.equal(out.results[2].cost, 0.33);
+    assert.ok(out.text.includes("mean score 0.5") && out.text.includes("✗ c2"));
+    assert.ok(out.text.includes("(+1 more failed criteria not shown)"));
+    console.log("✔ harvey/digest-results aggregates + formats");
+
+    // 4. artifacts/dir sub
+    const artifacts = fileArtifactsCapability(join(base, "artifacts"));
+    const dirStep = registry["artifacts/dir"]!;
+    const dirCtx = { ...ctxStub, services: { artifacts } };
+    const noSub: any = await dirStep.run(dirStep.input.parse({}), dirCtx);
+    assert.ok(noSub.path.endsWith("/r"));
+    const withSub: any = await dirStep.run(dirStep.input.parse({ sub: "a/b" }), dirCtx);
+    assert.ok(withSub.path.endsWith("/r/a/b"));
+    await assert.rejects(() => dirStep.run(dirStep.input.parse({ sub: "../nope" }), dirCtx), /relative path/);
+    await assert.rejects(() => dirStep.run(dirStep.input.parse({ sub: "/abs" }), dirCtx), /relative path/);
+    console.log("✔ artifacts/dir sub: create + traversal guards");
+
+    console.log("\nALL EVOLVE VALIDATION CHECKS PASSED");
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -12,17 +12,29 @@ import type { WorkspaceManager } from "vein";
  *
  * - `harvey/get-task` — instructions + documents, rubric stripped. Safe for
  *   producing agents.
- * - `harvey/evaluate` — stage this run's artifact deliverables + run the real
- *   eval. Grant ONLY to harness workflows, never to the producing agent.
+ * - `harvey/evaluate` — stage deliverables + run the real eval. Grant ONLY
+ *   to harness workflows, never to the producing agent.
+ * - `harvey/pack-result` — echo combiner (assemble workflow outputs; onError
+ *   fallbacks).
+ * - `harvey/digest-results` — aggregate graded results into the propose
+ *   digest (verdict channel only; see the step header).
  */
 const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "get-task.ts", type: "harvey/get-task" },
   { file: "evaluate.ts", type: "harvey/evaluate" },
+  { file: "pack-result.ts", type: "harvey/pack-result" },
+  { file: "digest-results.ts", type: "harvey/digest-results" },
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-const SEED_WORKFLOWS = ["harvey-run"];
+// Order matters only for readability — all four are plain publishes. The
+// produce/grade split (EVOLVE_SPEC §5): harvey-produce is the swappable
+// candidate unit, harvey-run/harvey-candidate-run are the grading harnesses,
+// harvey-evolve is the authoring harness over all of them. All seeded
+// UNSTAMPED (no publisher arg → not "ai"), so the meta surface can read but
+// never edit, run, or overwrite them.
+const SEED_WORKFLOWS = ["harvey-produce", "harvey-run", "harvey-candidate-run", "harvey-evolve"];
 
 export async function seedHarveyWorkflows(workspace: WorkspaceManager): Promise<void> {
   const dir = join(HERE, "workflows");

--- a/mcp/src/lab/harvey/steps/digest-results.ts
+++ b/mcp/src/lab/harvey/steps/digest-results.ts
@@ -1,0 +1,119 @@
+import { z, defineStep } from "vein";
+
+/**
+ * Aggregate a batch of graded Harvey results into the compact digest the
+ * evolve loop's PROPOSE beat consumes (EVOLVE_SPEC §2: a proposer must see
+ * the aggregate across the dataset, never one example, or it overfits).
+ *
+ * RUBRIC DISCIPLINE: what leaves this step is the VERDICT channel — per-
+ * criterion pass/fail plus a truncated excerpt of the judge's reasoning for
+ * FAILED criteria only. That is the channel EVOLVE_SPEC §6/§7 knowingly
+ * accepts (hill-climbing against verdicts is the train-set problem, answered
+ * by a train/val split — scores on the tuned tasks are TRAIN scores). The
+ * rubric itself is never read here: `harvey/get-task` strips it, and this
+ * step only sees what the benchmark's own score report emits.
+ *
+ * Input entries are harvey-run / harvey-candidate-run outputs (score,
+ * all_pass, criteria_results, plus optional error fields from onError
+ * fallbacks). Field access is defensive — the score report is the
+ * benchmark's own JSON, not a shape we control.
+ */
+
+interface AnyRec {
+  [k: string]: unknown;
+}
+
+function truncate(s: string, max: number): string {
+  const t = s.replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max) + " […]" : t;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v : undefined;
+}
+
+/** An error field may be a string or an { message } object (a RunResult's
+ *  error) — normalize both. */
+function errStr(v: unknown): string | undefined {
+  if (typeof v === "string") return str(v);
+  if (v && typeof v === "object") return str((v as AnyRec)["message"]);
+  return undefined;
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === "number" ? v : undefined;
+}
+
+function criterionFailed(c: AnyRec): boolean {
+  const verdict = str(c["verdict"]);
+  if (verdict) return verdict.toLowerCase() !== "pass";
+  const passed = c["passed"] ?? c["pass"] ?? c["met"];
+  if (typeof passed === "boolean") return !passed;
+  return false; // unknown shape — don't invent failures
+}
+
+function criterionNote(c: AnyRec, maxChars: number): string {
+  const label = str(c["id"]) ?? str(c["title"]) ?? str(c["criterion"]) ?? str(c["name"]) ?? "criterion";
+  const reason = str(c["reasoning"]) ?? str(c["rationale"]) ?? str(c["reason"]);
+  return truncate(reason ? `${label}: ${reason}` : label, maxChars);
+}
+
+export default defineStep({
+  type: "harvey/digest-results",
+  description:
+    "Aggregate an array of graded Harvey results (harvey-run / harvey-candidate-run outputs) into a compact digest: per-task score, all_pass, failed-criteria excerpts (capped), errors, plus mean score / all-pass count and a preformatted `text` block for an LLM prompt. Config: results (array), maxCriteria? (failed-criteria excerpts per task, default 6), maxChars? (per excerpt, default 240). Output: { n, meanScore, allPassCount, results, text }.",
+  input: z.object({
+    results: z.array(z.any()).describe("graded results, one per task (harvey-run / harvey-candidate-run outputs)"),
+    maxCriteria: z
+      .number()
+      .int()
+      .min(0)
+      .default(6)
+      .describe("max failed-criteria excerpts to keep per task (overflow is counted, not silently dropped)"),
+    maxChars: z.number().int().positive().default(240).describe("max characters per failed-criterion excerpt"),
+  }),
+  output: z.any(),
+  async run(cfg) {
+    const entries = (cfg.results as AnyRec[]).map((raw, i) => {
+      const r = (raw ?? {}) as AnyRec;
+      const task = str(r["task"]) ?? `result ${i + 1}`;
+      const score = typeof r["score"] === "number" ? (r["score"] as number) : 0;
+      const allPass = r["all_pass"] === true;
+      const crit = Array.isArray(r["criteria_results"]) ? (r["criteria_results"] as AnyRec[]) : [];
+      const failed = crit.filter(criterionFailed);
+      const error = errStr(r["error"]) ?? errStr(r["gradeError"]) ?? errStr(r["produceError"]);
+      const runOut = ((r["runResult"] as AnyRec | undefined)?.["output"] ?? {}) as AnyRec;
+      const cost = num(r["produceCost"]) ?? num(r["cost"]) ?? num(runOut["cost"]);
+      return {
+        task,
+        score,
+        all_pass: allPass,
+        nCriteria: crit.length,
+        nFailed: failed.length,
+        failed: failed.slice(0, cfg.maxCriteria).map((c) => criterionNote(c, cfg.maxChars)),
+        failedOmitted: Math.max(0, failed.length - cfg.maxCriteria),
+        ...(cost != null ? { cost } : {}),
+        ...(error ? { error: truncate(error, cfg.maxChars) } : {}),
+      };
+    });
+
+    const n = entries.length;
+    const meanScore = n ? Math.round((entries.reduce((s, e) => s + e.score, 0) / n) * 1000) / 1000 : 0;
+    const allPassCount = entries.filter((e) => e.all_pass).length;
+
+    // Preformatted for an LLM prompt ({{ digest.text }}) — objects
+    // interpolated into template strings would arrive as raw JSON.
+    const lines: string[] = [`${n} task(s) — mean score ${meanScore}, all-pass ${allPassCount}/${n}`];
+    for (const e of entries) {
+      lines.push(
+        `- ${e.task}  score ${e.score}  all_pass=${e.all_pass}` +
+          (e.nCriteria ? `  (${e.nFailed}/${e.nCriteria} criteria failed)` : ""),
+      );
+      for (const f of e.failed) lines.push(`    ✗ ${f}`);
+      if (e.failedOmitted > 0) lines.push(`    (+${e.failedOmitted} more failed criteria not shown)`);
+      if (e.error) lines.push(`    ERROR: ${e.error}`);
+    }
+
+    return { n, meanScore, allPassCount, results: entries, text: lines.join("\n") };
+  },
+});

--- a/mcp/src/lab/harvey/steps/evaluate.ts
+++ b/mcp/src/lab/harvey/steps/evaluate.ts
@@ -28,6 +28,25 @@ export default defineStep({
       .optional()
       .default("output")
       .describe("Subdirectory of this run's artifacts dir holding the deliverables (default 'output')."),
+    dir: z
+      .string()
+      .optional()
+      .describe(
+        "ABSOLUTE path of the deliverables directory to stage, overriding the runId-derived " +
+          "`<this run's artifacts dir>/<from>`. Use when grading a produce run that ran under its " +
+          "OWN runId — e.g. an agent-authored candidate via meta/run-workflow, whose output " +
+          "reports `outputDir` (see harvey-candidate-run).",
+      ),
+    fromRun: z
+      .any()
+      .optional()
+      .describe(
+        "A meta/run-workflow RESULT object ({ runId, status, output?, error? }) whose output " +
+          "reports `outputDir` — pass the WHOLE object (e.g. `{{ run }}`) and this step extracts " +
+          "the staging dir and produce metrics (cost/steps/usage) in code. Exists because workflow " +
+          "template expressions cannot safely deep-access a possibly-undefined `output` (the " +
+          "evaluator does not short-circuit). Takes precedence over `from`; `dir` wins over both.",
+      ),
     metrics: z
       .record(z.string(), z.any())
       .optional()
@@ -49,16 +68,55 @@ export default defineStep({
     const services = ctx.services as ({ harvey?: HarveyServices } & VeinCapabilities) | undefined;
     const harvey = services?.harvey;
     if (!harvey) throw new Error("harvey service unavailable — is this the lab vein?");
-    const artifacts = services?.artifacts;
-    if (!artifacts) throw new Error("artifacts capability unavailable");
     const typedCtx = ctx as StepContext<VeinCapabilities>;
-    const dir = await artifacts.dir(typedCtx.runId);
-    const sub = (cfg.from ?? "output").replace(/^\/+|\/+$/g, "");
+    // A produce run's result (meta/run-workflow shape). Extracted in code —
+    // template expressions can't guard deep access on a failed run's missing
+    // `output`.
+    const fromRun = cfg.fromRun as
+      | { output?: { outputDir?: unknown; cost?: unknown; steps?: unknown; usage?: { inputTokens?: unknown; outputTokens?: unknown } } }
+      | undefined;
+    const produceOut = fromRun && typeof fromRun === "object" ? fromRun.output : undefined;
+    let sourceDir: string;
+    if (cfg.dir) {
+      sourceDir = cfg.dir;
+    } else if (typeof produceOut?.outputDir === "string" && produceOut.outputDir) {
+      sourceDir = produceOut.outputDir;
+    } else if (fromRun) {
+      // The produce run failed before reporting an outputDir — there is
+      // nothing to stage. Fail loudly (the harness's grade onError records
+      // the honest zero) instead of accidentally staging this run's dir.
+      throw new Error("harvey/evaluate: fromRun has no output.outputDir (the produce run failed)");
+    } else {
+      const artifacts = services?.artifacts;
+      if (!artifacts) throw new Error("artifacts capability unavailable");
+      const dir = await artifacts.dir(typedCtx.runId);
+      const sub = (cfg.from ?? "output").replace(/^\/+|\/+$/g, "");
+      sourceDir = sub ? `${dir}/${sub}` : dir;
+    }
+    // Fold the produce run's own metrics in (explicit cfg.metrics wins).
+    const runMetrics: Record<string, unknown> = produceOut
+      ? {
+          ...(produceOut.usage && typeof produceOut.usage === "object"
+            ? { input_tokens: produceOut.usage.inputTokens, output_tokens: produceOut.usage.outputTokens }
+            : {}),
+          produce_cost: produceOut.cost,
+          produce_steps: produceOut.steps,
+        }
+      : {};
+    const metrics =
+      cfg.metrics || Object.keys(runMetrics).length ? { ...runMetrics, ...cfg.metrics } : undefined;
+    // Include the step PATH in the benchmark run id: subflows share their
+    // parent's runId, so a batch harness (harvey-evolve) grades many times
+    // under one vein runId — a bare `vein-<runId>` would re-stage every grade
+    // into the same results/<id>/output/ dir, leaving the previous task's
+    // deliverables mixed in (cp adds, it doesn't clean). The path is unique
+    // per step invocation (foreach iterations include `#<i>`); the service
+    // sanitizes the separators.
     return harvey.evaluate({
       task: cfg.task,
-      sourceDir: sub ? `${dir}/${sub}` : dir,
-      runId: `vein-${typedCtx.runId}`,
-      metrics: cfg.metrics,
+      sourceDir,
+      runId: `vein-${typedCtx.runId}-${typedCtx.path}`,
+      metrics,
       judgeModel: cfg.judgeModel,
       dual: cfg.dual,
       parallel: cfg.parallel,

--- a/mcp/src/lab/harvey/steps/pack-result.ts
+++ b/mcp/src/lab/harvey/steps/pack-result.ts
@@ -1,0 +1,19 @@
+import { z, defineStep } from "vein";
+
+/**
+ * Trivial combiner: echoes its (already-template-resolved) config back as
+ * the step output. Used as the final step of a workflow that needs to
+ * assemble fields from several earlier steps into one object (workflow
+ * output = the last step's output), and as an `onError` fallback that packs
+ * an explicit failure result instead of killing a batch run.
+ */
+export default defineStep({
+  type: "harvey/pack-result",
+  description:
+    "Echo the resolved config object back as output — a combiner for assembling fields from earlier steps into one object (workflow output = last step's output). Config: any JSON object. Output: the same object.",
+  input: z.record(z.any()),
+  output: z.any(),
+  async run(cfg) {
+    return cfg;
+  },
+});

--- a/mcp/src/lab/harvey/workflows/harvey-candidate-run.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-candidate-run.yaml
@@ -1,0 +1,89 @@
+name: harvey-candidate-run
+# Run an AGENT-AUTHORED candidate produce workflow on ONE task, then grade
+# its deliverables with the real benchmark eval. The harness half of the
+# EVOLVE_SPEC §5.2 loop:
+#
+#   author (meta/*) → run (THIS) → grade (THIS) → reflect
+#
+# The candidate runs via meta/run-workflow (services.authoring), which
+#   (a) runs ONLY workflows stamped publisher "ai" — i.e. published via
+#       meta/publish-workflow. It refuses the seeded harvey-produce; baseline
+#       runs go through harvey-run instead. So this harness can never be
+#       pointed back at (or used to launder) the seeded harness surface.
+#   (b) rebuilds the step registry FRESH at call time — a candidate STEP
+#       authored earlier in the same enclosing run is visible (§5.3.1),
+#       which a plain subflow (start-of-run registry snapshot) can't do.
+#   (c) runs the candidate under its OWN runId — its artifacts dir is its
+#       own, so parallel candidate runs never collide. Grading stages the
+#       outputDir the candidate reports: the WHOLE run result is handed to
+#       harvey/evaluate as `fromRun` and unpacked in code (template
+#       expressions cannot guard deep access on a failed run's missing
+#       `output` — the evaluator does not short-circuit).
+#
+# CANDIDATE CONTRACT (what the author must publish): input { task },
+# output (last step) includes outputDir (absolute), usage, cost, steps.
+#
+# If the candidate run fails, the grade step fails on the missing outputDir
+# and its onError records an honest zero — produceStatus/error in the result
+# keep the cause attributable, and a batch over many tasks always completes
+# with one result per task.
+#
+# Input:  { workflow, version?, task }
+#   workflow: candidate name (publisher "ai"); version pins it (default: active)
+# Output: { task, candidate, version, produceRunId, produceStatus, score,
+#           all_pass, summary, criteria_results, benchmarkRev, reportPath,
+#           runResult, error?, gradeError? }
+steps:
+  - id: run
+    type: meta/run-workflow
+    config:
+      name: "{{ input.workflow }}"
+      version: "{{ input.version }}"
+      input:
+        task: "{{ input.task }}"
+
+  - id: grade
+    type: harvey/evaluate
+    depends: run
+    options:
+      retry: { max: 1, delayMs: 15000 }
+      onError:
+        id: grade_failed
+        type: harvey/pack-result
+        config:
+          score: 0
+          all_pass: false
+          gradeError: "{{ $error.message }}"
+    config:
+      task: "{{ input.task }}"
+      fromRun: "{{ run }}"
+      dual: "{{ params.dual }}"
+      timeoutMs: "{{ params.evalTimeoutMs }}"
+
+  - id: result
+    type: harvey/pack-result
+    depends: grade
+    config:
+      task: "{{ input.task }}"
+      candidate: "{{ input.workflow }}"
+      version: "{{ input.version }}"
+      produceRunId: "{{ run.runId }}"
+      produceStatus: "{{ run.status }}"
+      # object ({ message, … }), string (an authoring-gate refusal), or
+      # absent — harvey/digest-results normalizes all three.
+      error: "{{ run.error }}"
+      # The full candidate run result (runId, status, output, error) for
+      # humans debugging a candidate — inspect further via meta/get-run.
+      runResult: "{{ run }}"
+      score: "{{ grade.score }}"
+      max_score: "{{ grade.max_score }}"
+      all_pass: "{{ grade.all_pass }}"
+      summary: "{{ grade.summary }}"
+      criteria_results: "{{ grade.criteria_results }}"
+      benchmarkRev: "{{ grade.benchmarkRev }}"
+      reportPath: "{{ grade.reportPath }}"
+      gradeError: "{{ grade.gradeError }}"
+
+params:
+  dual: false
+  evalTimeoutMs: 2400000

--- a/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
@@ -1,0 +1,248 @@
+name: harvey-evolve
+# The AUTHORING HARNESS (EVOLVE_SPEC §5.2 / §9.4): the first outer workflow
+# that exercises the meta/* authoring surface end to end. One generation of
+# the shared loop, with every beat a real, graded artifact:
+#
+#   capture   run the BASELINE produce workflow over the task set, grade it
+#             with the real benchmark eval, digest the aggregate misses
+#   propose   an AUTHORING agent — agentTools ["meta/*"] and NOTHING else
+#             (§5.3.2: never bash, never graders) — reads the digest,
+#             authors a CANDIDATE produce workflow via meta/publish-workflow
+#             (stamped publisher "ai"), smoke-tests it via meta/run-workflow,
+#             and iterates until structurally healthy
+#   evaluate  the HARNESS (not the author) runs the pinned candidate over
+#             the same tasks (harvey-candidate-run) and grades each
+#   promote   the report: candidate name + EXACT version, baseline vs
+#             candidate scores, the author's rationale, and any missing
+#             secrets the author captured. Promotion stays a HUMAN act —
+#             point harvey-run's input.produceWorkflow at the candidate, or
+#             fold its changes into the seeded harvey-produce, after review.
+#
+# MEASUREMENT DISCIPLINE (EVOLVE_SPEC §6/§7):
+#   - The author sees pass/fail VERDICTS + truncated judge reasoning for
+#     failed criteria (harvey/digest-results) — never the rubric itself.
+#     Hill-climbing against verdicts is the train-set problem: the scores in
+#     this report are TRAIN scores on the very tasks the candidate was tuned
+#     against. Validate on held-out tasks before believing the delta.
+#   - The author cannot grade: harvey/evaluate is not in its grants, and
+#     meta/run-workflow only reaches produce candidates. Its smoke tests
+#     check structure (run succeeds, deliverables exist), not quality.
+#   - Baselines run per-task workdirs (subflows share this run's artifacts
+#     dir); candidates run under their OWN runIds via meta/run-workflow.
+#
+# COST: roughly 2 × |tasks| × (produce + judge) + the author's own smoke
+# runs (produce only, ≤2 by instruction). Start with 2-3 tasks.
+#
+# Needs: ANTHROPIC_API_KEY, HARVEY_LABS_DIR (+ uv, git, pandoc on PATH).
+# Input:  { tasks: [taskId, …], mission }
+#   mission: what to improve and why — the gap statement handed to the
+#            author (e.g. a per-miss taxonomy line: "citations unverifiable;
+#            stale regulatory figures — needs an online research step").
+# Output: { candidate, candidateVersion, baselineMean, candidateMean,
+#           meanDelta, baseline, candidateResults, authorSummary,
+#           authorChanges, missingSecrets, … }
+steps:
+  - id: dir
+    type: artifacts/dir
+    config:
+      sub: author
+
+  # ── capture: baseline over the task set ────────────────────────────────
+  - id: baseline
+    type: foreach
+    config:
+      items: "{{ input.tasks }}"
+      body:
+        id: one
+        type: subflow
+        config:
+          workflow: harvey-run
+          input:
+            task: "{{ $current }}"
+            workdir: "{{ $current }}"
+
+  - id: basedigest
+    type: harvey/digest-results
+    depends: baseline
+    config:
+      results: "{{ baseline }}"
+      maxCriteria: "{{ params.digestMaxCriteria }}"
+
+  # ── propose: the authoring agent ───────────────────────────────────────
+  - id: author
+    type: agent
+    depends: [dir, basedigest]
+    options:
+      retry: { max: 1, delayMs: 15000 }
+    config:
+      cwd: "{{ dir.path }}"
+      system: "{{ params.authorSystem }}"
+      prompt: |
+        MISSION:
+        {{ input.mission }}
+
+        TASK SET ({{ input.tasks.length }} Harvey benchmark task(s)):
+        {{ input.tasks }}
+
+        BASELINE: the current produce workflow "{{ params.baseWorkflow }}"
+        was run on every task above and graded by the real benchmark.
+        Aggregate results:
+
+        {{ basedigest.text }}
+
+        Author an improved CANDIDATE produce workflow named EXACTLY
+        "{{ params.candidateName }}" that addresses the failure patterns
+        that RECUR across tasks (never one task's specifics). Start from the
+        base workflow's YAML, keep its hard contract, publish, smoke-test on
+        ONE task from the task set, and return the result.
+        {{ params.authorGuidance }}
+      model: "{{ params.authorModel }}"
+      maxSteps: "{{ params.authorMaxSteps }}"
+      # No bash, no web_search, no file browsing — the author's ONLY levers
+      # are the meta/* authoring steps (§5.3.2). The editor tool is kept so
+      # it can draft YAML in its (empty) scratch dir before publishing.
+      toolFilter: ["str_replace_based_edit_tool"]
+      agentTools: ["meta/*"]
+      schema:
+        type: object
+        properties:
+          candidate:
+            type: string
+            description: "the published candidate workflow name"
+          version:
+            type: string
+            description: "EXACT version string of the final healthy publish (from meta/publish-workflow)"
+          summary:
+            type: string
+            description: "what changed and why, each change tied to a recurring failure pattern from the digest"
+          changes:
+            type: array
+            items: { type: string }
+            description: "one line per concrete change"
+          missingSecrets:
+            type: array
+            description: "credentials the candidate needs that meta/list-secrets does not show — the capture artifact a human fulfills"
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                why: { type: string }
+              required: [name, why]
+              additionalProperties: false
+        required: [candidate, version, summary]
+        additionalProperties: false
+
+  # ── evaluate: the pinned candidate over the same tasks ─────────────────
+  - id: candeval
+    type: foreach
+    depends: author
+    config:
+      items: "{{ input.tasks }}"
+      body:
+        id: one
+        type: subflow
+        config:
+          workflow: harvey-candidate-run
+          input:
+            workflow: "{{ author.object.candidate }}"
+            version: "{{ author.object.version }}"
+            task: "{{ $current }}"
+
+  - id: canddigest
+    type: harvey/digest-results
+    depends: candeval
+    config:
+      results: "{{ candeval }}"
+      maxCriteria: "{{ params.digestMaxCriteria }}"
+
+  # ── promote: the reviewable report ─────────────────────────────────────
+  - id: report
+    type: harvey/pack-result
+    depends: [basedigest, canddigest]
+    config:
+      mission: "{{ input.mission }}"
+      tasks: "{{ input.tasks }}"
+      candidate: "{{ author.object.candidate }}"
+      candidateVersion: "{{ author.object.version }}"
+      baselineMean: "{{ basedigest.meanScore }}"
+      candidateMean: "{{ canddigest.meanScore }}"
+      meanDelta: "{{ canddigest.meanScore - basedigest.meanScore }}"
+      baselineAllPass: "{{ basedigest.allPassCount }}"
+      candidateAllPass: "{{ canddigest.allPassCount }}"
+      baseline: "{{ basedigest.results }}"
+      candidateResults: "{{ canddigest.results }}"
+      authorSummary: "{{ author.object.summary }}"
+      authorChanges: "{{ author.object.changes }}"
+      missingSecrets: "{{ author.object.missingSecrets }}"
+      authorCost: "{{ author.cost }}"
+      authorSteps: "{{ author.steps }}"
+      note: "TRAIN scores — the candidate was tuned against these tasks (EVOLVE_SPEC §7). Validate on held-out tasks before promoting. Promote by pointing harvey-run's input.produceWorkflow at the candidate, or by folding its diff into harvey-produce after review."
+
+params:
+  # The produce workflow the author starts from (read via meta/get-workflow).
+  baseWorkflow: harvey-produce
+  # The candidate's name. Publishing the same name again = a NEW VERSION on
+  # the same ai-stamped workflow, so successive evolve runs accumulate a
+  # versioned lineage instead of littering the registry with fresh names.
+  candidateName: harvey-produce-ai
+  authorModel: claude-sonnet-4-6
+  authorMaxSteps: 40
+  # Extra per-run steering appended to the author's task prompt (experiment
+  # surface — e.g. "the mission requires online research; grant http steps
+  # and reference the COURTLISTENER_API_KEY secret by name").
+  authorGuidance: ""
+  digestMaxCriteria: 6
+  # The author's persona + method — layer-1 tunable like any other prompt.
+  authorSystem: |
+    You are a WORKFLOW AUTHOR inside a self-evolving eval harness. You
+    improve HOW a benchmark task gets produced by authoring a new version of
+    a produce workflow. You never produce task deliverables yourself, and
+    you never see the grading rubric — only aggregate pass/fail results.
+
+    Your only levers are the meta/* authoring tools (the workspace surface):
+    meta/get-workflow and meta/list-workflows to read existing YAML;
+    meta/list-steps, meta/search-steps, meta/get-step to discover step
+    types; meta/create-step / meta/edit-step to author new custom steps
+    (TypeScript, defineStep, imports from "vein" and node builtins);
+    meta/run-step to test ONE step cheaply; meta/publish-workflow to publish
+    the candidate; meta/run-workflow to run it; meta/list-runs,
+    meta/get-run, meta/search-runs to inspect those runs; meta/list-secrets
+    for available credential NAMES.
+
+    METHOD
+    1. Read the base produce workflow's YAML FIRST (meta/get-workflow) —
+       your candidate starts from it, changed only where the evidence
+       points. Address failure patterns that recur across MULTIPLE tasks;
+       never encode one task's specifics.
+    2. Publish the candidate under the EXACT name given in the task prompt
+       (meta/publish-workflow). Republishing the same name creates a new
+       version — that is how you iterate.
+    3. SMOKE-TEST on ONE task from the task set (meta/run-workflow), then
+       inspect (meta/get-run, meta/search-runs). You cannot grade quality —
+       the harness grades after you finish. Check STRUCTURE only: the run
+       succeeds, the output object carries outputDir/usage/cost/steps, and
+       the deliverable files exist. Fix and republish until healthy. Runs
+       cost real money: one task, at most two smoke runs.
+
+    HARD CONTRACT for the candidate (the harness runs it as-is):
+    - input { task, workdir? }; thread workdir into an artifacts/dir step
+      (config sub) exactly as the base workflow does.
+    - the LAST step (use harvey/pack-result) must output: task, outputDir
+      (ABSOLUTE path containing the deliverable files), usage, cost, steps.
+    - deliverables are written under outputDir; the grader stages exactly
+      that directory.
+    - NEVER grant harvey/*, gaia/*, eval/*, or meta/* to any agent step
+      inside the candidate — graders and the authoring surface are
+      off-limits to producers. Steps you author yourself and other registry
+      namespaces are fair game.
+    - keep prompts in params (the tuning surface), keep the produce agent's
+      retry + onError fallback so one bad task cannot kill a batch.
+    - secrets: reference NAMES from meta/list-secrets (e.g. via
+      ctx.services.secrets in an authored step) — never paste credential
+      values. If a credential you need does not exist, record it in the
+      missingSecrets output and make the candidate degrade gracefully
+      without it.
+
+    When done, return: the candidate name, the EXACT version string of the
+    final healthy publish, a summary tying each change to a recurring
+    failure pattern, the list of changes, and any missing secrets.

--- a/mcp/src/lab/harvey/workflows/harvey-produce.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-produce.yaml
@@ -1,0 +1,177 @@
+name: harvey-produce
+# The PRODUCE half of the Harvey harness: load a benchmark task → agent
+# writes the deliverables into this run's artifacts dir. NO grading here —
+# harvey-run / harvey-candidate-run wrap this with harvey/evaluate.
+#
+# The produce/grade split (EVOLVE_SPEC §5) is what makes production a
+# SWAPPABLE CANDIDATE: an agent-authored produce variant (published via
+# meta/publish-workflow, stamped publisher "ai") replaces this one by REF —
+# harvey-run's input.produceWorkflow, or harvey-candidate-run — without ever
+# touching the grading harness. This seeded workflow itself is unstamped, so
+# the meta surface can read it but never edit or run it.
+#
+# The producing agent NEVER sees the rubric (harvey/get-task strips it in
+# the service) and is NOT granted harvey/evaluate, meta/*, or any grader —
+# grading happens in the wrapping harness. Prompts live in `params` (the
+# experiment surface).
+#
+# Needs: ANTHROPIC_API_KEY, HARVEY_LABS_DIR (+ uv, git, pandoc on PATH).
+# Input:  { task, workdir? }
+#   task:    e.g. "arbitration-international-dispute-resolution/draft-markup-of-arbitration-agreement"
+#   workdir: optional RELATIVE subdir of the run's artifacts dir to work in.
+#            Batch callers pass a per-task value (e.g. the task id) because
+#            subflows share the parent's runId → the same artifacts dir, and
+#            parallel tasks would otherwise collide on ./output/.
+# Output: { task, title, deliverables, outputDir, artifactsRunId, workdir,
+#           usage, cost, steps, produceError? }
+#         — outputDir is ABSOLUTE; graders stage exactly that directory.
+steps:
+  - id: dir
+    type: artifacts/dir
+    config:
+      sub: "{{ input.workdir }}"
+
+  - id: task
+    type: harvey/get-task
+    config:
+      task: "{{ input.task }}"
+
+  - id: produce
+    type: agent
+    depends: [dir, task]
+    # A severed API connection mid-generation kills an otherwise-healthy run
+    # (seen live: "other side closed" after the AI SDK's own 3 reconnects).
+    # One workflow-level retry restarts the agent step fresh — worst case one
+    # duplicate read phase, vs. a dead 10-minute run. NOTE: must nest under
+    # `options:` — the runner reads step.options.retry; a flat retry: key is
+    # silently ignored (learned the hard way).
+    #
+    # onError: a single task's agent blowing up must NOT kill an entire batch
+    # run (harvey-evolve runs this per task via foreach → subflow, and
+    # foreach bodies get no onError of their own). Fall back to an explicit
+    # failure record — the wrapping harness then grades an empty output dir
+    # and records an honest zero instead of aborting every other task.
+    options:
+      retry: { max: 1, delayMs: 15000 }
+      onError:
+        id: produce_failed
+        type: harvey/pack-result
+        config:
+          # usage: {} (not omitted) — the template evaluator does NOT
+          # short-circuit, so downstream `produced.usage.inputTokens` must
+          # always have an object to index into.
+          usage: {}
+          cost: 0
+          steps: 0
+          produceError: "{{ $error.message }}"
+    config:
+      cwd: "{{ dir.path }}"
+      # System prompt = the base persona/method + an OPTIONAL graph-guidance
+      # section (empty by default). Splitting them means the concepts arm of an
+      # A/B overrides ONLY graphGuidance (+ agentTools) — the base method stays
+      # byte-identical across arms.
+      system: "{{ params.system }}{{ params.graphGuidance }}"
+      prompt: |
+        {{ task.instructions }}
+
+        The task's input documents are in this READ-ONLY directory:
+        {{ task.documentsDir }}
+        List it first; extract .docx content with `pandoc <file> -t markdown`.
+
+        Required deliverable files (EXACT names, in ./output/ of your working
+        directory): {{ task.deliverables }}
+      model: "{{ params.model }}"
+      maxSteps: "{{ params.maxSteps }}"
+      toolFilter: "{{ params.toolFilter }}"
+      # Extra tool grants for the producing agent (registry step types; globs
+      # ok). Default NONE — the closed-book baseline. Override per run to arm
+      # e.g. read-only knowledge-graph access:
+      #   ["jarvis/graph-search","jarvis/graph-get","jarvis/graph-get-batched",
+      #    "jarvis/graph-neighbors","jarvis/get-ontology","jarvis/get-ontology-type"]
+      # NEVER grant the jarvis write steps, harvey/evaluate, or meta/* here.
+      agentTools: "{{ params.agentTools }}"
+
+  - id: result
+    type: harvey/pack-result
+    depends: produce
+    config:
+      task: "{{ input.task }}"
+      title: "{{ task.title }}"
+      deliverables: "{{ task.deliverables }}"
+      outputDir: "{{ dir.path }}/output"
+      artifactsRunId: "{{ dir.runId }}"
+      workdir: "{{ input.workdir }}"
+      usage: "{{ produce.usage }}"
+      cost: "{{ produce.cost }}"
+      steps: "{{ produce.steps }}"
+      produceError: "{{ produce.produceError }}"
+
+params:
+  model: claude-sonnet-4-6
+  # Generous budget: read 3-4 documents, draft substantial legal deliverables,
+  # convert to docx. The agent forces a final turn if it runs out.
+  maxSteps: 80
+  # No web_search: benchmark purity — the task is closed-book against the
+  # provided documents. (Empty would mean ALL built-ins, including web_search.)
+  toolFilter: ["bash", "str_replace_based_edit_tool", "repo_overview", "fulltext_search"]
+  # Producing agent's extra tool grants (see the produce step). Empty =
+  # closed-book baseline.
+  agentTools: []
+  # Appended to the system prompt when knowledge-graph access is granted.
+  # Default: empty (closed-book baseline). Pair with the read-only jarvis
+  # grants in agentTools. Learned from the first prod-tree A/B: enter via the
+  # Practice Area roots and SCAN EVERY ROOT'S CHILDREN — root names are opaque
+  # (the relevant checklist may live under a generic-sounding root) and
+  # semantic search on the tree is weak.
+  graphGuidance: ""
+  # The CANONICAL graph-guidance text for the concepts arm — versioned here so
+  # the experiment surface is visible/diffable in the UI, never buried in a
+  # launch script. To run the concepts arm: read this value and pass it as the
+  # per-run `graphGuidance` override (plus the agentTools read grants). It is
+  # deliberately NOT active by default.
+  graphGuidanceConcepts: |
+
+    Knowledge graph (consult BEFORE drafting):
+    A Concept knowledge graph holds legal review METHODOLOGY, organized under
+    "Practice Area" root concepts with PARENT_OF children from general to very
+    specific. Semantic search is unreliable on this graph — enter via the
+    roots:
+    1. jarvis_graph_search q="Practice Area" type=Concept — list ALL roots.
+    2. jarvis_graph_neighbors on EVERY root, ALWAYS with node_type=["Concept"]
+       (other node types are session noise). Root NAMES are opaque — scan the
+       full children list of each root before deciding what is relevant; the
+       best checklist may hang under a generic-sounding root.
+    3. jarvis_graph_get_batched the relevant ref_ids and READ their
+       documentation.
+    Use what you load as a CHECKLIST: cross-checks to run (e.g. reconcile
+    every pair of related figures), doctrines to apply, and terms whose
+    ABSENCE to flag. Facts still come ONLY from the task documents — the
+    graph guides HOW you review, never WHAT the documents say. Spend at most
+    ~12 tool calls on the graph phase, then draft.
+  system: |
+    You are a senior lawyer producing REAL work product for a demanding client.
+    Work ONLY from the documents provided in the task — do not invent facts,
+    parties, dates, or terms, and do not use outside sources.
+
+    Your WORKING DIRECTORY is where ALL your writes go — always use relative
+    paths (./draft.md, ./output/<name>.docx). The task documents directory is
+    READ-ONLY and OUTSIDE your working directory: read from its absolute path,
+    but NEVER write there — writes outside the working directory are rejected.
+
+    Method:
+    1. Read EVERY input document fully before drafting (convert .docx with
+       `pandoc <file> -t markdown`; read .xlsx with python3 + openpyxl,
+       printing EVERY sheet, row, and column — spreadsheets often hold the
+       facts the analysis hinges on; .eml files are plain text). The client's
+       instructions and any playbook control — follow them precisely,
+       including priorities and fallback positions.
+    2. Draft each deliverable as markdown first (work files in your working
+       directory are fine), covering every requirement in the instructions.
+       Be thorough and specific: cite the exact clauses/sections you change,
+       show precise replacement language, and explain each change briefly.
+    3. Produce the FINAL deliverables as real .docx files with EXACTLY the
+       requested filenames in ./output/ :  `pandoc draft.md -o output/<name>.docx`
+    4. Verify before finishing: `ls -la output/` shows every required file,
+       and each converts back cleanly (`pandoc output/<name>.docx -t markdown | head`).
+
+    Only files in ./output/ are graded. Missing or misnamed files score zero.

--- a/mcp/src/lab/harvey/workflows/harvey-run.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-run.yaml
@@ -1,151 +1,92 @@
 name: harvey-run
-# Harvey LAB harness: load a benchmark task → agent produces the deliverables
-# into this run's artifacts dir → grade with the REAL benchmark eval.
+# Single-task Harvey harness: PRODUCE (subflow, swappable by ref) → GRADE
+# with the REAL benchmark eval → pack one result object.
 #
-# The producing agent NEVER sees the rubric (harvey/get-task strips it in the
-# service) and is NOT granted harvey/evaluate — grading happens after the
-# agent finishes, in the harness. Prompts live in `params` (the experiment
-# surface). Deliverables are real files (usually .docx via pandoc) written to
-# ./output/ of the artifacts dir; the grade step stages exactly that dir.
+# The produce half lives in `harvey-produce` (EVOLVE_SPEC §5 split): this
+# harness invokes it as a subflow and stages EXACTLY the outputDir the
+# produce run reports. `input.produceWorkflow` swaps in a different produce
+# workflow by name — e.g. an agent-authored candidate (published via
+# meta/publish-workflow) — to A/B a structural variant against the same
+# grader. The ref runs at its ACTIVE version; for a version-pinned candidate
+# run use harvey-candidate-run (which also runs the candidate under its own
+# runId via meta/run-workflow).
+#
+# The producing agent NEVER sees the rubric and is never granted
+# harvey/evaluate — grading happens here, after the agent finishes.
+#
+# NOTE — params moved: the produce knobs (model, system, maxSteps,
+# toolFilter, agentTools, graphGuidance, …) now live on `harvey-produce`.
+# Override them per run with paramOverrides KEYED BY WORKFLOW NAME, which
+# reaches params at any subflow depth:
+#   { "input": { "task": "…" },
+#     "paramOverrides": { "harvey-produce": { "graphGuidance": "…" } } }
 #
 # Needs: ANTHROPIC_API_KEY, HARVEY_LABS_DIR (+ uv, git, pandoc on PATH).
-# Input:  { task }  e.g. "arbitration-international-dispute-resolution/draft-markup-of-arbitration-agreement"
-# Output: the benchmark's own scores (score, all_pass, criteria_results, …)
-#         + benchmarkRev + reportPath, plus produceCost/produceSteps passthrough.
+# Input:  { task, workdir?, produceWorkflow? }
+# Output: { task, produceWorkflow, score, max_score, all_pass, summary,
+#           criteria_results, benchmarkRev, reportPath, outputDir,
+#           produceCost, produceSteps, produceError?, gradeError? }
 steps:
-  - id: dir
-    type: artifacts/dir
-
-  - id: task
-    type: harvey/get-task
+  - id: produced
+    type: subflow
     config:
-      task: "{{ input.task }}"
-
-  - id: produce
-    type: agent
-    depends: [dir, task]
-    # A severed API connection mid-generation kills an otherwise-healthy run
-    # (seen live: "other side closed" after the AI SDK's own 3 reconnects).
-    # One workflow-level retry restarts the agent step fresh — worst case one
-    # duplicate read phase, vs. a dead 10-minute run. NOTE: must nest under
-    # `options:` — the runner reads step.options.retry; a flat retry: key is
-    # silently ignored (learned the hard way).
-    options:
-      retry: { max: 1, delayMs: 15000 }
-    config:
-      cwd: "{{ dir.path }}"
-      # System prompt = the base persona/method + an OPTIONAL graph-guidance
-      # section (empty by default). Splitting them means the concepts arm of an
-      # A/B overrides ONLY graphGuidance (+ agentTools) — the base method stays
-      # byte-identical across arms.
-      system: "{{ params.system }}{{ params.graphGuidance }}"
-      prompt: |
-        {{ task.instructions }}
-
-        The task's input documents are in this READ-ONLY directory:
-        {{ task.documentsDir }}
-        List it first; extract .docx content with `pandoc <file> -t markdown`.
-
-        Required deliverable files (EXACT names, in ./output/ of your working
-        directory): {{ task.deliverables }}
-      model: "{{ params.model }}"
-      maxSteps: "{{ params.maxSteps }}"
-      toolFilter: "{{ params.toolFilter }}"
-      # Extra tool grants for the producing agent (registry step types; globs
-      # ok). Default NONE — the closed-book baseline. Override per run to arm
-      # e.g. read-only knowledge-graph access:
-      #   ["jarvis/graph-search","jarvis/graph-get","jarvis/graph-get-batched",
-      #    "jarvis/graph-neighbors","jarvis/get-ontology","jarvis/get-ontology-type"]
-      # NEVER grant the jarvis write steps or harvey/evaluate here.
-      agentTools: "{{ params.agentTools }}"
+      workflow: "{{ input.produceWorkflow || 'harvey-produce' }}"
+      input:
+        task: "{{ input.task }}"
+        workdir: "{{ input.workdir }}"
 
   - id: grade
     type: harvey/evaluate
-    depends: produce
-    # Same hardening: the judge pass is long (dozens of LLM calls); staging is
-    # idempotent (same runId dir re-copied), so a retry is safe.
+    depends: produced
+    # Retry: the judge pass is long (dozens of LLM calls); staging is
+    # idempotent (same staged dir re-copied), so a retry is safe.
+    # onError: a grading failure must not kill a batch run (harvey-evolve
+    # runs this per task via foreach → subflow) — record an explicit zero
+    # with the error instead. gradeError distinguishes "grader crashed" from
+    # "graded and failed" so the digest doesn't misattribute infra failures.
     options:
       retry: { max: 1, delayMs: 15000 }
+      onError:
+        id: grade_failed
+        type: harvey/pack-result
+        config:
+          score: 0
+          all_pass: false
+          gradeError: "{{ $error.message }}"
     config:
       task: "{{ input.task }}"
-      from: output
+      dir: "{{ produced.outputDir }}"
+      # NOTE: no guards here — the template evaluator does not short-circuit,
+      # so these rely on harvey-produce ALWAYS packing usage (an {} on its
+      # onError path) and outputDir.
       metrics:
-        input_tokens: "{{ produce.usage.inputTokens }}"
-        output_tokens: "{{ produce.usage.outputTokens }}"
-        produce_cost: "{{ produce.cost }}"
-        produce_steps: "{{ produce.steps }}"
+        input_tokens: "{{ produced.usage.inputTokens }}"
+        output_tokens: "{{ produced.usage.outputTokens }}"
+        produce_cost: "{{ produced.cost }}"
+        produce_steps: "{{ produced.steps }}"
       dual: "{{ params.dual }}"
       timeoutMs: "{{ params.evalTimeoutMs }}"
 
-params:
-  model: claude-sonnet-4-6
-  # Generous budget: read 3-4 documents, draft substantial legal deliverables,
-  # convert to docx. The agent forces a final turn if it runs out.
-  maxSteps: 80
-  # No web_search: benchmark purity — the task is closed-book against the
-  # provided documents. (Empty would mean ALL built-ins, including web_search.)
-  toolFilter: ["bash", "str_replace_based_edit_tool", "repo_overview", "fulltext_search"]
-  dual: false
-  # Producing agent's extra tool grants (see the produce step). Empty =
-  # closed-book baseline.
-  agentTools: []
-  # Appended to the system prompt when knowledge-graph access is granted.
-  # Default: empty (closed-book baseline). Pair with the read-only jarvis
-  # grants in agentTools. Learned from the first prod-tree A/B: enter via the
-  # Practice Area roots and SCAN EVERY ROOT'S CHILDREN — root names are opaque
-  # (the relevant checklist may live under a generic-sounding root) and
-  # semantic search on the tree is weak.
-  graphGuidance: ""
-  # The CANONICAL graph-guidance text for the concepts arm — versioned here so
-  # the experiment surface is visible/diffable in the UI, never buried in a
-  # launch script. To run the concepts arm: read this value and pass it as the
-  # per-run `graphGuidance` override (plus the agentTools read grants). It is
-  # deliberately NOT active by default.
-  graphGuidanceConcepts: |
+  - id: result
+    type: harvey/pack-result
+    depends: grade
+    config:
+      task: "{{ input.task }}"
+      produceWorkflow: "{{ input.produceWorkflow || 'harvey-produce' }}"
+      score: "{{ grade.score }}"
+      max_score: "{{ grade.max_score }}"
+      all_pass: "{{ grade.all_pass }}"
+      summary: "{{ grade.summary }}"
+      criteria_results: "{{ grade.criteria_results }}"
+      benchmarkRev: "{{ grade.benchmarkRev }}"
+      reportPath: "{{ grade.reportPath }}"
+      outputDir: "{{ produced.outputDir }}"
+      produceCost: "{{ produced.cost }}"
+      produceSteps: "{{ produced.steps }}"
+      produceError: "{{ produced.produceError }}"
+      gradeError: "{{ grade.gradeError }}"
 
-    Knowledge graph (consult BEFORE drafting):
-    A Concept knowledge graph holds legal review METHODOLOGY, organized under
-    "Practice Area" root concepts with PARENT_OF children from general to very
-    specific. Semantic search is unreliable on this graph — enter via the
-    roots:
-    1. jarvis_graph_search q="Practice Area" type=Concept — list ALL roots.
-    2. jarvis_graph_neighbors on EVERY root, ALWAYS with node_type=["Concept"]
-       (other node types are session noise). Root NAMES are opaque — scan the
-       full children list of each root before deciding what is relevant; the
-       best checklist may hang under a generic-sounding root.
-    3. jarvis_graph_get_batched the relevant ref_ids and READ their
-       documentation.
-    Use what you load as a CHECKLIST: cross-checks to run (e.g. reconcile
-    every pair of related figures), doctrines to apply, and terms whose
-    ABSENCE to flag. Facts still come ONLY from the task documents — the
-    graph guides HOW you review, never WHAT the documents say. Spend at most
-    ~12 tool calls on the graph phase, then draft.
+params:
+  dual: false
   # 59-criterion tasks with parallel judges can take a while.
   evalTimeoutMs: 2400000
-  system: |
-    You are a senior lawyer producing REAL work product for a demanding client.
-    Work ONLY from the documents provided in the task — do not invent facts,
-    parties, dates, or terms, and do not use outside sources.
-
-    Your WORKING DIRECTORY is where ALL your writes go — always use relative
-    paths (./draft.md, ./output/<name>.docx). The task documents directory is
-    READ-ONLY and OUTSIDE your working directory: read from its absolute path,
-    but NEVER write there — writes outside the working directory are rejected.
-
-    Method:
-    1. Read EVERY input document fully before drafting (convert .docx with
-       `pandoc <file> -t markdown`; read .xlsx with python3 + openpyxl,
-       printing EVERY sheet, row, and column — spreadsheets often hold the
-       facts the analysis hinges on; .eml files are plain text). The client's
-       instructions and any playbook control — follow them precisely,
-       including priorities and fallback positions.
-    2. Draft each deliverable as markdown first (work files in your working
-       directory are fine), covering every requirement in the instructions.
-       Be thorough and specific: cite the exact clauses/sections you change,
-       show precise replacement language, and explain each change briefly.
-    3. Produce the FINAL deliverables as real .docx files with EXACTLY the
-       requested filenames in ./output/ :  `pandoc draft.md -o output/<name>.docx`
-    4. Verify before finishing: `ls -la output/` shows every required file,
-       and each converts back cleanly (`pandoc output/<name>.docx -t markdown | head`).
-
-    Only files in ./output/ are graded. Missing or misnamed files score zero.

--- a/vein/EVOLVE_SPEC.md
+++ b/vein/EVOLVE_SPEC.md
@@ -22,7 +22,7 @@ one measured run and the next. The guiding idea:
 | --- | --- | --- | --- | --- |
 | **1. Prompt** | a `params` value | param default + new workflow version | minutes; fully autonomous | **built** (`eval/optimize`) |
 | **2. Environment** | an `env.manifest` diff | rebuilt image | days; human-reviewed | **todo** (§4) |
-| **3. Structure** | a workflow version + step sources | published version | hours; agent-interactive | **mechanism built** (§5 — `meta/*` + `services.authoring`; optimize generalization §5.3.3 todo) |
+| **3. Structure** | a workflow version + step sources | published version | hours; agent-interactive | **built** (§5 — `meta/*` + `services.authoring`; first authoring harness `harvey-evolve` §9.4; optimize generalization §5.3.3 todo) |
 
 The layers are ordered by how cheap they are to try and how safely they can
 be automated. Prompt tuning is mechanical and reversible. Environment changes
@@ -248,7 +248,7 @@ grade   (harvey/evaluate | gaia/evaluate | eval/score)
 reflect (eval/reflect)                    → next candidate
 ```
 
-### 5.3 Four things that will bite
+### 5.3 Five things that will bite
 
 1. **The registry is a per-RUN snapshot, not just per-step.**
    `buildRegistryTools` resolves `agentTools` once when the agent step
@@ -271,6 +271,16 @@ reflect (eval/reflect)                    → next candidate
    and returns `null` — a step that doesn't compile simply doesn't exist. An
    authoring agent will flail against that; `meta/create-step` must
    typecheck-and-import before returning and hand the error back.
+5. **The template evaluator does not short-circuit.** `expr.ts` is a direct
+   evaluator: ternary and `&&`/`||` still evaluate BOTH sides, so
+   `{{ run.output ? run.output.outputDir : undefined }}` throws
+   ("Cannot access property of undefined") exactly when the guard was
+   needed. Harness YAML must never deep-access a possibly-undefined object:
+   pass the WHOLE object into a step and unpack in code
+   (`harvey/evaluate`'s `fromRun`), or keep error-path packs shape-stable
+   (`usage: {}` in every `onError` fallback so `x.usage.inputTokens` stays
+   safe). This bites generated workflows too — candidates should copy the
+   base workflow's patterns, not invent guards.
 
 ---
 
@@ -384,7 +394,21 @@ possible version of "capture."
    proposable artifact.
 4. ~~**`meta/*` steps + `services.authoring`** (§5.2) — closes layer 3.~~
    **Done** — `authoring.ts` + `steps/lib/meta/*`, auto-wired by
-   `createVein`; next is a first authoring-harness workflow that uses them.
+   `createVein`. ~~Next is a first authoring-harness workflow that uses
+   them.~~ **Done** — `harvey-evolve` in the lab
+   (`mcp/src/lab/harvey/workflows/`), built on the Harvey produce/grade
+   split: `harvey-produce` is the swappable candidate unit (per-task
+   `workdir` for batch isolation), `harvey-run` grades any produce workflow
+   by ref (`input.produceWorkflow`), and `harvey-candidate-run` runs an
+   ai-stamped candidate under its own runId via `meta/run-workflow` (fresh
+   registry — §5.3.1) and grades the `outputDir` it reports. The evolve run
+   is one full generation: baseline over the task set →
+   `harvey/digest-results` (verdict-channel digest, §6) → authoring agent
+   (`agentTools: ["meta/*"]`, no bash — §5.3.2) publishes + smoke-tests a
+   candidate → harness re-runs it pinned over the same tasks → report with
+   baseline/candidate deltas and any `missingSecrets` the author captured
+   (the credential-request beat). Scores are TRAIN scores (§7); promotion
+   stays human. Offline checks: `mcp/src/lab/harvey/evolve-smoke.ts`.
 5. **Generalize `eval/optimize`'s candidate** from prompt string to workflow
    ref + version (§5.3.3) — the change that lets one loop drive all three
    layers.


### PR DESCRIPTION
## What

Two pieces that close EVOLVE_SPEC §9.4 ("a first authoring-harness workflow that uses the meta/* steps"):

### 1. Harvey produce/grade split

- **`harvey-produce`** (new) — the produce half of the old monolithic `harvey-run`, params surface moved verbatim. Takes `{ task, workdir? }`; its last step packs `{ outputDir, usage, cost, steps, … }` — the contract graders and candidates share. `workdir` + a new guarded `sub` config on `artifacts/dir` give batch runs per-task isolation (subflows share the parent runId → the same artifacts dir, so parallel tasks would otherwise collide on `./output/`). A gaia-style `onError` fallback keeps one bad task from killing a batch.
- **`harvey-run`** (rewritten) — now a pure harness: subflow into `{{ input.produceWorkflow || 'harvey-produce' }}` (dynamic ref → an ai-authored candidate swaps in by name), grade exactly the `outputDir` the produce run reports, pack one result. Produce knobs are overridden via `paramOverrides: { "harvey-produce": { … } }`.
- **`harvey-candidate-run`** (new) — runs an ai-stamped candidate under its **own** runId via `meta/run-workflow` (fresh registry, so steps authored mid-run are visible — §5.3.1) and grades it pinned to an exact version.
- **`harvey/evaluate`** — new `dir`/`fromRun` staging overrides (grade a run that executed under its own runId; `fromRun` takes the whole run-result object and unpacks in code). The benchmark staging id now includes the step path: two grades in one vein run previously re-staged into the same `results/<id>/output/` dir with the prior task's deliverables still mixed in.

### 2. `harvey-evolve` — the authoring harness

One full generation of the §5.2 loop, every beat a real graded artifact:

- **capture** — baseline `harvey-run` over the task set → `harvey/digest-results` (verdict channel only: pass/fail + truncated judge reasoning for failed criteria; the rubric is never read)
- **propose** — an authoring agent with `agentTools: ["meta/*"]` and **no bash** (§5.3.2 by construction) reads the digest, publishes a candidate produce workflow (stamped `publisher: "ai"`), smoke-tests it structurally via `meta/run-workflow`, and returns `{ candidate, version, summary, changes, missingSecrets }` — `missingSecrets` is the credential-request capture beat (names only, human fulfills out-of-band)
- **evaluate** — the harness (not the author) re-runs the pinned candidate over the same tasks via `harvey-candidate-run`
- **promote** — a report with baseline/candidate means + delta and an explicit TRAIN-scores warning (§7). Promotion stays a human act: point `harvey-run`'s `input.produceWorkflow` at the candidate, or fold its diff into `harvey-produce` after review.

### Spec finding worth reading

The template evaluator **does not short-circuit** — ternary/`&&`/`||` evaluate both sides, so `{{ run.output ? run.output.outputDir : undefined }}` throws exactly when the guard is needed. Recorded as EVOLVE_SPEC §5.3 bite #5; the workflows pass whole objects into steps and unpack in code, and error-path packs stay shape-stable (`usage: {}`).

## Testing

- `cd mcp && npx tsc --noEmit` — clean
- `npx tsx src/lab/harvey/smoke.ts` — existing offline smoke, passes
- `npx tsx src/lab/harvey/evolve-smoke.ts` (new, offline, no LLM/uv) — all four workflows parse into Flows, every referenced step type resolves, the template patterns behave as relied upon (fallback, whole-object pass, no-short-circuit guard), `harvey/digest-results` aggregates the failure shapes, `artifacts/dir` sub creation + traversal guards

🤖 Generated with [Claude Code](https://claude.com/claude-code)