### PR TITLE
gaia: stop __pycache__ from dirtying the dataset checkout

### DIFF
--- a/mcp/src/lab/gaia/service.ts
+++ b/mcp/src/lab/gaia/service.ts
@@ -1,6 +1,6 @@
 import { spawn } from "node:child_process";
 import { createHash } from "node:crypto";
-import { mkdtemp, readFile, stat, writeFile } from "node:fs/promises";
+import { mkdtemp, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { ensureGaiaDataset, ensureGaiaPython, SCORER_SHA256 } from "./bootstrap.js";
@@ -238,6 +238,13 @@ export function buildGaiaServices(opts: BuildGaiaOptions = {}): GaiaServices {
     }
     const rev = head.stdout.trim();
 
+    // Importing scorer.py compiles bytecode into __pycache__/ — derived
+    // state, but also a shadowing vector: python prefers a matching .pyc over
+    // the (sha-pinned) source, so a doctored cache could bypass the pin.
+    // Delete it rather than tolerate it. score() runs python -B so it
+    // normally never appears; this also heals checkouts dirtied before -B.
+    await rm(join(abs, "__pycache__"), { recursive: true, force: true });
+
     // The dataset must be unmodified (a doctored metadata.jsonl = doctored
     // gold). scorer.py is expected untracked — it comes from the leaderboard
     // Space, not this repo.
@@ -346,7 +353,9 @@ export function buildGaiaServices(opts: BuildGaiaOptions = {}): GaiaServices {
     const python = autoSetup
       ? await ensureGaiaPython(opts.python ? { python: opts.python } : {})
       : (opts.python ?? process.env.GAIA_PYTHON ?? "python3");
-    const res = await exec(python, ["-c", DRIVER, root, pairsPath], {
+    // -B: never write __pycache__/ into the checkout (verifyDataset treats a
+    // dirty tree as doctored gold and refuses to grade).
+    const res = await exec(python, ["-B", "-c", DRIVER, root, pairsPath], {
       cwd: root,
       timeoutMs: o.timeoutMs ?? DEFAULT_SCORE_TIMEOUT_MS,
     });

--- a/mcp/src/lab/gaia/smoke.ts
+++ b/mcp/src/lab/gaia/smoke.ts
@@ -130,6 +130,14 @@ async function main() {
     // ── empty pairs refuses ──
     await assert.rejects(() => gaia.score([]), /no pairs/);
 
+    // ── untracked __pycache__/ is healed, not refused (and the driver runs
+    //    with -B, so score() itself must not have created one) ──
+    assert.ok(!existsSync(join(dir, "__pycache__")), "score() wrote __pycache__ despite -B");
+    mkdirSync(join(dir, "__pycache__"));
+    writeFileSync(join(dir, "__pycache__", "scorer.cpython-311.pyc"), "doctored");
+    await gaia.verifyDataset();
+    assert.ok(!existsSync(join(dir, "__pycache__")), "verifyDataset left __pycache__ behind");
+
     // ── dirty tree refuses (tracked file modified) ──
     writeFileSync(join(dir, "2023", "validation", "metadata.jsonl"), "{}\n");
     await assert.rejects(() => gaia.score([{ taskId: T1, answer: "4" }]), /local modifications/);


### PR DESCRIPTION
On prod, GAIA grading failed with:

```
gaia: dataset checkout has local modifications — refusing to grade. Restore it to a clean tree first:
?? __pycache__/
```

The scorer driver does `sys.path.insert(0, gaia_dir)` + `from scorer import question_scorer`, and CPython writes bytecode to `<GAIA_DIR>/__pycache__/` — so the **first** `score()` succeeds and dirties the tree, and every later grade refuses.

Fix:
- run the driver with `python -B` so bytecode is never written into the checkout
- `verifyDataset` deletes any existing `__pycache__/` before the clean-tree check — it's derived state, and a doctored `.pyc` with matching mtime/size could shadow the sha-pinned `scorer.py` source, so deleting (rather than tolerating it untracked) also closes that pin-bypass vector

Already-dirty prod checkouts heal themselves on the next grade. Smoke gains a regression case: a planted `__pycache__/` is removed, and `score()` is asserted not to create one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)