### PR TITLE
harvey: criteria pass-rate as the evolve fitness

### DIFF
--- a/mcp/src/lab/harvey/evolve-smoke.ts
+++ b/mcp/src/lab/harvey/evolve-smoke.ts
@@ -102,6 +102,12 @@ async function main() {
     );
     assert.equal(out.n, 3);
     assert.equal(out.meanScore, 0.5);
+    // pass-rate fitness: 1/3, 1/1, and 0 (no readable criteria → 0, never 1)
+    assert.equal(out.results[0].passRate, 0.333);
+    assert.equal(out.results[1].passRate, 1);
+    assert.equal(out.results[2].passRate, 0);
+    assert.equal(out.meanPassRate, 0.444);
+    assert.ok(out.text.includes("mean criteria pass-rate 0.444"));
     assert.equal(out.allPassCount, 1);
     assert.equal(out.results[0].nFailed, 2);
     assert.equal(out.results[0].failed.length, 1);
@@ -109,7 +115,7 @@ async function main() {
     assert.equal(out.results[0].cost, 1.1);
     assert.equal(out.results[2].error, "candidate run failed");
     assert.equal(out.results[2].cost, 0.33);
-    assert.ok(out.text.includes("mean score 0.5") && out.text.includes("✗ c2"));
+    assert.ok(out.text.includes("✗ c2"));
     assert.ok(out.text.includes("(+1 more failed criteria not shown)"));
     console.log("✔ harvey/digest-results aggregates + formats");
 

--- a/mcp/src/lab/harvey/steps/digest-results.ts
+++ b/mcp/src/lab/harvey/steps/digest-results.ts
@@ -61,7 +61,7 @@ function criterionNote(c: AnyRec, maxChars: number): string {
 export default defineStep({
   type: "harvey/digest-results",
   description:
-    "Aggregate an array of graded Harvey results (harvey-run / harvey-candidate-run outputs) into a compact digest: per-task score, all_pass, failed-criteria excerpts (capped), errors, plus mean score / all-pass count and a preformatted `text` block for an LLM prompt. Config: results (array), maxCriteria? (failed-criteria excerpts per task, default 6), maxChars? (per excerpt, default 240). Output: { n, meanScore, allPassCount, results, text }.",
+    "Aggregate an array of graded Harvey results (harvey-run / harvey-candidate-run outputs) into a compact digest: per-task criteria pass-RATE (the fitness — the benchmark's binary all-pass score has no gradient), all_pass, failed-criteria excerpts (capped), errors, plus mean pass-rate / all-pass count and a preformatted `text` block for an LLM prompt. Config: results (array), maxCriteria? (failed-criteria excerpts per task, default 6), maxChars? (per excerpt, default 240). Output: { n, meanScore, meanPassRate, allPassCount, results, text }.",
   input: z.object({
     results: z.array(z.any()).describe("graded results, one per task (harvey-run / harvey-candidate-run outputs)"),
     maxCriteria: z
@@ -84,9 +84,19 @@ export default defineStep({
       const error = errStr(r["error"]) ?? errStr(r["gradeError"]) ?? errStr(r["produceError"]);
       const runOut = ((r["runResult"] as AnyRec | undefined)?.["output"] ?? {}) as AnyRec;
       const cost = num(r["produceCost"]) ?? num(r["cost"]) ?? num(runOut["cost"]);
+      // THE FITNESS: criteria pass-RATE, not the benchmark's binary
+      // all-pass `score`. On a 50-criterion task the binary score is 0 for
+      // both a 45/50 and a 20/50 memo — no gradient, nothing can
+      // hill-climb. passRate keeps the benchmark's own per-criterion
+      // verdicts as the signal while giving the loop something monotone to
+      // move. A result with no readable criteria (grade error, empty
+      // report) is a 0, never a 1.
+      const passRate =
+        crit.length > 0 ? Math.round(((crit.length - failed.length) / crit.length) * 1000) / 1000 : 0;
       return {
         task,
         score,
+        passRate,
         all_pass: allPass,
         nCriteria: crit.length,
         nFailed: failed.length,
@@ -99,14 +109,19 @@ export default defineStep({
 
     const n = entries.length;
     const meanScore = n ? Math.round((entries.reduce((s, e) => s + e.score, 0) / n) * 1000) / 1000 : 0;
+    const meanPassRate = n
+      ? Math.round((entries.reduce((s, e) => s + e.passRate, 0) / n) * 1000) / 1000
+      : 0;
     const allPassCount = entries.filter((e) => e.all_pass).length;
 
     // Preformatted for an LLM prompt ({{ digest.text }}) — objects
     // interpolated into template strings would arrive as raw JSON.
-    const lines: string[] = [`${n} task(s) — mean score ${meanScore}, all-pass ${allPassCount}/${n}`];
+    const lines: string[] = [
+      `${n} task(s) — mean criteria pass-rate ${meanPassRate}, all-pass ${allPassCount}/${n}`,
+    ];
     for (const e of entries) {
       lines.push(
-        `- ${e.task}  score ${e.score}  all_pass=${e.all_pass}` +
+        `- ${e.task}  pass-rate ${e.passRate}  all_pass=${e.all_pass}` +
           (e.nCriteria ? `  (${e.nFailed}/${e.nCriteria} criteria failed)` : ""),
       );
       for (const f of e.failed) lines.push(`    ✗ ${f}`);
@@ -114,6 +129,6 @@ export default defineStep({
       if (e.error) lines.push(`    ERROR: ${e.error}`);
     }
 
-    return { n, meanScore, allPassCount, results: entries, text: lines.join("\n") };
+    return { n, meanScore, meanPassRate, allPassCount, results: entries, text: lines.join("\n") };
   },
 });

--- a/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
@@ -38,8 +38,8 @@ name: harvey-evolve
 #   mission: what to improve and why — the gap statement handed to the
 #            author (e.g. a per-miss taxonomy line: "citations unverifiable;
 #            stale regulatory figures — needs an online research step").
-# Output: { candidate, candidateVersion, baselineMean, candidateMean,
-#           meanDelta, baseline, candidateResults, authorSummary,
+# Output: { candidate, candidateVersion, baselinePassRate, candidatePassRate,
+#           passRateDelta, baseline, candidateResults, authorSummary,
 #           authorChanges, missingSecrets, … }
 steps:
   - id: dir
@@ -164,9 +164,13 @@ steps:
       tasks: "{{ input.tasks }}"
       candidate: "{{ author.object.candidate }}"
       candidateVersion: "{{ author.object.version }}"
-      baselineMean: "{{ basedigest.meanScore }}"
-      candidateMean: "{{ canddigest.meanScore }}"
-      meanDelta: "{{ canddigest.meanScore - basedigest.meanScore }}"
+      # THE FITNESS is criteria pass-rate, not the benchmark's binary
+      # all-pass score — binary at n=1 has no gradient to climb (observed:
+      # 45/50 vs 44/50 both report score 0). All-pass counts are kept as
+      # the headline benchmark metric; pass-rate is what a delta means.
+      baselinePassRate: "{{ basedigest.meanPassRate }}"
+      candidatePassRate: "{{ canddigest.meanPassRate }}"
+      passRateDelta: "{{ canddigest.meanPassRate - basedigest.meanPassRate }}"
       baselineAllPass: "{{ basedigest.allPassCount }}"
       candidateAllPass: "{{ canddigest.allPassCount }}"
       baseline: "{{ basedigest.results }}"


### PR DESCRIPTION
The first full evolve generation exposed this: baseline went 45/50 criteria, candidate 44/50 — and both report the benchmark's binary all-pass `score` of 0, so the report's delta read 0 and the loop had no gradient to climb.

- `harvey/digest-results` now computes a per-task `passRate` from the criteria verdicts it already parses (a result with no readable criteria — grade error, empty report — is a 0, never a 1), plus `meanPassRate`, and leads its prompt-facing `text` with it.
- `harvey-evolve`'s report replaces `baselineMean/candidateMean/meanDelta` with `baselinePassRate/candidatePassRate/passRateDelta`; all-pass counts stay as the headline benchmark metric.
- evolve-smoke extended for the new fields.

`npx tsc --noEmit` clean, `npx tsx src/lab/harvey/evolve-smoke.ts` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)