### PR TITLE
lab: gate /lab behind API_TOKEN (basic auth + x-api-token)

### DIFF
--- a/mcp/src/lab/mount.ts
+++ b/mcp/src/lab/mount.ts
@@ -35,6 +35,30 @@ function bridge(factory: () => Promise<{ app: { fetch: any } }>) {
  * Registration MUST happen before `express.json()` so vein receives the
  * raw request stream (same constraint as the graph SSE routes).
  */
+/**
+ * Gate every /lab route behind the mcp-wide API_TOKEN (unset = dev mode =
+ * open, the same posture as the /events route). Two accepted credentials:
+ * HTTP Basic `admin:<API_TOKEN>` — the browser prompts once for the UI and
+ * then attaches it to every request including EventSource streams, which
+ * cannot carry custom headers — and the `x-api-token` header, matching the
+ * rest of mcp for server-to-server callers.
+ */
+function labAuth(req: Request, res: Response, next: NextFunction): void {
+  const apiToken = process.env.API_TOKEN;
+  if (!apiToken) return next();
+  if (req.header("x-api-token") === apiToken) return next();
+  const header = req.header("authorization") ?? "";
+  if (header.startsWith("Basic ")) {
+    const decoded = Buffer.from(header.slice(6), "base64").toString();
+    const sep = decoded.indexOf(":");
+    const user = decoded.slice(0, sep);
+    const pass = decoded.slice(sep + 1);
+    if (sep > 0 && user === "admin" && pass === apiToken) return next();
+  }
+  res.set("WWW-Authenticate", 'Basic realm="stakgraph-lab"');
+  res.status(401).json({ error: "Unauthorized" });
+}
+
 export function mountLab(app: Express): void {
   // Trailing slash so the SPA's relative asset URLs resolve under /lab/.
   // Express routing is non-strict, so `/lab` also matches `/lab/`; guard
@@ -45,5 +69,5 @@ export function mountLab(app: Express): void {
     if (req.path === "/lab/") return next();
     res.redirect(308, "/lab/");
   });
-  app.use("/lab", bridge(() => createLabVein({ serveUi: true })));
+  app.use("/lab", labAuth, bridge(() => createLabVein({ serveUi: true })));
 }


### PR DESCRIPTION
## What

`/lab` is mounted before mcp's auth middleware, so the entire lab surface — workflow launches (which spend LLM budget), run logs, workspace step editing, secrets listing — was reachable unauthenticated on any host where mcp is exposed. This was the documented known follow-up in `mcp/src/lab/AGENTS.md`.

This gates the whole `/lab` mount behind the mcp-wide `API_TOKEN`:

- **HTTP Basic `admin:<API_TOKEN>`** — the browser prompts once for the UI, then attaches credentials to every request including EventSource/SSE streams (which can't carry custom headers), so the whole SPA + live run tailing works with zero UI changes
- **`x-api-token` header** — parity with the rest of mcp for server-to-server/script callers
- **`API_TOKEN` unset ⇒ open** (dev mode) — same posture as the existing `/events` route

## Testing

Verified against a live instance (`tsc --noEmit` clean):

| request | result |
|---|---|
| no credentials | 401 + `WWW-Authenticate: Basic realm="stakgraph-lab"` |
| wrong password / wrong user | 401 |
| `-u admin:<token>` on /lab/health and /lab/ UI | 200 |
| `x-api-token: <token>` | 200 |
| `API_TOKEN` unset | open (dev mode) |

Prod note: sphinx-swarm already injects `API_TOKEN` into the container env from boltwall's stakwork_secret, so this becomes enforced in prod automatically once the image updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)