### PR TITLE
vein: resolve agent-step models through aieo + bump to zod 4

### DIFF
--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -114,7 +114,7 @@ cd vein && npm run dev        # serves API + UI on :3000
 | `VEIN_PORT`         | `3000`         | HTTP server port                     |
 | `VEIN_API_KEY`      | (unset)        | Deployment-scoped shared secret. See "Auth" below. |
 | `VEIN_SECRET_KEY`   | (unset)        | Encryption key for the secret store (AES-256-GCM). Unset → a default dev key + one-time warning (obfuscated, not secure). See "Secrets". |
-| `VEIN_LLM_PROVIDER` | `anthropic`    | Default LLM provider for llm step    |
+| `VEIN_LLM_PROVIDER` | (inferred from model, else `anthropic`) | Default LLM provider for agent/llm steps (anthropic\|openai\|google\|openrouter\|xai, via aieo) |
 | `VEIN_LLM_MODEL`    | (per-provider) | Override model name                  |
 | `VEIN_CHAT_MODEL`   | `claude-sonnet-5` | Anthropic model for the AI-builder chat agent |
 | `VEIN_CHAT_MAX_STEPS` | `30`         | Max agent tool-call iterations per chat turn |
@@ -583,8 +583,11 @@ services bag can override it, same as `http`/`secrets`).
   `final_answer` tool's
   text (set `finalAnswer` to its description), a STRUCTURED object (set
   `schema` to a JSON Schema → `Output.object`, read off `res.output`), or
-  the final assistant text. Provider-direct (anthropic|openai), lazy-
-  loaded; needs the provider key in env + `git`/`rg` on PATH. Returns
+  the final assistant text. Provider-direct via aieo
+  (anthropic|openai|google|openrouter|xai — inferred from the model
+  name, which may be an alias like `sonnet`/`grok` or slash format like
+  `openrouter/moonshotai/kimi-k2.6`), lazy-loaded; needs the provider
+  key in env + `git`/`rg` on PATH. Returns
   `{ result, object?, steps, usage, cost }`. The full session
   (`messages`) is the seam for a future fork/sub-agent capability, but
   it's **opt-in** (`returnMessages`, default false): it's huge and the

--- a/vein/package.json
+++ b/vein/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@ai-sdk/anthropic": "3.0.92",
     "@ai-sdk/openai": "^3.0.67",
+    "aieo": "^0.1.34",
     "@googleapis/drive": "^20.2.0",
     "@hono/node-server": "^2.0.4",
     "@octokit/rest": "^22.0.1",
@@ -37,7 +38,7 @@
     "system-canvas": "^0.2.22",
     "system-canvas-react": "^0.2.22",
     "uuid": "^11.1.0",
-    "zod": "^3.23.0"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/html-to-text": "^9.0.4",

--- a/vein/src/ai/schemaHelpers.ts
+++ b/vein/src/ai/schemaHelpers.ts
@@ -18,10 +18,15 @@ export function zodToFields(schema: z.ZodTypeAny): FieldDesc[] {
   );
 }
 
+// zod v4 def layout: `_def.type` is a lowercase kind string ("object",
+// "optional", "default", ...), an object's `_def.shape` is a plain record,
+// a default's `_def.defaultValue` is the VALUE (not a thunk), and `.refine`
+// no longer wraps the schema (transforms become a "pipe" whose input is
+// `_def.in`).
 function getObjectShape(s: z.ZodTypeAny): Record<string, z.ZodTypeAny> | null {
-  const def = s._def;
-  if (def.typeName === "ZodObject") return (def as any).shape();
-  if (def.typeName === "ZodEffects") return getObjectShape(def.schema);
+  const def = s._def as any;
+  if (def.type === "object") return def.shape;
+  if (def.type === "pipe") return getObjectShape(def.in);
   return null;
 }
 
@@ -30,24 +35,24 @@ function describeField(name: string, s: z.ZodTypeAny): FieldDesc {
   let defaultVal: unknown;
   let inner = s;
   for (;;) {
-    const def = inner._def;
-    if (def.typeName === "ZodOptional") {
+    const def = inner._def as any;
+    if (def.type === "optional") {
       required = false;
       inner = def.innerType;
-    } else if (def.typeName === "ZodDefault") {
+    } else if (def.type === "default" || def.type === "prefault") {
       required = false;
-      defaultVal = def.defaultValue();
+      defaultVal = def.defaultValue;
       inner = def.innerType;
-    } else if (def.typeName === "ZodNullable") {
+    } else if (def.type === "nullable") {
       required = false;
       inner = def.innerType;
     } else break;
   }
-  const typeName = inner._def.typeName as string;
-  if (typeName === "ZodEnum")
-    return { name, kind: "enum", required, default: defaultVal, enumValues: inner._def.values };
-  if (typeName === "ZodString") return { name, kind: "string", required, default: defaultVal };
-  if (typeName === "ZodNumber") return { name, kind: "number", required, default: defaultVal };
-  if (typeName === "ZodBoolean") return { name, kind: "boolean", required, default: defaultVal };
+  const kind = (inner._def as any).type as string;
+  if (kind === "enum")
+    return { name, kind: "enum", required, default: defaultVal, enumValues: (inner as any).options };
+  if (kind === "string") return { name, kind: "string", required, default: defaultVal };
+  if (kind === "number") return { name, kind: "number", required, default: defaultVal };
+  if (kind === "boolean") return { name, kind: "boolean", required, default: defaultVal };
   return { name, kind: "json", required, default: defaultVal };
 }

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -307,7 +307,7 @@ export function buildTools(deps: AiDeps) {
             "Input passed to the workflow as a JSON OBJECT (not a string), referenced in step configs via {{ input.* }} — the run subject, e.g. { owner, repo, pull_number }. Use {} if none.",
           ),
         params: z
-          .record(z.any())
+          .record(z.string(), z.any())
           .optional()
           .describe(
             "Optional overrides for the workflow's `params` knobs (prompts, thresholds, sample sizes). Shallow-merged over the workflow's `params` defaults — set just the knobs you want to vary for this trial. Referenced in step configs via {{ params.* }}.",
@@ -388,7 +388,7 @@ export function buildTools(deps: AiDeps) {
       inputSchema: z.object({
         type: z.string().describe("Step type to run, e.g. 'stripe/list-charges' or 'http'."),
         config: z
-          .record(z.any())
+          .record(z.string(), z.any())
           .optional()
           .describe("The step's config (same shape as in a workflow). Templates like {{ input.* }} / {{ params.* }} are resolved."),
         input: z
@@ -396,7 +396,7 @@ export function buildTools(deps: AiDeps) {
           .optional()
           .describe("Workflow input object, referenced in config via {{ input.* }}."),
         params: z
-          .record(z.any())
+          .record(z.string(), z.any())
           .optional()
           .describe("Params knobs, referenced via {{ params.* }}."),
         cassette: z

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -220,10 +220,15 @@ function parsePromoteTarget(to: string): { workflow: string; param: string } | n
   return { workflow: to.slice(0, dot), param: to.slice(dot + 1) };
 }
 
+// zod v4 def layout: `_def.type` is a lowercase kind string ("object",
+// "optional", "default", ...), an object's `_def.shape` is a plain record,
+// a default's `_def.defaultValue` is the VALUE (not a thunk), and `.refine`
+// no longer wraps the schema (transforms become a "pipe" whose input is
+// `_def.in`).
 function getObjectShape(s: z.ZodTypeAny): Record<string, z.ZodTypeAny> | null {
-  const def = s._def;
-  if (def.typeName === "ZodObject") return (def as any).shape();
-  if (def.typeName === "ZodEffects") return getObjectShape(def.schema);
+  const def = s._def as any;
+  if (def.type === "object") return def.shape;
+  if (def.type === "pipe") return getObjectShape(def.in);
   return null;
 }
 
@@ -233,15 +238,15 @@ function describeField(name: string, s: z.ZodTypeAny): FieldDesc {
   let inner = s;
 
   for (;;) {
-    const def = inner._def;
-    if (def.typeName === "ZodOptional") {
+    const def = inner._def as any;
+    if (def.type === "optional") {
       required = false;
       inner = def.innerType;
-    } else if (def.typeName === "ZodDefault") {
+    } else if (def.type === "default" || def.type === "prefault") {
       required = false;
-      defaultVal = def.defaultValue();
+      defaultVal = def.defaultValue;
       inner = def.innerType;
-    } else if (def.typeName === "ZodNullable") {
+    } else if (def.type === "nullable") {
       required = false;
       inner = def.innerType;
     } else {
@@ -249,14 +254,14 @@ function describeField(name: string, s: z.ZodTypeAny): FieldDesc {
     }
   }
 
-  const typeName = inner._def.typeName as string;
+  const kind = (inner._def as any).type as string;
 
-  if (typeName === "ZodEnum") {
-    return { name, kind: "enum", required, default: defaultVal, enumValues: inner._def.values };
+  if (kind === "enum") {
+    return { name, kind: "enum", required, default: defaultVal, enumValues: (inner as any).options };
   }
-  if (typeName === "ZodString") return { name, kind: "string", required, default: defaultVal };
-  if (typeName === "ZodNumber") return { name, kind: "number", required, default: defaultVal };
-  if (typeName === "ZodBoolean") return { name, kind: "boolean", required, default: defaultVal };
+  if (kind === "string") return { name, kind: "string", required, default: defaultVal };
+  if (kind === "number") return { name, kind: "number", required, default: defaultVal };
+  if (kind === "boolean") return { name, kind: "boolean", required, default: defaultVal };
   return { name, kind: "json", required, default: defaultVal };
 }
 

--- a/vein/src/pricing.ts
+++ b/vein/src/pricing.ts
@@ -8,7 +8,7 @@
 // Pricing table copied from `mcp/src/aieo/src/provider.ts` ($ per 1M tokens).
 // Keep it in sync when that table changes.
 
-export type LLMProvider = "anthropic" | "openai" | "google" | "openrouter";
+export type LLMProvider = "anthropic" | "openai" | "google" | "openrouter" | "xai";
 
 export interface TokenPricing {
   inputTokenPrice: number; // $ per 1M non-cached input tokens
@@ -36,6 +36,13 @@ export const TOKEN_PRICING: Record<LLMProvider, TokenPricing> = {
   openrouter: {
     inputTokenPrice: 0.6,
     outputTokenPrice: 3.0,
+  },
+  // Grok has no cache-write charge — writes are billed as ordinary input,
+  // so no cacheWritePrice here.
+  xai: {
+    inputTokenPrice: 3.0,
+    outputTokenPrice: 15.0,
+    cacheReadPrice: 0.75,
   },
 };
 

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -1,4 +1,5 @@
 import { z } from "zod";
+import type { Provider as AieoProvider } from "aieo";
 import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
 import { usageFromResult, computeCost, addUsage, maxOutputTokensFor } from "../../pricing.js";
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
@@ -26,9 +27,10 @@ import os from "node:os";
  * automatically in finalAnswer mode and is always available regardless of
  * `toolFilter`.
  *
- * Provider-direct via the AI SDK (anthropic | openai), lazy-loaded. Needs the
- * provider's key in env (ANTHROPIC_API_KEY / OPENAI_API_KEY) and `git` + `rg` on
- * PATH for the repo tools. Output: { result, object?, steps, usage, cost }
+ * Provider-direct via the AI SDK, resolved through aieo (anthropic | openai |
+ * google | openrouter | xai), lazy-loaded. Needs the provider's key in env
+ * (ANTHROPIC_API_KEY / OPENAI_API_KEY / GOOGLE_API_KEY / OPENROUTER_API_KEY /
+ * XAI_API_KEY) and `git` + `rg` on PATH for the repo tools. Output: { result, object?, steps, usage, cost }
  * (+ `messages`, the full session, only when `returnMessages` is set — it's huge
  * and persisted per step, so it's off by default). `usage` is the aggregated
  * token counts across the whole agent loop
@@ -542,7 +544,7 @@ export function wrapToolsWithEmit(tools: Record<string, any>, ctx: StepContext |
 export default defineStep({
   type: "agent",
   description:
-    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of built-in tool names; empty = all), agentTools? (registry step TYPES exposed as extra tools — the 'tools are steps' model; each tool call emits a nested run event), secretsEnv? (secret NAMES injected as env vars into the bash subprocess only — the agent writes $NAME, values are masked out of all tool output; for narrow research sub-agents), model?, provider? (anthropic|openai), maxSteps (default 40), returnMessages? (default false — the full session is huge + persisted per step). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, usage, cost } (+ messages when returnMessages).",
+    "General tool-using agent (AI SDK ToolLoopAgent). Explores AND edits a working dir (cwd) with built-in tools (repo_overview, fulltext_search, bash, str_replace_based_edit_tool for viewing/creating/editing files, + anthropic web_search, + file_summary when the `stakgraph` AST CLI is on PATH) and returns either a final_answer (set `finalAnswer` to its tool description), a STRUCTURED object (set `schema` to a JSON Schema → Output.object), or the final text. Config: cwd, system, prompt, finalAnswer?, schema?, toolFilter? (subset of built-in tool names; empty = all), agentTools? (registry step TYPES exposed as extra tools — the 'tools are steps' model; each tool call emits a nested run event), secretsEnv? (secret NAMES injected as env vars into the bash subprocess only — the agent writes $NAME, values are masked out of all tool output; for narrow research sub-agents), model? (id, alias like 'sonnet'/'grok', or slash format like 'openrouter/moonshotai/kimi-k2' — the provider is inferred from it), provider? (anthropic|openai|google|openrouter|xai; usually omitted), maxSteps (default 40), returnMessages? (default false — the full session is huge + persisted per step). Needs the provider key in env + git/rg on PATH. Output: { result, object?, steps, usage, cost } (+ messages when returnMessages).",
   input: z.object({
     cwd: z.string().describe("working directory the tools operate in"),
     system: z.string().describe("system prompt / agent persona"),
@@ -571,8 +573,16 @@ export default defineStep({
       .describe(
         "secret NAMES (from the deployment's secret store) to inject as env vars into the bash tool's subprocess — the agent writes `$NAME` in commands (e.g. curl auth headers) and the shell expands it at exec time. The VALUE never enters the prompt, the model's context, or the event log: bash gets it via env only, and every tool output is masked before the model sees it. Grant narrowly (a dedicated research sub-agent), never to a drafting/producing agent. Residual risk (accepted): a prompt-injected agent can still SEND $NAME somewhere — masking stops leakage into context/logs, not egress.",
       ),
-    model: z.string().optional(),
-    provider: z.string().optional(),
+    model: z
+      .string()
+      .optional()
+      .describe(
+        "model id, aieo alias ('sonnet', 'gemini', 'grok', 'kimi'), or slash format ('openrouter/deepseek/deepseek-v3'); the provider is inferred from it when `provider` is omitted",
+      ),
+    provider: z
+      .string()
+      .optional()
+      .describe("anthropic | openai | google | openrouter | xai — usually omitted (inferred from `model`)"),
     maxSteps: z.number().int().positive().default(40),
     returnMessages: z
       .boolean()
@@ -585,39 +595,41 @@ export default defineStep({
   async run(cfg, ctx) {
     const { ToolLoopAgent, Output, tool, stepCountIs, hasToolCall, jsonSchema, streamText } = await import("ai");
 
-    const provider = cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? "anthropic";
+    // Model/provider resolution via aieo (shared with mcp): friendly aliases
+    // ("sonnet", "grok"), slash-format ids ("openrouter/moonshotai/kimi-k2"),
+    // per-provider env keys (ANTHROPIC_API_KEY, OPENROUTER_API_KEY, ...), LLM
+    // gateway routing, and a timeout-wrapped fetch all live there. When no
+    // provider is given it's INFERRED from the model name (unknown names
+    // default to anthropic), so `model: "openrouter/deepseek/deepseek-v3"`
+    // alone is enough to switch providers.
+    const { getModel, getProviderForModel, PROVIDERS } = await import("aieo");
     const modelName = cfg.model ?? process.env["VEIN_LLM_MODEL"];
+    const provider =
+      cfg.provider ?? process.env["VEIN_LLM_PROVIDER"] ?? getProviderForModel(modelName);
+    if (!PROVIDERS.includes(provider as AieoProvider)) {
+      throw new Error(
+        `Unknown LLM provider: "${provider}". Supported: ${PROVIDERS.join(", ")}`,
+      );
+    }
 
-    // Resolve the model + (anthropic-only) provider-defined web_search tool +
-    // provider options. For anthropic we enable EPHEMERAL PROMPT CACHING at the
-    // call level (the provider auto-inserts the cache breakpoints across the
-    // static prefix — system + tool schemas — that the loop resends every step).
-    // Big win for multi-step agents (and the future fork: the shared prefix is a
-    // cache hit across all forks). Same pattern as aieo's getProviderOptions.
-    let model: any;
+    // Anthropic-only extras: server-side web_search, the provider-defined text
+    // editor (the model is specially trained on its schema; we supply the
+    // execute that performs the edit inside cfg.cwd), and EPHEMERAL PROMPT
+    // CACHING at the call level (the provider auto-inserts the cache
+    // breakpoints across the static prefix — system + tool schemas — that the
+    // loop resends every step). Big win for multi-step agents (and the future
+    // fork: the shared prefix is a cache hit across all forks). Other
+    // providers fall back to the generic editor tool and no web search.
     let webSearchTool: any;
     let textEditorTool: any;
     let providerOptions: any;
-    switch (provider) {
-      case "anthropic": {
-        const { anthropic } = await import("@ai-sdk/anthropic");
-        model = anthropic(modelName ?? "claude-sonnet-5");
-        webSearchTool = anthropic.tools.webSearch_20260209({ maxUses: 3 });
-        // Provider-defined text editor (the model is specially trained on its
-        // schema); we supply the execute that performs the edit inside cfg.cwd.
-        textEditorTool = anthropic.tools.textEditor_20250728({
-          execute: async (input: TextEditInput) => textEdit(input, [cfg.cwd, os.tmpdir()]),
-        });
-        providerOptions = { anthropic: { cacheControl: { type: "ephemeral" } } };
-        break;
-      }
-      case "openai": {
-        const { openai } = await import("@ai-sdk/openai");
-        model = openai(modelName ?? "gpt-4o");
-        break;
-      }
-      default:
-        throw new Error(`Unknown LLM provider: "${provider}". Supported: anthropic, openai`);
+    if (provider === "anthropic") {
+      const { anthropic } = await import("@ai-sdk/anthropic");
+      webSearchTool = anthropic.tools.webSearch_20260209({ maxUses: 3 });
+      textEditorTool = anthropic.tools.textEditor_20250728({
+        execute: async (input: TextEditInput) => textEdit(input, [cfg.cwd, os.tmpdir()]),
+      });
+      providerOptions = { anthropic: { cacheControl: { type: "ephemeral" } } };
     }
 
     // ── secretsEnv: resolve named secrets → bash subprocess env ────────────
@@ -786,6 +798,10 @@ export default defineStep({
     // workflow author never picks this, and the SDK's 4096 default truncates
     // large tool calls mid-JSON.
     const maxOutputTokens = maxOutputTokensFor(provider);
+    // Resolved LAST (after all config validation): aieo's getModel resolves
+    // the provider API key eagerly and throws when it's absent — a config
+    // error should surface before a missing-key error.
+    const model: any = getModel(provider as AieoProvider, modelName ? { modelName } : undefined);
     const agent = new ToolLoopAgent({
       model,
       instructions: cfg.system,

--- a/vein/src/steps/core/http.ts
+++ b/vein/src/steps/core/http.ts
@@ -20,7 +20,7 @@ export default defineStep({
     url: z.string(),
     method: z.enum(["GET", "POST", "PUT", "DELETE", "PATCH"]).default("GET"),
     body: z.any().optional(),
-    headers: z.record(z.string()).optional(),
+    headers: z.record(z.string(), z.string()).optional(),
     timeout: z.number().positive().optional(),
   }),
   output: z.any(),

--- a/vein/src/steps/lib/github/fetch-pr.ts
+++ b/vein/src/steps/lib/github/fetch-pr.ts
@@ -19,7 +19,9 @@ const limitsSchema = z
     maxComments: z.number().int().positive().default(50),
     maxReviews: z.number().int().positive().default(20),
   })
-  .default({});
+  // zod v4: `.default()` now takes a fully-populated OUTPUT value; `.prefault`
+  // keeps the v3 behavior of parsing {} so the field defaults apply.
+  .prefault({});
 
 type Limits = z.infer<typeof limitsSchema>;
 

--- a/vein/src/steps/lib/meta/run-step.ts
+++ b/vein/src/steps/lib/meta/run-step.ts
@@ -9,11 +9,11 @@ export default defineStep({
   input: z.object({
     type: z.string().describe("Step type to run, e.g. 'candidates/my-fetcher' or 'http'."),
     config: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .describe("The step's config (same shape as in a workflow). Templates like {{ input.* }} / {{ params.* }} are resolved."),
     input: z.any().optional().describe("Workflow input object, referenced in config via {{ input.* }}."),
-    params: z.record(z.any()).optional().describe("Params knobs, referenced via {{ params.* }}."),
+    params: z.record(z.string(), z.any()).optional().describe("Params knobs, referenced via {{ params.* }}."),
     cassette: z
       .enum(["record", "replay"])
       .optional()

--- a/vein/src/steps/lib/meta/run-workflow.ts
+++ b/vein/src/steps/lib/meta/run-workflow.ts
@@ -15,7 +15,7 @@ export default defineStep({
         "Input passed to the workflow as a JSON OBJECT (not a string), referenced in its steps via {{ input.* }}. Use {} if none.",
       ),
     params: z
-      .record(z.any())
+      .record(z.string(), z.any())
       .optional()
       .describe(
         "Optional overrides for the workflow's `params` knobs (prompts, thresholds), shallow-merged over its defaults — those are runs, not versions.",

--- a/vein/src/steps/lib/slack/post-message.ts
+++ b/vein/src/steps/lib/slack/post-message.ts
@@ -19,7 +19,7 @@ export default defineStep({
     /** Message text (markdown-ish "mrkdwn"). Required unless `blocks` is set. */
     text: z.string().optional(),
     /** Slack Block Kit blocks, for rich messages. Overrides `text` layout. */
-    blocks: z.array(z.record(z.unknown())).optional(),
+    blocks: z.array(z.record(z.string(), z.unknown())).optional(),
     /** Reply in a thread by passing the parent message's `ts`. */
     thread_ts: z.string().optional(),
     token: z.string().optional(),

--- a/vein/yarn.lock
+++ b/vein/yarn.lock
@@ -2,6 +2,14 @@
 # yarn lockfile v1
 
 
+"@ai-sdk/anthropic@3.0.105":
+  version "3.0.105"
+  resolved "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.105.tgz"
+  integrity sha512-6B9UjgK14JwG4PtyhHKMQrqg49s90FClsreNZ9HmMdSWZ9tJFHuYmy4cauS/BqO/6rKC+qcNEXTP45+qivdypA==
+  dependencies:
+    "@ai-sdk/provider" "3.0.14"
+    "@ai-sdk/provider-utils" "4.0.41"
+
 "@ai-sdk/anthropic@3.0.92":
   version "3.0.92"
   resolved "https://registry.npmjs.org/@ai-sdk/anthropic/-/anthropic-3.0.92.tgz"
@@ -9,6 +17,15 @@
   dependencies:
     "@ai-sdk/provider" "3.0.13"
     "@ai-sdk/provider-utils" "4.0.35"
+
+"@ai-sdk/gateway@3.0.110":
+  version "3.0.110"
+  resolved "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-3.0.110.tgz"
+  integrity sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@ai-sdk/provider-utils" "4.0.26"
+    "@vercel/oidc" "3.2.0"
 
 "@ai-sdk/gateway@3.0.157":
   version "3.0.157"
@@ -19,6 +36,14 @@
     "@ai-sdk/provider-utils" "4.0.40"
     "@vercel/oidc" "3.2.0"
 
+"@ai-sdk/google@3.0.67":
+  version "3.0.67"
+  resolved "https://registry.npmjs.org/@ai-sdk/google/-/google-3.0.67.tgz"
+  integrity sha512-Qeq+SidYtzMrcf0fdw3L0QLmtXK+ErwdBzbxS4+0Q/2UP85Ges8RJJcbAj7SO8e2JbeJoM35BLqkeNy1o3wJvQ==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@ai-sdk/provider-utils" "4.0.26"
+
 "@ai-sdk/openai@^3.0.67":
   version "3.0.88"
   resolved "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.88.tgz"
@@ -26,6 +51,23 @@
   dependencies:
     "@ai-sdk/provider" "3.0.14"
     "@ai-sdk/provider-utils" "4.0.40"
+
+"@ai-sdk/openai@3.0.61":
+  version "3.0.61"
+  resolved "https://registry.npmjs.org/@ai-sdk/openai/-/openai-3.0.61.tgz"
+  integrity sha512-L5FdlTo+7IBOdXbnTZqVzowRdLGWnxPn01vHe4leLPp0G4ydoXhySu0tp0ttkoO0ZSzPjHo7iiAkYoT0J91Q8Q==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@ai-sdk/provider-utils" "4.0.26"
+
+"@ai-sdk/provider-utils@4.0.26":
+  version "4.0.26"
+  resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.26.tgz"
+  integrity sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ==
+  dependencies:
+    "@ai-sdk/provider" "3.0.10"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.8"
 
 "@ai-sdk/provider-utils@4.0.35":
   version "4.0.35"
@@ -45,6 +87,23 @@
     "@standard-schema/spec" "^1.1.0"
     eventsource-parser "^3.0.8"
 
+"@ai-sdk/provider-utils@4.0.41":
+  version "4.0.41"
+  resolved "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-4.0.41.tgz"
+  integrity sha512-I7hhjfw01yEI8NkuAsT8Mv6xbWFr/lqLXMdaJQ2zWfXEpxog1eT7skDcv1+RY29/+5btzH8wD+vVvy48bk9oNQ==
+  dependencies:
+    "@ai-sdk/provider" "3.0.14"
+    "@standard-schema/spec" "^1.1.0"
+    eventsource-parser "^3.0.8"
+    undici "^5.29.0"
+
+"@ai-sdk/provider@3.0.10":
+  version "3.0.10"
+  resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.10.tgz"
+  integrity sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw==
+  dependencies:
+    json-schema "^0.4.0"
+
 "@ai-sdk/provider@3.0.13":
   version "3.0.13"
   resolved "https://registry.npmjs.org/@ai-sdk/provider/-/provider-3.0.13.tgz"
@@ -59,135 +118,15 @@
   dependencies:
     json-schema "^0.4.0"
 
-"@esbuild/aix-ppc64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/aix-ppc64/-/aix-ppc64-0.28.1.tgz#7a01a8d2ec2fbb2dac78adad09b0fa781e4082be"
-  integrity sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==
-
-"@esbuild/android-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm64/-/android-arm64-0.28.1.tgz#b540a27d14e4afd058496a4dbec4d3f414db110a"
-  integrity sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg==
-
-"@esbuild/android-arm@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-arm/-/android-arm-0.28.1.tgz#704bd297de6d762de54eabbeafbf55f6756abe2f"
-  integrity sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ==
-
-"@esbuild/android-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/android-x64/-/android-x64-0.28.1.tgz#d1cb166d34b0fbf0fe8ab460a5594f24a378701e"
-  integrity sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng==
-
 "@esbuild/darwin-arm64@0.28.1":
   version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz#1034b26457fc886368fe61bbd09f653f6afa8e54"
+  resolved "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.28.1.tgz"
   integrity sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q==
 
-"@esbuild/darwin-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/darwin-x64/-/darwin-x64-0.28.1.tgz#65556a432a1e4d72032d8218c1932fcca1a49772"
-  integrity sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ==
-
-"@esbuild/freebsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-arm64/-/freebsd-arm64-0.28.1.tgz#2e61e0592f9030d7e3dae18ee25ebc535918aef6"
-  integrity sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw==
-
-"@esbuild/freebsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/freebsd-x64/-/freebsd-x64-0.28.1.tgz#c95ec289959ef8079c4dca817a1e2c4be66b9bd3"
-  integrity sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ==
-
-"@esbuild/linux-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm64/-/linux-arm64-0.28.1.tgz#40b22175dda06182f3ee8141186c5ff304c4a717"
-  integrity sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g==
-
-"@esbuild/linux-arm@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-arm/-/linux-arm-0.28.1.tgz#c09a0f67917592ac0de892a9be4d3814debd2a6c"
-  integrity sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ==
-
-"@esbuild/linux-ia32@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ia32/-/linux-ia32-0.28.1.tgz#a580f9c676797833891e519fc7a1337c8afd8db3"
-  integrity sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w==
-
-"@esbuild/linux-loong64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.28.1.tgz#46452cf321dc7f9e91c2fa780a56bb56e79cd68b"
-  integrity sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg==
-
-"@esbuild/linux-mips64el@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-mips64el/-/linux-mips64el-0.28.1.tgz#4211b3184dd6608f53dcb22e39f5d34ee08852c8"
-  integrity sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ==
-
-"@esbuild/linux-ppc64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-ppc64/-/linux-ppc64-0.28.1.tgz#697857c2a61cb9b0b6bb6652e40c1dc5e1ca8e5d"
-  integrity sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ==
-
-"@esbuild/linux-riscv64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-riscv64/-/linux-riscv64-0.28.1.tgz#d192943eb146a40ac4c6497d0cf7be35b986bf08"
-  integrity sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ==
-
-"@esbuild/linux-s390x@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/linux-s390x/-/linux-s390x-0.28.1.tgz#acea0356da0e0ebc08f97cf7b9c2e401e1e648dc"
-  integrity sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag==
-
-"@esbuild/linux-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.28.1.tgz"
-  integrity sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA==
-
-"@esbuild/netbsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-arm64/-/netbsd-arm64-0.28.1.tgz#8bcd77077a0dce3378b574fedb26d2a253b73d36"
-  integrity sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw==
-
-"@esbuild/netbsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/netbsd-x64/-/netbsd-x64-0.28.1.tgz#e7fb2a01e99c830c94e6623cd9fefb4c8fb58347"
-  integrity sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg==
-
-"@esbuild/openbsd-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-arm64/-/openbsd-arm64-0.28.1.tgz#c52909372db8b86e2c55e05a8940033b5660a3b2"
-  integrity sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q==
-
-"@esbuild/openbsd-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openbsd-x64/-/openbsd-x64-0.28.1.tgz#c427b9be5a64c262ff9a7eb70b5fbbaadf446c6c"
-  integrity sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw==
-
-"@esbuild/openharmony-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/openharmony-arm64/-/openharmony-arm64-0.28.1.tgz#dc9b147baca2e6c4b3c85571741ef4860a489097"
-  integrity sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg==
-
-"@esbuild/sunos-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/sunos-x64/-/sunos-x64-0.28.1.tgz#ce866d12df13c15e4c99f073a3d466f6e0649b3a"
-  integrity sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ==
-
-"@esbuild/win32-arm64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-arm64/-/win32-arm64-0.28.1.tgz#7468e3692d01d629d5941e5d83817bb80f9e39b4"
-  integrity sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA==
-
-"@esbuild/win32-ia32@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-ia32/-/win32-ia32-0.28.1.tgz#a5bc0063fb2bcab6d0ed63f2a1537958bc269ec6"
-  integrity sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg==
-
-"@esbuild/win32-x64@0.28.1":
-  version "0.28.1"
-  resolved "https://registry.yarnpkg.com/@esbuild/win32-x64/-/win32-x64-0.28.1.tgz#10064ee44f4347b90c9a02b446bbf80a91632b12"
-  integrity sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A==
+"@fastify/busboy@^2.0.0":
+  version "2.1.1"
+  resolved "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz"
+  integrity sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==
 
 "@googleapis/drive@^20.2.0":
   version "20.2.0"
@@ -218,7 +157,7 @@
   resolved "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz"
   integrity sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==
 
-"@octokit/core@^7.0.6":
+"@octokit/core@^7.0.6", "@octokit/core@>=6":
   version "7.0.6"
   resolved "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz"
   integrity sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==
@@ -308,10 +247,20 @@
   dependencies:
     "@octokit/openapi-types" "^27.0.0"
 
+"@openrouter/ai-sdk-provider@2.10.0":
+  version "2.10.0"
+  resolved "https://registry.npmjs.org/@openrouter/ai-sdk-provider/-/ai-sdk-provider-2.10.0.tgz"
+  integrity sha512-FMsAEjLUt5pWuRE2LDC/LCvVrFjLlrEzUITH5+5SZtfq7KZ2wrOHjQVxzz92sju8S9ltpzW87CLW8/b0oBXVCw==
+
 "@opentelemetry/api@^1.9.0":
   version "1.9.1"
   resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.1.tgz"
   integrity sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q==
+
+"@opentelemetry/api@1.9.0":
+  version "1.9.0"
+  resolved "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz"
+  integrity sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -320,7 +269,7 @@
 
 "@selderee/plugin-htmlparser2@~0.12.0":
   version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.12.0.tgz#2ec72ba6c6032cac142f39bec71c5ecb5f348adc"
+  resolved "https://registry.npmjs.org/@selderee/plugin-htmlparser2/-/plugin-htmlparser2-0.12.0.tgz"
   integrity sha512-oELmoyA6ML9jDRMV3kgcMQFKxUfBU0yFVn6yTctVaLT5ygXnxH52I3TZEgV9EhXJC68/uFvE5Daj1/25c0Xa/A==
   dependencies:
     domelementtype "~2.3.0"
@@ -333,7 +282,7 @@
 
 "@types/html-to-text@^9.0.4":
   version "9.0.4"
-  resolved "https://registry.yarnpkg.com/@types/html-to-text/-/html-to-text-9.0.4.tgz#4a83dd8ae8bfa91457d0b1ffc26f4d0537eff58c"
+  resolved "https://registry.npmjs.org/@types/html-to-text/-/html-to-text-9.0.4.tgz"
   integrity sha512-pUY3cKH/Nm2yYrEmDlPR1mR7yszjGx4DrwPjQ702C4/D5CwHuZTgZdIdwPkRbcuhs7BAh2L5rg3CL5cbRiGTCQ==
 
 "@types/js-yaml@^4.0.9":
@@ -363,7 +312,7 @@ agent-base@^7.1.2:
   resolved "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz"
   integrity sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==
 
-ai@^6.0.196:
+ai@^6.0.0, ai@^6.0.196:
   version "6.0.235"
   resolved "https://registry.npmjs.org/ai/-/ai-6.0.235.tgz"
   integrity sha512-Uyeuvowo20XChpFC0lUaQq8xf0Kg7OElA56fEjUYoeWMJIzqshDTz4S57KXobcJ4m+iDQxMeJoUj06CIxSLx7A==
@@ -372,6 +321,28 @@ ai@^6.0.196:
     "@ai-sdk/provider" "3.0.14"
     "@ai-sdk/provider-utils" "4.0.40"
     "@opentelemetry/api" "^1.9.0"
+
+ai@6.0.175:
+  version "6.0.175"
+  resolved "https://registry.npmjs.org/ai/-/ai-6.0.175.tgz"
+  integrity sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA==
+  dependencies:
+    "@ai-sdk/gateway" "3.0.110"
+    "@ai-sdk/provider" "3.0.10"
+    "@ai-sdk/provider-utils" "4.0.26"
+    "@opentelemetry/api" "1.9.0"
+
+aieo@^0.1.34:
+  version "0.1.34"
+  resolved "https://registry.npmjs.org/aieo/-/aieo-0.1.34.tgz"
+  integrity sha512-0ZV2LvbBd5N1pc69EYzrnSF5dfX517n4CFITOM08K/+QkpWNBquGnJIpGTz7SN1Xa2CdQ/YPNs94rRTyF4q7qw==
+  dependencies:
+    "@ai-sdk/anthropic" "3.0.105"
+    "@ai-sdk/google" "3.0.67"
+    "@ai-sdk/openai" "3.0.61"
+    "@openrouter/ai-sdk-provider" "2.10.0"
+    ai "6.0.175"
+    zod "4.3.6"
 
 ansi-regex@^5.0.1:
   version "5.0.1"
@@ -504,7 +475,7 @@ cross-spawn@^7.0.6:
   dependencies:
     d3-color "1 - 3"
 
-"d3-selection@2 - 3", d3-selection@3, d3-selection@^3.0.0:
+d3-selection@^3.0.0, "d3-selection@2 - 3", d3-selection@3:
   version "3.0.0"
   resolved "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz"
   integrity sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==
@@ -514,7 +485,7 @@ cross-spawn@^7.0.6:
   resolved "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz"
   integrity sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==
 
-"d3-transition@2 - 3", d3-transition@^3.0.0:
+d3-transition@^3.0.0, "d3-transition@2 - 3":
   version "3.0.1"
   resolved "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz"
   integrity sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==
@@ -550,12 +521,12 @@ debug@4:
 
 deepmerge-ts@^8.0.1:
   version "8.0.2"
-  resolved "https://registry.yarnpkg.com/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz#4f3e5588c3a7c59ea80d54b583948d6f404cf13e"
+  resolved "https://registry.npmjs.org/deepmerge-ts/-/deepmerge-ts-8.0.2.tgz"
   integrity sha512-uqbvqLUMrc6p0MO+WBRtTxY55hmyh94WRwI5a++PZe54X+bfVh59FSN7uWCBCW1CCVjzjnrwzfI8zidE2obMMw==
 
 dom-serializer@^2.0.0:
   version "2.0.0"
-  resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-2.0.0.tgz#e41b802e1eedf9f6cae183ce5e622d789d7d8e53"
+  resolved "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz"
   integrity sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==
   dependencies:
     domelementtype "^2.3.0"
@@ -564,19 +535,19 @@ dom-serializer@^2.0.0:
 
 domelementtype@^2.3.0, domelementtype@~2.3.0:
   version "2.3.0"
-  resolved "https://registry.yarnpkg.com/domelementtype/-/domelementtype-2.3.0.tgz#5c45e8e869952626331d7aab326d01daf65d589d"
+  resolved "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz"
   integrity sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==
 
 domhandler@^5.0.2, domhandler@^5.0.3, domhandler@~5.0.3:
   version "5.0.3"
-  resolved "https://registry.yarnpkg.com/domhandler/-/domhandler-5.0.3.tgz#cc385f7f751f1d1fc650c21374804254538c7d31"
+  resolved "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz"
   integrity sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==
   dependencies:
     domelementtype "^2.3.0"
 
 domutils@^3.2.2:
   version "3.2.2"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.2.2.tgz#edbfe2b668b0c1d97c24baf0f1062b132221bc78"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz"
   integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
   dependencies:
     dom-serializer "^2.0.0"
@@ -597,7 +568,7 @@ eastasianwidth@^0.2.0:
   resolved "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz"
   integrity sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==
 
-ecdsa-sig-formatter@1.0.11, ecdsa-sig-formatter@^1.0.11:
+ecdsa-sig-formatter@^1.0.11, ecdsa-sig-formatter@1.0.11:
   version "1.0.11"
   resolved "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz"
   integrity sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==
@@ -616,12 +587,12 @@ emoji-regex@^9.2.2:
 
 entities@^4.2.0:
   version "4.5.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
+  resolved "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
 
 entities@^7.0.1:
   version "7.0.1"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-7.0.1.tgz#26e8a88889db63417dcb9a1e79a3f1bc92b5976b"
+  resolved "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz"
   integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 es-define-property@^1.0.1:
@@ -708,7 +679,7 @@ formdata-polyfill@^4.0.10:
 
 fsevents@~2.3.3:
   version "2.3.3"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"
+  resolved "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz"
   integrity sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==
 
 function-bind@^1.1.2:
@@ -716,7 +687,7 @@ function-bind@^1.1.2:
   resolved "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz"
   integrity sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==
 
-gaxios@7.1.3, gaxios@^7.0.0:
+gaxios@^7.0.0, gaxios@7.1.3:
   version "7.1.3"
   resolved "https://registry.npmjs.org/gaxios/-/gaxios-7.1.3.tgz"
   integrity sha512-YGGyuEdVIjqxkxVH1pUTMY/XtmmsApXrCVv5EU25iX6inEPbV+VakJfLealkBtJN69AQmh1eGOdCl9Sm1UP6XQ==
@@ -784,7 +755,7 @@ google-auth-library@10.5.0:
     gtoken "^8.0.0"
     jws "^4.0.0"
 
-google-logging-utils@1.1.3, google-logging-utils@^1.0.0:
+google-logging-utils@^1.0.0, google-logging-utils@1.1.3:
   version "1.1.3"
   resolved "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz"
   integrity sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==
@@ -826,14 +797,14 @@ hasown@^2.0.2:
   dependencies:
     function-bind "^1.1.2"
 
-hono@^4.12.23:
+hono@^4, hono@^4.12.23:
   version "4.12.32"
   resolved "https://registry.npmjs.org/hono/-/hono-4.12.32.tgz"
   integrity sha512-XcuyW9qE2kJn07PkecMOBd5Vq/hMy7mmGw+idz1yblbg9N17ijJODrvPkn7/dwL3Kulj8LcRJ69DLOWf91dRUg==
 
 html-to-text@^10.0.1:
   version "10.0.1"
-  resolved "https://registry.yarnpkg.com/html-to-text/-/html-to-text-10.0.1.tgz#69ce814bf3c1a9aaf05f721f98c48f3d40fe7308"
+  resolved "https://registry.npmjs.org/html-to-text/-/html-to-text-10.0.1.tgz"
   integrity sha512-GiVhRI1BatGARSCmlXWNCjDT0cWrwBWoeduLoV0WSKAgaV/wa+hUWy5LiQLUs4UwiUrE52ZCMfBGiKD87TDPrg==
   dependencies:
     "@selderee/plugin-htmlparser2" "~0.12.0"
@@ -844,7 +815,7 @@ html-to-text@^10.0.1:
 
 htmlparser2@^10.1.0:
   version "10.1.0"
-  resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-10.1.0.tgz#fe3f2e12c73b6e462d4e10395db9c1119e4d6ae4"
+  resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz"
   integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
   dependencies:
     domelementtype "^2.3.0"
@@ -922,7 +893,7 @@ jws@^4.0.0:
 
 leac@^0.7.0:
   version "0.7.0"
-  resolved "https://registry.yarnpkg.com/leac/-/leac-0.7.0.tgz#27632daa46e58b4fa36178bcbeb10bf1d4a1699a"
+  resolved "https://registry.npmjs.org/leac/-/leac-0.7.0.tgz"
   integrity sha512-qMrZeyEekgdRQ9o6a4NAB2EQZrv827GJdn1vnapwSJ90hWRB4TzUSunvacPkxQ2TnNqHNI1/zSt0hlo0crG8Jw==
 
 lru-cache@^10.2.0:
@@ -978,7 +949,7 @@ package-json-from-dist@^1.0.0:
 
 parseley@~0.13.1:
   version "0.13.1"
-  resolved "https://registry.yarnpkg.com/parseley/-/parseley-0.13.1.tgz#1dfc3dd43afee3414367a548e8072f2ef77b2a52"
+  resolved "https://registry.npmjs.org/parseley/-/parseley-0.13.1.tgz"
   integrity sha512-uNBJZzmb60l6p6VWLTmevizNAGnE0xoSf1n0B4q3ntegDNzcS68NRCcBDZTcyXHxt2XhBChsCuqj4M+nChvE/A==
   dependencies:
     leac "^0.7.0"
@@ -999,7 +970,7 @@ path-scurry@^1.11.1:
 
 peberminta@^0.10.0:
   version "0.10.0"
-  resolved "https://registry.yarnpkg.com/peberminta/-/peberminta-0.10.0.tgz#307eb09c747891baa4ba13bc6e896d83147da354"
+  resolved "https://registry.npmjs.org/peberminta/-/peberminta-0.10.0.tgz"
   integrity sha512-80B2AsU+I4Qdb0ZAPSfe9UwvGzwkM37IKIFEvdS3D/3Ndgv2bsuJ0bfG1+iEYO+l7Gfd4EUJmuRyq7efLgRMzQ==
 
 qs@^6.7.0:
@@ -1009,6 +980,18 @@ qs@^6.7.0:
   dependencies:
     es-define-property "^1.0.1"
     side-channel "^1.1.1"
+
+"react-dom@^18.0.0 || ^19.0.0":
+  version "19.2.8"
+  resolved "https://registry.npmjs.org/react-dom/-/react-dom-19.2.8.tgz"
+  integrity sha512-rVprimfGBG3DR+Tq0IQG2DT5PxKth1WIGDmj5yPmlzr4YBe7uyE+Du4oVqTDXZSHGGGXRtTJEGSSePyQCMBglQ==
+  dependencies:
+    scheduler "^0.27.0"
+
+"react@^18.0.0 || ^19.0.0", react@^19.2.8:
+  version "19.2.8"
+  resolved "https://registry.npmjs.org/react/-/react-19.2.8.tgz"
+  integrity sha512-PWaYA1L/q9u2u7xYQi+Y3L3Yfnie7XyLeaJICV1MGD6LprsBxcAqGjYyr0eY3p+QdsA+x/Irkt4Qif8D63+Sbw==
 
 rimraf@^5.0.1:
   version "5.0.10"
@@ -1022,9 +1005,14 @@ safe-buffer@^5.0.1:
   resolved "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
+scheduler@^0.27.0:
+  version "0.27.0"
+  resolved "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz"
+  integrity sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==
+
 selderee@~0.12.0:
   version "0.12.0"
-  resolved "https://registry.yarnpkg.com/selderee/-/selderee-0.12.0.tgz#996d5a174814905431e849d150e6dba536bfee88"
+  resolved "https://registry.npmjs.org/selderee/-/selderee-0.12.0.tgz"
   integrity sha512-b1YMh3+DHZp59DLna3qVwQ5iOla/nrI6mLBNW02XxU77M3046Df6VLkoaJyFz20VsGIG5kkp+FK0kg4K4HnUFw==
   dependencies:
     parseley "~0.13.1"
@@ -1168,6 +1156,13 @@ undici-types@~6.21.0:
   resolved "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz"
   integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
+undici@^5.29.0:
+  version "5.29.0"
+  resolved "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz"
+  integrity sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==
+  dependencies:
+    "@fastify/busboy" "^2.0.0"
+
 universal-user-agent@^7.0.0, universal-user-agent@^7.0.2:
   version "7.0.3"
   resolved "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz"
@@ -1213,7 +1208,12 @@ wrap-ansi@^8.1.0:
     string-width "^5.0.1"
     strip-ansi "^7.0.1"
 
-zod@^3.23.0:
-  version "3.25.76"
-  resolved "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz"
-  integrity sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==
+"zod@^3.25.0 || ^4.0.0", "zod@^3.25.76 || ^4.1.8", zod@^4.3.6:
+  version "4.5.4"
+  resolved "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz"
+  integrity sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==
+
+zod@4.3.6:
+  version "4.3.6"
+  resolved "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz"
+  integrity sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==


### PR DESCRIPTION
## What

- **aieo as vein's provider layer**: the core `agent` step now resolves model/provider through [aieo](https://www.npmjs.com/package/aieo) instead of its own two-case (anthropic|openai) switch. That buys openrouter/google/xai support, friendly aliases (`sonnet`, `grok`, `kimi`), slash-format ids (`openrouter/moonshotai/kimi-k2.6`) with **provider inference from the model name**, per-provider env keys, LLM gateway routing, and the timeout-wrapped fetch.
- **zod 3 → 4** across vein (aligns with aieo, which is already on zod 4).

## Why

Lets the lab GAIA harness A/B non-anthropic models with zero workflow changes — `gaia-produce` already threads `params.model` into the agent step, so e.g. `model: "openrouter/deepseek/deepseek-v3.1"` now Just Works (with `OPENROUTER_API_KEY` set).

## Notes

- Anthropic-only extras (server-side `web_search`, provider-defined text editor, ephemeral prompt caching) stay gated on `provider === "anthropic"`; other providers get the generic editor tool and no web search. GAIA runs on non-anthropic models therefore lose `web_search` — the produce prompt leans on it, so cross-provider accuracy comparisons should account for that.
- Model resolution moved AFTER config validation: aieo's `getModel` resolves the API key eagerly, and a missing-key error shouldn't preempt a config error (two agent tests pin this ordering).
- zod 4 mechanics: two-arg `z.record`, `.prefault({})` for the parse-through-defaults object in `github/fetch-pr`, and the schema-introspection helpers (`createVein` `zodToFields` + `ai/schemaHelpers`) ported to the v4 def layout (`_def.type` kind strings, `shape` as a plain record, `defaultValue` as a value, enum `.options`).
- `xai` added to vein's pricing table (copied from aieo's). The flat openrouter rate remains a rough approximation — per-model openrouter pricing is a follow-up if the evolve loop's cost signal needs to be accurate there.

## Testing

- `npx tsc` clean; full vein suite: **544 pass / 0 fail**.
- Smoke-verified `getProviderForModel` + `getModel` resolve `openrouter/moonshotai/kimi-k2.6` → openrouter provider, model id `moonshotai/kimi-k2.6`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)