### PR TITLE
vein: secretsEnv on the agent step — authenticated bash for research sub-agents

### DIFF
--- a/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
@@ -268,10 +268,29 @@ params:
       meta/run-step therefore CANNOT authenticate: you have no real value
       to put in the header, and a placeholder guarantees a 401 that says
       NOTHING about whether the stored credential works. Never debug auth
-      through raw http probes. Test authenticated calls ONLY through an
-      authored step that reads ctx.services.secrets.get(<name>) — the value
-      is injected in code at runtime. Raw probes are fine for endpoints
-      that need no auth.
+      through raw http probes.
+    - THE WAY TO USE AN AUTHENTICATED API is a RESEARCH SUB-AGENT: an
+      `agent` step with toolFilter ["bash"] and secretsEnv: [<secret
+      names from meta/list-secrets>]. Its bash gets the values as env
+      vars — it writes $NAME in curl commands and pipes through jq to
+      keep outputs small; values are injected at exec time and masked in
+      all output, so neither you nor it ever sees them. PREFER this over
+      authoring TypeScript wrapper steps around an API: a wrapper
+      hardcodes today's guesses (and dies on the first endpoint quirk);
+      a sub-agent prompt adapts, and the prompt stays tunable by the
+      optimize loop afterward.
+    - ITERATE THE SUB-AGENT LIVE: run it in isolation with meta/run-step
+      (type "agent", config { cwd: <your own working directory>, system:
+      <the research method draft>, prompt: <a sample research question>,
+      toolFilter: ["bash"], secretsEnv: [...], maxSteps: ~20 }). Judge its
+      output structurally — did it return verified citations, current
+      figures with sources, HTTP 200s? Refine the system prompt and rerun.
+      Ask it to also report the exact command patterns that WORKED, and
+      distill those worked examples into the final method prompt you embed
+      in the candidate's params. In the candidate, the sub-agent step
+      feeds its memo to the drafting agent; the drafting agent itself
+      NEVER gets secretsEnv or web access — external authority comes only
+      through the research memo.
 
     When done, return: the candidate name, the EXACT version string of the
     final healthy publish, a summary tying each change to a recurring

--- a/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
@@ -246,6 +246,33 @@ params:
        check meta/list-steps before creating: edit and reuse them instead
        of re-authoring from scratch.
 
+    WORKFLOW DESIGN PATTERNS — vocabulary, not prescription. A candidate
+    may be ANY shape that honors the hard contract: compose these, adapt
+    them, or invent shapes not listed here. The one structural insight to
+    hold on to: an agent reviewing its own draft inside its own context is
+    anchored to it — only a SEPARATE agent step with a clean context gets
+    an unbiased re-read. A longer prompt cannot buy fresh eyes; structure
+    can. Several agent steps that each do ONE thing usually beat one agent
+    with more tools and a longer prompt.
+    - fresh-eyes verifier: after the producing agent, a separate agent
+      step re-reads the task instructions + the deliverable files and
+      emits a gap list; a revise step applies the fixes. Fits: explicit
+      requirements silently dropped (addressee/format, a mandated topic
+      never discussed).
+    - checklist extraction: a cheap early step distills the instructions
+      into an explicit requirements checklist that the drafter (and any
+      verifier) consume. Fits: long instructions where details get lost.
+    - researcher → drafter: a specialist sub-agent gathers external
+      authority into a memo (see the secretsEnv rule); the drafter
+      consumes the memo and stays closed-book. Fits: unverifiable
+      citations, stale agency figures.
+    - draft → critique → revise: a critic step judges the draft's analysis
+      against the instructions and documents; the drafter revises. Fits:
+      shallow or generic analysis.
+    Every added step costs real money and the report weighs quality
+    against cost — buy structure only where the digest shows a failure it
+    answers.
+
     HARD CONTRACT for the candidate (the harness runs it as-is):
     - input { task, workdir? }; thread workdir into an artifacts/dir step
       (config sub) exactly as the base workflow does.

--- a/vein/EVOLVE_SPEC.md
+++ b/vein/EVOLVE_SPEC.md
@@ -176,7 +176,39 @@ CI rebuilds. The manifest becomes the same class of object as a workflow
 version: agent-authored, human-reviewed, diffable, pinned — and the mutation
 happens at **build** time, where it can be attributed.
 
-### 4.3 Current baseline (what `mcp/Dockerfile` provides)
+### 4.3 Credentials — `secretsEnv` (built)
+
+How an in-workflow agent uses an authenticated API without ever seeing a
+credential. The `agent` step takes `secretsEnv: [<secret name>, …]`; the
+step resolves the names via `ctx.services.secrets` **in code** and injects
+the values into the bash tool's subprocess env only. The model writes
+`curl -H "Authorization: Token $COURTLISTENER_API_KEY" …`; the shell
+expands it at exec time. Two guarantees and one accepted residual:
+
+- **Values never enter context or logs.** The prompt and event log carry
+  `$NAME` literally, and every tool output is masked
+  (`wrapToolsWithMask`, applied inside the emit wrapper) before the model
+  or `events.jsonl` sees it — covering `echo $KEY`, `env`, curl errors
+  echoing the URL, and files the shell wrote that another tool later reads.
+- **Grant discipline.** `secretsEnv` goes on a dedicated, narrow research
+  sub-agent (an `agent` step whose whole job is e.g. case-law lookup) —
+  never on a drafting/producing agent, never on the meta/* author.
+- **Accepted residual: egress.** A prompt-injected agent can still *send*
+  `$KEY` somewhere — masking stops leakage into context/logs, not
+  exfiltration by the shell itself. This is the trade for bash-native
+  exploration (agents iterate curl+jq far faster than any structured http
+  tool); bound it by keeping the sub-agent's inputs narrow (legal APIs,
+  not arbitrary pages) and its grant list minimal.
+
+Why bash-env beats a per-API wrapper step: the first live evolve run showed
+the author routing around the value firewall by authoring brittle TS
+wrappers (the only place values could be injected), one of which shipped
+hardcoded "fallback data" — the exact staleness it was built to fix. With
+`secretsEnv`, a research capability is one `agent` step whose entire
+content is a *prompt* (tunable by layer 1 forever after), and the author
+can iterate it live via `meta/run-step type=agent`.
+
+### 4.4 Current baseline (what `mcp/Dockerfile` provides)
 
 `/usr/src/agent-venv` first on `PATH` — numpy, pandas, openpyxl, pypdf,
 pdfplumber, pillow, requests, beautifulsoup4, yt-dlp — plus `pdftotext`

--- a/vein/src/shell.test.ts
+++ b/vein/src/shell.test.ts
@@ -35,6 +35,24 @@ describe("shell helpers", () => {
     }
   });
 
+  it("extraEnv widens the scrubbed env without unscrubbing it", async () => {
+    process.env.VEIN_TEST_FAKE_KEY = "sk-super-secret";
+    try {
+      const out = await runShell('echo "got:$INJECTED_TOKEN"; env', dir, 15000, 10000, {
+        INJECTED_TOKEN: "tok-abc123",
+      });
+      assert.match(out, /got:tok-abc123/); // injected value expands in the shell
+      assert.doesNotMatch(out, /VEIN_TEST_FAKE_KEY/); // scrubbing still applies
+    } finally {
+      delete process.env.VEIN_TEST_FAKE_KEY;
+    }
+  });
+
+  it("empty extraEnv is identical to no extraEnv", async () => {
+    const out = await runShell("echo ok", dir, 15000, 10000, {});
+    assert.equal(out.trim(), "ok");
+  });
+
   it("minimalEnv contains only allowlisted keys", () => {
     process.env.VEIN_TEST_FAKE_KEY = "x";
     try {

--- a/vein/src/shell.ts
+++ b/vein/src/shell.ts
@@ -93,10 +93,29 @@ export const runCmd = (cmd: string, args: string[], cwd: string, timeoutMs = 100
   );
 
 /** Run an arbitrary shell command string (the `bash` tools need a full shell).
- *  Scrubbed env — model-authored commands never see the server's API keys. */
-export const runShell = (command: string, cwd: string, timeoutMs = 15000, maxBytes = 10000) =>
+ *  Scrubbed env — model-authored commands never see the server's API keys.
+ *
+ *  `extraEnv` is the ONE sanctioned widening of the scrubbed env: the agent
+ *  step's `secretsEnv` config resolves named secrets via ctx.services.secrets
+ *  and injects the VALUES here — into the subprocess env only, never into a
+ *  prompt or log (the model writes `$NAME`; the shell expands it at exec
+ *  time, and the agent step masks the values out of every tool output before
+ *  the model or the event log sees them). Callers other than that path should
+ *  not pass it. */
+export const runShell = (
+  command: string,
+  cwd: string,
+  timeoutMs = 15000,
+  maxBytes = 10000,
+  extraEnv?: Record<string, string>,
+) =>
   capture(
-    spawn(command, { cwd, shell: true, stdio: ["ignore", "pipe", "pipe"], env: minimalEnv() }),
+    spawn(command, {
+      cwd,
+      shell: true,
+      stdio: ["ignore", "pipe", "pipe"],
+      env: extraEnv && Object.keys(extraEnv).length ? { ...minimalEnv(), ...extraEnv } : minimalEnv(),
+    }),
     timeoutMs,
     maxBytes,
   );

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -6,7 +6,16 @@ import { join } from "node:path";
 import { z } from "zod";
 import { coreRegistry } from "../registry.js";
 import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
-import agent, { repoTree, textEdit, buildRegistryTools, expandAgentTools, wrapToolsWithEmit } from "./agent.js";
+import agent, {
+  repoTree,
+  textEdit,
+  buildRegistryTools,
+  expandAgentTools,
+  wrapToolsWithEmit,
+  maskSecretValues,
+  maskDeep,
+  wrapToolsWithMask,
+} from "./agent.js";
 
 // These tests are OFFLINE: they exercise registration, the input schema, and the
 // config-validation guards in run() that fire BEFORE any model call. The actual
@@ -423,5 +432,65 @@ describe("textEdit (str_replace_based_edit_tool handler)", () => {
   it("refuses absolute path outside all roots (e.g. /etc/passwd)", () => {
     const out = textEdit({ command: "view", path: "/etc/passwd" }, [cwd, tmpdir()]);
     assert.match(out, /escapes the working directory/);
+  });
+});
+
+describe("secretsEnv masking", () => {
+  const VALUES = ["tok-abc123def", "sk-other-secret-9"];
+
+  it("maskSecretValues replaces every occurrence of every value", () => {
+    const out = maskSecretValues("a tok-abc123def b tok-abc123def c sk-other-secret-9", VALUES);
+    assert.equal(out, "a [MASKED_SECRET] b [MASKED_SECRET] c [MASKED_SECRET]");
+  });
+
+  it("maskDeep masks string leaves in nested objects/arrays, preserves shape", () => {
+    const out = maskDeep(
+      { a: "x tok-abc123def", n: 7, ok: true, none: null, arr: ["sk-other-secret-9", { b: "clean" }] },
+      VALUES,
+    ) as any;
+    assert.deepEqual(out, {
+      a: "x [MASKED_SECRET]",
+      n: 7,
+      ok: true,
+      none: null,
+      arr: ["[MASKED_SECRET]", { b: "clean" }],
+    });
+  });
+
+  it("maskDeep with no values is identity", () => {
+    const v = { a: "tok-abc123def" };
+    assert.equal(maskDeep(v, []), v);
+  });
+
+  it("wrapToolsWithMask masks tool results (the echo-$KEY path)", async () => {
+    const tools: Record<string, any> = {
+      bash: {
+        execute: async ({ command }: { command: string }) =>
+          command === "echo $KEY" ? "tok-abc123def\n" : "ok",
+      },
+      // provider-executed tool (no execute) must be skipped, not crash
+      web_search: {},
+    };
+    wrapToolsWithMask(tools, VALUES);
+    assert.equal(await tools.bash.execute({ command: "echo $KEY" }), "[MASKED_SECRET]\n");
+    assert.equal(await tools.bash.execute({ command: "other" }), "ok");
+  });
+
+  it("run() fails loudly when secretsEnv is set but no secrets capability exists", async () => {
+    const cfg = (agent.input as any).parse({
+      cwd: tmpdir(),
+      system: "s",
+      prompt: "p",
+      secretsEnv: ["SOME_KEY"],
+    });
+    await assert.rejects(
+      () => agent.run(cfg, { runId: "r", path: "p", scope: {}, input: undefined, emit: async () => {}, services: {}, registry: {} } as any),
+      /secretsEnv requires the secrets capability/,
+    );
+  });
+
+  it("secretsEnv defaults to []", () => {
+    const cfg = (agent.input as any).parse({ cwd: "/tmp/x", system: "s", prompt: "p" });
+    assert.deepEqual(cfg.secretsEnv, []);
   });
 });

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -456,6 +456,51 @@ export function buildRegistryTools(
  * (provider-executed tools like anthropic `web_search`). Output is truncated in
  * the event only (the model still sees the full result).
  */
+/** Replace every occurrence of each secret value in `text` with a marker.
+ *  Plain string splitting (no regex) — values are opaque tokens. */
+export function maskSecretValues(text: string, values: string[]): string {
+  let out = text;
+  for (const v of values) out = out.split(v).join("[MASKED_SECRET]");
+  return out;
+}
+
+/** Recursively mask secret values in every string leaf of a tool result.
+ *  Tool outputs are JSON-ish (they get persisted to run events), so a plain
+ *  object/array/primitive walk covers them. */
+export function maskDeep(value: unknown, values: string[]): unknown {
+  if (!values.length) return value;
+  if (typeof value === "string") return maskSecretValues(value, values);
+  if (Array.isArray(value)) return value.map((x) => maskDeep(x, values));
+  if (value && typeof value === "object") {
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value)) out[k] = maskDeep(v, values);
+    return out;
+  }
+  return value;
+}
+
+/**
+ * Wrap every tool's `execute` so its RESULT is masked before the model (and
+ * the event log — this runs inside `wrapToolsWithEmit`'s wrapping) sees it.
+ * The complement to `secretsEnv`: values reach the bash SUBPROCESS, and this
+ * guarantees they never travel back into the model's context via any tool
+ * output — `echo $KEY`, `env`, a curl error echoing the URL, or a file the
+ * shell wrote and the editor tool later views. Mutates `tools` in place.
+ *
+ * What it cannot do: stop the shell itself from SENDING `$KEY` somewhere
+ * (egress under prompt injection). That residual is accepted and documented
+ * (EVOLVE_SPEC §4.4) — grant secretsEnv only to narrow research agents.
+ */
+export function wrapToolsWithMask(tools: Record<string, any>, secretValues: string[]): void {
+  if (!secretValues.length) return;
+  for (const t of Object.values(tools)) {
+    const orig = t?.execute;
+    if (typeof orig !== "function") continue;
+    t.execute = async (input: unknown, opts: unknown) =>
+      maskDeep(await (orig as (i: unknown, o: unknown) => Promise<unknown>)(input, opts), secretValues);
+  }
+}
+
 export function wrapToolsWithEmit(tools: Record<string, any>, ctx: StepContext | undefined): void {
   if (!ctx?.emit || !ctx.path) return;
   const basePath = ctx.path;
@@ -497,7 +542,7 @@ export function wrapToolsWithEmit(tools: Record<string, any>, ctx: StepContext |
 export default defineStep({
   type: "agent",
   description:
-    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of built-in tool names; empty = all), agentTools? (registry step TYPES exposed as extra tools — the 'tools are steps' model; each tool call emits a nested run event), model?, provider? (anthropic|openai), maxSteps (default 40), returnMessages? (default false — the full session is huge + persisted per step). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, usage, cost } (+ messages when returnMessages).",
+    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of built-in tool names; empty = all), agentTools? (registry step TYPES exposed as extra tools — the 'tools are steps' model; each tool call emits a nested run event), secretsEnv? (secret NAMES injected as env vars into the bash subprocess only — the agent writes $NAME, values are masked out of all tool output; for narrow research sub-agents), model?, provider? (anthropic|openai), maxSteps (default 40), returnMessages? (default false — the full session is huge + persisted per step). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, usage, cost } (+ messages when returnMessages).",
   input: z.object({
     cwd: z.string().describe("working directory the tools operate in"),
     system: z.string().describe("system prompt / agent persona"),
@@ -519,6 +564,12 @@ export default defineStep({
       .default([])
       .describe(
         "registry step TYPES to expose as additional LLM tools (the 'tools are steps' model, e.g. ['gitsee/read-logs']). Entries may be glob patterns over step types ('jarvis/*' grants the whole namespace; new steps in it are picked up automatically). Each step's input schema becomes the tool schema and its run() is the executor, called with a nested ctx so every tool call emits a step.start/step.end run event (visible in the events panel). Merged ON TOP of the built-ins (not subject to toolFilter). Unknown types are skipped. Requires the runner-populated ctx.registry.",
+      ),
+    secretsEnv: z
+      .array(z.string())
+      .default([])
+      .describe(
+        "secret NAMES (from the deployment's secret store) to inject as env vars into the bash tool's subprocess — the agent writes `$NAME` in commands (e.g. curl auth headers) and the shell expands it at exec time. The VALUE never enters the prompt, the model's context, or the event log: bash gets it via env only, and every tool output is masked before the model sees it. Grant narrowly (a dedicated research sub-agent), never to a drafting/producing agent. Residual risk (accepted): a prompt-injected agent can still SEND $NAME somewhere — masking stops leakage into context/logs, not egress.",
       ),
     model: z.string().optional(),
     provider: z.string().optional(),
@@ -569,6 +620,37 @@ export default defineStep({
         throw new Error(`Unknown LLM provider: "${provider}". Supported: anthropic, openai`);
     }
 
+    // ── secretsEnv: resolve named secrets → bash subprocess env ────────────
+    // Values are fetched here (in code, via the secrets capability) and go two
+    // places ONLY: the bash child env, and the mask list. Never the prompt.
+    const secretEnv: Record<string, string> = {};
+    const missingSecretNames: string[] = [];
+    if (cfg.secretsEnv.length) {
+      const secrets = (ctx?.services as { secrets?: { get(name: string): Promise<string | undefined> } } | undefined)
+        ?.secrets;
+      if (!secrets || typeof secrets.get !== "function") {
+        throw new Error("agent: secretsEnv requires the secrets capability (ctx.services.secrets)");
+      }
+      for (const name of cfg.secretsEnv) {
+        const v = await secrets.get(name);
+        if (v) secretEnv[name] = v;
+        else missingSecretNames.push(name);
+      }
+    }
+    // Very short values would mask common substrings all over the output;
+    // real credentials are long. (A <6-char "secret" is not protectable anyway.)
+    const secretValues = Object.values(secretEnv).filter((v) => v.length >= 6);
+    // Tell the model what's available — by NAME only — in the bash tool's own
+    // description (not the prompt: descriptions travel with the tool).
+    const secretsNote = cfg.secretsEnv.length
+      ? " Credential env vars available in this shell (values injected at exec time and masked in all output — write $NAME, never expect to see the value): " +
+        (Object.keys(secretEnv).join(", ") || "none") +
+        "." +
+        (missingSecretNames.length
+          ? ` Requested but NOT in the secret store (the $VAR will be empty — degrade gracefully and report it): ${missingSecretNames.join(", ")}.`
+          : "")
+      : "";
+
     // Built-in tools (operate on cfg.cwd). `inputSchema` cast to any to stop the
     // SDK's tool() from deeply inferring the zod type (TS2589 in strict builds).
     const allTools: Record<string, any> = {
@@ -598,7 +680,8 @@ export default defineStep({
       }),
       bash: tool({
         description:
-          "Execute a bash command inside the working dir. Use for listing dirs, reading files (cat/head), inspecting manifests/lockfiles/docker files, running installs/builds, and anything the other tools don't cover. Long-running commands are allowed (up to a 10-minute timeout); a command that never exits (e.g. a dev server) will block until killed at the timeout.",
+          "Execute a bash command inside the working dir. Use for listing dirs, reading files (cat/head), inspecting manifests/lockfiles/docker files, running installs/builds, and anything the other tools don't cover. Long-running commands are allowed (up to a 10-minute timeout); a command that never exits (e.g. a dev server) will block until killed at the timeout." +
+          secretsNote,
         inputSchema: z.object({ command: z.string().describe("The bash command to execute") }) as any,
         execute: async ({ command }: { command: string }) => {
           try {
@@ -606,7 +689,7 @@ export default defineStep({
             // 10-minute timeout so the agent can run real installs/builds (not just
             // quick inspection). Note: a non-terminating process (a dev server)
             // still blocks until killed at this timeout.
-            return await runShell(command, cfg.cwd, 600_000);
+            return await runShell(command, cfg.cwd, 600_000, 10000, secretEnv);
           } catch (e) {
             return `Command execution failed: ${e}`;
           }
@@ -682,6 +765,12 @@ export default defineStep({
         execute: async ({ answer }: { answer: string }) => answer,
       });
     }
+
+    // Mask secret values out of EVERY tool result — must wrap INSIDE the emit
+    // wrapper (i.e. be applied first) so run events also only ever see masked
+    // output. Covers indirect paths too: bash writes a secret to a file, the
+    // editor tool views it — still masked.
+    wrapToolsWithMask(tools, secretValues);
 
     // Emit a nested run event per tool call (built-ins + agentTools) so every
     // iteration is visible in the UI events panel / run drill-down. No-op when


### PR DESCRIPTION
## What

The bash-native answer to "how does an in-workflow agent use an authenticated API without ever seeing a credential" — agents are fluent in curl+jq and iterate on it fast, so credentials go to the *shell*, never the *context*:

- **`secretsEnv: ["COURTLISTENER_API_KEY", …]`** on the `agent` step: names resolved via `ctx.services.secrets` in code, values injected into the **bash subprocess env only** (`runShell` gains an `extraEnv` overlay on the scrubbed `minimalEnv` — the one sanctioned widening, documented at the seam). The model writes `$NAME`; the shell expands it at exec time. Prompt and event log only ever contain the literal string `$NAME`.
- **Output masking** (`wrapToolsWithMask`, applied inside the emit wrapper): every tool result is scanned for the injected values and masked before the model or `events.jsonl` sees it — covering `echo $KEY`, `env`, curl errors echoing the URL, and the indirect path (bash writes a secret to a file, the editor tool views it).
- The bash tool's **description** names the available/missing env vars, so the agent discovers what `$VAR`s exist without the prompt carrying anything.
- **Accepted residual, documented in EVOLVE_SPEC §4.3**: masking stops leakage into context/logs, not egress — a prompt-injected shell can still *send* `$KEY` somewhere. The trade for bash-native exploration; bounded by grant discipline (narrow research sub-agents only, never drafters, never the meta/* author).

## Why (from the first live evolve run)

The author couldn't authenticate raw probes (placeholder-401s) and routed around the value firewall the only way it could: brittle per-API TypeScript wrappers — one of which shipped hardcoded "fallback data", the exact staleness it was built to fix. With `secretsEnv`, a research capability is one `agent` step whose entire content is a *prompt* (tunable by layer-1 optimize forever after), and the author can iterate it live via `meta/run-step type=agent`. The harvey-evolve author method now says exactly that: build research sub-agents (`toolFilter: ["bash"]` + `secretsEnv`), judge their memos structurally, distill the worked curl+jq patterns into the candidate's params; the drafting agent never gets secretsEnv or web access.

## Testing

- vein: full suite, **497/497** — including new coverage: mask helpers (nested shapes, identity, every-occurrence), `wrapToolsWithMask` (echo-$KEY path, skips provider-executed tools), the loud failure when `secretsEnv` is set without a secrets capability, and `runShell` extraEnv (injected value expands; scrubbing still applies; empty overlay is identity)
- mcp: `refresh-vein`, `tsc --noEmit` clean, `evolve-smoke.ts` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)