### PR TITLE
Remove date_added_to_graph coercion shims and fix cache-control age math for ms epoch

### DIFF
--- a/mcp/src/graph/neo4j.ts
+++ b/mcp/src/graph/neo4j.ts
@@ -29,7 +29,7 @@ import {
   nameFileOnly,
 } from "./utils.js";
 import * as Q from "./queries.js";
-import { nowEpochMs } from "./time.js";
+import { nowEpochMs, epochValueToMs } from "./time.js";
 import { vectorizeCodeDocument, vectorizeQuery } from "../vector/index.js";
 import { v4 as uuidv4 } from "uuid";
 import { createByModelName } from "@microsoft/tiktokenizer";
@@ -106,7 +106,11 @@ class Db {
       const r = await session.run(Q.listQueryForLabel(safe, since != null), {
         extensions,
         limit,
-        since: since ?? null,
+        // `date_added_to_graph` is a canonical epoch-ms Integer (see ./time.ts).
+        // Normalize a seconds-magnitude `since` to ms here — the single bind
+        // site for `listQueryForLabel` — so every caller's "recently added"
+        // filter is guaranteed to compare ms against ms.
+        since: since == null ? null : epochValueToMs(since),
       });
       return r.records.map((record) => deser_node(record, "f"));
     } finally {
@@ -166,8 +170,8 @@ class Db {
     return results
       .flat()
       .sort((a, b) => {
-        const at = Number(a.properties.date_added_to_graph || 0);
-        const bt = Number(b.properties.date_added_to_graph || 0);
+        const at = a.properties.date_added_to_graph || 0;
+        const bt = b.properties.date_added_to_graph || 0;
         return bt - at;
       })
       .slice(0, limit_total);

--- a/mcp/src/graph/queries.test.ts
+++ b/mcp/src/graph/queries.test.ts
@@ -1,0 +1,101 @@
+/**
+ * Unit tests for `listQueryForLabel`'s `$since` filter after the
+ * `toFloat(date_added_to_graph)` coercion shim removal.
+ *
+ * `date_added_to_graph` is a canonical epoch-ms Integer (see ./time.ts), so
+ * the property compares directly against an epoch-ms `$since`. These tests:
+ *   1. pin the generated query text to the bare, coercion-free predicate;
+ *   2. prove the clause's selection semantics on ms-magnitude fixtures —
+ *      a recently-added node is selected, a stale one is not;
+ *   3. prove a seconds-magnitude `$since` must be normalized (×1000) before
+ *      binding — which `nodes_by_type` does via `epochValueToMs`.
+ *
+ * Runs under NO_DB=true — no Neo4j contacted.
+ */
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { listQueryForLabel } from "./queries.js";
+import { epochValueToMs } from "./time.js";
+
+const HOUR_MS = 3600 * 1000;
+
+describe("listQueryForLabel $since filter (post toFloat removal)", () => {
+  it("compares date_added_to_graph directly — no toFloat coercion remains", () => {
+    const q = listQueryForLabel("Function", true);
+    assert.doesNotMatch(
+      q,
+      /toFloat\s*\(/,
+      "toFloat coercion shim must be gone"
+    );
+    assert.match(q, /f\.date_added_to_graph >= \$since/);
+    assert.match(
+      q,
+      /ORDER BY coalesce\(f\.date_added_to_graph, 0\) DESC, f\.node_key/
+    );
+  });
+
+  it("omits the since clause and ordering entirely when withSince is false", () => {
+    const q = listQueryForLabel("Function", false);
+    assert.ok(!q.includes("$since"));
+    assert.ok(!q.includes("date_added_to_graph"));
+    assert.ok(!q.includes("ORDER BY"));
+  });
+
+  /**
+   * Mirror of the generated clause:
+   *   `$since IS NULL OR (f.date_added_to_graph IS NOT NULL
+   *                       AND f.date_added_to_graph >= $since)`
+   * The text assertions above pin the template to this exact predicate, so
+   * the mirror cannot silently drift from what the query actually does.
+   */
+  function selects(nodeDate: number | null, sinceMs: number | null): boolean {
+    return sinceMs === null || (nodeDate !== null && nodeDate >= sinceMs);
+  }
+
+  it("selects recently-added (ms-magnitude) nodes and excludes stale ones", () => {
+    const now = Date.now();
+    const fresh = now - 1 * HOUR_MS; // added 1h ago (ms-magnitude ~1.7e12)
+    const stale = now - 72 * HOUR_MS; // added 72h ago
+    const undated: number | null = null; // property absent
+    const sinceMs = now - 24 * HOUR_MS; // "added within the last 24h"
+
+    assert.ok(selects(fresh, sinceMs), "fresh node (1h old) must be selected");
+    assert.ok(
+      !selects(stale, sinceMs),
+      "stale node (72h old) must be excluded"
+    );
+    assert.ok(
+      !selects(undated, sinceMs),
+      "node without date_added_to_graph must be excluded"
+    );
+    assert.ok(
+      selects(fresh, null) && selects(stale, null),
+      "$since IS NULL selects everything"
+    );
+  });
+
+  it("normalizes a seconds-magnitude $since before comparing (as nodes_by_type does)", () => {
+    const now = Date.now();
+    const fresh = now - 1 * HOUR_MS;
+    const stale = now - 72 * HOUR_MS;
+    const rawSecondsSince = Math.floor((now - 24 * HOUR_MS) / 1000);
+
+    // Without normalization the seconds-magnitude bound never excludes
+    // ms-magnitude values — the "recently added" filter degenerates and
+    // matches every node.
+    assert.ok(
+      stale >= rawSecondsSince && fresh >= rawSecondsSince,
+      "precondition: an unnormalized seconds-since matches stale nodes too"
+    );
+
+    // `nodes_by_type` binds `epochValueToMs(since)`, restoring the filter.
+    const sinceMs = epochValueToMs(rawSecondsSince);
+    assert.ok(
+      sinceMs > stale,
+      "normalized bound must be ms-magnitude (above any seconds value)"
+    );
+    assert.ok(selects(fresh, sinceMs), "fresh node still selected");
+    assert.ok(!selects(stale, sinceMs), "stale node excluded again");
+  });
+});

--- a/mcp/src/graph/queries.ts
+++ b/mcp/src/graph/queries.ts
@@ -697,11 +697,15 @@ export function listQueryForLabel(
   label: string,
   withSince: boolean = false,
 ): string {
+  // `date_added_to_graph` is a canonical epoch-ms Integer (see ./time.ts), so
+  // it compares directly against an epoch-ms `$since` — no toFloat coercion.
+  // `nodes_by_type` normalizes caller-supplied `since` values to ms via
+  // `epochValueToMs` before binding.
   const sinceClause = withSince
-    ? `AND ($since IS NULL OR (f.date_added_to_graph IS NOT NULL AND toFloat(f.date_added_to_graph) >= $since))`
+    ? `AND ($since IS NULL OR (f.date_added_to_graph IS NOT NULL AND f.date_added_to_graph >= $since))`
     : "";
   const orderBy = withSince
-    ? `ORDER BY coalesce(toFloat(f.date_added_to_graph), 0) DESC, f.node_key`
+    ? `ORDER BY coalesce(f.date_added_to_graph, 0) DESC, f.node_key`
     : "";
   return `
 MATCH (f:${label})

--- a/mcp/src/graph/time.test.ts
+++ b/mcp/src/graph/time.test.ts
@@ -1,8 +1,9 @@
+import { readFileSync } from "node:fs";
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import neo4j from "neo4j-driver";
 
-import { nowEpochMs } from "./time.js";
+import { nowEpochMs, epochValueToMs, dateAddedAgeHours } from "./time.js";
 import {
   ADD_NODE_QUERY,
   CREATE_AGENT_SESSION_STUB_QUERY,
@@ -141,4 +142,84 @@ describe("gitsee node prep leaves timestamping to the write path", () => {
       );
     });
   }
+});
+
+describe("epochValueToMs", () => {
+  it("scales seconds-magnitude values ×1000", () => {
+    assert.equal(epochValueToMs(1_700_000_000), 1_700_000_000_000);
+  });
+
+  it("treats exactly 10**12 as still-seconds (matches TimeFormatter.epoch_value_to_ms boundary)", () => {
+    assert.equal(epochValueToMs(1e12), 1e15);
+  });
+
+  it("passes ms-magnitude values through without double-scaling", () => {
+    const ms = 1_700_000_000_123; // already canonical epoch-ms
+    assert.equal(epochValueToMs(ms), ms);
+  });
+
+  it("truncates sub-ms precision like the backend int() conversion", () => {
+    // 7-decimal string seconds (legacy shape) round-trips to ms via floor
+    assert.equal(epochValueToMs(1700000000.1234567), 1700000000123);
+  });
+
+  it("accepts a nowEpochMs() stamp unchanged", () => {
+    const ts = nowEpochMs().toNumber();
+    assert.equal(epochValueToMs(ts), ts);
+  });
+});
+
+describe("dateAddedAgeHours (intelligence cache-control age math)", () => {
+  const HOUR_MS = 3600 * 1000;
+
+  it("computes age in hours from a canonical ms-magnitude stamp", () => {
+    const stamp = 1_700_000_000_000; // canonical epoch-ms Integer
+    const now = stamp + 3 * HOUR_MS;
+    assert.equal(dateAddedAgeHours(stamp, now), 3);
+  });
+
+  it("a fresh node (1h old) is within a 24h maxAgeHours window", () => {
+    const now = Date.now();
+    const stamp = now - 1 * HOUR_MS;
+    assert.ok(dateAddedAgeHours(stamp, now) < 24);
+  });
+
+  it("a stale node (72h old) exceeds a 24h maxAgeHours window", () => {
+    const now = Date.now();
+    const stamp = now - 72 * HOUR_MS;
+    assert.ok(dateAddedAgeHours(stamp, now) > 24);
+  });
+
+  it("defaults `now` to Date.now()", () => {
+    const stamp = Date.now() - 2 * HOUR_MS;
+    const hours = dateAddedAgeHours(stamp);
+    assert.ok(hours > 1.9 && hours < 2.1, `expected ~2h, got ${hours}`);
+  });
+});
+
+describe("intelligence cache-control regression guard (source scan)", () => {
+  /**
+   * The cache-control branch reads `date_added_to_graph` without going
+   * through any toInteger/toFloat shim, so a shim-only grep would miss a
+   * regression to the old seconds-assuming math (`Date.now() / 1000`,
+   * `... / 3600`). Scan the source directly to pin the ms semantics.
+   */
+  it("reads date_added_to_graph as epoch-ms via dateAddedAgeHours", () => {
+    const src = readFileSync(
+      new URL("../tools/intelligence/index.ts", import.meta.url),
+      "utf8"
+    );
+    assert.ok(
+      src.includes("dateAddedAgeHours(nodeAge)"),
+      "cache branch must use the canonical dateAddedAgeHours helper"
+    );
+    assert.ok(
+      !src.includes("Date.now() / 1000"),
+      "seconds-assuming currentTime must not return"
+    );
+    assert.ok(
+      !src.includes("/ 3600"),
+      "hours conversion must go through the helper, not a seconds-based divide"
+    );
+  });
 });

--- a/mcp/src/graph/time.ts
+++ b/mcp/src/graph/time.ts
@@ -13,3 +13,38 @@ import neo4j, { Integer } from "neo4j-driver";
 export function nowEpochMs(): Integer {
   return neo4j.int(Date.now());
 }
+
+/**
+ * Canonical magnitude boundary for a `date_added_to_graph` value: anything
+ * **above** this is epoch-milliseconds (already canonical); at-or-below is
+ * still epoch-seconds. Must match jarvis-backend's
+ * `TimeFormatter.epoch_value_to_ms` boundary exactly (values ≤ 10**12 are
+ * seconds) — do not introduce a divergent variant.
+ */
+export const EPOCH_MS_BOUNDARY = 1_000_000_000_000;
+
+/**
+ * Normalize an epoch value that may be in seconds or milliseconds to
+ * epoch-milliseconds, mirroring jarvis-backend's
+ * `TimeFormatter.epoch_value_to_ms`: seconds-magnitude values (≤ 10^12)
+ * scale ×1000, ms-magnitude values pass through. Sub-ms precision is
+ * truncated (`floor`) to match the backend's integer conversion.
+ */
+export function epochValueToMs(value: number): number {
+  return value <= EPOCH_MS_BOUNDARY
+    ? Math.floor(value * 1000)
+    : Math.floor(value);
+}
+
+/**
+ * Age in hours of a node stamped with the canonical `date_added_to_graph`
+ * stamp (**epoch milliseconds** — the unit `nowEpochMs()` writes). Used by the
+ * intelligence tools' cache-control age check. Kept here, next to the stamp
+ * definition, so the canonical unit lives in exactly one module.
+ */
+export function dateAddedAgeHours(
+  dateAddedMs: number,
+  now: number = Date.now(),
+): number {
+  return (now - dateAddedMs) / (3600 * 1000);
+}

--- a/mcp/src/tools/intelligence/index.ts
+++ b/mcp/src/tools/intelligence/index.ts
@@ -6,6 +6,7 @@ import { recomposeAnswer, RecomposedAnswer } from "./answer.js";
 import { LEARN_HTML } from "./learn.js";
 import * as G from "../../graph/graph.js";
 import { db } from "../../graph/neo4j.js";
+import { dateAddedAgeHours } from "../../graph/time.js";
 import { vectorizeQuery } from "../../vector/index.js";
 
 /**
@@ -122,8 +123,7 @@ export async function ask_prompt(
       } else if (cacheControl?.maxAgeHours) {
         const nodeAge = top.properties.date_added_to_graph;
         if (nodeAge) {
-          const currentTime = Date.now() / 1000; // Convert to seconds
-          const ageInHours = (currentTime - nodeAge) / 3600; // Convert to hours
+          const ageInHours = dateAddedAgeHours(nodeAge);
 
           if (ageInHours > cacheControl.maxAgeHours) {
             console.log(


### PR DESCRIPTION
## Summary
- Removes `toFloat`/`Number` coercion shims around `date_added_to_graph` in `listQueryForLabel` and node sorting — the property is a canonical epoch-ms Integer (see `./time.ts`)
- Normalizes caller-supplied `since` values to ms via new `epochValueToMs` helper (mirrors jarvis-backend `TimeFormatter.epoch_value_to_ms` boundary: ≤ 10^12 = seconds) at the single bind site in `nodes_by_type`
- Fixes intelligence cache-control age math to treat `date_added_to_graph` as epoch-ms via new `dateAddedAgeHours` helper (previous code divided `Date.now()/1000` against ms stamps)
- Adds unit tests for `epochValueToMs`, `dateAddedAgeHours`, a source-scan regression guard, and `listQueryForLabel` since/order-by SQL

## Test plan
- `cd mcp && NO_DB=true npx tsx --test --test-timeout=30000 src/graph/time.test.ts src/graph/queries.test.ts` — 35 tests pass