### PR TITLE
harvey: hill-climb generations — evolve-loop + evolve-gen

### DIFF
--- a/mcp/src/lab/harvey/evolve-smoke.ts
+++ b/mcp/src/lab/harvey/evolve-smoke.ts
@@ -23,7 +23,7 @@ async function main() {
     await seedHarveyWorkflows(workspace);
 
     // 1. every seeded workflow parses into a Flow
-    for (const name of ["harvey-produce", "harvey-run", "harvey-candidate-run", "harvey-evolve"]) {
+    for (const name of ["harvey-produce", "harvey-run", "harvey-candidate-run", "harvey-evolve-gen", "harvey-evolve"]) {
       const flow = await workspace.getWorkflow(name);
       assert.equal(flow.name, name);
       assert.ok(Array.isArray(flow.steps) && flow.steps.length > 0, `${name} has steps`);
@@ -34,7 +34,7 @@ async function main() {
     const { registry } = await buildRegistry(workspace.path);
     const wanted = [
       "harvey/get-task", "harvey/evaluate", "harvey/pack-result", "harvey/digest-results",
-      "artifacts/dir", "meta/run-workflow", "agent", "subflow", "foreach",
+      "harvey/evolve-loop", "artifacts/dir", "meta/run-workflow", "agent", "subflow", "foreach",
     ];
     for (const t of wanted) assert.ok(registry[t], `registry has ${t}`);
     console.log("✔ all referenced step types resolve");
@@ -130,6 +130,82 @@ async function main() {
     await assert.rejects(() => dirStep.run(dirStep.input.parse({ sub: "../nope" }), dirCtx), /relative path/);
     await assert.rejects(() => dirStep.run(dirStep.input.parse({ sub: "/abs" }), dirCtx), /relative path/);
     console.log("✔ artifacts/dir sub: create + traversal guards");
+
+    // 5. the hill-climb loop, driven by a fake optimizer:
+    //    rates 0.85, 0.86, 0.86, 0.95 vs baseline 0.90 (improveMargin 0.02,
+    //    exploreAfter 2) → gens 0-1 exploit and fail to improve, gens 2-3
+    //    get the EXPLORE directive, gen 3 beats best and hits stopPassRate.
+    const loop = registry["harvey/evolve-loop"]!;
+    const genCalls: any[] = [];
+    const rates = [0.85, 0.86, 0.86, 0.95];
+    const fakeOpt = {
+      run: async (_name: string, input: any) => {
+        genCalls.push(input);
+        const g = input.generation as number;
+        return {
+          runId: `genrun-${g}`,
+          status: "success",
+          output: {
+            candidate: input.candidateName,
+            version: `v${g + 1}`,
+            summary: `approach ${g}`,
+            authorCost: 1,
+            digest: { meanPassRate: rates[g], allPassCount: 0, text: `digest ${g}`, results: [{ cost: 2 }] },
+          },
+        };
+      },
+    };
+    const loopCtx = { ...ctxStub, services: { optimizer: fakeOpt } };
+    const loopOut: any = await loop.run(
+      loop.input.parse({
+        tasks: ["a/b"],
+        mission: "m",
+        baseline: { meanPassRate: 0.9, text: "baseline digest" },
+        candidateName: "harvey-produce-ai",
+        maxGenerations: 6,
+        stopPassRate: 0.94,
+        improveMargin: 0.02,
+        exploreAfter: 2,
+      }),
+      loopCtx,
+    );
+    assert.equal(genCalls.length, 4); // stopped at gen 3 (0.95 ≥ 0.94), not 6
+    assert.equal(loopOut.stopReason, "stopPassRate 0.94 reached");
+    assert.equal(loopOut.bestGen, 3);
+    assert.equal(loopOut.bestVersion, "v4");
+    assert.equal(loopOut.bestPassRate, 0.95);
+    assert.equal(loopOut.baselinePassRate, 0.9);
+    assert.equal(loopOut.improved, true);
+    assert.equal(loopOut.totalKnownCost, 12); // 4 gens × (author 1 + produce 2)
+    // directive flip: gens 0-1 exploit, gens 2-3 explore
+    assert.ok(!genCalls[0].briefing.includes("GENUINELY DIFFERENT"));
+    assert.ok(!genCalls[1].briefing.includes("GENUINELY DIFFERENT"));
+    assert.ok(genCalls[2].briefing.includes("GENUINELY DIFFERENT"));
+    assert.ok(genCalls[3].briefing.includes("GENUINELY DIFFERENT"));
+    // history accumulates: gen 3's briefing lists all prior attempts + baseline anchor
+    assert.ok(genCalls[0].briefing.includes("none — this is the first attempt"));
+    assert.ok(genCalls[3].briefing.includes("attempt 0"));
+    assert.ok(genCalls[3].briefing.includes("attempt 2"));
+    assert.ok(genCalls[3].briefing.includes("harvey-produce-ai@v3"));
+    assert.ok(genCalls[3].briefing.includes("BEST SO FAR: the baseline itself"));
+    console.log("✔ harvey/evolve-loop: best-anchoring, explore flip, history, early stop");
+
+    // two consecutive generation failures abort the loop
+    const failOpt = { run: async () => ({ runId: "x", status: "failed", error: { message: "boom" } }) };
+    const failOut: any = await loop.run(
+      loop.input.parse({
+        tasks: ["a/b"],
+        mission: "m",
+        baseline: { meanPassRate: 0.9, text: "b" },
+        candidateName: "c",
+        maxGenerations: 6,
+      }),
+      { ...ctxStub, services: { optimizer: failOpt } },
+    );
+    assert.equal(failOut.stopReason, "two consecutive generation failures");
+    assert.equal(failOut.generations.length, 2);
+    assert.equal(failOut.improved, false);
+    console.log("✔ harvey/evolve-loop: aborts after consecutive failures");
 
     console.log("\nALL EVOLVE VALIDATION CHECKS PASSED");
   } finally {

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -24,6 +24,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "evaluate.ts", type: "harvey/evaluate" },
   { file: "pack-result.ts", type: "harvey/pack-result" },
   { file: "digest-results.ts", type: "harvey/digest-results" },
+  { file: "evolve-loop.ts", type: "harvey/evolve-loop" },
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -34,7 +35,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
 // harvey-evolve is the authoring harness over all of them. All seeded
 // UNSTAMPED (no publisher arg → not "ai"), so the meta surface can read but
 // never edit, run, or overwrite them.
-const SEED_WORKFLOWS = ["harvey-produce", "harvey-run", "harvey-candidate-run", "harvey-evolve"];
+const SEED_WORKFLOWS = ["harvey-produce", "harvey-run", "harvey-candidate-run", "harvey-evolve-gen", "harvey-evolve"];
 
 export async function seedHarveyWorkflows(workspace: WorkspaceManager): Promise<void> {
   const dir = join(HERE, "workflows");

--- a/mcp/src/lab/harvey/steps/evolve-loop.ts
+++ b/mcp/src/lab/harvey/steps/evolve-loop.ts
@@ -1,0 +1,333 @@
+import { z, defineStep, type RunEvent } from "vein";
+
+/**
+ * The HILL-CLIMB over workflow versions (EVOLVE_SPEC §5.3.3, the harvey
+ * instance): run `harvey-evolve-gen` up to maxGenerations times, feeding
+ * each generation a BRIEFING composed from the baseline digest plus every
+ * previous attempt's version, pass-rate, approach summary, and failure
+ * digest — anchored to the best-so-far (never the latest, which may have
+ * regressed; the same guarantee eval/optimize makes for prompts).
+ *
+ * EXPLOIT vs EXPLORE: while attempts keep beating the best, the directive
+ * says refine the best version. After `exploreAfter` consecutive
+ * non-improving attempts, it flips: try a GENUINELY DIFFERENT approach,
+ * with the already-tried approaches listed so "different" is checkable.
+ *
+ * Judge noise: an improvement must clear `improveMargin` (default 0.02 —
+ * one criterion on a 50-criterion task) to count; smaller deltas are ties.
+ *
+ * Runs generations through `services.optimizer` (vein.run — same capability
+ * eval/optimize uses), each as its own persisted run linked from this
+ * step's per-generation progress events. Stops on: stopPassRate reached,
+ * generations exhausted, or two consecutive generation-run failures (a
+ * broken harness should not burn ten generations of budget).
+ *
+ * TRAIN-SET caveat rides on the output: every generation tunes against the
+ * same tasks; the final pass-rate is a train score (EVOLVE_SPEC §7).
+ */
+
+interface AnyRec {
+  [k: string]: unknown;
+}
+
+interface RunResultLike {
+  runId: string;
+  status: string;
+  output?: unknown;
+  error?: { message?: string };
+}
+
+interface Optimizer {
+  run(
+    name: string,
+    input: unknown,
+    opts?: { paramOverrides?: Record<string, Record<string, unknown>> },
+  ): Promise<RunResultLike>;
+}
+
+function excerpt(s: unknown, max: number): string {
+  if (typeof s !== "string") return "";
+  const t = s.replace(/[ \t]+/g, " ").trim();
+  return t.length > max ? t.slice(0, max) + " […]" : t;
+}
+
+function num(v: unknown): number | undefined {
+  return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function indent(s: string, pad: string): string {
+  return s
+    .split("\n")
+    .map((l) => pad + l)
+    .join("\n");
+}
+
+/** One completed generation, as both output record and briefing material. */
+interface GenEntry {
+  gen: number;
+  genRunId: string;
+  version?: string;
+  passRate: number;
+  allPassCount?: number;
+  summary?: string;
+  changes?: unknown;
+  missingSecrets?: unknown;
+  digestText?: string;
+  authorCost?: number;
+  produceCost?: number;
+  explore: boolean;
+  error?: string;
+}
+
+export function composeBriefing(args: {
+  baseWorkflow: string;
+  candidateName: string;
+  baselineText: string;
+  baselinePassRate: number;
+  generations: GenEntry[];
+  best: { gen: number; version?: string; passRate: number; digestText: string };
+  explore: boolean;
+  sinceImprove: number;
+  improveMargin: number;
+}): string {
+  const { generations, best } = args;
+  const lines: string[] = [];
+
+  lines.push(
+    `BASELINE — the seeded produce workflow "${args.baseWorkflow}" was run on every task and graded (mean pass-rate ${args.baselinePassRate}):`,
+  );
+  lines.push(indent(args.baselineText, "  "));
+  lines.push("");
+
+  lines.push("PREVIOUS ATTEMPTS in this evolution run (oldest → newest):");
+  if (!generations.length) {
+    lines.push("  (none — this is the first attempt)");
+  } else {
+    for (const g of generations) {
+      if (g.error) {
+        lines.push(`- attempt ${g.gen}: FAILED to complete (${excerpt(g.error, 200)})`);
+        continue;
+      }
+      const delta = Math.round((g.passRate - args.baselinePassRate) * 1000) / 1000;
+      lines.push(
+        `- attempt ${g.gen} → published ${args.candidateName}@${g.version ?? "?"}: mean pass-rate ${g.passRate} (${delta >= 0 ? "+" : ""}${delta} vs baseline)`,
+      );
+      if (g.summary) lines.push(`  approach: ${excerpt(g.summary, 400)}`);
+      if (g.digestText) lines.push(indent(excerpt(g.digestText, 700), "    "));
+    }
+  }
+  lines.push("");
+
+  if (best.gen < 0) {
+    lines.push(`BEST SO FAR: the baseline itself (mean pass-rate ${best.passRate}) — no attempt has beaten it yet.`);
+  } else {
+    lines.push(
+      `BEST SO FAR: attempt ${best.gen} → ${args.candidateName}@${best.version} (mean pass-rate ${best.passRate}). Its result digest:`,
+    );
+    lines.push(indent(excerpt(best.digestText, 900), "  "));
+  }
+  lines.push("");
+
+  if (args.explore) {
+    lines.push(
+      `DIRECTIVE — EXPLORE. The last ${args.sinceImprove} attempt(s) did NOT beat the best. ` +
+        `Do NOT keep refining the same approach. Choose a GENUINELY DIFFERENT strategy this ` +
+        `generation: a different structure (e.g. sub-agent split vs single agent, a fresh-eyes ` +
+        `verification pass vs a research phase), a different method, a different allocation of the ` +
+        `step budget. Every approach summarized above has been tried — pick one that is none of ` +
+        `them. A regression from a distinct attempt is worth more than a marginal tweak that ` +
+        `changes nothing.`,
+    );
+  } else if (best.gen < 0) {
+    lines.push(
+      `DIRECTIVE — EXPLOIT. Start from the base workflow "${args.baseWorkflow}" (read its YAML with ` +
+        `meta/get-workflow) and fix exactly what the baseline failures above show.`,
+    );
+  } else {
+    lines.push(
+      `DIRECTIVE — EXPLOIT. Improve FROM the best attempt: read ${args.candidateName}@${best.version} ` +
+        `(meta/get-workflow with that EXACT version — the active version may be a worse later ` +
+        `attempt) and refine it: keep what worked, fix exactly what its failed criteria show.`,
+    );
+  }
+  lines.push(
+    `Deltas within ±${args.improveMargin} are judge noise — treat them as ties, not as signal to chase.`,
+  );
+
+  return lines.join("\n");
+}
+
+export default defineStep({
+  type: "harvey/evolve-loop",
+  description:
+    "Hill-climb candidate produce workflows over generations: repeatedly run a generation workflow (default harvey-evolve-gen: author → run candidate over tasks → digest), composing each generation's briefing from the baseline digest + all previous attempts, anchored to the best-so-far, flipping to an explore directive after `exploreAfter` non-improving attempts. Requires services.optimizer. Config: tasks, mission, baseline (a harvey/digest-results object), candidateName, baseWorkflow?, genWorkflow?, maxGenerations? (default 5, max 20), stopPassRate? (default 1), improveMargin? (default 0.02), exploreAfter? (default 2), genParams? (paramOverrides for the generation workflow). Output: { candidate, baselinePassRate, bestGen, bestVersion, bestPassRate, improved, generations, totalKnownCost, stopReason }.",
+  input: z.object({
+    tasks: z.array(z.string()).min(1).describe("Harvey task ids the loop optimizes against (the TRAIN set)"),
+    mission: z.string().describe("the standing gap statement handed to every generation's author"),
+    baseline: z
+      .any()
+      .describe("the baseline harvey/digest-results object ({ meanPassRate, text, … }) — generation 0's anchor"),
+    candidateName: z.string().describe("the candidate workflow name every generation publishes to (versioned lineage)"),
+    baseWorkflow: z.string().default("harvey-produce").describe("the seeded produce workflow the baseline ran"),
+    genWorkflow: z.string().default("harvey-evolve-gen").describe("the one-generation workflow the loop runs"),
+    maxGenerations: z.number().int().min(1).max(20).default(5),
+    stopPassRate: z.number().min(0).max(1).default(1).describe("stop early once a generation's mean pass-rate reaches this"),
+    improveMargin: z
+      .number()
+      .min(0)
+      .default(0.02)
+      .describe("an attempt must beat the best by MORE than this to count as an improvement (judge noise floor; 0.02 ≈ one criterion on a 50-criterion task)"),
+    exploreAfter: z
+      .number()
+      .int()
+      .min(1)
+      .default(2)
+      .describe("consecutive non-improving attempts before the directive flips from exploit to explore"),
+    genParams: z
+      .record(z.any())
+      .optional()
+      .describe("param overrides for the generation workflow (e.g. { authorModel, authorMaxSteps }) — applied via paramOverrides keyed by genWorkflow"),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const opt = (ctx.services as { optimizer?: Optimizer } | undefined)?.optimizer;
+    if (!opt) {
+      throw new Error("harvey/evolve-loop requires a `services.optimizer` capability (injected in createLabVein).");
+    }
+
+    const baseline = (cfg.baseline ?? {}) as AnyRec;
+    const baselinePassRate = num(baseline["meanPassRate"]) ?? 0;
+    const baselineText =
+      typeof baseline["text"] === "string" && baseline["text"]
+        ? (baseline["text"] as string)
+        : excerpt(JSON.stringify(baseline), 800);
+
+    let best = { gen: -1, version: undefined as string | undefined, passRate: baselinePassRate, digestText: baselineText };
+    let sinceImprove = 0;
+    let consecutiveFailures = 0;
+    let totalKnownCost = 0;
+    let stopReason = "maxGenerations exhausted";
+    const generations: GenEntry[] = [];
+
+    // Per-generation progress rows (same pattern as eval/optimize): synthetic
+    // `<path>#<gen>` events so each try is visible — and linkable — mid-run.
+    const emitGen = (gen: number, e: Partial<RunEvent> & { type: RunEvent["type"] }) =>
+      ctx.emit({
+        ts: new Date().toISOString(),
+        runId: ctx.runId,
+        path: `${ctx.path}#${gen}`,
+        stepType: "harvey/evolve-loop",
+        iteration: gen,
+        ...e,
+      } as RunEvent);
+
+    for (let gen = 0; gen < cfg.maxGenerations; gen++) {
+      const explore = sinceImprove >= cfg.exploreAfter;
+      const briefing = composeBriefing({
+        baseWorkflow: cfg.baseWorkflow,
+        candidateName: cfg.candidateName,
+        baselineText,
+        baselinePassRate,
+        generations,
+        best,
+        explore,
+        sinceImprove,
+        improveMargin: cfg.improveMargin,
+      });
+      const genStart = Date.now();
+      await emitGen(gen, {
+        type: "step.start",
+        input: { gen, directive: explore ? "explore" : "exploit", bestPassRate: best.passRate, briefing: excerpt(briefing, 2000) },
+      });
+
+      const run = await opt.run(
+        cfg.genWorkflow,
+        { tasks: cfg.tasks, mission: cfg.mission, candidateName: cfg.candidateName, generation: gen, briefing },
+        cfg.genParams && Object.keys(cfg.genParams).length
+          ? { paramOverrides: { [cfg.genWorkflow]: cfg.genParams } }
+          : undefined,
+      );
+
+      if (run.status !== "success") {
+        const message = run.error?.message ?? "unknown";
+        generations.push({ gen, genRunId: run.runId, passRate: 0, explore, error: message });
+        await emitGen(gen, {
+          type: "step.error",
+          durationMs: Date.now() - genStart,
+          error: { message: `gen ${gen}: ${message}` },
+        });
+        sinceImprove++;
+        if (++consecutiveFailures >= 2) {
+          stopReason = "two consecutive generation failures";
+          break;
+        }
+        continue;
+      }
+      consecutiveFailures = 0;
+
+      const out = (run.output ?? {}) as AnyRec;
+      const digest = (out["digest"] ?? {}) as AnyRec;
+      const passRate = num(digest["meanPassRate"]) ?? 0;
+      const digestResults = Array.isArray(digest["results"]) ? (digest["results"] as AnyRec[]) : [];
+      const authorCost = num(out["authorCost"]) ?? 0;
+      const produceCost = digestResults.reduce((s, r) => s + (num(r["cost"]) ?? 0), 0);
+      totalKnownCost += authorCost + produceCost;
+
+      const entry: GenEntry = {
+        gen,
+        genRunId: run.runId,
+        version: typeof out["version"] === "string" ? (out["version"] as string) : undefined,
+        passRate,
+        allPassCount: num(digest["allPassCount"]),
+        summary: typeof out["summary"] === "string" ? (out["summary"] as string) : undefined,
+        changes: out["changes"],
+        missingSecrets: out["missingSecrets"],
+        digestText: typeof digest["text"] === "string" ? (digest["text"] as string) : undefined,
+        authorCost,
+        produceCost: Math.round(produceCost * 10000) / 10000,
+        explore,
+      };
+      generations.push(entry);
+
+      if (passRate > best.passRate + cfg.improveMargin) {
+        best = { gen, version: entry.version, passRate, digestText: entry.digestText ?? "" };
+        sinceImprove = 0;
+      } else {
+        sinceImprove++;
+      }
+
+      await emitGen(gen, {
+        type: "step.end",
+        durationMs: Date.now() - genStart,
+        output: {
+          gen,
+          directive: explore ? "explore" : "exploit",
+          version: entry.version,
+          passRate,
+          bestPassRate: best.passRate,
+          bestGen: best.gen,
+          knownCost: Math.round((authorCost + produceCost) * 10000) / 10000,
+          runs: [{ label: `generation ${gen}`, workflow: cfg.genWorkflow, runId: run.runId }],
+        },
+      });
+
+      if (passRate >= cfg.stopPassRate) {
+        stopReason = `stopPassRate ${cfg.stopPassRate} reached`;
+        break;
+      }
+    }
+
+    return {
+      candidate: cfg.candidateName,
+      baselinePassRate,
+      bestGen: best.gen,
+      bestVersion: best.version,
+      bestPassRate: best.passRate,
+      improved: best.gen >= 0,
+      generations,
+      totalKnownCost: Math.round(totalKnownCost * 10000) / 10000,
+      stopReason,
+      note: "TRAIN scores — every generation tuned against the same tasks (EVOLVE_SPEC §7). Validate the best version on held-out tasks before promoting. totalKnownCost = author + produce costs; judge cost is not surfaced by the benchmark and is additional.",
+    };
+  },
+});

--- a/mcp/src/lab/harvey/workflows/harvey-evolve-gen.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve-gen.yaml
@@ -1,0 +1,272 @@
+name: harvey-evolve-gen
+# ONE GENERATION of the harvey evolution loop: author a candidate → run it
+# over the task set → digest the grades. The outer loop (harvey/evolve-loop,
+# invoked by harvey-evolve) runs this workflow repeatedly, composing each
+# generation's `briefing` from the baseline digest + every previous
+# attempt's result, so successive authors hill-climb instead of starting
+# blind (EVOLVE_SPEC §5.2's reflect beat, §5.3.3's loop-over-versions).
+#
+# The author is the standard meta/* authoring agent (§5.3.2 grants: meta/*
+# and the editor tool, never bash, never graders). It sees pass/fail
+# verdicts only — never the rubric — and cannot grade its own candidate;
+# grading happens here, after it finishes, exactly as in harvey-evolve.
+#
+# Input:  { tasks, mission, candidateName, generation, briefing }
+#   briefing: composed by harvey/evolve-loop — baseline digest, previous
+#             attempts (version, pass-rate, approach, failures), best-so-far
+#             anchor, and the exploit-or-explore directive.
+# Output: { candidate, generation, version, summary, changes,
+#           missingSecrets, authorCost, authorSteps, digest }
+#   digest: the harvey/digest-results object for this generation's candidate
+#           runs (meanPassRate is the fitness the loop climbs).
+steps:
+  - id: dir
+    type: artifacts/dir
+    config:
+      sub: author
+
+  # ── propose: the authoring agent ───────────────────────────────────────
+  - id: author
+    type: agent
+    depends: dir
+    options:
+      retry: { max: 1, delayMs: 15000 }
+    config:
+      cwd: "{{ dir.path }}"
+      system: "{{ params.authorSystem }}"
+      prompt: |
+        MISSION:
+        {{ input.mission }}
+
+        TASK SET ({{ input.tasks.length }} Harvey benchmark task(s)):
+        {{ input.tasks }}
+
+        This is GENERATION {{ input.generation }} of an evolution run.
+
+        {{ input.briefing }}
+
+        Author an improved CANDIDATE produce workflow named EXACTLY
+        "{{ input.candidateName }}", following the DIRECTIVE above. Address
+        failure patterns that RECUR across tasks (never one task's
+        specifics). Keep the hard contract, publish, smoke-test on ONE task
+        from the task set, and return the result.
+        {{ params.authorGuidance }}
+      model: "{{ params.authorModel }}"
+      maxSteps: "{{ params.authorMaxSteps }}"
+      # No bash, no web_search, no file browsing — the author's ONLY levers
+      # are the meta/* authoring steps (§5.3.2). The editor tool is kept so
+      # it can draft YAML in its (empty) scratch dir before publishing.
+      toolFilter: ["str_replace_based_edit_tool"]
+      agentTools: ["meta/*"]
+      schema:
+        type: object
+        properties:
+          candidate:
+            type: string
+            description: "the published candidate workflow name"
+          version:
+            type: string
+            description: "EXACT version string of the final healthy publish (from meta/publish-workflow)"
+          summary:
+            type: string
+            description: "the APPROACH this generation took and why — tied to the directive and the recurring failure patterns; the next generation reads this to know what has been tried"
+          changes:
+            type: array
+            items: { type: string }
+            description: "one line per concrete change"
+          missingSecrets:
+            type: array
+            description: "credentials the candidate needs that meta/list-secrets does not show — the capture artifact a human fulfills"
+            items:
+              type: object
+              properties:
+                name: { type: string }
+                why: { type: string }
+              required: [name, why]
+              additionalProperties: false
+        required: [candidate, version, summary]
+        additionalProperties: false
+
+  # ── evaluate: the pinned candidate over the task set ───────────────────
+  - id: candeval
+    type: foreach
+    depends: author
+    config:
+      items: "{{ input.tasks }}"
+      body:
+        id: one
+        type: subflow
+        config:
+          workflow: harvey-candidate-run
+          input:
+            workflow: "{{ author.object.candidate }}"
+            version: "{{ author.object.version }}"
+            task: "{{ $current }}"
+
+  - id: canddigest
+    type: harvey/digest-results
+    depends: candeval
+    config:
+      results: "{{ candeval }}"
+      maxCriteria: "{{ params.digestMaxCriteria }}"
+
+  - id: result
+    type: harvey/pack-result
+    depends: canddigest
+    config:
+      candidate: "{{ input.candidateName }}"
+      generation: "{{ input.generation }}"
+      version: "{{ author.object.version }}"
+      summary: "{{ author.object.summary }}"
+      changes: "{{ author.object.changes }}"
+      missingSecrets: "{{ author.object.missingSecrets }}"
+      authorCost: "{{ author.cost }}"
+      authorSteps: "{{ author.steps }}"
+      digest: "{{ canddigest }}"
+
+params:
+  authorModel: claude-sonnet-5
+  # Observed live: 40 was not enough — an author that debugs a real HTTP
+  # step burns 40 calls before ever publishing, and the forced final turn
+  # then dies with AI_NoObjectGeneratedError (the §1/§8 at-the-cap failure,
+  # now at layer 3). A generous cap + the publish-early rule in
+  # authorSystem is the §8 lesson applied.
+  authorMaxSteps: 200
+  # Extra per-run steering appended to the author's task prompt (experiment
+  # surface — e.g. "the mission requires online research; use the research
+  # sub-agent pattern with the COURTLISTENER_API_KEY secret name").
+  authorGuidance: ""
+  digestMaxCriteria: 6
+  # The author's persona + method — layer-1 tunable like any other prompt.
+  authorSystem: |
+    You are a WORKFLOW AUTHOR inside a self-evolving eval harness. You
+    improve HOW a benchmark task gets produced by authoring a new version of
+    a produce workflow. You never produce task deliverables yourself, and
+    you never see the grading rubric — only aggregate pass/fail results.
+
+    You are ONE GENERATION in a hill-climbing loop: earlier generations'
+    attempts and results are in your task prompt, and your published version
+    and summary will be handed to the next generation. Follow the DIRECTIVE
+    in the briefing — build on the best attempt when told to exploit, and
+    genuinely change strategy when told to explore. Deltas within ±0.02
+    (one criterion on a 50-criterion task) are judge noise — treat them as
+    ties, not signal.
+
+    Your only levers are the meta/* authoring tools (the workspace surface):
+    meta/get-workflow and meta/list-workflows to read existing YAML;
+    meta/list-steps, meta/search-steps, meta/get-step to discover step
+    types; meta/create-step / meta/edit-step to author new custom steps
+    (TypeScript, defineStep, imports from "vein" and node builtins);
+    meta/run-step to test ONE step cheaply; meta/publish-workflow to publish
+    the candidate; meta/run-workflow to run it; meta/list-runs,
+    meta/get-run, meta/search-runs to inspect those runs; meta/list-secrets
+    for available credential NAMES.
+
+    METHOD
+    1. Read the DIRECTIVE's anchor first: the best-so-far candidate version
+       (meta/get-workflow with the exact version) when exploiting, or the
+       base produce workflow when nothing has beaten the baseline. Your
+       candidate starts from that YAML, changed only where the evidence
+       points.
+    2. PUBLISH EARLY. Before any deep step-authoring, publish a first
+       candidate version (meta/publish-workflow) that is a modest, safe
+       improvement on your anchor. The harness grades whatever your FINAL
+       answer names: a rough published candidate beats a perfect
+       unpublished one, and if you run out of steps with nothing published,
+       this generation's budget is wasted. Republishing the same name
+       creates a new version — that is how you iterate upward.
+    3. BUDGET YOUR CALLS. You have a hard tool-call cap. Reserve the LAST
+       ~5 calls for: final meta/publish-workflow, one verification read,
+       and your final structured answer. Time-box debugging: if an external
+       endpoint or credential fails twice in a row (e.g. persistent 401s —
+       likely a bad secret, which you cannot fix), STOP debugging it,
+       record it in missingSecrets, make that path degrade gracefully, and
+       move on with what works.
+    4. SMOKE-TEST on ONE task from the task set (meta/run-workflow), then
+       inspect (meta/get-run, meta/search-runs). You cannot grade quality —
+       the harness grades after you finish. Check STRUCTURE only: the run
+       succeeds, the output object carries outputDir/usage/cost/steps, and
+       the deliverable files exist. Fix and republish until healthy. Runs
+       cost real money: one task, at most two smoke runs.
+    5. Steps you (or a prior generation) already authored may exist —
+       check meta/list-steps before creating: edit and reuse them instead
+       of re-authoring from scratch. But when the DIRECTIVE says explore,
+       reuse must not drag you back into an approach that already failed.
+
+    WORKFLOW DESIGN PATTERNS — vocabulary, not prescription. A candidate
+    may be ANY shape that honors the hard contract: compose these, adapt
+    them, or invent shapes not listed here. The one structural insight to
+    hold on to: an agent reviewing its own draft inside its own context is
+    anchored to it — only a SEPARATE agent step with a clean context gets
+    an unbiased re-read. A longer prompt cannot buy fresh eyes; structure
+    can. Several agent steps that each do ONE thing usually beat one agent
+    with more tools and a longer prompt.
+    - fresh-eyes verifier: after the producing agent, a separate agent
+      step re-reads the task instructions + the deliverable files and
+      emits a gap list; a revise step applies the fixes. Fits: explicit
+      requirements silently dropped (addressee/format, a mandated topic
+      never discussed).
+    - checklist extraction: a cheap early step distills the instructions
+      into an explicit requirements checklist that the drafter (and any
+      verifier) consume. Fits: long instructions where details get lost.
+    - researcher → drafter: a specialist sub-agent gathers external
+      authority into a memo (see the secretsEnv rule); the drafter
+      consumes the memo and stays closed-book. Fits: unverifiable
+      citations, stale agency figures.
+    - draft → critique → revise: a critic step judges the draft's analysis
+      against the instructions and documents; the drafter revises. Fits:
+      shallow or generic analysis.
+    Every added step costs real money and the report weighs quality
+    against cost — buy structure only where the digest shows a failure it
+    answers.
+
+    HARD CONTRACT for the candidate (the harness runs it as-is):
+    - input { task, workdir? }; thread workdir into an artifacts/dir step
+      (config sub) exactly as the base workflow does.
+    - the LAST step (use harvey/pack-result) must output: task, outputDir
+      (ABSOLUTE path containing the deliverable files), usage, cost, steps.
+    - deliverables are written under outputDir; the grader stages exactly
+      that directory.
+    - NEVER grant harvey/*, gaia/*, eval/*, or meta/* to any agent step
+      inside the candidate — graders and the authoring surface are
+      off-limits to producers. Steps you author yourself and other registry
+      namespaces are fair game.
+    - keep prompts in params (the tuning surface), keep the produce agent's
+      retry + onError fallback so one bad task cannot kill a batch.
+    - secrets: reference NAMES from meta/list-secrets (e.g. via
+      ctx.services.secrets in an authored step) — never paste credential
+      values. If a credential you need does not exist, record it in the
+      missingSecrets output and make the candidate degrade gracefully
+      without it.
+    - YOU CANNOT SEE SECRET VALUES — only names. A raw `http` step run via
+      meta/run-step therefore CANNOT authenticate: you have no real value
+      to put in the header, and a placeholder guarantees a 401 that says
+      NOTHING about whether the stored credential works. Never debug auth
+      through raw http probes.
+    - THE WAY TO USE AN AUTHENTICATED API is a RESEARCH SUB-AGENT: an
+      `agent` step with toolFilter ["bash"] and secretsEnv: [<secret
+      names from meta/list-secrets>]. Its bash gets the values as env
+      vars — it writes $NAME in curl commands and pipes through jq to
+      keep outputs small; values are injected at exec time and masked in
+      all output, so neither you nor it ever sees them. PREFER this over
+      authoring TypeScript wrapper steps around an API: a wrapper
+      hardcodes today's guesses (and dies on the first endpoint quirk);
+      a sub-agent prompt adapts, and the prompt stays tunable by the
+      optimize loop afterward.
+    - ITERATE THE SUB-AGENT LIVE: run it in isolation with meta/run-step
+      (type "agent", config { cwd: <your own working directory>, system:
+      <the research method draft>, prompt: <a sample research question>,
+      toolFilter: ["bash"], secretsEnv: [...], maxSteps: ~20 }). Judge its
+      output structurally — did it return verified citations, current
+      figures with sources, HTTP 200s? Refine the system prompt and rerun.
+      Ask it to also report the exact command patterns that WORKED, and
+      distill those worked examples into the final method prompt you embed
+      in the candidate's params. In the candidate, the sub-agent step
+      feeds its memo to the drafting agent; the drafting agent itself
+      NEVER gets secretsEnv or web access — external authority comes only
+      through the research memo.
+
+    When done, return: the candidate name, the EXACT version string of the
+    final healthy publish, a summary of the APPROACH this generation took
+    (the next generation reads it to know what has been tried), the list of
+    changes, and any missing secrets.

--- a/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
@@ -1,52 +1,51 @@
 name: harvey-evolve
-# The AUTHORING HARNESS (EVOLVE_SPEC §5.2 / §9.4): the first outer workflow
-# that exercises the meta/* authoring surface end to end. One generation of
-# the shared loop, with every beat a real, graded artifact:
+# The AUTHORING HARNESS (EVOLVE_SPEC §5.2 / §9.4), now a HILL-CLIMB
+# (§5.3.3, harvey instance): baseline once, then up to maxGenerations
+# author→run→grade cycles, each generation briefed with every previous
+# attempt's version, pass-rate, approach, and failures — anchored to the
+# best-so-far, flipping to an explicit "try a genuinely different
+# approach" directive after `exploreAfter` non-improving attempts.
 #
 #   capture   run the BASELINE produce workflow over the task set, grade it
 #             with the real benchmark eval, digest the aggregate misses
-#   propose   an AUTHORING agent — agentTools ["meta/*"] and NOTHING else
-#             (§5.3.2: never bash, never graders) — reads the digest,
-#             authors a CANDIDATE produce workflow via meta/publish-workflow
-#             (stamped publisher "ai"), smoke-tests it via meta/run-workflow,
-#             and iterates until structurally healthy
-#   evaluate  the HARNESS (not the author) runs the pinned candidate over
-#             the same tasks (harvey-candidate-run) and grades each
-#   promote   the report: candidate name + EXACT version, baseline vs
-#             candidate scores, the author's rationale, and any missing
-#             secrets the author captured. Promotion stays a HUMAN act —
-#             point harvey-run's input.produceWorkflow at the candidate, or
-#             fold its changes into the seeded harvey-produce, after review.
+#   loop      harvey/evolve-loop runs harvey-evolve-gen per generation:
+#             an authoring agent (meta/* only — §5.3.2) publishes a new
+#             version of the candidate, the harness runs it pinned over the
+#             same tasks and digests the grades; the loop composes the next
+#             generation's briefing and directive from the results
+#   promote   the report: best version + its pass-rate vs baseline, the
+#             full generation history, costs. Promotion stays a HUMAN act —
+#             point harvey-run's input.produceWorkflow at the best version,
+#             or fold its diff into the seeded harvey-produce, after review.
 #
 # MEASUREMENT DISCIPLINE (EVOLVE_SPEC §6/§7):
-#   - The author sees pass/fail VERDICTS + truncated judge reasoning for
-#     failed criteria (harvey/digest-results) — never the rubric itself.
-#     Hill-climbing against verdicts is the train-set problem: the scores in
-#     this report are TRAIN scores on the very tasks the candidate was tuned
-#     against. Validate on held-out tasks before believing the delta.
-#   - The author cannot grade: harvey/evaluate is not in its grants, and
-#     meta/run-workflow only reaches produce candidates. Its smoke tests
-#     check structure (run succeeds, deliverables exist), not quality.
-#   - Baselines run per-task workdirs (subflows share this run's artifacts
-#     dir); candidates run under their OWN runIds via meta/run-workflow.
+#   - Authors see pass/fail VERDICTS + truncated judge reasoning for failed
+#     criteria — never the rubric. Hill-climbing against verdicts is the
+#     train-set problem: every score in this report is a TRAIN score on the
+#     very tasks the candidates were tuned against. Validate the best
+#     version on held-out tasks before believing the delta.
+#   - The fitness is criteria pass-RATE (harvey/digest-results) — the
+#     benchmark's binary all-pass score has no gradient. Improvements must
+#     clear `improveMargin` (judge-noise floor) to count.
+#   - Authors cannot grade: grading happens in the harness after each
+#     author finishes, and candidates run under their OWN runIds via
+#     meta/run-workflow (harvey-candidate-run).
 #
-# COST: roughly 2 × |tasks| × (produce + judge) + the author's own smoke
-# runs (produce only, ≤2 by instruction). Start with 2-3 tasks.
+# COST: roughly (1 + generations) × |tasks| × (produce + judge) + each
+# generation's author (incl. its ≤2 smoke runs). With maxGenerations 5 and
+# one task, expect tens of dollars. Start small; raise input.generations
+# (cap 20) to let it rip.
 #
 # Needs: ANTHROPIC_API_KEY, HARVEY_LABS_DIR (+ uv, git, pandoc on PATH).
-# Input:  { tasks: [taskId, …], mission }
-#   mission: what to improve and why — the gap statement handed to the
-#            author (e.g. a per-miss taxonomy line: "citations unverifiable;
-#            stale regulatory figures — needs an online research step").
-# Output: { candidate, candidateVersion, baselinePassRate, candidatePassRate,
-#           passRateDelta, baseline, candidateResults, authorSummary,
-#           authorChanges, missingSecrets, … }
+# Input:  { tasks: [taskId, …], mission, generations? }
+#   mission:     the standing gap statement handed to every generation's
+#                author (the digest evidence rides alongside it and, per
+#                the author method, outranks it).
+#   generations: override params.maxGenerations for this run (e.g. 10).
+# Output: { candidate, bestGen, bestVersion, bestPassRate,
+#           baselinePassRate, improved, generations, totalKnownCost,
+#           stopReason, baseline, … }
 steps:
-  - id: dir
-    type: artifacts/dir
-    config:
-      sub: author
-
   # ── capture: baseline over the task set ────────────────────────────────
   - id: baseline
     type: foreach
@@ -68,261 +67,66 @@ steps:
       results: "{{ baseline }}"
       maxCriteria: "{{ params.digestMaxCriteria }}"
 
-  # ── propose: the authoring agent ───────────────────────────────────────
-  - id: author
-    type: agent
-    depends: [dir, basedigest]
-    options:
-      retry: { max: 1, delayMs: 15000 }
+  # ── the hill-climb: author → run → grade, up to N generations ──────────
+  - id: evolve
+    type: harvey/evolve-loop
+    depends: basedigest
     config:
-      cwd: "{{ dir.path }}"
-      system: "{{ params.authorSystem }}"
-      prompt: |
-        MISSION:
-        {{ input.mission }}
-
-        TASK SET ({{ input.tasks.length }} Harvey benchmark task(s)):
-        {{ input.tasks }}
-
-        BASELINE: the current produce workflow "{{ params.baseWorkflow }}"
-        was run on every task above and graded by the real benchmark.
-        Aggregate results:
-
-        {{ basedigest.text }}
-
-        Author an improved CANDIDATE produce workflow named EXACTLY
-        "{{ params.candidateName }}" that addresses the failure patterns
-        that RECUR across tasks (never one task's specifics). Start from the
-        base workflow's YAML, keep its hard contract, publish, smoke-test on
-        ONE task from the task set, and return the result.
-        {{ params.authorGuidance }}
-      model: "{{ params.authorModel }}"
-      maxSteps: "{{ params.authorMaxSteps }}"
-      # No bash, no web_search, no file browsing — the author's ONLY levers
-      # are the meta/* authoring steps (§5.3.2). The editor tool is kept so
-      # it can draft YAML in its (empty) scratch dir before publishing.
-      toolFilter: ["str_replace_based_edit_tool"]
-      agentTools: ["meta/*"]
-      schema:
-        type: object
-        properties:
-          candidate:
-            type: string
-            description: "the published candidate workflow name"
-          version:
-            type: string
-            description: "EXACT version string of the final healthy publish (from meta/publish-workflow)"
-          summary:
-            type: string
-            description: "what changed and why, each change tied to a recurring failure pattern from the digest"
-          changes:
-            type: array
-            items: { type: string }
-            description: "one line per concrete change"
-          missingSecrets:
-            type: array
-            description: "credentials the candidate needs that meta/list-secrets does not show — the capture artifact a human fulfills"
-            items:
-              type: object
-              properties:
-                name: { type: string }
-                why: { type: string }
-              required: [name, why]
-              additionalProperties: false
-        required: [candidate, version, summary]
-        additionalProperties: false
-
-  # ── evaluate: the pinned candidate over the same tasks ─────────────────
-  - id: candeval
-    type: foreach
-    depends: author
-    config:
-      items: "{{ input.tasks }}"
-      body:
-        id: one
-        type: subflow
-        config:
-          workflow: harvey-candidate-run
-          input:
-            workflow: "{{ author.object.candidate }}"
-            version: "{{ author.object.version }}"
-            task: "{{ $current }}"
-
-  - id: canddigest
-    type: harvey/digest-results
-    depends: candeval
-    config:
-      results: "{{ candeval }}"
-      maxCriteria: "{{ params.digestMaxCriteria }}"
+      tasks: "{{ input.tasks }}"
+      mission: "{{ input.mission }}"
+      baseline: "{{ basedigest }}"
+      candidateName: "{{ params.candidateName }}"
+      baseWorkflow: "{{ params.baseWorkflow }}"
+      genWorkflow: "{{ params.genWorkflow }}"
+      maxGenerations: "{{ input.generations || params.maxGenerations }}"
+      stopPassRate: "{{ params.stopPassRate }}"
+      improveMargin: "{{ params.improveMargin }}"
+      exploreAfter: "{{ params.exploreAfter }}"
+      genParams: "{{ params.genParams }}"
 
   # ── promote: the reviewable report ─────────────────────────────────────
   - id: report
     type: harvey/pack-result
-    depends: [basedigest, canddigest]
+    depends: evolve
     config:
       mission: "{{ input.mission }}"
       tasks: "{{ input.tasks }}"
-      candidate: "{{ author.object.candidate }}"
-      candidateVersion: "{{ author.object.version }}"
-      # THE FITNESS is criteria pass-rate, not the benchmark's binary
-      # all-pass score — binary at n=1 has no gradient to climb (observed:
-      # 45/50 vs 44/50 both report score 0). All-pass counts are kept as
-      # the headline benchmark metric; pass-rate is what a delta means.
-      baselinePassRate: "{{ basedigest.meanPassRate }}"
-      candidatePassRate: "{{ canddigest.meanPassRate }}"
-      passRateDelta: "{{ canddigest.meanPassRate - basedigest.meanPassRate }}"
-      baselineAllPass: "{{ basedigest.allPassCount }}"
-      candidateAllPass: "{{ canddigest.allPassCount }}"
+      candidate: "{{ evolve.candidate }}"
+      bestGen: "{{ evolve.bestGen }}"
+      bestVersion: "{{ evolve.bestVersion }}"
+      bestPassRate: "{{ evolve.bestPassRate }}"
+      baselinePassRate: "{{ evolve.baselinePassRate }}"
+      passRateDelta: "{{ evolve.bestPassRate - evolve.baselinePassRate }}"
+      improved: "{{ evolve.improved }}"
+      generations: "{{ evolve.generations }}"
+      totalKnownCost: "{{ evolve.totalKnownCost }}"
+      stopReason: "{{ evolve.stopReason }}"
       baseline: "{{ basedigest.results }}"
-      candidateResults: "{{ canddigest.results }}"
-      authorSummary: "{{ author.object.summary }}"
-      authorChanges: "{{ author.object.changes }}"
-      missingSecrets: "{{ author.object.missingSecrets }}"
-      authorCost: "{{ author.cost }}"
-      authorSteps: "{{ author.steps }}"
-      note: "TRAIN scores — the candidate was tuned against these tasks (EVOLVE_SPEC §7). Validate on held-out tasks before promoting. Promote by pointing harvey-run's input.produceWorkflow at the candidate, or by folding its diff into harvey-produce after review."
+      note: "{{ evolve.note }}"
 
 params:
-  # The produce workflow the author starts from (read via meta/get-workflow).
+  # The produce workflow the baseline runs and generation-0 authors start
+  # from (read via meta/get-workflow).
   baseWorkflow: harvey-produce
-  # The candidate's name. Publishing the same name again = a NEW VERSION on
-  # the same ai-stamped workflow, so successive evolve runs accumulate a
-  # versioned lineage instead of littering the registry with fresh names.
+  # The candidate's name. Every generation republishes it — a NEW VERSION
+  # each time, so one evolve run leaves a versioned lineage (and the report
+  # pins the best version, which may not be the latest).
   candidateName: harvey-produce-ai
-  authorModel: claude-sonnet-5
-  # Observed live: 40 was not enough — an author that debugs a real HTTP
-  # step (bad credentials, endpoint quirks) burns 40 calls before ever
-  # publishing, and the forced final turn then dies with
-  # AI_NoObjectGeneratedError (the §1/§8 at-the-cap failure, now at layer
-  # 3). A generous cap + the publish-early rule in authorSystem is the §8
-  # lesson applied: raise the envelope AND stop treating the cap as
-  # unreachable.
-  authorMaxSteps: 200
-  # Extra per-run steering appended to the author's task prompt (experiment
-  # surface — e.g. "the mission requires online research; grant http steps
-  # and reference the COURTLISTENER_API_KEY secret by name").
-  authorGuidance: ""
+  # The one-generation workflow the loop runs (author → candidate eval →
+  # digest). Its own params (authorModel, authorMaxSteps, authorSystem, …)
+  # are the author's experiment surface — override per run via genParams.
+  genWorkflow: harvey-evolve-gen
+  maxGenerations: 5
+  # Stop early once a generation's mean pass-rate reaches this (1 = every
+  # criterion on every task — rarely reached; generations are the real cap).
+  stopPassRate: 1
+  # Judge-noise floor: an attempt must beat the best by MORE than this to
+  # count as an improvement (0.02 ≈ one criterion on a 50-criterion task).
+  improveMargin: 0.02
+  # Consecutive non-improving attempts before the directive flips from
+  # "refine the best" to "try a genuinely different approach".
+  exploreAfter: 2
   digestMaxCriteria: 6
-  # The author's persona + method — layer-1 tunable like any other prompt.
-  authorSystem: |
-    You are a WORKFLOW AUTHOR inside a self-evolving eval harness. You
-    improve HOW a benchmark task gets produced by authoring a new version of
-    a produce workflow. You never produce task deliverables yourself, and
-    you never see the grading rubric — only aggregate pass/fail results.
-
-    Your only levers are the meta/* authoring tools (the workspace surface):
-    meta/get-workflow and meta/list-workflows to read existing YAML;
-    meta/list-steps, meta/search-steps, meta/get-step to discover step
-    types; meta/create-step / meta/edit-step to author new custom steps
-    (TypeScript, defineStep, imports from "vein" and node builtins);
-    meta/run-step to test ONE step cheaply; meta/publish-workflow to publish
-    the candidate; meta/run-workflow to run it; meta/list-runs,
-    meta/get-run, meta/search-runs to inspect those runs; meta/list-secrets
-    for available credential NAMES.
-
-    METHOD
-    1. Read the base produce workflow's YAML FIRST (meta/get-workflow) —
-       your candidate starts from it, changed only where the evidence
-       points. Address failure patterns that recur across MULTIPLE tasks;
-       never encode one task's specifics.
-    2. PUBLISH EARLY. Before any deep step-authoring, publish a first
-       candidate version (meta/publish-workflow) that is a modest, safe
-       improvement on the base — prompt/params changes at minimum. The
-       harness grades whatever your FINAL answer names: a rough published
-       candidate beats a perfect unpublished one, and if you run out of
-       steps with nothing published, the entire run's budget is wasted.
-       Republishing the same name creates a new version — that is how you
-       iterate upward from the banked version.
-    3. BUDGET YOUR CALLS. You have a hard tool-call cap. Reserve the LAST
-       ~5 calls for: final meta/publish-workflow, one verification read,
-       and your final structured answer. Time-box debugging: if an external
-       endpoint or credential fails twice in a row (e.g. persistent 401s —
-       likely a bad secret, which you cannot fix), STOP debugging it,
-       record it in missingSecrets, make that path degrade gracefully, and
-       move on with what works.
-    4. SMOKE-TEST on ONE task from the task set (meta/run-workflow), then
-       inspect (meta/get-run, meta/search-runs). You cannot grade quality —
-       the harness grades after you finish. Check STRUCTURE only: the run
-       succeeds, the output object carries outputDir/usage/cost/steps, and
-       the deliverable files exist. Fix and republish until healthy. Runs
-       cost real money: one task, at most two smoke runs.
-    5. Steps you (or a prior evolve run) already authored may exist —
-       check meta/list-steps before creating: edit and reuse them instead
-       of re-authoring from scratch.
-
-    WORKFLOW DESIGN PATTERNS — vocabulary, not prescription. A candidate
-    may be ANY shape that honors the hard contract: compose these, adapt
-    them, or invent shapes not listed here. The one structural insight to
-    hold on to: an agent reviewing its own draft inside its own context is
-    anchored to it — only a SEPARATE agent step with a clean context gets
-    an unbiased re-read. A longer prompt cannot buy fresh eyes; structure
-    can. Several agent steps that each do ONE thing usually beat one agent
-    with more tools and a longer prompt.
-    - fresh-eyes verifier: after the producing agent, a separate agent
-      step re-reads the task instructions + the deliverable files and
-      emits a gap list; a revise step applies the fixes. Fits: explicit
-      requirements silently dropped (addressee/format, a mandated topic
-      never discussed).
-    - checklist extraction: a cheap early step distills the instructions
-      into an explicit requirements checklist that the drafter (and any
-      verifier) consume. Fits: long instructions where details get lost.
-    - researcher → drafter: a specialist sub-agent gathers external
-      authority into a memo (see the secretsEnv rule); the drafter
-      consumes the memo and stays closed-book. Fits: unverifiable
-      citations, stale agency figures.
-    - draft → critique → revise: a critic step judges the draft's analysis
-      against the instructions and documents; the drafter revises. Fits:
-      shallow or generic analysis.
-    Every added step costs real money and the report weighs quality
-    against cost — buy structure only where the digest shows a failure it
-    answers.
-
-    HARD CONTRACT for the candidate (the harness runs it as-is):
-    - input { task, workdir? }; thread workdir into an artifacts/dir step
-      (config sub) exactly as the base workflow does.
-    - the LAST step (use harvey/pack-result) must output: task, outputDir
-      (ABSOLUTE path containing the deliverable files), usage, cost, steps.
-    - deliverables are written under outputDir; the grader stages exactly
-      that directory.
-    - NEVER grant harvey/*, gaia/*, eval/*, or meta/* to any agent step
-      inside the candidate — graders and the authoring surface are
-      off-limits to producers. Steps you author yourself and other registry
-      namespaces are fair game.
-    - keep prompts in params (the tuning surface), keep the produce agent's
-      retry + onError fallback so one bad task cannot kill a batch.
-    - secrets: reference NAMES from meta/list-secrets (e.g. via
-      ctx.services.secrets in an authored step) — never paste credential
-      values. If a credential you need does not exist, record it in the
-      missingSecrets output and make the candidate degrade gracefully
-      without it.
-    - YOU CANNOT SEE SECRET VALUES — only names. A raw `http` step run via
-      meta/run-step therefore CANNOT authenticate: you have no real value
-      to put in the header, and a placeholder guarantees a 401 that says
-      NOTHING about whether the stored credential works. Never debug auth
-      through raw http probes.
-    - THE WAY TO USE AN AUTHENTICATED API is a RESEARCH SUB-AGENT: an
-      `agent` step with toolFilter ["bash"] and secretsEnv: [<secret
-      names from meta/list-secrets>]. Its bash gets the values as env
-      vars — it writes $NAME in curl commands and pipes through jq to
-      keep outputs small; values are injected at exec time and masked in
-      all output, so neither you nor it ever sees them. PREFER this over
-      authoring TypeScript wrapper steps around an API: a wrapper
-      hardcodes today's guesses (and dies on the first endpoint quirk);
-      a sub-agent prompt adapts, and the prompt stays tunable by the
-      optimize loop afterward.
-    - ITERATE THE SUB-AGENT LIVE: run it in isolation with meta/run-step
-      (type "agent", config { cwd: <your own working directory>, system:
-      <the research method draft>, prompt: <a sample research question>,
-      toolFilter: ["bash"], secretsEnv: [...], maxSteps: ~20 }). Judge its
-      output structurally — did it return verified citations, current
-      figures with sources, HTTP 200s? Refine the system prompt and rerun.
-      Ask it to also report the exact command patterns that WORKED, and
-      distill those worked examples into the final method prompt you embed
-      in the candidate's params. In the candidate, the sub-agent step
-      feeds its memo to the drafting agent; the drafting agent itself
-      NEVER gets secretsEnv or web access — external authority comes only
-      through the research memo.
-
-    When done, return: the candidate name, the EXACT version string of the
-    final healthy publish, a summary tying each change to a recurring
-    failure pattern, the list of changes, and any missing secrets.
+  # Param overrides for harvey-evolve-gen (e.g. { authorModel: "...",
+  # authorMaxSteps: 120, authorGuidance: "..." }). Empty = its defaults.
+  genParams: {}

--- a/vein/EVOLVE_SPEC.md
+++ b/vein/EVOLVE_SPEC.md
@@ -443,4 +443,12 @@ possible version of "capture."
    stays human. Offline checks: `mcp/src/lab/harvey/evolve-smoke.ts`.
 5. **Generalize `eval/optimize`'s candidate** from prompt string to workflow
    ref + version (§5.3.3) — the change that lets one loop drive all three
-   layers.
+   layers. **Harvey instance built** — `harvey/evolve-loop` (lab): up to N
+   generations of `harvey-evolve-gen` (author → run pinned candidate →
+   digest), each briefed with every prior attempt's version/pass-rate/
+   approach/failures, anchored to the best-so-far (never the latest), with
+   the directive flipping from exploit to "try a GENUINELY DIFFERENT
+   approach" after `exploreAfter` non-improving attempts. Fitness is
+   criteria pass-rate (binary all-pass has no gradient); improvements must
+   clear a judge-noise margin (default 0.02 ≈ one criterion at n=50). The
+   GENERIC step remains open — this is the shape it should generalize.


### PR DESCRIPTION
## What

harvey-evolve goes from one-shot to a real hill-climb — "let it rip with a max of N and see what it can do":

- **`harvey-evolve-gen`** (new workflow): one generation — the meta/* authoring agent publishes a new version of the candidate, the harness runs it pinned over the task set via harvey-candidate-run, and the graded digest is the output. The author's system prompt moves here, extended with generation awareness: it knows it's one step in a chain, follows the loop's directive, and treats ±0.02 deltas as judge-noise ties.
- **`harvey/evolve-loop`** (new seeded step, runs on `services.optimizer` like eval/optimize): drives up to `maxGenerations` (default 5, `input.generations` overrides, hard cap 20) runs of the gen workflow. Each generation's **briefing** carries the baseline digest plus every previous attempt's published version, pass-rate (Δ vs baseline), approach summary, and failure digest — **anchored to the best-so-far, never the latest** (the directive names the exact version to `meta/get-workflow`, since the active version may be a worse later attempt). After `exploreAfter` (default 2) consecutive non-improving attempts, the directive flips from exploit to **"choose a GENUINELY DIFFERENT strategy — every approach above has been tried; pick one that is none of them"**. Improvements must clear `improveMargin` (default 0.02 ≈ one criterion on a 50-criterion task). Stops on `stopPassRate`, generations exhausted, or two consecutive generation-run failures. Per-generation progress events link each gen's own run.
- **`harvey-evolve`** (rewritten): baseline → digest → evolve-loop → report (best version + pass-rate delta vs baseline, full generation history, known costs, stop reason, train-set caveat).

Every generation republishes the same candidate name → one versioned lineage per run; the report pins the best version, which promotion (still human) points harvey-run at.

## Testing

`npx tsc --noEmit` clean; `evolve-smoke.ts` extended with a fake-optimizer drive of the loop: rates 0.85/0.86/0.86/0.95 against baseline 0.90 verify best-anchoring ("BEST SO FAR: the baseline itself" until beaten), the exploit→explore flip at the right generation, history accumulation in briefings, the stopPassRate early stop, cost totals — plus a consecutive-failure abort case.

## Stacking

Builds on #1607 (pass-rate fitness — the loop climbs `meanPassRate`) and #1608 (secretsEnv — the author method's research-sub-agent pattern). Merge those first; this diff includes their commits until they land.

🤖 Generated with [Claude Code](https://claude.com/claude-code)