### PR TITLE
gaia: wire phase-1 measurement into the evolve capture stage

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -446,10 +446,16 @@ are thin plumbing over `ctx.services.gaia.*`.
   `gaia-candidate-run` (runs an ai-stamped candidate on one task via
   `meta/run-workflow`, scores its reported answer via `gaia/evaluate`'s
   `fromRun` unpack — a failed run is an honest zero), `gaia-evolve-gen`
-  (one generation: meta/* author → pinned candidate over the task set →
-  digest) and `gaia-evolve` (baseline → hill-climb → report;
-  `improveMargin: 0` since exact-match has no judge noise — the residual
-  produce-sampling noise is answered by held-out validation, not a margin).
+  (one generation: meta/* author → pinned candidate over the task set,
+  `produceConcurrency`-wide → digest) and `gaia-evolve` (capture →
+  hill-climb → report). The capture stage runs the baseline
+  `baselineSamples` times (nested foreach, numeric outer items) and folds
+  the samples with `eval/matrix`: the matrix object IS the loop's baseline
+  (`fitness` = the MAX sample, the conservative bar) and its MEASURED
+  produce-sampling floor (`noise.suggestedMargin`, the max fitness delta
+  between identical-YAML re-runs) becomes the loop's `improveMargin` —
+  `params.improveMargin: 0` is only the fallback when the floor is
+  unmeasured (`baselineSamples: 1`, the pre-Phase-1 behavior).
   Candidate contract: input `{ taskId }`, last step outputs `taskId`,
   `answer` (bare string), `cost`, `steps`; candidates may use
   `gaia/get-task` / `gaia/pack-result` as steps but NEVER `gaia/evaluate`

--- a/mcp/src/lab/eval/matrix-smoke.ts
+++ b/mcp/src/lab/eval/matrix-smoke.ts
@@ -48,6 +48,7 @@ async function main() {
         meas("v11", false, "7"), // the accidental re-measurement
       ],
       maxAnswerChars: 120,
+      maxQuestionChars: 200,
     },
     ctx,
   )) as AnyRec;
@@ -89,7 +90,7 @@ async function main() {
 
   // 4. single measurement per version → floor UNKNOWN, never zero
   const single = (await matrix.run(
-    { measurements: [meas("gaia-produce", true, "x"), meas("v10", false, "y")], maxAnswerChars: 120 },
+    { measurements: [meas("gaia-produce", true, "x"), meas("v10", false, "y")], maxAnswerChars: 120, maxQuestionChars: 200 },
     ctx,
   )) as AnyRec;
   const n2 = single.noise as AnyRec;
@@ -114,6 +115,7 @@ async function main() {
         },
       ],
       maxAnswerChars: 120,
+      maxQuestionChars: 200,
     },
     ctx,
   )) as AnyRec;
@@ -123,6 +125,57 @@ async function main() {
   assert.equal(sById["c"]!.band, "ceiling");
   assert.equal(sById["d"]!.band, "ceiling"); // unreadable → false, never true
   console.log("✔ all three graded-result shapes normalize");
+
+  // 6. single-version `samples` mode (the k-sample baseline capture): the
+  // nested-foreach output shape, a top-level fitness = MAX sample, and the
+  // question excerpt threading through for non-floor tasks.
+  const sampleResults = (flip: boolean) => [
+    res("floor-1", true, "right"),
+    res("stuck-1", false, "36", 3, { question: "What is the average number of pre-2020 works?" }),
+    res("flip-1", flip, flip ? "ok" : "nope"),
+  ];
+  const base = (await matrix.run(
+    {
+      version: "gaia-produce",
+      samples: [sampleResults(true), sampleResults(false), sampleResults(true)],
+      maxAnswerChars: 120,
+      maxQuestionChars: 200,
+    },
+    ctx,
+  )) as AnyRec;
+  const bVersions = base.versions as AnyRec[];
+  assert.equal(bVersions.length, 1);
+  assert.deepEqual((bVersions[0] as AnyRec).fitness, [0.667, 0.333, 0.667]);
+  assert.equal(base.fitness, 0.667, "top-level fitness is the MAX sample (the conservative bar)");
+  const bNoise = base.noise as AnyRec;
+  assert.equal(bNoise.sameVersionPairs, 3); // 3 samples → 3 pairs
+  assert.equal(bNoise.floorKnown, true);
+  const bTasks = Object.fromEntries((base.tasks as AnyRec[]).map((t) => [t.taskId as string, t]));
+  assert.ok(String(bTasks["stuck-1"]!.question).includes("pre-2020"), "ceiling task carries its question");
+  assert.equal(bTasks["floor-1"]!.question, undefined, "floor tasks stay question-free");
+  assert.ok((base.text as string).includes("question:"), "text shows stuck-task questions");
+  console.log("✔ samples mode: nested-foreach shape, MAX-sample fitness, questions threaded");
+
+  // exactly-one-mode validation
+  await assert.rejects(
+    () => matrix.run({ maxAnswerChars: 120, maxQuestionChars: 200 } as never, ctx),
+    /exactly one mode/,
+  );
+  await assert.rejects(
+    () =>
+      matrix.run(
+        {
+          measurements: [{ version: "v", results: [] }],
+          version: "v",
+          samples: [[]],
+          maxAnswerChars: 120,
+          maxQuestionChars: 200,
+        } as never,
+        ctx,
+      ),
+    /exactly one mode/,
+  );
+  console.log("✔ mode exclusivity enforced");
 
   console.log("\nmatrix smoke: all checks passed");
 }

--- a/mcp/src/lab/eval/steps/matrix.ts
+++ b/mcp/src/lab/eval/steps/matrix.ts
@@ -86,7 +86,7 @@ interface Obs {
 export default defineStep({
   type: "eval/matrix",
   description:
-    "Fold MULTIPLE graded measurements (each: one version run over the task set) into the task×version matrix: per-task bands (floor / movable / ceiling), per-version fitness samples, an EMPIRICAL noise floor from same-version re-measurements (fitness deltas + task flips on identical YAML), and bias-vs-variance tags for never-correct tasks (byte-identical wrong answer across ≥3 measurements = bias; distinct wrong answers = variance). Gold never enters or leaves. Config: measurements (array of { version, results }, oldest → newest; results are gaia-run / gaia-candidate-run style graded outputs), maxAnswerChars? (default 120). Output: { tasks, versions, bands, noise, text }.",
+    "Fold MULTIPLE graded measurements (each: one version run over the task set) into the task×version matrix: per-task bands (floor / movable / ceiling), per-version fitness samples, an EMPIRICAL noise floor from same-version re-measurements (fitness deltas + task flips on identical YAML), and bias-vs-variance tags for never-correct tasks (byte-identical wrong answer across ≥3 measurements = bias; distinct wrong answers = variance). Gold never enters or leaves. Two input modes (exactly one): `measurements` (array of { version, results }, oldest → newest) for mixed versions, or `version` + `samples` (array of results-arrays) for k re-measurements of ONE version — the baseline-capture form a workflow's nested foreach produces, since template expressions cannot construct object arrays. When exactly one version was measured, the output adds top-level `fitness` (the MAX sample — the conservative bar a challenger must beat), so the matrix object plugs straight into eval/evolve-loop's `baseline`. Results are gaia-run / gaia-candidate-run style graded outputs. Config: measurements? | (version? + samples?), maxAnswerChars? (default 120), maxQuestionChars? (default 200). Output: { tasks, versions, bands, noise, text, fitness? }.",
   input: z.object({
     measurements: z
       .array(
@@ -96,13 +96,34 @@ export default defineStep({
         }),
       )
       .min(1)
-      .describe("all measurements so far, oldest → newest"),
+      .optional()
+      .describe("all measurements so far, oldest → newest (mixed-version mode)"),
+    version: z.string().optional().describe("single-version mode: the version every entry in `samples` measured"),
+    samples: z
+      .array(z.array(z.any()))
+      .min(1)
+      .optional()
+      .describe("single-version mode: k re-measurements of `version`, each an array of graded results (a nested foreach's output)"),
     maxAnswerChars: z.number().int().positive().default(120),
+    maxQuestionChars: z.number().int().positive().default(200),
   }),
   output: z.any(),
-  async run(cfg) {
+  async run(rawCfg) {
+    const modeA = rawCfg.measurements != null;
+    const modeB = rawCfg.version != null && rawCfg.samples != null;
+    if (modeA === modeB) {
+      throw new Error(
+        "eval/matrix takes EITHER `measurements` OR `version` + `samples` — exactly one mode",
+      );
+    }
+    const cfg = {
+      ...rawCfg,
+      measurements:
+        rawCfg.measurements ??
+        rawCfg.samples!.map((results) => ({ version: rawCfg.version!, results })),
+    };
     // ── fold every measurement into per-task observations ────────────────
-    const byTask = new Map<string, { level: number | null; obs: Obs[] }>();
+    const byTask = new Map<string, { level: number | null; question?: string; obs: Obs[] }>();
     const versionOrder: string[] = [];
     const byVersion = new Map<string, { fitness: number[]; vectors: Map<string, boolean>[] }>();
 
@@ -123,6 +144,9 @@ export default defineStep({
         vec.set(taskId, correct);
         const rec = byTask.get(taskId) ?? { level: num(r["level"]) ?? null, obs: [] };
         rec.level ??= num(r["level"]) ?? null;
+        // Task-visible text only (every producer sees the question) — never
+        // the gold. Kept so briefings can show WHAT a stuck task asks.
+        rec.question ??= str(r["question"]);
         rec.obs.push({
           version: m.version,
           measurement: mi,
@@ -138,7 +162,7 @@ export default defineStep({
     });
 
     // ── per-task rows: band, flips, bias-vs-variance ─────────────────────
-    const tasks = [...byTask.entries()].map(([taskId, { level, obs }]) => {
+    const tasks = [...byTask.entries()].map(([taskId, { level, question, obs }]) => {
       const n = obs.length;
       const solved = obs.filter((o) => o.correct).length;
       const band = solved === n ? "floor" : solved === 0 ? "ceiling" : "movable";
@@ -159,6 +183,7 @@ export default defineStep({
         n,
         solved,
         flips,
+        ...(band !== "floor" && question ? { question: truncate(question, cfg.maxQuestionChars) } : {}),
         ...(wrongAnswers.length
           ? { wrongAnswers: wrongAnswers.slice(0, 5).map((a) => truncate(a, cfg.maxAnswerChars)) }
           : {}),
@@ -272,6 +297,7 @@ export default defineStep({
           `- ${t.taskId}${t.level != null ? ` (L${t.level})` : ""}: correct ${t.solved}/${t.n}, ${t.flips} flip(s)` +
             (t.wrongAnswers?.length ? ` — wrong answers seen: ${t.wrongAnswers.map((a) => `"${a}"`).join(", ")}` : ""),
         );
+        if (t.question) lines.push(`    question: ${t.question}`);
       }
     }
     const ceiling = tasks.filter((t) => t.band === "ceiling");
@@ -289,9 +315,17 @@ export default defineStep({
                 : `every measurement returned an empty answer`) +
             (t.errors?.length ? ` [errors: ${t.errors.join(" | ")}]` : ""),
         );
+        if (t.question) lines.push(`    question: ${t.question}`);
       }
     }
 
-    return { tasks, versions, bands, noise, text: lines.join("\n") };
+    // Single-version matrices (the k-sample baseline capture) also report a
+    // top-level `fitness` — the MAX sample, i.e. the baseline's best observed
+    // draw, the conservative bar a challenger must beat by more than the
+    // measured margin — so this object plugs directly into eval/evolve-loop's
+    // `baseline` (which reads `.fitness` and `.text`).
+    const single = versions.length === 1 ? { fitness: versions[0]!.maxFitness } : {};
+
+    return { tasks, versions, bands, noise, ...single, text: lines.join("\n") };
   },
 });

--- a/mcp/src/lab/gaia/evolve-smoke.ts
+++ b/mcp/src/lab/gaia/evolve-smoke.ts
@@ -39,6 +39,7 @@ async function main() {
     const wanted = [
       "gaia/list-tasks", "gaia/get-task", "gaia/evaluate", "gaia/pack-result",
       "gaia/summarize-batch", "gaia/digest-results", "eval/evolve-loop",
+      "eval/matrix",
       "artifacts/dir", "meta/run-workflow", "agent", "subflow", "foreach",
     ];
     for (const t of wanted) assert.ok(registry[t], `registry has ${t}`);
@@ -256,6 +257,71 @@ async function main() {
     );
     assert.equal(loopOut.generations[1].summary, "approach 1");
     console.log("✔ eval/evolve-loop: climbs gaia `fitness`, accuracy naming, margin-0 tie handling, junk-summary guard");
+
+    // 6. the capture stage (Phase 1 wiring): a k-sample baseline folded by
+    //    eval/matrix plugs into the loop AS the baseline object, and the
+    //    measured noise floor feeds improveMargin via the yaml's fallback
+    //    expression.
+    const matrixStep = registry["eval/matrix"]!;
+    // Two identical-YAML baseline samples, one task flipping between them —
+    // gaia-run result shape (correct as 0/1 count with total 1).
+    const bSample = (flip: boolean) => [
+      { taskId: "t-1", level: 2, correct: 1, total: 1, answer: "42", question: "Q1" },
+      { taskId: "t-2", level: 2, correct: flip ? 1 : 0, total: 1, answer: flip ? "ok" : "no", question: "Q2" },
+    ];
+    const basematrix: any = await matrixStep.run(
+      matrixStep.input.parse({ version: "gaia-produce", samples: [bSample(true), bSample(false)] }),
+      ctxStub,
+    );
+    assert.equal(basematrix.fitness, 1); // MAX sample (2/2) — the conservative bar
+    assert.equal(basematrix.noise.floorKnown, true);
+    assert.equal(basematrix.noise.suggestedMargin, 0.5); // 1 flip on n=2
+    assert.ok(basematrix.text.includes("question: Q2"), "stuck-task question in the baseline text");
+    // the yaml's margin expression: measured floor wins, fallback when unmeasured
+    const mScope = { basematrix, params: { improveMargin: 0 } };
+    assert.equal((resolveConfig as any)("{{ basematrix.noise.suggestedMargin || params.improveMargin }}", mScope), 0.5);
+    const mScopeUnknown = { basematrix: { noise: { floorKnown: false } }, params: { improveMargin: 0 } };
+    assert.equal(
+      (resolveConfig as any)("{{ basematrix.noise.suggestedMargin || params.improveMargin }}", mScopeUnknown),
+      0,
+    );
+    // the matrix object IS a valid loop baseline: fitness + text read through
+    const mLoopCalls: any[] = [];
+    const mLoopOut: any = await loop.run(
+      loop.input.parse({
+        tasks: ["t-1", "t-2"],
+        mission: "m",
+        baseline: basematrix,
+        candidateName: "gaia-produce-ai",
+        baseWorkflow: "gaia-produce",
+        genWorkflow: "gaia-evolve-gen",
+        fitnessName: "accuracy",
+        maxGenerations: 1,
+        stopFitness: 1,
+        improveMargin: 0.5,
+        exploreAfter: 2,
+      }),
+      {
+        ...ctxStub,
+        services: {
+          optimizer: {
+            run: async (_n: string, input: any) => {
+              mLoopCalls.push(input);
+              return {
+                runId: "genrun-m",
+                status: "success",
+                output: { version: "v1", summary: "an approach", digest: { fitness: 1, text: "d", results: [] } },
+              };
+            },
+          },
+        },
+      },
+    );
+    assert.equal(mLoopOut.baselineFitness, 1); // read from basematrix.fitness
+    assert.ok(mLoopCalls[0].briefing.includes("TASK×VERSION MATRIX"), "matrix text is the baseline briefing block");
+    // fitness 1 vs baseline 1 with margin 0.5: a tie, not an improvement
+    assert.equal(mLoopOut.improved, false);
+    console.log("✔ capture wiring: k-sample matrix as loop baseline, measured-margin fallback expression");
 
     // 6. NO-OP generation: the gen workflow's `published` gate reports that an
     //    author shipped nothing, so nothing was graded. The loop must record

--- a/mcp/src/lab/gaia/workflows/gaia-evolve-gen.yaml
+++ b/mcp/src/lab/gaia/workflows/gaia-evolve-gen.yaml
@@ -148,6 +148,10 @@ steps:
     when: true
     config:
       items: "{{ input.tasks }}"
+      # Parallel candidate runs are safe (each runs under its OWN runId via
+      # meta/run-workflow, so artifacts dirs never collide). Kept low: the
+      # tasks hit rate-limited targets (429s observed live).
+      concurrency: "{{ params.produceConcurrency }}"
       body:
         id: one
         type: subflow
@@ -191,6 +195,9 @@ steps:
       digest: "{{ canddigest }}"
 
 params:
+  # Parallel candidate produce runs (candeval foreach concurrency). Low on
+  # purpose — the tasks hit rate-limited targets.
+  produceConcurrency: 3
   authorModel: claude-sonnet-5
   # Generous — an author that reads several workflows, drafts steps, and
   # smoke-tests burns calls fast; the publish-early rule in authorSystem is

--- a/mcp/src/lab/gaia/workflows/gaia-evolve.yaml
+++ b/mcp/src/lab/gaia/workflows/gaia-evolve.yaml
@@ -7,9 +7,12 @@ name: gaia-evolve
 # genuinely different approach" directive after `exploreAfter`
 # non-improving attempts.
 #
-#   capture   run the BASELINE produce workflow over the task set, score it
-#             with the real leaderboard scorer, digest the misses (tagged
-#             wrong-answer / empty-answer / produce-error — §8's taxonomy)
+#   capture   run the BASELINE produce workflow over the task set
+#             `baselineSamples` times (identical YAML re-runs — the noise
+#             instrument), score each with the real leaderboard scorer, and
+#             fold the samples into the eval/matrix task×version view:
+#             bands, per-task wrong answers + questions, and the MEASURED
+#             produce-sampling floor that becomes the loop's improveMargin
 #   loop      eval/evolve-loop runs gaia-evolve-gen per generation: an
 #             authoring agent (meta/* only — §5.3.2) publishes a new
 #             version of the candidate, the harness runs it pinned over the
@@ -22,12 +25,16 @@ name: gaia-evolve
 #             Review must also check the candidate never embeds
 #             gaia/evaluate (produce-time oracle access — §6).
 #
-# MEASUREMENT DISCIPLINE (EVOLVE_SPEC §6/§7):
-#   - Scoring is exact-match, so there is no judge noise — improveMargin
-#     defaults to 0 (any task flip counts). The noise that remains is
-#     PRODUCE-SAMPLING noise: the same workflow re-run can flip tasks by
-#     luck, and on n tasks one flip is 1/n. Small task sets make single
-#     flips loud — n=5 is an anecdote (§7); prefer ~10+ train tasks.
+# MEASUREMENT DISCIPLINE (EVOLVE_SPEC §6/§7; the plan doc's Phase 1):
+#   - Scoring is exact-match, so there is no judge noise. What remains is
+#     PRODUCE-SAMPLING noise: the same workflow re-run flips tasks by luck
+#     (observed live: identical YAML re-measured 0.76 vs 0.80). The k
+#     baseline samples MEASURE that floor — eval/matrix reports the max
+#     fitness delta between same-version re-runs, and the loop's
+#     improveMargin defaults to it, so a challenger must beat the
+#     baseline's best draw by more than identical YAML wobbles on its own.
+#     params.improveMargin is only the fallback if the floor is unmeasured
+#     (baselineSamples: 1).
 #   - Every score in this report is a TRAIN score on the very tasks the
 #     candidates were tuned against. Validate the best version on held-out
 #     tasks (gaia-batch over a different slice) before believing the delta.
@@ -35,9 +42,10 @@ name: gaia-evolve
 #     author finishes, and candidates run under their OWN runIds via
 #     meta/run-workflow (gaia-candidate-run).
 #
-# COST: roughly (1 + generations) × |tasks| × produce + each generation's
-# author (incl. its ≤2 smoke runs). Scoring is a local python subprocess —
-# free. Start small; raise input.generations (cap 20) to let it rip.
+# COST: roughly (baselineSamples + generations) × |tasks| × produce + each
+# generation's author (incl. its ≤2 smoke runs). Scoring is a local python
+# subprocess — free. produceConcurrency shrinks wall-clock, not dollars.
+# Start small; raise input.generations (cap 20) to let it rip.
 #
 # Needs: ANTHROPIC_API_KEY, HF_TOKEN (or a populated GAIA_DIR checkout;
 # git-lfs for attachments).
@@ -56,40 +64,62 @@ name: gaia-evolve
 #           baselineAccuracy, improved, generations, totalKnownCost,
 #           stopReason, baseline, … }
 steps:
-  # ── capture: baseline over the task set ────────────────────────────────
+  # ── capture: k baseline samples over the task set ──────────────────────
+  # Outer foreach counts 0..baselineSamples-1 (numeric items — the
+  # parameterized-repeat form); each sample is a full pass over the tasks.
+  # Identical YAML re-runs are the noise instrument: their score spread IS
+  # the produce-sampling floor, measured for free before the loop spends
+  # anything on generations.
   - id: baseline
     type: foreach
     config:
-      items: "{{ input.tasks }}"
+      items: "{{ params.baselineSamples }}"
       body:
-        id: one
-        type: subflow
+        id: sample
+        type: foreach
         config:
-          workflow: gaia-run
-          input:
-            taskId: "{{ $current }}"
+          items: "{{ input.tasks }}"
+          # Tasks hit rate-limited targets (observed 429s) — keep this low.
+          concurrency: "{{ params.produceConcurrency }}"
+          body:
+            id: one
+            type: subflow
+            config:
+              workflow: gaia-run
+              input:
+                taskId: "{{ $current }}"
 
-  - id: basedigest
-    type: gaia/digest-results
+  # The task×version matrix over the samples (single-version mode). Output
+  # carries `fitness` (MAX sample — the baseline's best observed draw, the
+  # conservative bar), `noise.suggestedMargin` (the measured floor), bands,
+  # and a `text` block with per-task wrong answers + questions — it IS the
+  # loop's baseline object.
+  - id: basematrix
+    type: eval/matrix
     depends: baseline
     config:
-      results: "{{ baseline }}"
+      version: "{{ params.baseWorkflow }}"
+      samples: "{{ baseline }}"
 
   # ── the hill-climb: author → run → grade, up to N generations ──────────
   - id: evolve
     type: eval/evolve-loop
-    depends: basedigest
+    depends: basematrix
     config:
       tasks: "{{ input.tasks }}"
       mission: "{{ input.mission }}"
-      baseline: "{{ basedigest }}"
+      baseline: "{{ basematrix }}"
       candidateName: "{{ params.candidateName }}"
       baseWorkflow: "{{ params.baseWorkflow }}"
       genWorkflow: "{{ params.genWorkflow }}"
       fitnessName: accuracy
       maxGenerations: "{{ input.generations || params.maxGenerations }}"
       stopFitness: "{{ params.stopAccuracy }}"
-      improveMargin: "{{ params.improveMargin }}"
+      # The MEASURED produce-sampling floor (max fitness delta between the
+      # identical-YAML baseline samples); params.improveMargin only when
+      # unmeasured (baselineSamples: 1). A measured 0 also falls through —
+      # indistinguishable here, and the fallback is 0 anyway.
+      improveMargin: "{{ basematrix.noise.suggestedMargin || params.improveMargin }}"
       exploreAfter: "{{ params.exploreAfter }}"
       genParams: "{{ params.genParams }}"
       maxCost: "{{ input.maxCost || params.maxCost }}"
@@ -112,7 +142,11 @@ steps:
       generations: "{{ evolve.generations }}"
       totalKnownCost: "{{ evolve.totalKnownCost }}"
       stopReason: "{{ evolve.stopReason }}"
-      baseline: "{{ basedigest.results }}"
+      # The per-task matrix rows (bands, flips, wrong answers, questions)
+      # and the measured noise floor — the report's evidence base.
+      baseline: "{{ basematrix.tasks }}"
+      baselineNoise: "{{ basematrix.noise }}"
+      baselineSamples: "{{ params.baselineSamples }}"
       note: "{{ evolve.note }}"
 
 params:
@@ -131,9 +165,17 @@ params:
   # Stop early once a generation's accuracy reaches this (1 = every task —
   # reachable on tuned-against train sets; generations are the real cap).
   stopAccuracy: 1
-  # Exact-match scoring has no judge noise — any single task flip counts as
-  # an improvement. The residual produce-sampling noise is answered by the
-  # held-out validation the report's note demands, not by a margin.
+  # How many identical baseline passes to run — ≥2 measures the
+  # produce-sampling noise floor (eval/matrix's suggestedMargin) that
+  # becomes the loop's improveMargin. 1 = old single-sample behavior with
+  # an UNKNOWN floor; the fallback margin below applies then.
+  baselineSamples: 2
+  # Parallel produce runs per pass (foreach concurrency). Tasks hit
+  # rate-limited targets (metmuseum/NIST 429s observed) — keep low.
+  produceConcurrency: 3
+  # FALLBACK margin, used only when the floor is unmeasured
+  # (baselineSamples: 1) or measured exactly 0. Exact-match scoring has no
+  # judge noise, so 0 = any task flip counts — the pre-Phase-1 behavior.
   improveMargin: 0
   # Consecutive non-improving attempts before the directive flips from
   # "refine the best" to "try a genuinely different approach".

--- a/vein/src/control-flow.test.ts
+++ b/vein/src/control-flow.test.ts
@@ -632,6 +632,68 @@ describe("foreach step", () => {
     assert.ok(result.error?.message.includes("body"));
   });
 
+  it("accepts a non-negative integer for items (iterate 0..N-1)", async () => {
+    const wf = flow("foreach-range", {
+      input: z.object({}),
+      params: { samples: 3 },
+      steps: [
+        step("each", "foreach", {
+          items: "{{ params.samples }}",
+          body: step("pair", "echo", { i: "{{ $index }}", cur: "{{ $current }}" }),
+        }),
+      ],
+    });
+
+    const result = await runWorkflow(wf, {}, makeRegistry());
+    assert.equal(result.status, "success");
+    assert.deepEqual(result.output, [
+      { i: 0, cur: 0 },
+      { i: 1, cur: 1 },
+      { i: 2, cur: 2 },
+    ]);
+
+    const zero = flow("foreach-range-0", {
+      input: z.object({}),
+      steps: [step("each", "foreach", { items: 0, body: step("v", "value", { result: 1 }) })],
+    });
+    assert.deepEqual((await runWorkflow(zero, {}, makeRegistry())).output, []);
+  });
+
+  it("rejects a fractional or negative items number", async () => {
+    for (const items of [2.5, -1]) {
+      const wf = flow("foreach-bad-range", {
+        input: z.object({}),
+        steps: [step("each", "foreach", { items, body: step("v", "value", { result: 1 }) })],
+      });
+      const result = await runWorkflow(wf, {}, makeRegistry());
+      assert.equal(result.status, "error");
+      assert.ok(result.error?.message.includes("non-negative integer"));
+    }
+  });
+
+  it("nests: a foreach body may itself be a foreach (k samples of a task set)", async () => {
+    const wf = flow("foreach-nested", {
+      input: z.object({ tasks: z.array(z.string()) }),
+      params: { samples: 2 },
+      steps: [
+        step("baseline", "foreach", {
+          items: "{{ params.samples }}",
+          body: step("sample", "foreach", {
+            items: "{{ input.tasks }}",
+            body: step("run", "echo", { task: "{{ $current }}" }),
+          }),
+        }),
+      ],
+    });
+
+    const result = await runWorkflow(wf, { tasks: ["a", "b"] }, makeRegistry());
+    assert.equal(result.status, "success");
+    assert.deepEqual(result.output, [
+      [{ task: "a" }, { task: "b" }],
+      [{ task: "a" }, { task: "b" }],
+    ]);
+  });
+
   describe("concurrency", () => {
     /** A step that records how many bodies are in flight at once. */
     function gauge() {

--- a/vein/src/runner.ts
+++ b/vein/src/runner.ts
@@ -720,22 +720,32 @@ async function executeForeach(
   exec: Exec,
   path: string,
 ): Promise<unknown> {
-  // Resolve `items` once against the parent scope.
+  // Resolve `items` once against the parent scope. A non-negative integer N
+  // means "iterate 0..N-1" ($current = $index) — the range form the template
+  // language deliberately cannot construct (e.g. `items: {{ params.samples }}`
+  // to repeat a body a parameterized number of times).
   const itemsResolved = resolveConfig(step.config["items"], scope);
 
-  if (!Array.isArray(itemsResolved)) {
+  if (
+    !Array.isArray(itemsResolved) &&
+    !(typeof itemsResolved === "number" && Number.isInteger(itemsResolved) && itemsResolved >= 0)
+  ) {
     throw new Error(
-      `foreach step "${step.id}" requires "items" to resolve to an array, got ${
+      `foreach step "${step.id}" requires "items" to resolve to an array or a non-negative integer, got ${
         itemsResolved === null
           ? "null"
           : typeof itemsResolved === "object"
             ? "object"
-            : typeof itemsResolved
+            : typeof itemsResolved === "number"
+              ? `number (${itemsResolved})`
+              : typeof itemsResolved
       }`,
     );
   }
 
-  const items = itemsResolved as unknown[];
+  const items: unknown[] = Array.isArray(itemsResolved)
+    ? itemsResolved
+    : Array.from({ length: itemsResolved as number }, (_, i) => i);
   const maxIterations = step.config["maxIterations"] != null
     ? (resolveConfig(step.config["maxIterations"], scope) as number)
     : undefined;

--- a/vein/src/steps/core/foreach.ts
+++ b/vein/src/steps/core/foreach.ts
@@ -16,7 +16,7 @@ const EXAMPLE = `- id: process_changes
 
 export default defineStep({
   type: "foreach",
-  description: `Iterate over a list, running "body" once per item. Config: "items" (template expression evaluating to an array), "body" (single Step), "concurrency" (optional, default 1: run up to N iterations at once through a bounded pool — results stay in input order and each iteration keeps its own #i event path; size it to what the body's targets tolerate, e.g. rate-limited sites want 1-4). Inside body: "$current" is the current item, "$index" is the zero-based position. Output is the array of body results, one per item, in order.\n\n${EXAMPLE}`,
+  description: `Iterate over a list, running "body" once per item. Config: "items" (template expression evaluating to an array, or a non-negative integer N meaning iterate 0..N-1 — the parameterized-repeat form), "body" (single Step), "concurrency" (optional, default 1: run up to N iterations at once through a bounded pool — results stay in input order and each iteration keeps its own #i event path; size it to what the body's targets tolerate, e.g. rate-limited sites want 1-4). Inside body: "$current" is the current item, "$index" is the zero-based position. Output is the array of body results, one per item, in order.\n\n${EXAMPLE}`,
   input: z.object({
     items: z.any(), // template expression → array (resolved per-iteration scope)
     body: z.any(), // Step object


### PR DESCRIPTION
The `gaia-evolve` wiring for the Phase-1 measurement infra (#1624; plan #1623). The capture stage becomes the noise instrument:

- **vein `foreach` accepts numeric `items`** (iterate 0..N−1) — the parameterized-repeat form the sandboxed template language deliberately can't construct. Nested foreach (body = another foreach) is now covered by tests, since the k-sample baseline depends on it.
- **`eval/matrix` single-version mode** (`version` + `samples`, the shape a nested foreach emits — templates can't build object arrays), question excerpts on non-floor tasks, and a top-level `fitness` = the MAX sample when one version was measured, so the matrix object plugs straight into `eval/evolve-loop`'s `baseline`.
- **`gaia-evolve` capture** runs the baseline `baselineSamples`× (default 2) at `produceConcurrency`-wide task fan-out (default 3 — the tasks hit rate-limited targets), folds with `eval/matrix`, and hands the loop the matrix as its baseline. `improveMargin` becomes the **measured** produce-sampling floor (max fitness delta between identical-YAML samples); `params.improveMargin: 0` is only the unmeasured-floor fallback. `gaia-evolve-gen`'s candeval gets the same concurrency (safe: candidates run under their own runIds).

Net effect on the next prod run: the baseline costs one extra pass (~$7.50), and in exchange the loop starts with a known noise floor, a conservative bar (the baseline's best draw), briefings that show bands + stuck-task questions + the bias/variance split, and ~3× less wall-clock per pass.

Tests: vein 547/547; `matrix-smoke` + `gaia/evolve-smoke` pass (new capture-wiring section); both packages typecheck.

🤖 Generated with [Claude Code](https://claude.com/claude-code)