### PR TITLE
vein: generic storage boundary + Neo4j workspace store + run/chat projector

### DIFF
--- a/mcp/src/lab/artifacts/seed.ts
+++ b/mcp/src/lab/artifacts/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /** Generic artifact plumbing steps (NOT an experiment). Today just
  *  `artifacts/dir` — see steps/dir.ts. */
@@ -11,7 +11,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-export async function seedArtifactSteps(workspace: WorkspaceManager): Promise<void> {
+export async function seedArtifactSteps(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {
     try {

--- a/mcp/src/lab/concepts/seed.ts
+++ b/mcp/src/lab/concepts/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /**
  * Workflow + step templates shipped with the concepts experiment. They are
@@ -60,7 +60,7 @@ const HERE = dirname(fileURLToPath(import.meta.url));
  * content hash. Idempotent; edits publish a new active version.
  */
 export async function seedConceptWorkflows(
-  workspace: WorkspaceManager,
+  workspace: WorkspaceStore,
 ): Promise<void> {
   const dir = join(HERE, "workflows");
   for (const name of SEED_WORKFLOWS) {
@@ -89,7 +89,7 @@ export async function seedConceptWorkflows(
  * edits publish a new active version while prior versions are archived.
  */
 export async function seedConceptSteps(
-  workspace: WorkspaceManager,
+  workspace: WorkspaceStore,
 ): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -151,7 +151,7 @@ export async function createLabVein(
   // stay on disk under `workspacePath` either way.
   const graphBacked = graphWorkspaceRequested();
   const workspace: WorkspaceStore = graphBacked
-    ? (await graphWorkspaceFromEnv()).workspace
+    ? (await graphWorkspaceFromEnv(process.env, { dataDir: workspacePath })).workspace
     : new WorkspaceManager(workspacePath);
   if (graphBacked) console.log(`[lab] vein workspace: Neo4jWorkspaceStore (data dir: ${workspacePath})`);
   // Generic, domain-agnostic eval primitives (steps). The concept-specific eval

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -1,6 +1,12 @@
 import {
   createVein,
   WorkspaceManager,
+  FileRunStore,
+  FileChatStore,
+  FileSecretStore,
+  graphWorkspaceRequested,
+  graphWorkspaceFromEnv,
+  type WorkspaceStore,
   type Vein,
   type RunResult,
 } from "vein";
@@ -132,12 +138,22 @@ export async function createLabVein(
     "./lab-workspace";
 
   // Seed each experiment's workflow + step templates into the workspace
-  // BEFORE building the vein, so the registry's disk discovery picks up the
-  // seeded steps. Steps are now self-contained custom steps on disk (not
-  // injected in-code) — content-hash reconciled, editable + versioned via the
-  // vein API/UI. No `registry` is passed, so createVein discovers core + lib +
-  // these custom steps from `workspace.path` (and step publishing is enabled).
-  const workspace = new WorkspaceManager(workspacePath);
+  // BEFORE building the vein, so the registry's discovery picks up the
+  // seeded steps. Steps are self-contained custom steps (not injected
+  // in-code) — content-hash reconciled, editable + versioned via the vein
+  // API/UI. No `registry` is passed, so createVein discovers core + lib +
+  // these custom steps via `workspace.materializeCustomSteps()` (and step
+  // publishing is enabled).
+  //
+  // VEIN_WORKSPACE_BACKEND=graph keeps workflows/steps in Neo4j
+  // (vein's Neo4jWorkspaceStore; NEO4J_HOST/USER/PASSWORD, same defaults as
+  // this host's own client). Runs, chats, secrets, artifacts, and cassettes
+  // stay on disk under `workspacePath` either way.
+  const graphBacked = graphWorkspaceRequested();
+  const workspace: WorkspaceStore = graphBacked
+    ? (await graphWorkspaceFromEnv()).workspace
+    : new WorkspaceManager(workspacePath);
+  if (graphBacked) console.log(`[lab] vein workspace: Neo4jWorkspaceStore (data dir: ${workspacePath})`);
   // Generic, domain-agnostic eval primitives (steps). The concept-specific eval
   // WORKFLOWS that wire them (concepts-eval*) are seeded with the concepts
   // experiment below.
@@ -171,6 +187,16 @@ export async function createLabVein(
     workspace,
     services,
     serveUi: opts.serveUi ?? true,
+    // A non-file workspace would otherwise default the run/chat/secret
+    // stores to memory — pin them to disk so history survives restarts.
+    ...(graphBacked
+      ? {
+          dataDir: workspacePath,
+          store: new FileRunStore(workspacePath),
+          chatStore: new FileChatStore(workspacePath),
+          secretStore: new FileSecretStore(workspacePath),
+        }
+      : {}),
   });
 
   // Inject the run-sub-workflows capability now that the instance exists.

--- a/mcp/src/lab/eval/seed.ts
+++ b/mcp/src/lab/eval/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /**
  * GENERIC, domain-agnostic eval primitives (STEPS only), seeded into the vein
@@ -35,7 +35,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-export async function seedEvalSteps(workspace: WorkspaceManager): Promise<void> {
+export async function seedEvalSteps(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {
     try {

--- a/mcp/src/lab/gaia/seed.ts
+++ b/mcp/src/lab/gaia/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /**
  * GAIA LAB steps + workflows — the harness that scored 5/5 on the first
@@ -74,7 +74,7 @@ const SEED_WORKFLOWS: Array<{ name: string; description: string }> = [
   },
 ];
 
-export async function seedGaiaWorkflows(workspace: WorkspaceManager): Promise<void> {
+export async function seedGaiaWorkflows(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "workflows");
   for (const { name, description } of SEED_WORKFLOWS) {
     try {
@@ -87,7 +87,7 @@ export async function seedGaiaWorkflows(workspace: WorkspaceManager): Promise<vo
   }
 }
 
-export async function seedGaiaSteps(workspace: WorkspaceManager): Promise<void> {
+export async function seedGaiaSteps(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {
     try {

--- a/mcp/src/lab/gitsee/seed.ts
+++ b/mcp/src/lab/gitsee/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /**
  * Workflow + step templates for the `gitsee` experiment (self-contained port of
@@ -66,7 +66,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-export async function seedGitseeWorkflows(workspace: WorkspaceManager): Promise<void> {
+export async function seedGitseeWorkflows(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "workflows");
   for (const name of SEED_WORKFLOWS) {
     try {
@@ -82,7 +82,7 @@ export async function seedGitseeWorkflows(workspace: WorkspaceManager): Promise<
   }
 }
 
-export async function seedGitseeSteps(workspace: WorkspaceManager): Promise<void> {
+export async function seedGitseeSteps(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {
     try {

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /**
  * Harvey LAB verification steps — THIN plumbing only. The actual grader is
@@ -116,7 +116,7 @@ async function expandIncludes(yaml: string): Promise<string> {
   return out.join("\n");
 }
 
-export async function seedHarveyWorkflows(workspace: WorkspaceManager): Promise<void> {
+export async function seedHarveyWorkflows(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "workflows");
   for (const name of SEED_WORKFLOWS) {
     try {
@@ -129,7 +129,7 @@ export async function seedHarveyWorkflows(workspace: WorkspaceManager): Promise<
   }
 }
 
-export async function seedHarveySteps(workspace: WorkspaceManager): Promise<void> {
+export async function seedHarveySteps(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {
     try {

--- a/mcp/src/lab/jarvis/seed.ts
+++ b/mcp/src/lab/jarvis/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /**
  * Jarvis knowledge-graph steps, seeded into the vein workspace. Each is a
@@ -38,7 +38,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-export async function seedJarvisSteps(workspace: WorkspaceManager): Promise<void> {
+export async function seedJarvisSteps(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {
     try {

--- a/mcp/src/lab/sheets/seed.ts
+++ b/mcp/src/lab/sheets/seed.ts
@@ -1,7 +1,7 @@
 import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
-import type { WorkspaceManager } from "vein";
+import type { WorkspaceStore } from "vein";
 
 /**
  * Google Sheets steps, seeded into the vein workspace. Each is a
@@ -30,7 +30,7 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
-export async function seedSheetsSteps(workspace: WorkspaceManager): Promise<void> {
+export async function seedSheetsSteps(workspace: WorkspaceStore): Promise<void> {
   const dir = join(HERE, "steps");
   for (const { file, type } of SEED_STEPS) {
     try {

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -284,7 +284,9 @@ services bag can override it, same as `http`/`secrets`).
   `VeinStepVersion` nodes (content-addressed versions; soft deletes;
   `USES_STEP`/`DEPENDS_ON` edges) and passes the same conformance suite
   (`npm run test:graph`, live). `VEIN_WORKSPACE_BACKEND=graph` switches
-  the default server to it (`src/graph/wiring.ts`). Runs/chats stay in
+  the default server to it (`src/graph/wiring.ts`; connection from
+  `NEO4J_URI` / `NEO4J_HOST` / `NEO4J_USER` / `NEO4J_PASSWORD`, defaulting
+  to localhost:7687 / neo4j / testtest like the mcp host). Runs/chats stay in
   their stores; `src/graph/projector.ts` (or the `graph/project` step)
   projects them into `VeinRun`/`VeinAgentSession`/`VeinToolCall`/
   `VeinChat`/`VeinTurn` with `EXECUTED`/`IN_RUN`/`IN_SESSION`/`SPAWNED`/

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -36,7 +36,7 @@ vein/
 │   ├── runner.ts          # execution engine: DAG (topological), retry, onError, control flow, journal replay
 │   ├── run-control.ts     # RunController: cooperative cancel/pause/resume for run TREES (RUN_CONTROL_SPEC.md)
 │   ├── journal.ts         # resume journal: step.end outputs → {path→output}; `from` invalidation
-│   ├── store.ts           # RunStore interface + FileRunStore + MemoryRunStore + tailJsonl (shared append-only tail engine)
+│   ├── store.ts           # RunStore interface (writes + reads + tail) + FileRunStore + MemoryRunStore + tailJsonl / tailFromPolling
 │   ├── chat-store.ts      # ChatStore interface + FileChatStore + MemoryChatStore (chats/<id>/: meta.json + messages.jsonl + events.jsonl) + truncateToolMessages
 │   ├── workspace.ts       # WorkspaceManager: versioning, _metadata.json, YAML loading
 │   ├── createVein.ts      # createVein() factory: Hono HTTP API + detached run launch + SSE run reattach (tail) + detached /chat (launch+reattach) + static serving; injectable registry/store/chatStore/services
@@ -424,7 +424,7 @@ services bag can override it, same as `http`/`secrets`).
   connection (closing the client, proxy timeouts, etc. can't kill it).
   To watch a run — live **or** after it finished — open
   `GET /workflows/:name/runs/:runId/stream` (SSE). That endpoint calls
-  `FileRunStore.tailEvents`, which **tails the events file**: replay
+  `RunStore.tailEvents`; the file store **tails the events file**: replay
   from byte offset 0 → EOF (history), then follow appends (polling
   `intervalMs`, default 250ms) until the terminal event
   (`run.end`/`run.error`), then sends a final `done` carrying the
@@ -433,9 +433,12 @@ services bag can override it, same as `http`/`secrets`).
   from EOF — no sequence numbers, no dedupe), and **one code path
   serves completed and in-flight runs**. Pass an `AbortSignal` (wired
   to `stream.onAbort` on client disconnect) to stop the tail early.
-  Streaming requires a `FileRunStore` (the tail reads the file);
-  `MemoryRunStore` runs still launch but the stream endpoint returns
-  501. **Crash caveat:** in-flight *execution* is in-memory, so a
+  `RunStore` is the FULL contract (append/finalize + listRuns/
+  getRunSummary/getRunEvents/tailEvents/lastRunAt): no endpoint
+  capability-gates on the concrete class. A backend without a native
+  tail delegates `tailEvents` to `tailFromPolling` (re-read + index
+  cursor) — `MemoryRunStore` does, so memory-mode vein has run history,
+  SSE reattach, durable resume, and promotions. **Crash caveat:** in-flight *execution* is in-memory, so a
   crash mid-run loses the remaining work (the log up to the crash
   survives); true resume is a later add. The web UI's
   `api.runWorkflow` hides the two steps — it POSTs to launch, then

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -17,7 +17,7 @@ versioned artifact, and what must never evolve.
 | ----------- | -------------------------------------------------------------------------- |
 | Engine      | TypeScript (Node 22+), Zod for schemas, custom expression evaluator        |
 | HTTP        | Hono + @hono/node-server                                                   |
-| Persistence | Filesystem (JSONL events + JSON summaries). Swappable via `RunStore` iface |
+| Persistence | One interface per layer — `WorkspaceStore` (workflows/steps), `RunStore` (runs), `ChatStore`, `SecretStore` — with File + Memory impls; local blobs (artifacts/cassettes/shell scratch) live under an explicit `dataDir` |
 | Web UI      | Preact + Vite + system-canvas-react. Vanilla CSS, no Tailwind              |
 | Tests       | Node native test runner (`node:test`) via tsx                              |
 | LLM step    | Vercel AI SDK (ai + @ai-sdk/anthropic + @ai-sdk/openai) — lazy-loaded      |
@@ -38,7 +38,8 @@ vein/
 │   ├── journal.ts         # resume journal: step.end outputs → {path→output}; `from` invalidation
 │   ├── store.ts           # RunStore interface (writes + reads + tail) + FileRunStore + MemoryRunStore + tailJsonl / tailFromPolling
 │   ├── chat-store.ts      # ChatStore interface + FileChatStore + MemoryChatStore (chats/<id>/: meta.json + messages.jsonl + events.jsonl) + truncateToolMessages
-│   ├── workspace.ts       # WorkspaceManager: versioning, _metadata.json, YAML loading
+│   ├── workspace.ts       # WorkspaceStore interface + FileWorkspaceStore (alias WorkspaceManager): versioning, _metadata.json, YAML loading
+│   ├── storage-conformance.test.ts  # the storage boundary's spec: one suite per layer, run over every impl
 │   ├── createVein.ts      # createVein() factory: Hono HTTP API + detached run launch + SSE run reattach (tail) + detached /chat (launch+reattach) + static serving; injectable registry/store/chatStore/services
 │   ├── server.ts          # thin wrapper over createVein() (getApp/startServer) — default filesystem-backed server
 │   ├── auth.ts            # requireApiKey middleware + warnIfUnconfigured (VEIN_API_KEY shared secret)
@@ -263,9 +264,21 @@ services bag can override it, same as `http`/`secrets`).
   `services`, plus `run()`/`listen()`/`rebuildRegistry()` helpers — and
   mounts every route (`/workflows`, `/steps`, `/secrets`, `/chat` +
   `/chats`, `/health`, static UI). Everything is injectable via
-  `VeinOptions`: pass your own `registry` (disables filesystem step
-  discovery + publishing), `store` (e.g. `MemoryRunStore`), `chatStore`,
-  `secretStore`, `services` bag, or toggle `serveUi`/`enableChat`.
+  `VeinOptions`: pass your own `workspace` (any `WorkspaceStore`),
+  `registry` (disables step discovery + publishing), `store` (e.g.
+  `MemoryRunStore`), `chatStore`, `secretStore`, `services` bag,
+  `dataDir`, or toggle `serveUi`/`enableChat`.
+  **Storage boundary:** nothing outside `workspace.ts` reads a workspace
+  directory. `WorkspaceStore` exposes custom step code two ways —
+  `getStepSource(type)` (text, all tiers) and `materializeCustomSteps()`
+  (an importable dir for `buildRegistry`). The inherently-local things —
+  run artifacts, step cassettes, the chat builder's shell cwd + scratch/ —
+  hang off `dataDir` (default: the file workspace's root, so a
+  file-backed deployment keeps one directory). Unspecified store defaults
+  follow the workspace's kind (file → file stores under `dataDir`; any
+  other impl → memory); an explicitly passed store always wins, and no
+  capability is gated on a concrete class. `storage-conformance.test.ts`
+  is the boundary's spec — a new backend passes by running it.
   `server.ts` is a thin wrapper (`getApp`/`startServer`) over
   `createVein()` with filesystem defaults.
 
@@ -291,7 +304,7 @@ services bag can override it, same as `http`/`secrets`).
 
 - **`createRegistry(steps)`** builds a registry from in-code step defs
   layered on core + lib (no filesystem custom/ discovery) — the
-  library-usage counterpart to `buildRegistry(workspacePath)`. User
+  library-usage counterpart to `buildRegistry(customDir)`. User
   steps may shadow core/lib steps (with a warning); duplicates throw.
   Like `buildRegistry`, it imports every lib step *file* at build time
   (cheap: schema + metadata only) — heavy SDK deps load lazily in `run()`

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -279,6 +279,17 @@ services bag can override it, same as `http`/`secrets`).
   other impl → memory); an explicitly passed store always wins, and no
   capability is gated on a concrete class. `storage-conformance.test.ts`
   is the boundary's spec — a new backend passes by running it.
+  **Graph backend:** `Neo4jWorkspaceStore` (`src/graph/workspace-store.ts`)
+  keeps workflows/steps as `VeinWorkflow`/`VeinWorkflowVersion`/`VeinStep`/
+  `VeinStepVersion` nodes (content-addressed versions; soft deletes;
+  `USES_STEP`/`DEPENDS_ON` edges) and passes the same conformance suite
+  (`npm run test:graph`, live). `VEIN_WORKSPACE_BACKEND=graph` switches
+  the default server to it (`src/graph/wiring.ts`). Runs/chats stay in
+  their stores; `src/graph/projector.ts` (or the `graph/project` step)
+  projects them into `VeinRun`/`VeinAgentSession`/`VeinToolCall`/
+  `VeinChat`/`VeinTurn` with `EXECUTED`/`IN_RUN`/`IN_SESSION`/`SPAWNED`/
+  `IN_CHAT` edges — summaries + `log_ref` pointers, never payloads,
+  idempotent upserts.
   `server.ts` is a thin wrapper (`getApp`/`startServer`) over
   `createVein()` with filesystem defaults.
 

--- a/vein/SPEC.md
+++ b/vein/SPEC.md
@@ -455,11 +455,11 @@ Swap in S3, Postgres, etc. without changing the runner.
 
 ## 8. Type Safety
 
-The registry is the single source of truth. It is built at server startup by `buildRegistry(workspacePath?)` in `src/steps/registry.ts`:
+The registry is the single source of truth. It is built at server startup by `buildRegistry(customDir?)` in `src/steps/registry.ts`, where `customDir` is whatever `WorkspaceStore.materializeCustomSteps()` returns (the file store's `<workspace>/steps/custom/`):
 
 - **Core** steps are statically imported (always present, always in the bundle).
 - **Lib** steps are discovered by walking `src/steps/lib/` and `await import()`-ing each `.ts` file. Their step name is derived from the path (e.g. `lib/github/fetch-pr.ts` → `"github/fetch-pr"`).
-- **Custom** steps are discovered the same way under `<workspace>/steps/custom/`.
+- **Custom** steps are discovered the same way under `customDir` — the directory the workspace store materializes its active custom steps into.
 
 Sketch:
 
@@ -471,11 +471,11 @@ import http from "./core/http.js";
 const CORE_STEPS = { http, if: ifStep, loop, subflow, log, llm, wait };
 const LIB_DIR = join(dirname(fileURLToPath(import.meta.url)), "lib");
 
-export async function buildRegistry(workspacePath?: string): Promise<StepRegistry> {
+export async function buildRegistry(customDir?: string): Promise<StepRegistry> {
   const registry: StepRegistry = { ...CORE_STEPS };
   await loadStepsFrom(LIB_DIR, registry, "lib");
-  if (workspacePath) {
-    await loadStepsFrom(join(workspacePath, "steps", "custom"), registry, "custom");
+  if (customDir) {
+    await loadStepsFrom(customDir, registry, "custom");
   }
   return registry;
 }
@@ -706,24 +706,36 @@ The **active** version's source is materialized at `steps/custom/<name>.ts` (wha
 
 The engine can function without this file — it discovers steps by scanning `.ts` files — but the UI needs it for version listing and rollback. Versioning is disabled when the registry is injected at construction time (`createRegistry`/`registry` option).
 
-### 11.3 WorkspaceManager API
+### 11.3 WorkspaceStore API
 
-The engine exposes programmatic helpers used by the HTTP server:
+Workflows and steps persist behind the `WorkspaceStore` interface (`src/workspace.ts`); `FileWorkspaceStore` (alias `WorkspaceManager`) is the default implementation and any backend implementing the same surface can be passed as `VeinOptions.workspace`. The HTTP server, the authoring capability, and the chat builder only ever see the interface — nothing outside `workspace.ts` reads a workspace directory. Sketch (see the source for the full signatures):
 
 ```ts
-interface WorkspaceManager {
+interface WorkspaceStore {
   // Workflows
-  listWorkflows(): Promise<WorkflowInfo[]>;
+  listWorkflows(): Promise<WorkflowListEntry[]>;
   getWorkflow(name: string): Promise<Flow>;
+  getWorkflowVersion(name: string, version: string): Promise<Flow>;
   getWorkflowSource(name: string, version: string): Promise<string>; // raw YAML
-  publishWorkflow(name: string, version: string, content: { steps: any[] } | string, description?: string): Promise<void>;
-  setActiveVersion(name: string, version: string): Promise<void>;
+  getWorkflowHash(name: string, version?: string): Promise<string | null>;
+  getWorkflowMetadata(name: string): Promise<WorkflowMetadata | null>;
+  createWorkflow(...): Promise<{ name: string; version: string }>;
+  publishWorkflow(...): Promise<void>;
+  publishWorkflowByContent(...): Promise<{ version: string; changed: boolean }>;
+  setWorkflowCategory / setActiveVersion / setParam
 
-  // Steps
-  listSteps(): Promise<StepInfo[]>;
-  publishStep(namespace: string, name: string, code: string, description?: string): Promise<void>;
+  // Steps (custom tier)
+  listSteps(filter?): Promise<StepListEntry[]>;
+  publishStep(name, code, description?, publisher?): Promise<{ version: string; changed: boolean }>;
+  listStepVersions / getStepVersionSource / setActiveStepVersion / deleteStep / deleteStepsByPublisher
+
+  // Step source + code loading
+  getStepSource(type): Promise<{ code: string; origin: "core" | "lib" | "custom" } | null>;
+  materializeCustomSteps(): Promise<string>; // importable dir for buildRegistry()
 }
 ```
+
+Runs are the `RunStore`'s records (full read/write/tail contract, `src/store.ts`), and the inherently-local things — run artifacts, step cassettes, the chat builder's shell cwd — live under the server's `dataDir` (`VeinOptions.dataDir`, default: the file workspace's root). `src/storage-conformance.test.ts` is the behavioral spec every implementation of each layer must pass.
 
 ---
 

--- a/vein/package.json
+++ b/vein/package.json
@@ -22,7 +22,7 @@
     "build:web": "npm --prefix web run build",
     "dev": "npm run build:web && tsx --env-file=.env src/server.ts",
     "start": "node build/server.js",
-    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/run-control.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/authoring.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts src/artifacts.test.ts src/slack.test.ts src/gdrive.test.ts src/html-extract.test.ts src/shell.test.ts",
+    "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/run-control.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/storage-conformance.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/authoring.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/auth.test.ts src/secret-store.test.ts src/artifacts.test.ts src/slack.test.ts src/gdrive.test.ts src/html-extract.test.ts src/shell.test.ts",
     "test:graph": "tsx --test --test-concurrency=1 \"src/graph/*.test.ts\" \"src/steps/lib/graph/*.test.ts\""
   },
   "dependencies": {

--- a/vein/plans/generic-storage.md
+++ b/vein/plans/generic-storage.md
@@ -1,5 +1,15 @@
 # Generic storage — one boundary per layer, filesystem as one implementation
 
+> **Status (2026-09-01):** §1–§6 implemented on branch `vein-generic-storage`
+> (two commits: step 1, then steps 2–5). `RunStore` is the full contract;
+> `WorkspaceStore` + `FileWorkspaceStore` (alias `WorkspaceManager`);
+> `getStepSource` / `materializeCustomSteps`; `dataDir`; one resolved
+> default mode; `src/storage-conformance.test.ts`. Remaining: §7 (the
+> graph workspace store + projector) and the v2 provenance convention.
+> The §7 label registry already exists in code — `src/graph/vein-schemas.ts`
+> (seeded by `schema-seed.ts`); the backend seam is `openGraphBackend` in
+> `src/graph/backend.ts`.
+
 ## Problem
 
 AGENTS.md claims "Persistence: Filesystem … Swappable via `RunStore` iface".

--- a/vein/plans/generic-storage.md
+++ b/vein/plans/generic-storage.md
@@ -4,11 +4,17 @@
 > (two commits: step 1, then steps 2–5). `RunStore` is the full contract;
 > `WorkspaceStore` + `FileWorkspaceStore` (alias `WorkspaceManager`);
 > `getStepSource` / `materializeCustomSteps`; `dataDir`; one resolved
-> default mode; `src/storage-conformance.test.ts`. Remaining: §7 (the
-> graph workspace store + projector) and the v2 provenance convention.
-> The §7 label registry already exists in code — `src/graph/vein-schemas.ts`
-> (seeded by `schema-seed.ts`); the backend seam is `openGraphBackend` in
-> `src/graph/backend.ts`.
+> default mode; `src/storage-conformance.test.ts`. §7 is built too:
+> `src/graph/workspace-store.ts` (`Neo4jWorkspaceStore`, passes the
+> workspace conformance suite live — `npm run test:graph`),
+> `src/graph/projector.ts` (post-hoc run/chat projector, idempotent
+> upserts) + the `graph/project` lib step, and `src/graph/wiring.ts`
+> (`VEIN_WORKSPACE_BACKEND=graph` for the default server). Not projected
+> yet: `ACCESSED` (needs the v2 provenance convention below) and
+> `PROMOTED_FROM` (promotion doesn't record its source run). One deliberate
+> deviation from the file store: graph versions are content-addressed —
+> publishing identical content under a new label re-labels the existing
+> version node instead of duplicating it.
 
 ## Problem
 

--- a/vein/plans/jarvis-graph-compat.md
+++ b/vein/plans/jarvis-graph-compat.md
@@ -28,9 +28,12 @@ so they ship with the engine and are auto-discovered by the registry).
 Tests: `npm run test:graph` in `vein/` (live, against a throwaway Neo4j —
 see `src/graph/test-util.ts`; add `VEIN_TEST_EMBEDDINGS=1` for the
 real-model parity case; includes the end-to-end step test).
-Not yet built (parallel track, generic-storage §1–5): `Neo4jWorkspaceStore`
-and the run/chat projector; `openGraphBackend` in `src/graph/backend.ts` is
-the seam they plug into.
+Not yet built: `Neo4jWorkspaceStore` and the run/chat projector;
+`openGraphBackend` in `src/graph/backend.ts` is the seam they plug into.
+The vein-native boundary they implement against (generic-storage §1–5:
+`WorkspaceStore`, the full `RunStore`, `dataDir`, and the conformance
+suite in `src/storage-conformance.test.ts`) landed on branch
+`vein-generic-storage`.
 
 **Beyond the original scope — jarvis-typed data.** The harvey lab pipeline
 writes jarvis's own types (Document, EvalSet, EvalRequirement, EvalTrigger,

--- a/vein/plans/jarvis-graph-compat.md
+++ b/vein/plans/jarvis-graph-compat.md
@@ -28,12 +28,12 @@ so they ship with the engine and are auto-discovered by the registry).
 Tests: `npm run test:graph` in `vein/` (live, against a throwaway Neo4j —
 see `src/graph/test-util.ts`; add `VEIN_TEST_EMBEDDINGS=1` for the
 real-model parity case; includes the end-to-end step test).
-Not yet built: `Neo4jWorkspaceStore` and the run/chat projector;
-`openGraphBackend` in `src/graph/backend.ts` is the seam they plug into.
-The vein-native boundary they implement against (generic-storage §1–5:
-`WorkspaceStore`, the full `RunStore`, `dataDir`, and the conformance
-suite in `src/storage-conformance.test.ts`) landed on branch
-`vein-generic-storage`.
+Also on branch `vein-generic-storage`: the vein-native storage boundary
+(generic-storage §1–5) and, on top of it, `Neo4jWorkspaceStore`
+(`src/graph/workspace-store.ts`) + the run/chat projector
+(`src/graph/projector.ts`, `graph/project` step) + env wiring
+(`src/graph/wiring.ts`, `VEIN_WORKSPACE_BACKEND=graph`). Their live tests
+run under `npm run test:graph`.
 
 **Beyond the original scope — jarvis-typed data.** The harvey lab pipeline
 writes jarvis's own types (Document, EvalSet, EvalRequirement, EvalTrigger,

--- a/vein/src/ai-integration.test.ts
+++ b/vein/src/ai-integration.test.ts
@@ -418,19 +418,24 @@ describe("AI list_runs / get_run tools", () => {
     assert.ok(res.error && /not found/.test(res.error));
   });
 
-  it("run-history tools degrade gracefully on a non-readable store", async () => {
+  it("run-history tools read from a MemoryRunStore like any other", async () => {
     const registry = await createRegistry([]);
+    const store = new MemoryRunStore();
+    await store.append("x", "1", { ts: new Date().toISOString(), runId: "1", path: "x", type: "run.start" });
     const deps = {
       workspace: new WorkspaceManager(tempDir),
       registry,
-      store: new MemoryRunStore(),
+      store,
       getRegistry: async () => registry,
     };
     const tools = buildTools(deps) as any;
-    const list = await tools.list_runs.execute({ name: "x" });
-    assert.ok(list.error && /unavailable/.test(list.error));
-    const get = await tools.get_run.execute({ name: "x", runId: "1" });
-    assert.ok(get.error && /unavailable/.test(get.error));
+    const list = await tools.list_runs.execute({ name: "x", limit: 20 });
+    assert.deepEqual(list.runs.map((r: { runId: string }) => r.runId), ["1"]);
+    const get = await tools.get_run.execute({ name: "x", runId: "1", fullEvents: false });
+    assert.equal(get.runId, "1");
+    assert.equal(get.events.length, 1);
+    const missing = await tools.get_run.execute({ name: "x", runId: "2", fullEvents: false });
+    assert.ok(missing.error && /not found/.test(missing.error));
   });
 });
 

--- a/vein/src/ai/prompts.ts
+++ b/vein/src/ai/prompts.ts
@@ -1,5 +1,5 @@
 import type { StepRegistry, RunResult } from "../core.js";
-import type { WorkspaceManager } from "../workspace.js";
+import type { WorkspaceStore } from "../workspace.js";
 import type { RunStore } from "../store.js";
 import type { SecretInfo } from "../secret-store.js";
 import { lsSteps } from "./stepHelpers.js";
@@ -7,9 +7,12 @@ import { lsSteps } from "./stepHelpers.js";
 // ── Types ──────────────────────────────────────────────────────────────────
 
 export interface AiDeps {
-  workspace: WorkspaceManager;
+  workspace: WorkspaceStore;
   registry: StepRegistry;
   store: RunStore;
+  /** Local directory for cassettes (`run_step` record/replay). Optional:
+   *  without it, cassette modes report an error instead of recording. */
+  dataDir?: string;
   getRegistry: () => Promise<StepRegistry>;
   /** Whether custom-step publishing is allowed (false when the registry was
    *  injected at construction). Defaults to enabled when unset. */
@@ -25,8 +28,8 @@ export interface AiDeps {
    *  `list_secrets` tool degrades gracefully when absent. */
   secrets?: { list(): Promise<SecretInfo[]> };
   /** Build-time shell access for the chat builder's `bash` tool: commands run
-   *  with cwd at the workspace root (artifacts/, steps/_history/, and a
-   *  scratch/ dir for clones/experiments are all visible) under a SCRUBBED
+   *  with cwd at the server's data dir (artifacts/ and a scratch/ dir for
+   *  clones/experiments are visible) under a SCRUBBED
    *  env (see shell.ts — server API keys never reach model-authored
    *  commands). Optional: without it the bash tool isn't offered. */
   shell?: { cwd: string };

--- a/vein/src/ai/stepHelpers.ts
+++ b/vein/src/ai/stepHelpers.ts
@@ -1,16 +1,16 @@
 
-import { readdir, readFile, stat } from "node:fs/promises";
+import { readdir, stat } from "node:fs/promises";
 import { join } from "node:path";
 import { CORE_STEP_TYPES, LIB_DIR } from "../steps/registry.js";
 import type { StepRegistry } from "../core.js";
-import type { WorkspaceManager } from "../workspace.js";
+import type { WorkspaceStore } from "../workspace.js";
 
 /**
  * The subset of dependencies the step-explorer helpers need. Both the chat
  * builder's `AiDeps` and the authoring capability satisfy it structurally.
  */
 export interface StepExplorerDeps {
-  workspace: WorkspaceManager;
+  workspace: Pick<WorkspaceStore, "listSteps" | "getStepSource">;
   registry: StepRegistry;
 }
 
@@ -198,38 +198,15 @@ export async function searchSteps(query: string, deps: StepExplorerDeps) {
 }
 
 /**
- * Read the source code for a step. Looks in:
- *   - src/steps/lib/<...>.ts  (built-in lib steps)
- *   - <workspace>/steps/custom/<name>.ts  (user custom steps)
- * Returns undefined for core steps or anything not found.
+ * Read the source code for a lib or custom step through the workspace
+ * boundary. Returns undefined for core steps (the AI gets their schema and
+ * description instead) or anything the store has no source for.
  */
 export async function readStepSource(
   type: string,
   deps: StepExplorerDeps,
 ): Promise<string | undefined> {
   if (CORE_STEP_TYPES.includes(type)) return undefined;
-
-  const parts = type.split("/");
-  const candidates: string[] = [];
-
-  if (parts.length > 1) {
-    // Likely a lib step: src/steps/lib/<...>.ts
-    candidates.push(join(LIB_DIR, ...parts.slice(0, -1), `${parts.at(-1)}.ts`));
-    // Or a nested custom step: <workspace>/steps/custom/<...>.ts
-    candidates.push(
-      join(deps.workspace.path, "steps", "custom", ...parts.slice(0, -1), `${parts.at(-1)}.ts`),
-    );
-  } else {
-    // Flat custom step
-    candidates.push(join(deps.workspace.path, "steps", "custom", `${type}.ts`));
-  }
-
-  for (const file of candidates) {
-    try {
-      return await readFile(file, "utf-8");
-    } catch {
-      // try next
-    }
-  }
-  return undefined;
+  const found = await deps.workspace.getStepSource(type);
+  return found?.code;
 }

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -410,13 +410,16 @@ export function buildTools(deps: AiDeps) {
       execute: async ({ type, config, input, params, cassette, cassetteName }) => {
         const registry = deps.registry;
         if (!registry[type]) return { error: `Step type "${type}" not found` };
+        if (cassette && !deps.dataDir) {
+          return { error: "Cassette record/replay is unavailable (no local data dir configured)." };
+        }
         return runSingleStep(type, registry, deps.services, {
           config: coerceJsonArg(config) as Record<string, unknown> | undefined,
           input: coerceJsonArg(input),
           params: coerceJsonArg(params) as Record<string, unknown> | undefined,
           workspace: deps.workspace,
           ...(cassette
-            ? { cassette: { mode: cassette, path: cassettePath(deps.workspace.path, cassetteName ?? type) } }
+            ? { cassette: { mode: cassette, path: cassettePath(deps.dataDir!, cassetteName ?? type) } }
             : {}),
         });
       },
@@ -496,7 +499,7 @@ export function buildTools(deps: AiDeps) {
       ? {
           bash: tool({
             description:
-              "Execute a bash command in the workspace directory — for BUILD-TIME exploration while authoring: curl an API to see its real response shape before writing a step, clone a repo into scratch/ to inspect a data format, check a CLI exists, read a run's file outputs under artifacts/<runId>/. Commands run under a scrubbed environment (no server API keys — use placeholder values when probing an authed API, or author the step and run_step it with the real secret). This tool is NOT how production workflows reach the outside world: steps you author must still use ctx.services.http + ctx.services.secrets so runs stay recordable and secrets scrubbed. Output is captured with a cap; default timeout 30s (raise timeoutMs up to 10 min for clones/installs).",
+              "Execute a bash command in the server's data directory — for BUILD-TIME exploration while authoring: curl an API to see its real response shape before writing a step, clone a repo into scratch/ to inspect a data format, check a CLI exists, read a run's file outputs under artifacts/<runId>/. Commands run under a scrubbed environment (no server API keys — use placeholder values when probing an authed API, or author the step and run_step it with the real secret). This tool is NOT how production workflows reach the outside world: steps you author must still use ctx.services.http + ctx.services.secrets so runs stay recordable and secrets scrubbed. Output is captured with a cap; default timeout 30s (raise timeoutMs up to 10 min for clones/installs).",
             inputSchema: z.object({
               command: z.string().describe("The bash command to execute"),
               timeoutMs: z

--- a/vein/src/ai/tools.ts
+++ b/vein/src/ai/tools.ts
@@ -13,7 +13,6 @@ import { generateRunId } from "../store.js";
 // ownership gating — this surface is human-supervised).
 import {
   AI_PUBLISHER,
-  asReadStore,
   coerceJsonArg,
   listRunSummaries,
   publishNewStep,
@@ -436,14 +435,7 @@ export function buildTools(deps: AiDeps) {
           .describe("Max number of recent runs to return (default 20)."),
       }),
       execute: async ({ name, limit }) => {
-        const store = asReadStore(deps.store);
-        if (!store) {
-          return {
-            error:
-              "Run history is unavailable (the run store does not support reading back runs).",
-          };
-        }
-        return { workflow: name, runs: await listRunSummaries(store, name, limit) };
+        return { workflow: name, runs: await listRunSummaries(deps.store, name, limit) };
       },
     }),
 
@@ -459,14 +451,7 @@ export function buildTools(deps: AiDeps) {
           .describe("Include full per-step input/output payloads in events (default false: slimmed)."),
       }),
       execute: async ({ name, runId, fullEvents }) => {
-        const store = asReadStore(deps.store);
-        if (!store) {
-          return {
-            error:
-              "Run history is unavailable (the run store does not support reading back runs).",
-          };
-        }
-        return readRun(store, name, runId, fullEvents);
+        return readRun(deps.store, name, runId, fullEvents);
       },
     }),
 
@@ -501,14 +486,7 @@ export function buildTools(deps: AiDeps) {
         ignoreCase: z.boolean().default(true).describe("Case-insensitive matching (default true)."),
       }),
       execute: async ({ name, pattern, runIds, runLimit, maxMatches, ignoreCase }) => {
-        const store = asReadStore(deps.store);
-        if (!store) {
-          return {
-            error:
-              "Run history is unavailable (the run store does not support reading back runs).",
-          };
-        }
-        return searchRunEvents(store, name, pattern, { runIds, runLimit, maxMatches, ignoreCase });
+        return searchRunEvents(deps.store, name, pattern, { runIds, runLimit, maxMatches, ignoreCase });
       },
     }),
 

--- a/vein/src/authoring.ts
+++ b/vein/src/authoring.ts
@@ -36,26 +36,6 @@ export const AI_PUBLISHER = "ai";
 
 // ── Run-history reads (shared mechanism) ───────────────────────────────────
 
-// The run-history read methods live on `FileRunStore`, not the base `RunStore`
-// interface (which is write-only: append/finalize). `MemoryRunStore` lacks
-// them. Feature-detect so run-history reads degrade gracefully on stores that
-// can't read back (they return an error rather than throwing).
-export interface RunReadStore {
-  listRuns(workflow: string): Promise<string[]>;
-  getRunSummary(workflow: string, runId: string): Promise<RunSummary | null>;
-  getRunEvents(workflow: string, runId: string): Promise<RunEvent[]>;
-}
-
-export function asReadStore(store: unknown): RunReadStore | null {
-  const s = store as Partial<RunReadStore> | undefined;
-  return s &&
-    typeof s.listRuns === "function" &&
-    typeof s.getRunSummary === "function" &&
-    typeof s.getRunEvents === "function"
-    ? (s as RunReadStore)
-    : null;
-}
-
 /** Drop bulky input/output payloads from an event so a run's event list stays
  *  token-cheap; the caller can re-fetch a specific run's full events if needed. */
 export function slimEvent(e: RunEvent) {
@@ -69,12 +49,9 @@ export function slimEvent(e: RunEvent) {
   };
 }
 
-const NO_RUN_HISTORY_ERROR =
-  "Run history is unavailable (the run store does not support reading back runs).";
-
 /** List a workflow's recent runs (newest first) as slim summaries. */
 export async function listRunSummaries(
-  store: RunReadStore,
+  store: Pick<RunStore, "listRuns" | "getRunSummary" | "getRunEvents">,
   name: string,
   limit: number,
 ) {
@@ -95,7 +72,7 @@ export async function listRunSummaries(
 
 /** Read one run's summary + events (slimmed unless `fullEvents`). */
 export async function readRun(
-  store: RunReadStore,
+  store: Pick<RunStore, "listRuns" | "getRunSummary" | "getRunEvents">,
   name: string,
   runId: string,
   fullEvents: boolean,
@@ -154,7 +131,7 @@ const SNIPPET_AFTER = 160;
  * the run window rather than raising the cap.
  */
 export async function searchRunEvents(
-  store: RunReadStore,
+  store: Pick<RunStore, "listRuns" | "getRunSummary" | "getRunEvents">,
   name: string,
   pattern: string,
   opts: RunSearchOptions = {},
@@ -608,25 +585,19 @@ export function buildAuthoringCapability(deps: AuthoringDeps): AuthoringCapabili
     async listRuns(name, limit = 20) {
       const gate = await notOwned(name, "reads run history of");
       if (gate) return { error: gate };
-      const read = asReadStore(store);
-      if (!read) return { error: NO_RUN_HISTORY_ERROR };
-      return { workflow: name, runs: await listRunSummaries(read, name, limit) };
+      return { workflow: name, runs: await listRunSummaries(store, name, limit) };
     },
 
     async getRun(name, runId, fullEvents = false) {
       const gate = await notOwned(name, "reads run history of");
       if (gate) return { error: gate };
-      const read = asReadStore(store);
-      if (!read) return { error: NO_RUN_HISTORY_ERROR };
-      return readRun(read, name, runId, fullEvents);
+      return readRun(store, name, runId, fullEvents);
     },
 
     async searchRuns(name, pattern, opts) {
       const gate = await notOwned(name, "reads run history of");
       if (gate) return { error: gate };
-      const read = asReadStore(store);
-      if (!read) return { error: NO_RUN_HISTORY_ERROR };
-      return searchRunEvents(read, name, pattern, opts);
+      return searchRunEvents(store, name, pattern, opts);
     },
 
     async listSecrets() {

--- a/vein/src/authoring.ts
+++ b/vein/src/authoring.ts
@@ -1,6 +1,6 @@
 import { join } from "node:path";
 import type { RunEvent, RunResult, RunSummary, StepRegistry } from "./core.js";
-import type { WorkspaceManager } from "./workspace.js";
+import type { WorkspaceStore } from "./workspace.js";
 import type { RunStore } from "./store.js";
 import { generateRunId } from "./store.js";
 import { runWorkflow } from "./runner.js";
@@ -219,7 +219,7 @@ export function coerceJsonArg(v: unknown): unknown {
  *  structurally; the authoring capability builds its own. `getRegistry` must
  *  return a FRESH registry (re-scanned from the workspace). */
 export interface StepPublishDeps {
-  workspace: WorkspaceManager;
+  workspace: WorkspaceStore;
   getRegistry(): Promise<StepRegistry>;
   publishingEnabled?: boolean;
 }
@@ -246,7 +246,7 @@ async function verifyLoaded(
   const fresh = await deps.getRegistry();
   if (fresh[name]) return { loaded: true };
   const err = await stepLoadError(
-    join(deps.workspace.path, "steps", "custom", `${name}.ts`),
+    join(await deps.workspace.materializeCustomSteps(), `${name}.ts`),
   );
   return {
     loaded: false,
@@ -377,6 +377,9 @@ export interface AuthoringCapability {
 
 export interface AuthoringDeps extends StepPublishDeps {
   store: RunStore;
+  /** Local directory for step cassettes (`runStep` record/replay). Optional:
+   *  without it, cassette modes report an error instead of recording. */
+  dataDir?: string;
   /** Capabilities bag threaded into `runWorkflow` / `runStep` so authored
    *  steps reach `ctx.services` (http, secrets, and any consumer services). */
   services?: unknown;
@@ -474,6 +477,9 @@ export function buildAuthoringCapability(deps: AuthoringDeps): AuthoringCapabili
       // snapshot and would not contain it (EVOLVE_SPEC §5.3.1).
       const registry = await deps.getRegistry();
       if (!registry[type]) return { error: `Step type "${type}" not found` };
+      if (args.cassette && !deps.dataDir) {
+        return { error: "Cassette record/replay is unavailable (no local data dir configured)." };
+      }
       return runSingleStep(type, registry, deps.services, {
         config: coerceJsonArg(args.config) as Record<string, unknown> | undefined,
         input: coerceJsonArg(args.input),
@@ -483,7 +489,7 @@ export function buildAuthoringCapability(deps: AuthoringDeps): AuthoringCapabili
           ? {
               cassette: {
                 mode: args.cassette,
-                path: cassettePath(workspace.path, args.cassetteName ?? type),
+                path: cassettePath(deps.dataDir!, args.cassetteName ?? type),
               },
             }
           : {}),

--- a/vein/src/chat-store.ts
+++ b/vein/src/chat-store.ts
@@ -319,11 +319,25 @@ export class MemoryChatStore implements ChatStore {
     this.events.set(chatId, arr);
   }
 
-  async *tailEvents(chatId: string, turn: number): AsyncGenerator<ChatEvent> {
-    // Tests use this only for already-finished turns; replay what we have.
-    for (const e of this.events.get(chatId) ?? []) {
-      if (e.turn === turn) yield e;
-      if (e.turn === turn && isChatTerminal(e)) return;
+  /** Same contract as the file tail: replay the turn's history, then follow
+   *  live appends (index cursor + poll) until the turn's terminal event. */
+  async *tailEvents(
+    chatId: string,
+    turn: number,
+    opts: { intervalMs?: number; signal?: AbortSignal } = {},
+  ): AsyncGenerator<ChatEvent> {
+    const intervalMs = opts.intervalMs ?? 250;
+    let cursor = 0;
+    while (true) {
+      if (opts.signal?.aborted) return;
+      const log = this.events.get(chatId) ?? [];
+      while (cursor < log.length) {
+        const e = log[cursor++]!;
+        if (e.turn !== turn) continue;
+        yield e;
+        if (isChatTerminal(e)) return;
+      }
+      await new Promise((r) => setTimeout(r, intervalMs));
     }
   }
 

--- a/vein/src/createVein.test.ts
+++ b/vein/src/createVein.test.ts
@@ -468,15 +468,23 @@ describe("createVein", () => {
     assert.ok(text.includes("event: done"));
   });
 
-  it("refuses run streaming when the store is not a FileRunStore", async () => {
+  it("streams a completed run's events from a MemoryRunStore (no capability gate)", async () => {
     const vein = await createVein({
       workspace: new WorkspaceManager(tempDir),
       store: new MemoryRunStore(),
       serveUi: false,
       enableChat: false,
     });
-    const res = await vein.app.request("/workflows/x/runs/123/stream");
-    assert.equal(res.status, 501);
+    const wf = flow("mem-stream", {
+      input: z.object({}),
+      steps: [step("g", "log", { message: "hello" })],
+    });
+    const result = await vein.run(wf, {});
+    const res = await vein.app.request(`/workflows/mem-stream/runs/${result.runId}/stream`);
+    assert.equal(res.status, 200);
+    const text = await res.text();
+    assert.ok(text.includes("run.start"));
+    assert.ok(text.includes("event: done"));
   });
 
   it("rebuildRegistry is a no-op when the registry was injected", async () => {
@@ -501,7 +509,7 @@ describe("createVein", () => {
     assert.deepEqual(before, after);
   });
 
-  it("works with an in-memory store (no FileRunStore methods called)", async () => {
+  it("serves run history from an in-memory store (list, lookup, events)", async () => {
     const memStore = new MemoryRunStore();
     const vein = await createVein({
       workspace: new WorkspaceManager(tempDir),
@@ -518,10 +526,42 @@ describe("createVein", () => {
     const result = await vein.run(wf, {});
     assert.equal(result.status, "success");
 
-    // The /runs endpoint should refuse, not crash, when the store
-    // doesn't support listing.
-    const res = await vein.app.request("/workflows/mem-test/runs");
-    assert.equal(res.status, 501);
+    // Every read endpoint works over the memory store — it is a complete
+    // ephemeral backend, not a write-only stub.
+    const list = await vein.app.request("/workflows/mem-test/runs");
+    assert.equal(list.status, 200);
+    const runs = (await list.json()) as { runId: string; status: string }[];
+    assert.deepEqual(runs.map((r) => [r.runId, r.status]), [[result.runId, "success"]]);
+
+    const one = await vein.app.request(`/workflows/mem-test/runs/${result.runId}`);
+    assert.equal(one.status, 200);
+    assert.equal(((await one.json()) as { status: string }).status, "success");
+
+    const events = await vein.app.request(`/workflows/mem-test/runs/${result.runId}/events`);
+    assert.equal(events.status, 200);
+    const types = ((await events.json()) as { type: string }[]).map((e) => e.type);
+    assert.ok(types.includes("run.start") && types.includes("run.end"));
+
+    const missing = await vein.app.request("/workflows/mem-test/runs/nope");
+    assert.equal(missing.status, 404);
+  });
+
+  it("GET /workflows decorates entries with lastRunAt from the run store", async () => {
+    const ws = new WorkspaceManager(tempDir);
+    await ws.publishWorkflow("ran", "v1", { steps: [{ id: "g", type: "log", config: { message: "x" } }] });
+    await ws.publishWorkflow("never", "v1", { steps: [{ id: "g", type: "log", config: { message: "x" } }] });
+    const vein = await createVein({
+      workspace: ws,
+      store: new MemoryRunStore(),
+      serveUi: false,
+      enableChat: false,
+    });
+    const result = await vein.run("ran", {});
+    const res = await vein.app.request("/workflows");
+    const list = (await res.json()) as { name: string; lastRunAt?: number }[];
+    const byName = Object.fromEntries(list.map((w) => [w.name, w.lastRunAt]));
+    assert.equal(byName["ran"], Number(result.runId));
+    assert.equal(byName["never"], undefined);
   });
 
   it("resolves + applies a declared promotion (run output → target param)", async () => {

--- a/vein/src/createVein.test.ts
+++ b/vein/src/createVein.test.ts
@@ -9,6 +9,7 @@ import { z } from "zod";
 import { createVein } from "./createVein.js";
 import { createRegistry } from "./steps/registry.js";
 import { defineStep, flow, step } from "./core.js";
+import { pathlessWorkspace } from "./test-util/pathless-workspace.js";
 import { WorkspaceManager } from "./workspace.js";
 import { MemoryRunStore, FileRunStore } from "./store.js";
 
@@ -544,6 +545,41 @@ describe("createVein", () => {
 
     const missing = await vein.app.request("/workflows/mem-test/runs/nope");
     assert.equal(missing.status, 404);
+  });
+
+  it("a non-file WorkspaceStore gets in-memory store defaults and still loads custom steps", async () => {
+    const ws = pathlessWorkspace(new WorkspaceManager(tempDir));
+    // Import-free step source (the temp dir sits outside the project tree,
+    // so `import "vein"` wouldn't resolve — same trick as registry.test.ts).
+    await ws.publishStep(
+      "conf-step",
+      `export default {
+        type: "conf-step",
+        input: { _def: { typeName: 'ZodObject', shape: () => ({}) } },
+        output: { _def: { typeName: 'ZodAny' } },
+        async run() { return "ok"; },
+      };`,
+    );
+    const vein = await createVein({ workspace: ws, dataDir: join(tempDir, "data"), serveUi: false, enableChat: false });
+    assert.ok(vein.store instanceof MemoryRunStore, "run store defaults to memory for a non-file workspace");
+    assert.equal(vein.dataDir, join(tempDir, "data"));
+    assert.ok("conf-step" in vein.getRegistry(), "custom steps load via materializeCustomSteps()");
+    const health = (await (await vein.app.request("/health")).json()) as { dataDir: string };
+    assert.equal(health.dataDir, join(tempDir, "data"));
+    const meta = await vein.app.request("/workflows/nope");
+    assert.equal(meta.status, 404);
+  });
+
+  it("dataDir defaults to the file workspace root and is overridable", async () => {
+    const a = await createVein({ workspace: new WorkspaceManager(tempDir), serveUi: false, enableChat: false });
+    assert.equal(a.dataDir, tempDir);
+    const b = await createVein({
+      workspace: new WorkspaceManager(tempDir),
+      dataDir: join(tempDir, "elsewhere"),
+      serveUi: false,
+      enableChat: false,
+    });
+    assert.equal(b.dataDir, join(tempDir, "elsewhere"));
   });
 
   it("GET /workflows decorates entries with lastRunAt from the run store", async () => {

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -442,8 +442,17 @@ export async function createVein<TServices = unknown>(
   // ── Workflows ────────────────────────────────────────────────────────────
 
   app.get("/workflows", async (c) => {
+    // The workspace lists what it stores; the run store decorates with each
+    // workflow's newest run time. Composed here so neither layer reads the
+    // other's records.
     const workflows = await workspace.listWorkflows();
-    return c.json(workflows);
+    const decorated = await Promise.all(
+      workflows.map(async (w) => {
+        const lastRunAt = await store.lastRunAt(w.name);
+        return lastRunAt != null ? { ...w, lastRunAt } : w;
+      }),
+    );
+    return c.json(decorated);
   });
 
   app.post("/workflows", async (c) => {
@@ -502,9 +511,6 @@ export async function createVein<TServices = unknown>(
 
   app.get("/workflows/:name/runs", async (c) => {
     const name = c.req.param("name");
-    if (!(store instanceof FileRunStore)) {
-      return c.json({ error: "Run listing requires a FileRunStore" }, 501);
-    }
     const runIds = await store.listRuns(name);
     const runs = [];
     for (const runId of runIds) {
@@ -520,9 +526,6 @@ export async function createVein<TServices = unknown>(
 
   app.get("/workflows/:name/runs/:runId", async (c) => {
     const { name, runId } = c.req.param();
-    if (!(store instanceof FileRunStore)) {
-      return c.json({ error: "Run lookup requires a FileRunStore" }, 501);
-    }
     const summary = await store.getRunSummary(name, runId);
     if (summary) return c.json(summary);
     // No run.json — in-flight, or orphaned before finalize (crash/restart).
@@ -539,9 +542,6 @@ export async function createVein<TServices = unknown>(
 
   app.get("/workflows/:name/runs/:runId/events", async (c) => {
     const { name, runId } = c.req.param();
-    if (!(store instanceof FileRunStore)) {
-      return c.json({ error: "Event lookup requires a FileRunStore" }, 501);
-    }
     const events = await store.getRunEvents(name, runId);
     return c.json(events);
   });
@@ -549,12 +549,9 @@ export async function createVein<TServices = unknown>(
   // Reattach to a run (live or completed) — SSE tail of its event log.
   // Replays history from the start of the file, then follows appends until
   // the terminal event, then sends a final `done` carrying the RunResult.
-  // One path serves in-flight and finished runs (see `FileRunStore.tailEvents`).
+  // One path serves in-flight and finished runs (see `RunStore.tailEvents`).
   app.get("/workflows/:name/runs/:runId/stream", async (c) => {
     const { name, runId } = c.req.param();
-    if (!(store instanceof FileRunStore)) {
-      return c.json({ error: "Run streaming requires a FileRunStore" }, 501);
-    }
     return streamSSE(c, async (stream) => {
       const ac = new AbortController();
       stream.onAbort(() => ac.abort());
@@ -587,10 +584,8 @@ export async function createVein<TServices = unknown>(
    *  whether the run exists at all. */
   const findRun = async (name: string, runId: string) => {
     const controller = controllers.get(`${name}/${runId}`) ?? null;
-    const summary =
-      store instanceof FileRunStore ? await store.getRunSummary(name, runId) : null;
-    const events =
-      store instanceof FileRunStore ? await store.getRunEvents(name, runId) : [];
+    const summary = await store.getRunSummary(name, runId);
+    const events = await store.getRunEvents(name, runId);
     return { controller, summary, exists: controller != null || events.length > 0 };
   };
 
@@ -648,9 +643,6 @@ export async function createVein<TServices = unknown>(
     }
 
     // No controller → durable resume: journal replay (§5).
-    if (!(store instanceof FileRunStore)) {
-      return c.json({ error: "Durable resume requires a FileRunStore" }, 501);
-    }
     if (!exists) return c.json({ error: `Run "${runId}" not found` }, 404);
     if (summary?.status === "success" && !body.from) {
       return c.json(
@@ -728,9 +720,6 @@ export async function createVein<TServices = unknown>(
   // written until the human POSTs to `/promote`.
   app.get("/workflows/:name/runs/:runId/promotions", async (c) => {
     const { name, runId } = c.req.param();
-    if (!(store instanceof FileRunStore)) {
-      return c.json({ error: "Promotions require a FileRunStore" }, 501);
-    }
     let flow: Flow;
     try {
       flow = await workspace.getWorkflow(name);
@@ -776,9 +765,6 @@ export async function createVein<TServices = unknown>(
   // version + before/after.
   app.post("/workflows/:name/runs/:runId/promote", async (c) => {
     const { name, runId } = c.req.param();
-    if (!(store instanceof FileRunStore)) {
-      return c.json({ error: "Promotions require a FileRunStore" }, 501);
-    }
     const body = await c.req.json<{ to?: string }>();
     if (!body.to) return c.json({ error: "to is required" }, 400);
 

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 
 import type { Flow, StepRegistry, RunEvent, RunResult } from "./core.js";
 import type { RunStore } from "./store.js";
-import { FileRunStore, generateRunId, summarizeFromEvents } from "./store.js";
+import { FileRunStore, MemoryRunStore, generateRunId, summarizeFromEvents } from "./store.js";
 import type { ChatStore, ChatEvent } from "./chat-store.js";
 import {
   FileChatStore,
@@ -18,8 +18,8 @@ import {
   generateChatId,
   truncateToolMessages,
 } from "./chat-store.js";
-import { WorkspaceManager } from "./workspace.js";
-import { buildRegistry, readStepSourceFromDisk } from "./steps/registry.js";
+import { FileWorkspaceStore, type WorkspaceStore } from "./workspace.js";
+import { buildRegistry } from "./steps/registry.js";
 import { maxOutputTokensFor } from "./pricing.js";
 import type { StepSources } from "./steps/registry.js";
 import { runWorkflow } from "./runner.js";
@@ -49,14 +49,22 @@ import { createChatNotifier, formatRunNotification } from "./ai/notifier.js";
  * any subset to embed vein in your own app.
  */
 export interface VeinOptions<TServices = unknown> {
-  /** Persistent workspace for workflows/runs. Defaults to a new
-   *  `WorkspaceManager()` (reads `VEIN_WORKSPACE` env, falls back to
-   *  `./workspace`). */
-  workspace?: WorkspaceManager;
+  /** Persistent store for workflows and steps. Defaults to a new
+   *  `FileWorkspaceStore()` (reads `VEIN_WORKSPACE` env, falls back to
+   *  `./workspace`). Any `WorkspaceStore` implementation works. */
+  workspace?: WorkspaceStore;
+
+  /** Local directory for the inherently-local things: run artifacts,
+   *  step cassettes, the chat builder's shell cwd + scratch/. Defaults to
+   *  the file workspace's root (so a file-backed deployment keeps one
+   *  directory), else `VEIN_WORKSPACE` / `./workspace`. A non-file
+   *  workspace can point this at any scratch volume — losing it loses
+   *  blobs and cassettes, never workspace records. */
+  dataDir?: string;
 
   /** Step registry. If supplied, used as-is and `rebuildRegistry` becomes
    *  a no-op (the consumer owns step composition). If omitted, vein
-   *  discovers steps from disk via `buildRegistry(workspace.path)`. */
+   *  discovers steps via `buildRegistry(await workspace.materializeCustomSteps())`. */
   registry?: StepRegistry;
 
   /** Where to persist run events + summaries. Defaults to a `FileRunStore`
@@ -134,7 +142,9 @@ export interface Vein<TServices = unknown> {
   /** Hono app with all vein routes mounted. Mount under your own router
    *  with `parent.route("/vein", vein.app)`, or call `vein.listen(port)`. */
   app: Hono;
-  workspace: WorkspaceManager;
+  workspace: WorkspaceStore;
+  /** Resolved local data directory (see `VeinOptions.dataDir`). */
+  dataDir: string;
   store: RunStore;
   /** Deployment-scoped secret store backing `ctx.services.secrets` + the
    *  `/secrets` endpoints. */
@@ -293,8 +303,16 @@ function describeField(name: string, s: z.ZodTypeAny): FieldDesc {
 export async function createVein<TServices = unknown>(
   opts: VeinOptions<TServices> = {},
 ): Promise<Vein<TServices>> {
-  const workspace = opts.workspace ?? new WorkspaceManager();
-  const store = opts.store ?? new FileRunStore(workspace.path);
+  const workspace: WorkspaceStore = opts.workspace ?? new FileWorkspaceStore();
+  // Backend mode, used ONLY to pick unspecified defaults: the run/chat/secret
+  // stores follow the workspace's kind (file-backed → file stores under
+  // dataDir; anything else → in-memory). No capability is gated on it —
+  // every store is the full interface. An explicitly passed store always wins.
+  const fileBacked = workspace instanceof FileWorkspaceStore;
+  const dataDir =
+    opts.dataDir ??
+    (fileBacked ? workspace.path : (process.env["VEIN_WORKSPACE"] ?? "./workspace"));
+  const store = opts.store ?? (fileBacked ? new FileRunStore(dataDir) : new MemoryRunStore());
   // Controllers for runs currently executing **in this process** (keyed
   // `${workflow}/${runId}`) — RUN_CONTROL_SPEC §2.2. A controller's presence
   // IS "in-flight" (superseding the old `activeRuns` set): detached execution
@@ -349,9 +367,7 @@ export async function createVein<TServices = unknown>(
   // file store for the standard server, in-memory when runs are in-memory.
   const secretStore: SecretStore =
     opts.secretStore ??
-    (store instanceof FileRunStore
-      ? new FileSecretStore(workspace.path)
-      : new MemorySecretStore());
+    (fileBacked ? new FileSecretStore(dataDir) : new MemorySecretStore());
   // Did the consumer inject their own `secrets` capability? If so we leave it
   // alone and the `/secrets` endpoints (which manage *our* store) report 501.
   const secretsInjected =
@@ -365,9 +381,9 @@ export async function createVein<TServices = unknown>(
   // existing out of the box.
   const services = {
     ...(standardServices({ secretStore }) as unknown as Record<string, unknown>),
-    // Per-run artifact files, rooted in the workspace. A consumer bag can
-    // override with its own ArtifactsCapability (spread below wins).
-    artifacts: fileArtifactsCapability(join(workspace.path, "artifacts")),
+    // Per-run artifact files, rooted in the local data dir. A consumer bag
+    // can override with its own ArtifactsCapability (spread below wins).
+    artifacts: fileArtifactsCapability(join(dataDir, "artifacts")),
     ...((opts.services ?? {}) as Record<string, unknown>),
   } as TServices;
   const artifacts = (services as Record<string, unknown>)["artifacts"] as
@@ -376,10 +392,7 @@ export async function createVein<TServices = unknown>(
   const serveUi = opts.serveUi ?? true;
   const enableChat = opts.enableChat ?? true;
   const chatStore: ChatStore =
-    opts.chatStore ??
-    (store instanceof FileRunStore
-      ? new FileChatStore(workspace.path)
-      : new MemoryChatStore());
+    opts.chatStore ?? (fileBacked ? new FileChatStore(dataDir) : new MemoryChatStore());
   const chatMaxSteps =
     opts.chatMaxSteps ?? Number(process.env["VEIN_CHAT_MAX_STEPS"] ?? 100);
   const chatModel =
@@ -404,7 +417,7 @@ export async function createVein<TServices = unknown>(
 
   async function rebuildRegistry(): Promise<void> {
     if (registryWasInjected) return; // consumer owns the registry
-    const bundle = await buildRegistry(workspace.path);
+    const bundle = await buildRegistry(await workspace.materializeCustomSteps());
     registry = bundle.registry;
     stepSources = bundle.sources;
   }
@@ -424,6 +437,7 @@ export async function createVein<TServices = unknown>(
   if (!(services as Record<string, unknown>)["authoring"]) {
     (services as Record<string, unknown>)["authoring"] = buildAuthoringCapability({
       workspace,
+      dataDir,
       store,
       services,
       trackRun,
@@ -498,15 +512,9 @@ export async function createVein<TServices = unknown>(
 
   app.get("/workflows/:name", async (c) => {
     const name = c.req.param("name");
-    try {
-      const meta = await readFile(
-        join(workspace.path, "workflows", name, "_metadata.json"),
-        "utf-8",
-      );
-      return c.json(JSON.parse(meta));
-    } catch {
-      return c.json({ error: `Workflow "${name}" not found` }, 404);
-    }
+    const meta = await workspace.getWorkflowMetadata(name);
+    if (!meta) return c.json({ error: `Workflow "${name}" not found` }, 404);
+    return c.json(meta);
   });
 
   app.get("/workflows/:name/runs", async (c) => {
@@ -991,8 +999,8 @@ export async function createVein<TServices = unknown>(
   });
 
   // Source code for a step. In-code steps (injected via createRegistry) carry
-  // their source on the def; everything else is read from disk
-  // (core / lib / workspace custom). `source` is null when none is available.
+  // their source on the def; everything else comes through the workspace
+  // boundary (core / lib / custom). `source` is null when none is available.
   app.get("/steps/:type{.+}/source", async (c) => {
     const type = c.req.param("type");
     const def = registry[type];
@@ -1000,11 +1008,11 @@ export async function createVein<TServices = unknown>(
     if (def.source) {
       return c.json({ type, source: def.source, origin: "registry" });
     }
-    const onDisk = await readStepSourceFromDisk(type, workspace.path);
+    const found = await workspace.getStepSource(type);
     return c.json({
       type,
-      source: onDisk?.code ?? null,
-      origin: onDisk?.origin ?? null,
+      source: found?.code ?? null,
+      origin: found?.origin ?? null,
     });
   });
 
@@ -1107,7 +1115,7 @@ export async function createVein<TServices = unknown>(
       params: body.params,
       workspace,
       ...(mode
-        ? { cassette: { mode, path: cassettePath(workspace.path, body.cassetteName ?? type) } }
+        ? { cassette: { mode, path: cassettePath(dataDir, body.cassetteName ?? type) } }
         : {}),
     });
     return c.json(result);
@@ -1259,18 +1267,19 @@ export async function createVein<TServices = unknown>(
 
           const deps = {
             workspace,
+            dataDir,
             registry,
             store,
             services,
             secrets: secretsInjected ? undefined : secretStore,
-            // Build-time bash for the chat builder, cwd'd at the workspace
-            // root (scrubbed env — see shell.ts).
-            shell: { cwd: workspace.path },
+            // Build-time bash for the chat builder, cwd'd at the local data
+            // dir (scrubbed env — see shell.ts).
+            shell: { cwd: dataDir },
             webSearch: true,
             publishingEnabled: !registryWasInjected,
             getRegistry: async () => {
               if (registryWasInjected) return registry;
-              const bundle = await buildRegistry(workspace.path);
+              const bundle = await buildRegistry(await workspace.materializeCustomSteps());
               registry = bundle.registry;
               stepSources = bundle.sources;
               return bundle.registry;
@@ -1503,7 +1512,7 @@ export async function createVein<TServices = unknown>(
   app.get("/health", (c) => {
     return c.json({
       ok: true,
-      workspace: workspace.path,
+      dataDir,
       stepCount: Object.keys(registry).length,
     });
   });
@@ -1580,7 +1589,11 @@ export async function createVein<TServices = unknown>(
   async function listen(port?: number): Promise<number> {
     warnIfUnconfigured();
     const p = port ?? parseInt(process.env["VEIN_PORT"] ?? "3000", 10);
-    console.log(`vein workspace: ${workspace.path}`);
+    console.log(
+      fileBacked
+        ? `vein workspace: ${dataDir}`
+        : `vein workspace: ${workspace.constructor.name} (data dir: ${dataDir})`,
+    );
     console.log(`vein steps: ${Object.keys(registry).length} registered`);
     console.log(`vein server: http://localhost:${p}`);
     serve({ fetch: app.fetch, port: p });
@@ -1590,6 +1603,7 @@ export async function createVein<TServices = unknown>(
   return {
     app,
     workspace,
+    dataDir,
     store,
     secretStore,
     services,

--- a/vein/src/graph/projector.test.ts
+++ b/vein/src/graph/projector.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import type { RunEvent } from "../core.js";
+import { MemoryRunStore } from "../store.js";
+import { MemoryChatStore } from "../chat-store.js";
+import { openGraphBackend, type GraphBackend } from "./backend.js";
+import { seedVeinDomain } from "./schema-seed.js";
+import { testGraphConfig, wipeGraph } from "./test-util.js";
+import { Neo4jWorkspaceStore } from "./workspace-store.js";
+import { messageText, preview, projectAll, projectChats, projectRunEvents, projectRuns, spawnedRunIds } from "./projector.js";
+
+const cfg = testGraphConfig();
+let backend: GraphBackend;
+
+const WF = "harvey-deliver";
+const RUN = "1788307097627";
+const T0 = Date.parse("2026-09-01T20:00:00Z");
+const ts = (i: number) => new Date(T0 + i * 1000).toISOString();
+const ev = (i: number, type: RunEvent["type"], path: string, extra: Partial<RunEvent> = {}): RunEvent => ({
+  ts: ts(i),
+  runId: RUN,
+  path,
+  type,
+  ...extra,
+});
+
+/** A run with one agent step that made two tool calls, then finished. */
+function sampleEvents(workflowHash: string): RunEvent[] {
+  return [
+    ev(0, "run.start", WF, { input: { q: "deliver" }, workflowHash, params: { model: "m" } }),
+    ev(1, "step.start", `${WF}/plan`, { stepType: "agent", input: { prompt: "Plan the delivery", model: "claude" } }),
+    ev(2, "step.start", `${WF}/plan/001-search`, { stepType: "tool:graph/graph-search", input: { query: "docs" } }),
+    ev(3, "step.end", `${WF}/plan/001-search`, { stepType: "tool:graph/graph-search", output: { hits: 3 }, durationMs: 800 }),
+    ev(4, "step.start", `${WF}/plan/002-read`, { stepType: "tool:read", input: { id: "x" } }),
+    ev(5, "step.error", `${WF}/plan/002-read`, { stepType: "tool:read", error: { message: "not found" }, durationMs: 10 }),
+    ev(6, "step.end", `${WF}/plan`, { stepType: "agent", output: "Plan: ship it", durationMs: 5000 }),
+    ev(7, "step.start", `${WF}/ship`, { stepType: "log" }),
+    ev(8, "step.end", `${WF}/ship`, { stepType: "log", output: "shipped" }),
+    ev(9, "run.end", WF, { output: { delivered: 60 } }),
+  ];
+}
+
+describe("projectRunEvents (pure)", () => {
+  it("derives run, session, and tool-call nodes with previews and log refs", () => {
+    const p = projectRunEvents(WF, RUN, sampleEvents("abc123def456"), null)!;
+    assert.equal(p.run.type, "VeinRun");
+    assert.equal(p.run.data["status"], "success");
+    assert.equal(p.run.data["workflow_hash"], "abc123def456");
+    assert.equal(p.run.data["params_json"], '{"model":"m"}');
+    assert.equal(p.run.data["log_ref"], `${WF}/${RUN}`);
+    assert.equal(p.run.data["input_preview"], '{"q":"deliver"}');
+    assert.equal(p.workflowHash, "abc123def456");
+
+    assert.equal(p.sessions.length, 1);
+    assert.equal(p.sessions[0]!.data["prompt_preview"], "Plan the delivery");
+    assert.equal(p.sessions[0]!.data["result_preview"], "Plan: ship it");
+    assert.equal(p.sessions[0]!.data["model"], "claude");
+    assert.equal(p.sessions[0]!.data["duration_ms"], 5000);
+
+    assert.deepEqual(
+      p.toolCalls.map((t) => [t.node.data["seq"], t.node.data["tool_name"], t.node.data["error_message"], t.sessionPath]),
+      [
+        [1, "graph/graph-search", undefined, `${WF}/plan`],
+        [2, "read", "not found", `${WF}/plan`],
+      ],
+    );
+  });
+
+  it("uses the summary when present, and marks a finalize-less log stale", () => {
+    const events = sampleEvents("h").slice(0, 3);
+    assert.equal(projectRunEvents(WF, RUN, events, null)!.run.data["status"], "stale");
+    const withSummary = projectRunEvents(WF, RUN, events, {
+      runId: RUN,
+      workflow: WF,
+      startedAt: ts(0),
+      finishedAt: ts(9),
+      durationMs: 9000,
+      status: "error",
+      input: {},
+      error: { message: "boom" },
+    })!;
+    assert.equal(withSummary.run.data["status"], "error");
+    assert.equal(withSummary.run.data["error_message"], "boom");
+    assert.equal(withSummary.run.data["summary"], "error: boom");
+    assert.equal(projectRunEvents(WF, RUN, [], null), null);
+  });
+
+  it("preview caps length; messageText + spawnedRunIds read transcripts", () => {
+    assert.equal(preview("x".repeat(600))!.length, 500);
+    assert.equal(preview({ a: 1 }), '{"a":1}');
+    assert.equal(preview(undefined), undefined);
+    assert.equal(messageText([{ type: "text", text: "hi" }, { type: "text", text: "there" }]), "hi\nthere");
+    assert.equal(messageText("plain"), "plain");
+    assert.deepEqual(
+      spawnedRunIds([
+        { role: "user", content: "go" },
+        { role: "tool", content: [{ type: "tool-result", toolName: "run_workflow", output: { type: "json", value: { runId: "1", status: "success" } } }] },
+        { role: "tool", content: [{ type: "tool-result", toolName: "list_runs", output: { runs: [{ runId: "99" }] } }] },
+      ]),
+      ["1"],
+    );
+  });
+});
+
+describe("projector (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4J_URI not set" }, () => {
+  let store: MemoryRunStore;
+  let ws: Neo4jWorkspaceStore;
+
+  before(async () => {
+    backend = await openGraphBackend(cfg!, { embeddings: false, skipBoot: true });
+  });
+  after(async () => {
+    await backend.close();
+  });
+  beforeEach(async () => {
+    await wipeGraph(backend.bolt);
+    await seedVeinDomain(backend.bolt);
+    store = new MemoryRunStore();
+    ws = new Neo4jWorkspaceStore(backend);
+    await ws.publishWorkflow(WF, "v1", { steps: [{ id: "plan", type: "agent", config: {} }] });
+  });
+
+  const count = async (label: string) =>
+    Number((await backend.bolt.run(`MATCH (n:\`${label}\`) RETURN count(n) AS c`))[0]!["c"]);
+  const edges = async (edge: string) =>
+    Number((await backend.bolt.run(`MATCH (:Data_Bank)-[r:\`${edge}\`]->(:Data_Bank) RETURN count(r) AS c`))[0]!["c"]);
+
+  it("projects runs into VeinRun / VeinAgentSession / VeinToolCall with IN_RUN, IN_SESSION, EXECUTED edges", async () => {
+    const hash = (await ws.getWorkflowHash(WF))!;
+    for (const e of sampleEvents(hash)) await store.append(WF, RUN, e);
+    await store.finalize(WF, RUN, {
+      runId: RUN, workflow: WF, startedAt: ts(0), finishedAt: ts(9), durationMs: 9000, status: "success", input: { q: "deliver" }, output: { delivered: 60 },
+    });
+
+    const report = await projectRuns(backend, store, { workflows: [WF] });
+    assert.deepEqual([report.runs, report.sessions, report.toolCalls, report.edges, report.skipped], [1, 1, 2, 4, 0]);
+    assert.equal(await count("VeinRun"), 1);
+    assert.equal(await count("VeinAgentSession"), 1);
+    assert.equal(await count("VeinToolCall"), 2);
+    assert.equal(await edges("IN_RUN"), 1);
+    assert.equal(await edges("IN_SESSION"), 2);
+    assert.equal(await edges("EXECUTED"), 1);
+
+    const run = (await backend.bolt.run(`MATCH (r:VeinRun) RETURN properties(r) AS p`))[0]!["p"] as Record<string, unknown>;
+    assert.equal(run["status"], "success");
+    assert.equal(run["output_preview"], '{"delivered":60}');
+    assert.equal(run["unique_source_id"], `veinrun:${RUN}`);
+    assert.equal(run["started_at"], Math.floor(T0 / 1000));
+    assert.equal(run["duration_ms"], 9000);
+
+    // "which runs executed this version" is one hop.
+    const rows = await backend.bolt.run(
+      `MATCH (r:VeinRun)-[:EXECUTED]->(v:VeinWorkflowVersion)<-[:ACTIVE_VERSION]-(w:VeinWorkflow) RETURN w.name AS wf, r.run_id AS run`,
+    );
+    assert.deepEqual(rows, [{ wf: WF, run: RUN }]);
+  });
+
+  it("is idempotent, skips settled runs, and re-projects an unsettled run once it finalizes", async () => {
+    const events = sampleEvents("h");
+    for (const e of events.slice(0, 7)) await store.append(WF, RUN, e); // no terminal event yet
+    let report = await projectRuns(backend, store, { workflows: [WF] });
+    assert.equal(report.runs, 1);
+    let run = (await backend.bolt.run(`MATCH (r:VeinRun) RETURN r.status AS s, r.ref_id AS id`))[0]!;
+    assert.equal(run["s"], "stale");
+
+    // Re-run with nothing new: the stale run is re-read (not settled), same nodes.
+    report = await projectRuns(backend, store, { workflows: [WF] });
+    assert.equal(report.runs, 1);
+    assert.equal(await count("VeinRun"), 1);
+    assert.equal(await count("VeinToolCall"), 2);
+    assert.equal(await edges("IN_SESSION"), 2);
+
+    for (const e of events.slice(7)) await store.append(WF, RUN, e);
+    await store.finalize(WF, RUN, {
+      runId: RUN, workflow: WF, startedAt: ts(0), finishedAt: ts(9), durationMs: 9000, status: "success", input: {},
+    });
+    report = await projectRuns(backend, store, { workflows: [WF] });
+    const after = (await backend.bolt.run(`MATCH (r:VeinRun) RETURN r.status AS s, r.ref_id AS id`))[0]!;
+    assert.equal(after["s"], "success");
+    assert.equal(after["id"], run["id"], "upsert keeps the node identity");
+
+    report = await projectRuns(backend, store, { workflows: [WF] });
+    assert.deepEqual([report.runs, report.skipped], [0, 1], "settled runs are skipped");
+    report = await projectRuns(backend, store, { workflows: [WF], skipSettled: false });
+    assert.deepEqual([report.runs, report.skipped], [1, 0]);
+    assert.equal(await count("VeinRun"), 1);
+  });
+
+  it("projects chats and turns with IN_CHAT edges and SPAWNED edges to runs the chat launched", async () => {
+    for (const e of sampleEvents("h")) await store.append(WF, RUN, e);
+    const chats = new MemoryChatStore();
+    await chats.createChat({ id: "c1", title: "Deliver", model: "claude" });
+    await chats.appendMessages("c1", [
+      { role: "user", content: "run the delivery" },
+      { role: "assistant", content: [{ type: "tool-call", toolName: "run_workflow", input: { name: WF } }] },
+      { role: "tool", content: [{ type: "tool-result", toolName: "run_workflow", output: { type: "json", value: { runId: RUN, status: "success" } } }] },
+      { role: "assistant", content: [{ type: "text", text: "Done — 60 delivered." }] },
+      { role: "user", content: "thanks" },
+      { role: "assistant", content: "Any time." },
+    ]);
+
+    const report = await projectAll(backend, { store, chatStore: chats, workflows: [WF] });
+    assert.deepEqual([report.runs, report.chats, report.turns], [1, 1, 2]);
+    assert.equal(await edges("IN_CHAT"), 2);
+    assert.equal(await edges("SPAWNED"), 1);
+    const turns = await backend.bolt.run(`MATCH (t:VeinTurn) RETURN t.turn AS n, t.user_text_preview AS u, t.assistant_text_preview AS a ORDER BY n`);
+    assert.deepEqual(turns, [
+      { n: 0, u: "run the delivery", a: "Done — 60 delivered." },
+      { n: 1, u: "thanks", a: "Any time." },
+    ]);
+    const chain = await backend.bolt.run(`MATCH (c:VeinChat)-[:SPAWNED]->(r:VeinRun)<-[:IN_RUN]-(s:VeinAgentSession)<-[:IN_SESSION]-(t:VeinToolCall) RETURN count(t) AS c`);
+    assert.equal(chain[0]!["c"], 2, "chat → run → session → tool call provenance chain");
+
+    // Idempotent.
+    await projectChats(backend, chats);
+    assert.equal(await count("VeinChat"), 1);
+    assert.equal(await count("VeinTurn"), 2);
+    assert.equal(await edges("IN_CHAT"), 2);
+  });
+});

--- a/vein/src/graph/projector.ts
+++ b/vein/src/graph/projector.ts
@@ -1,0 +1,378 @@
+/**
+ * Run + chat PROJECTOR (plans/generic-storage.md §7): a post-hoc consumer of
+ * any `RunStore` / `ChatStore` that builds the graph's picture of usage —
+ * `VeinRun`, `VeinAgentSession`, `VeinToolCall`, `VeinChat`, `VeinTurn`
+ * nodes and the `EXECUTED` / `IN_RUN` / `IN_SESSION` / `SPAWNED` /
+ * `IN_CHAT` edges — with summaries and a `log_ref` pointer back to the raw
+ * log, never full payloads.
+ *
+ * The raw log stays the store of record (tailing, resume, replay); this is
+ * the queryable skeleton on top. Zero coupling to the hot path: run it at
+ * boot, on a schedule, as a workflow, or by hand, and re-run it whenever the
+ * edge vocabulary grows — every write is an idempotent `upsert` keyed by
+ * the node's identity (`unique_source_id` stamped for cheap reconciliation).
+ *
+ * Not projected (v2, "provenance convention"): `ACCESSED` edges from tool
+ * calls to the domain nodes they touched — the log has no structured record
+ * of those yet. `PROMOTED_FROM` likewise: promotions publish a new version
+ * without recording the source run.
+ */
+import type { RunEvent, RunSummary } from "../core.js";
+import type { RunStore } from "../store.js";
+import type { ChatStore, StoredMessage } from "../chat-store.js";
+import type { GraphBackend } from "./backend.js";
+import type { NodeInput } from "./node-writer.js";
+import type { EdgeInput } from "./edge-writer.js";
+import { PREVIEW_MAX_CHARS } from "./vein-schemas.js";
+
+export interface ProjectRunsOptions {
+  /** Workflows to project. Default: every workflow with runs is unknown to a
+   *  bare store, so callers pass the list (e.g. from `workspace.listWorkflows`). */
+  workflows: string[];
+  /** Newest N runs per workflow (default: all). */
+  limitPerWorkflow?: number;
+  /** Skip runs the graph already holds with a terminal status (cheap
+   *  incremental re-runs; default true). Pass false to force re-projection. */
+  skipSettled?: boolean;
+}
+
+export interface ProjectReport {
+  runs: number;
+  sessions: number;
+  toolCalls: number;
+  chats: number;
+  turns: number;
+  edges: number;
+  skipped: number;
+}
+
+const emptyReport = (): ProjectReport => ({ runs: 0, sessions: 0, toolCalls: 0, chats: 0, turns: 0, edges: 0, skipped: 0 });
+
+/** A bounded text preview of any value — the only shape of payload that
+ *  reaches the graph. */
+export function preview(v: unknown, max = PREVIEW_MAX_CHARS): string | undefined {
+  if (v === undefined || v === null) return undefined;
+  const s = typeof v === "string" ? v : JSON.stringify(v);
+  if (!s) return undefined;
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
+function compact(o: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(o)) if (v !== undefined && v !== null && v !== "") out[k] = v;
+  return out;
+}
+
+const TERMINAL = new Set(["run.end", "run.error", "run.cancelled"]);
+
+function isTerminalStatus(s: unknown): boolean {
+  return s === "success" || s === "error" || s === "cancelled";
+}
+
+/** Status of a run from its summary, else from the last terminal event in
+ *  the log, else "stale" (never finalized — crashed or still in flight). */
+function runStatus(summary: RunSummary | null, events: RunEvent[]): string {
+  if (summary) return summary.status;
+  for (let i = events.length - 1; i >= 0; i--) {
+    const e = events[i]!;
+    if (e.type === "run.resumed") return "stale";
+    if (e.type === "run.end") return "success";
+    if (e.type === "run.error") return "error";
+    if (e.type === "run.cancelled") return "cancelled";
+  }
+  return "stale";
+}
+
+interface RunProjection {
+  run: NodeInput;
+  sessions: NodeInput[];
+  toolCalls: Array<{ node: NodeInput; sessionPath: string }>;
+  workflowHash?: string;
+}
+
+/** Pure: the nodes one run contributes (no graph access). */
+export function projectRunEvents(workflow: string, runId: string, events: RunEvent[], summary: RunSummary | null): RunProjection | null {
+  if (events.length === 0 && !summary) return null;
+  const start = events.find((e) => e.type === "run.start");
+  const status = runStatus(summary, events);
+  const lastError = [...events].reverse().find((e) => e.type === "step.error" || e.type === "run.error")?.error;
+  const stepEnds = events.filter((e) => e.type === "step.end").length;
+  const durationMs = summary?.durationMs;
+  const errorMessage = summary?.error?.message ?? lastError?.message;
+  const summaryText = errorMessage
+    ? `${status}: ${errorMessage}`.slice(0, PREVIEW_MAX_CHARS)
+    : `${status} · ${stepEnds} step${stepEnds === 1 ? "" : "s"} completed${durationMs != null ? ` in ${durationMs}ms` : ""}`;
+  const logRef = `${workflow}/${runId}`;
+
+  const run: NodeInput = {
+    type: "VeinRun",
+    data: compact({
+      run_id: runId,
+      workflow_name: workflow,
+      status,
+      summary: summaryText,
+      started_at: summary?.startedAt ?? start?.ts ?? events[0]?.ts ?? new Date(Number(runId) || Date.now()).toISOString(),
+      finished_at: summary?.finishedAt,
+      duration_ms: durationMs,
+      workflow_hash: start?.workflowHash,
+      params_json: start?.params ? JSON.stringify(start.params) : undefined,
+      input_preview: preview(summary?.input ?? start?.input),
+      output_preview: preview(summary?.output),
+      error_message: errorMessage,
+      log_ref: logRef,
+      unique_source_id: `veinrun:${runId}`,
+    }),
+  };
+
+  // Agent sessions: every `agent` step.start, paired with its end/error at
+  // the same path (+ iteration).
+  const sessions: NodeInput[] = [];
+  const sessionPaths: string[] = [];
+  const keyOf = (e: RunEvent) => `${e.path}${e.iteration != null ? `#${e.iteration}` : ""}`;
+  const ends = new Map<string, RunEvent>();
+  for (const e of events) if ((e.type === "step.end" || e.type === "step.error") && e.stepType === "agent") ends.set(keyOf(e), e);
+  for (const e of events) {
+    if (e.type !== "step.start" || e.stepType !== "agent") continue;
+    const end = ends.get(keyOf(e));
+    const input = (e.input ?? {}) as Record<string, unknown>;
+    sessionPaths.push(e.path);
+    sessions.push({
+      type: "VeinAgentSession",
+      data: compact({
+        run_id: runId,
+        path: keyOf(e),
+        step_type: e.stepType,
+        model: typeof input["model"] === "string" ? input["model"] : undefined,
+        iteration: e.iteration,
+        prompt_preview: preview(input["prompt"] ?? input["system"] ?? e.input),
+        result_preview: preview(end?.output),
+        started_at: e.ts,
+        duration_ms: end?.durationMs,
+        error_message: end?.error?.message,
+        log_ref: logRef,
+        unique_source_id: `veinagentsession:${runId}:${keyOf(e)}`,
+      }),
+    });
+  }
+
+  // Tool calls: `tool:<name>` steps nested under a session path, numbered
+  // per session in log order.
+  const toolCalls: RunProjection["toolCalls"] = [];
+  const seqBySession = new Map<string, number>();
+  const toolEnds = new Map<string, RunEvent>();
+  for (const e of events) if ((e.type === "step.end" || e.type === "step.error") && e.stepType?.startsWith("tool:")) toolEnds.set(keyOf(e), e);
+  for (const e of events) {
+    if (e.type !== "step.start" || !e.stepType?.startsWith("tool:")) continue;
+    const session = sessionPaths.filter((p) => e.path.startsWith(`${p}/`)).sort((a, b) => b.length - a.length)[0];
+    if (!session) continue;
+    const seq = (seqBySession.get(session) ?? 0) + 1;
+    seqBySession.set(session, seq);
+    const end = toolEnds.get(keyOf(e));
+    toolCalls.push({
+      sessionPath: session,
+      node: {
+        type: "VeinToolCall",
+        data: compact({
+          run_id: runId,
+          path: keyOf(e),
+          seq,
+          tool_name: e.stepType.slice("tool:".length),
+          input_preview: preview(e.input),
+          output_preview: preview(end?.output),
+          started_at: e.ts,
+          duration_ms: end?.durationMs,
+          error_message: end?.error?.message,
+          log_ref: logRef,
+          unique_source_id: `veintoolcall:${runId}:${keyOf(e)}:${seq}`,
+        }),
+      },
+    });
+  }
+
+  return { run, sessions, toolCalls, workflowHash: start?.workflowHash };
+}
+
+/** Project runs from a `RunStore` into the graph. */
+export async function projectRuns(backend: GraphBackend, store: RunStore, opts: ProjectRunsOptions): Promise<ProjectReport> {
+  const report = emptyReport();
+  const ns = backend.cfg.namespace;
+  for (const workflow of opts.workflows) {
+    let runIds = await store.listRuns(workflow);
+    if (opts.limitPerWorkflow != null) runIds = runIds.slice(0, opts.limitPerWorkflow);
+    if (runIds.length === 0) continue;
+
+    // Settled runs already in the graph don't need re-reading.
+    let settled = new Set<string>();
+    if (opts.skipSettled !== false) {
+      const rows = await backend.bolt.run(
+        `MATCH (r:VeinRun {namespace: $ns, workflow_name: $wf}) WHERE r.run_id IN $ids RETURN r.run_id AS id, r.status AS status`,
+        { ns, wf: workflow, ids: runIds },
+      );
+      settled = new Set(rows.filter((r) => isTerminalStatus(r["status"])).map((r) => r["id"] as string));
+    }
+
+    for (const runId of runIds) {
+      if (settled.has(runId)) {
+        report.skipped++;
+        continue;
+      }
+      const [events, summary] = await Promise.all([store.getRunEvents(workflow, runId), store.getRunSummary(workflow, runId)]);
+      const p = projectRunEvents(workflow, runId, events, summary);
+      if (!p) continue;
+
+      const nodes = [p.run, ...p.sessions, ...p.toolCalls.map((t) => t.node)];
+      const written = await backend.nodes.writeMany(nodes, "upsert");
+      const runRef = written[0]!.ref_id;
+      const sessionRef = new Map<string, string>();
+      p.sessions.forEach((s, i) => sessionRef.set(String(s.data["path"]).replace(/#\d+$/, ""), written[1 + i]!.ref_id));
+      report.runs++;
+      report.sessions += p.sessions.length;
+      report.toolCalls += p.toolCalls.length;
+
+      const edges: EdgeInput[] = [];
+      p.sessions.forEach((s) => {
+        const ref = sessionRef.get(String(s.data["path"]).replace(/#\d+$/, ""))!;
+        edges.push({ edge: "IN_RUN", source_ref_id: ref, target_ref_id: runRef });
+      });
+      p.toolCalls.forEach((t, i) => {
+        const ref = written[1 + p.sessions.length + i]!.ref_id;
+        edges.push({ edge: "IN_SESSION", source_ref_id: ref, target_ref_id: sessionRef.get(t.sessionPath)! });
+      });
+      if (p.workflowHash) {
+        const rows = await backend.bolt.run(
+          `MATCH (v:VeinWorkflowVersion {namespace: $ns, name: $wf, content_hash: $h}) RETURN v.ref_id AS ref_id LIMIT 1`,
+          { ns, wf: workflow, h: p.workflowHash },
+        );
+        if (rows.length) edges.push({ edge: "EXECUTED", source_ref_id: runRef, target_ref_id: rows[0]!["ref_id"] as string });
+      }
+      if (edges.length) {
+        await backend.edges.writeMany(edges);
+        report.edges += edges.length;
+      }
+    }
+  }
+  return report;
+}
+
+// ── Chats ─────────────────────────────────────────────────────────────────
+
+/** Plain text of a stored message's content (string, or AI-SDK parts). */
+export function messageText(content: unknown): string | undefined {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    const texts = content
+      .map((p) => (p && typeof p === "object" && typeof (p as Record<string, unknown>)["text"] === "string" ? (p as Record<string, unknown>)["text"] : ""))
+      .filter(Boolean);
+    return texts.length ? texts.join("\n") : undefined;
+  }
+  return undefined;
+}
+
+/** Run ids launched from this transcript: every `run_workflow` tool result
+ *  carrying a `runId` (deep search — the tool-result envelope shape varies
+ *  by SDK version). */
+export function spawnedRunIds(messages: StoredMessage[]): string[] {
+  const ids = new Set<string>();
+  const findRunId = (v: unknown, depth = 0): string | undefined => {
+    if (!v || typeof v !== "object" || depth > 8) return undefined;
+    const o = v as Record<string, unknown>;
+    if (typeof o["runId"] === "string") return o["runId"];
+    for (const x of Object.values(o)) {
+      const r = findRunId(x, depth + 1);
+      if (r) return r;
+    }
+    return undefined;
+  };
+  const walk = (v: unknown, depth = 0): void => {
+    if (!v || typeof v !== "object" || depth > 8) return;
+    const o = v as Record<string, unknown>;
+    if (o["toolName"] === "run_workflow") {
+      const id = findRunId(o);
+      if (id) ids.add(id);
+    }
+    for (const x of Object.values(o)) walk(x, depth + 1);
+  };
+  for (const m of messages) if (m.role === "tool" || m.role === "assistant") walk(m.content);
+  return [...ids];
+}
+
+/** Project every chat (and its turns) from a `ChatStore` into the graph. */
+export async function projectChats(backend: GraphBackend, chatStore: ChatStore): Promise<ProjectReport> {
+  const report = emptyReport();
+  const ns = backend.cfg.namespace;
+  for (const meta of await chatStore.listChats()) {
+    const messages = await chatStore.loadMessages(meta.id);
+    const turns: NodeInput[] = [];
+    let turn = -1;
+    for (let i = 0; i < messages.length; i++) {
+      const m = messages[i]!;
+      if (m.role !== "user") continue;
+      turn++;
+      const assistant = messages.slice(i + 1).find((x) => x.role === "assistant" && messageText(x.content));
+      turns.push({
+        type: "VeinTurn",
+        data: compact({
+          chat_id: meta.id,
+          turn,
+          user_text_preview: preview(messageText(m.content)),
+          assistant_text_preview: preview(assistant ? messageText(assistant.content) : undefined),
+          log_ref: `${meta.id}/${turn}`,
+          unique_source_id: `veinturn:${meta.id}:${turn}`,
+        }),
+      });
+    }
+    const chat: NodeInput = {
+      type: "VeinChat",
+      data: compact({
+        chat_id: meta.id,
+        title: meta.title,
+        summary: preview(turns[0] ? (turns[0].data["user_text_preview"] as string) : undefined),
+        status: meta.status,
+        model: meta.model,
+        created_at: meta.createdAt,
+        last_active_at: meta.updatedAt,
+        turn_count: turns.length,
+        log_ref: meta.id,
+        unique_source_id: `veinchat:${meta.id}`,
+      }),
+    };
+    const written = await backend.nodes.writeMany([chat, ...turns], "upsert");
+    const chatRef = written[0]!.ref_id;
+    report.chats++;
+    report.turns += turns.length;
+
+    const edges: EdgeInput[] = turns.map((_, i) => ({ edge: "IN_CHAT", source_ref_id: written[1 + i]!.ref_id, target_ref_id: chatRef }));
+    const runIds = spawnedRunIds(messages);
+    if (runIds.length) {
+      const rows = await backend.bolt.run(
+        `MATCH (r:VeinRun {namespace: $ns}) WHERE r.run_id IN $ids RETURN r.ref_id AS ref_id`,
+        { ns, ids: runIds },
+      );
+      for (const r of rows) edges.push({ edge: "SPAWNED", source_ref_id: chatRef, target_ref_id: r["ref_id"] as string });
+    }
+    if (edges.length) {
+      await backend.edges.writeMany(edges);
+      report.edges += edges.length;
+    }
+  }
+  return report;
+}
+
+/** Runs first (so chats can link to them), then chats. */
+export async function projectAll(
+  backend: GraphBackend,
+  src: { store: RunStore; chatStore?: ChatStore; workflows: string[] },
+  opts: Omit<ProjectRunsOptions, "workflows"> = {},
+): Promise<ProjectReport> {
+  const a = await projectRuns(backend, src.store, { ...opts, workflows: src.workflows });
+  const b = src.chatStore ? await projectChats(backend, src.chatStore) : emptyReport();
+  return {
+    runs: a.runs + b.runs,
+    sessions: a.sessions + b.sessions,
+    toolCalls: a.toolCalls + b.toolCalls,
+    chats: a.chats + b.chats,
+    turns: a.turns + b.turns,
+    edges: a.edges + b.edges,
+    skipped: a.skipped + b.skipped,
+  };
+}

--- a/vein/src/graph/wiring.test.ts
+++ b/vein/src/graph/wiring.test.ts
@@ -1,0 +1,17 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { graphConfigFromEnv } from "./bolt.js";
+import { DEFAULT_NEO4J_HOST, graphWorkspaceRequested } from "./wiring.js";
+
+describe("graph workspace wiring defaults", () => {
+  it("VEIN_WORKSPACE_BACKEND=graph is the switch (case-insensitive)", () => {
+    assert.equal(graphWorkspaceRequested({}), false);
+    assert.equal(graphWorkspaceRequested({ VEIN_WORKSPACE_BACKEND: "Graph" }), true);
+  });
+  it("connection defaults match the mcp host: localhost:7687 / neo4j / testtest; env wins", () => {
+    const d = graphConfigFromEnv({ NEO4J_HOST: DEFAULT_NEO4J_HOST })!;
+    assert.deepEqual([d.uri, d.user, d.password, d.namespace], ["bolt://localhost:7687", "neo4j", "testtest", "default"]);
+    const e = graphConfigFromEnv({ NEO4J_HOST: DEFAULT_NEO4J_HOST, NEO4J_URI: "bolt://db:7688", NEO4J_PASSWORD: "pw" })!;
+    assert.deepEqual([e.uri, e.password], ["bolt://db:7688", "pw"]);
+  });
+});

--- a/vein/src/graph/wiring.test.ts
+++ b/vein/src/graph/wiring.test.ts
@@ -1,12 +1,15 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { graphConfigFromEnv } from "./bolt.js";
-import { DEFAULT_NEO4J_HOST, graphWorkspaceRequested } from "./wiring.js";
+import { DEFAULT_NEO4J_HOST, graphMaterializeDir, graphWorkspaceRequested } from "./wiring.js";
 
 describe("graph workspace wiring defaults", () => {
   it("VEIN_WORKSPACE_BACKEND=graph is the switch (case-insensitive)", () => {
     assert.equal(graphWorkspaceRequested({}), false);
     assert.equal(graphWorkspaceRequested({ VEIN_WORKSPACE_BACKEND: "Graph" }), true);
+  });
+  it("materializes custom steps inside the data dir (module resolution), apart from steps/custom", () => {
+    assert.equal(graphMaterializeDir("./lab-workspace"), "lab-workspace/steps/_graph");
   });
   it("connection defaults match the mcp host: localhost:7687 / neo4j / testtest; env wins", () => {
     const d = graphConfigFromEnv({ NEO4J_HOST: DEFAULT_NEO4J_HOST })!;

--- a/vein/src/graph/wiring.ts
+++ b/vein/src/graph/wiring.ts
@@ -1,0 +1,32 @@
+/**
+ * Env-driven wiring for the graph-backed workspace: set
+ * `VEIN_WORKSPACE_BACKEND=graph` (plus the `NEO4J_*` connection vars) and
+ * the default server keeps workflows/steps in Neo4j instead of the
+ * filesystem. Runs, chats, secrets, artifacts, and cassettes stay local
+ * under `dataDir` (`VEIN_WORKSPACE`) — the run/chat projector
+ * (`projector.ts`, or the `graph/project` step) builds their graph view.
+ */
+import type { GraphBackend, GraphBackendOptions } from "./backend.js";
+import { openGraphBackendFromEnv } from "./backend.js";
+import { Neo4jWorkspaceStore, type Neo4jWorkspaceStoreOptions } from "./workspace-store.js";
+
+export function graphWorkspaceRequested(env: Record<string, string | undefined> = process.env): boolean {
+  return (env["VEIN_WORKSPACE_BACKEND"] ?? "").toLowerCase() === "graph";
+}
+
+/**
+ * Open the graph backend from env and wrap it in a `Neo4jWorkspaceStore`.
+ * Throws when no connection is configured — a deployment that asked for
+ * the graph backend must not silently fall back to files.
+ */
+export async function graphWorkspaceFromEnv(
+  env: Record<string, string | undefined> = process.env,
+  opts: { backend?: GraphBackendOptions; store?: Neo4jWorkspaceStoreOptions } = {},
+): Promise<{ backend: GraphBackend; workspace: Neo4jWorkspaceStore }> {
+  const pending = openGraphBackendFromEnv(env, opts.backend);
+  if (!pending) {
+    throw new Error("VEIN_WORKSPACE_BACKEND=graph needs NEO4J_URI (or NEO4J_HOST) — no Neo4j connection configured");
+  }
+  const backend = await pending;
+  return { backend, workspace: new Neo4jWorkspaceStore(backend, opts.store) };
+}

--- a/vein/src/graph/wiring.ts
+++ b/vein/src/graph/wiring.ts
@@ -14,19 +14,21 @@ export function graphWorkspaceRequested(env: Record<string, string | undefined> 
   return (env["VEIN_WORKSPACE_BACKEND"] ?? "").toLowerCase() === "graph";
 }
 
+/** Same default as the mcp host's own Neo4j client and the `graph/*` steps:
+ *  a local Neo4j needs nothing configured. */
+export const DEFAULT_NEO4J_HOST = "localhost:7687";
+
 /**
  * Open the graph backend from env and wrap it in a `Neo4jWorkspaceStore`.
- * Throws when no connection is configured — a deployment that asked for
- * the graph backend must not silently fall back to files.
+ * Connection: `NEO4J_URI`, else `bolt://<NEO4J_HOST>` (default
+ * `localhost:7687`); `NEO4J_USER` / `NEO4J_PASSWORD` default to
+ * neo4j / testtest — the same resolution as the mcp host, so a deployment's
+ * existing vars just work and a local Neo4j needs none.
  */
 export async function graphWorkspaceFromEnv(
   env: Record<string, string | undefined> = process.env,
   opts: { backend?: GraphBackendOptions; store?: Neo4jWorkspaceStoreOptions } = {},
 ): Promise<{ backend: GraphBackend; workspace: Neo4jWorkspaceStore }> {
-  const pending = openGraphBackendFromEnv(env, opts.backend);
-  if (!pending) {
-    throw new Error("VEIN_WORKSPACE_BACKEND=graph needs NEO4J_URI (or NEO4J_HOST) — no Neo4j connection configured");
-  }
-  const backend = await pending;
+  const backend = await openGraphBackendFromEnv({ NEO4J_HOST: DEFAULT_NEO4J_HOST, ...env }, opts.backend)!;
   return { backend, workspace: new Neo4jWorkspaceStore(backend, opts.store) };
 }

--- a/vein/src/graph/wiring.ts
+++ b/vein/src/graph/wiring.ts
@@ -6,6 +6,7 @@
  * under `dataDir` (`VEIN_WORKSPACE`) — the run/chat projector
  * (`projector.ts`, or the `graph/project` step) builds their graph view.
  */
+import { join } from "node:path";
 import type { GraphBackend, GraphBackendOptions } from "./backend.js";
 import { openGraphBackendFromEnv } from "./backend.js";
 import { Neo4jWorkspaceStore, type Neo4jWorkspaceStoreOptions } from "./workspace-store.js";
@@ -19,16 +20,32 @@ export function graphWorkspaceRequested(env: Record<string, string | undefined> 
 export const DEFAULT_NEO4J_HOST = "localhost:7687";
 
 /**
+ * Where the graph store materializes active custom steps for the module
+ * loader: INSIDE the data dir, beside where a file workspace would keep
+ * `steps/custom`. Custom steps `import "vein"` (and "zod"), and Node resolves
+ * that by walking up from the FILE's directory — so the dir must sit in the
+ * same tree as the file store's, never under the OS temp dir. Distinct from
+ * `steps/custom` so switching backends on one dir can't prune the other's
+ * files.
+ */
+export function graphMaterializeDir(dataDir: string): string {
+  return join(dataDir, "steps", "_graph");
+}
+
+/**
  * Open the graph backend from env and wrap it in a `Neo4jWorkspaceStore`.
  * Connection: `NEO4J_URI`, else `bolt://<NEO4J_HOST>` (default
  * `localhost:7687`); `NEO4J_USER` / `NEO4J_PASSWORD` default to
  * neo4j / testtest — the same resolution as the mcp host, so a deployment's
- * existing vars just work and a local Neo4j needs none.
+ * existing vars just work and a local Neo4j needs none. `dataDir` (default
+ * `VEIN_WORKSPACE` / `./workspace`) is where custom steps are materialized.
  */
 export async function graphWorkspaceFromEnv(
   env: Record<string, string | undefined> = process.env,
-  opts: { backend?: GraphBackendOptions; store?: Neo4jWorkspaceStoreOptions } = {},
+  opts: { dataDir?: string; backend?: GraphBackendOptions; store?: Neo4jWorkspaceStoreOptions } = {},
 ): Promise<{ backend: GraphBackend; workspace: Neo4jWorkspaceStore }> {
   const backend = await openGraphBackendFromEnv({ NEO4J_HOST: DEFAULT_NEO4J_HOST, ...env }, opts.backend)!;
-  return { backend, workspace: new Neo4jWorkspaceStore(backend, opts.store) };
+  const dataDir = opts.dataDir ?? env["VEIN_WORKSPACE"] ?? "./workspace";
+  const store = { materializeDir: graphMaterializeDir(dataDir), ...opts.store };
+  return { backend, workspace: new Neo4jWorkspaceStore(backend, store) };
 }

--- a/vein/src/graph/workspace-store.test.ts
+++ b/vein/src/graph/workspace-store.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { openGraphBackend, type GraphBackend } from "./backend.js";
+import { seedVeinDomain } from "./schema-seed.js";
+import { testGraphConfig, wipeGraph } from "./test-util.js";
+import { Neo4jWorkspaceStore } from "./workspace-store.js";
+import { workspaceConformance } from "../test-util/workspace-conformance.js";
+
+/**
+ * Live tests (opt-in via VEIN_TEST_NEO4J_URI — see test-util.ts). The
+ * graph store passes the same `WorkspaceStore` conformance suite as the
+ * file store; the cases below cover what is graph-specific: the edges,
+ * soft deletion, and persistence across store instances.
+ */
+
+const cfg = testGraphConfig();
+let backend: GraphBackend;
+let scratch: string;
+
+async function reset() {
+  await wipeGraph(backend.bolt);
+  await seedVeinDomain(backend.bolt);
+  await rm(scratch, { recursive: true, force: true });
+}
+
+if (cfg) {
+  before(async () => {
+    backend = await openGraphBackend(cfg, { embeddings: false, skipBoot: true });
+    scratch = await mkdtemp(join(tmpdir(), "vein-graph-ws-"));
+  });
+  after(async () => {
+    await backend.close();
+    await rm(scratch, { recursive: true, force: true });
+  });
+}
+
+workspaceConformance({
+  name: "Neo4jWorkspaceStore",
+  skip: cfg ? false : "VEIN_TEST_NEO4J_URI not set",
+  reset,
+  make: () => new Neo4jWorkspaceStore(backend, { materializeDir: join(scratch, "steps") }),
+});
+
+const STEP = (type: string) => `export default { type: ${JSON.stringify(type)}, input: {}, output: {}, async run() { return 1; } };`;
+
+describe("Neo4jWorkspaceStore (graph-specific)", { skip: cfg ? false : "VEIN_TEST_NEO4J_URI not set" }, () => {
+  let ws: Neo4jWorkspaceStore;
+  beforeEach(async () => {
+    await reset();
+    ws = new Neo4jWorkspaceStore(backend, { materializeDir: join(scratch, "steps") });
+  });
+
+  const edgesOf = async (edge: string) =>
+    backend.bolt.run(`MATCH (a:Data_Bank)-[r:\`${edge}\`]->(b:Data_Bank) RETURN a.node_key AS a, b.node_key AS b ORDER BY a, b`);
+
+  it("writes jarvis-dialect nodes with the Vein labels and VERSION_OF / ACTIVE_VERSION edges", async () => {
+    await ws.publishWorkflow("wf", "v1", { steps: [{ id: "a", type: "log", config: { message: "x" } }] }, "first");
+    const rows = await backend.bolt.run(
+      `MATCH (n:Domain_vein) RETURN labels(n) AS labels, n.node_key AS key, n.namespace AS ns ORDER BY key`,
+    );
+    assert.deepEqual(
+      rows.map((r) => [(r["labels"] as string[]).filter((l) => l.startsWith("Vein"))[0], r["key"], r["ns"]]),
+      [
+        ["VeinWorkflow", "veinworkflow-wf", cfg!.namespace],
+        ["VeinWorkflowVersion", `veinworkflowversion-wf-${await ws.getWorkflowHash("wf")}`, cfg!.namespace],
+      ],
+    );
+    assert.equal((await edgesOf("VERSION_OF")).length, 1);
+    assert.equal((await edgesOf("ACTIVE_VERSION")).length, 1);
+  });
+
+  it("swaps the ACTIVE_VERSION edge on activation and never duplicates it", async () => {
+    await ws.publishWorkflow("wf", "v1", { steps: [{ id: "a", type: "log", config: { message: "1" } }] });
+    await ws.publishWorkflow("wf", "v2", { steps: [{ id: "a", type: "log", config: { message: "2" } }] });
+    let active = await edgesOf("ACTIVE_VERSION");
+    assert.equal(active.length, 1);
+    assert.equal(active[0]!["b"], `veinworkflowversion-wf-${await ws.getWorkflowHash("wf", "v2")}`);
+    await ws.setActiveVersion("wf", "v1");
+    active = await edgesOf("ACTIVE_VERSION");
+    assert.equal(active.length, 1);
+    assert.equal(active[0]!["b"], `veinworkflowversion-wf-${await ws.getWorkflowHash("wf", "v1")}`);
+    assert.equal((await edgesOf("VERSION_OF")).length, 2);
+  });
+
+  it("links a version to the custom steps it uses and the workflows it depends on", async () => {
+    await ws.publishStep("my/tool", STEP("my/tool"));
+    await ws.publishWorkflow("child", "v1", { steps: [{ id: "a", type: "log", config: { message: "c" } }] });
+    await ws.publishWorkflow("parent", "v1", {
+      steps: [
+        { id: "t", type: "my/tool", config: {} },
+        { id: "s", type: "subflow", config: { workflow: "child" } },
+        { id: "l", type: "loop", config: { steps: [{ id: "inner", type: "my/tool", config: {} }] } },
+      ],
+    });
+    assert.deepEqual(
+      (await edgesOf("USES_STEP")).map((r) => [r["a"], r["b"]]),
+      [[`veinworkflowversion-parent-${await ws.getWorkflowHash("parent")}`, "veinstep-mytool"]],
+    );
+    assert.deepEqual(
+      (await edgesOf("DEPENDS_ON")).map((r) => [r["a"], r["b"]]),
+      [[`veinworkflowversion-parent-${await ws.getWorkflowHash("parent")}`, "veinworkflow-child"]],
+    );
+  });
+
+  it("re-labels rather than duplicates when the same content is published under a new label", async () => {
+    const content = { steps: [{ id: "a", type: "log", config: { message: "same" } }] };
+    await ws.publishWorkflow("wf", "v1", content);
+    await ws.publishWorkflow("wf", "v9", content);
+    const meta = await ws.getWorkflowMetadata("wf");
+    assert.deepEqual(Object.keys(meta!.versions), ["v9"]);
+    assert.equal(meta!.active, "v9");
+    const count = await backend.bolt.run(`MATCH (v:VeinWorkflowVersion) RETURN count(v) AS c`);
+    assert.equal(count[0]!["c"], 1);
+  });
+
+  it("deleteStep is a soft delete: nodes stay, flagged, and a republish restores the identity", async () => {
+    await ws.publishStep("s", STEP("s"), "one");
+    const before = await backend.bolt.run(`MATCH (n:VeinStep) RETURN n.ref_id AS ref_id`);
+    assert.equal(await ws.deleteStep("s"), true);
+    const flagged = await backend.bolt.run(`MATCH (n) WHERE n:VeinStep OR n:VeinStepVersion RETURN n.is_deleted AS d`);
+    assert.deepEqual(flagged.map((r) => r["d"]), [true, true]);
+    assert.deepEqual(await ws.listSteps(), []);
+    assert.equal(await ws.getStepSource("s"), null);
+
+    await ws.publishStep("s", STEP("s"), "again");
+    const after = await backend.bolt.run(`MATCH (n:VeinStep) WHERE n.is_deleted = false RETURN n.ref_id AS ref_id`);
+    assert.equal(after[0]!["ref_id"], before[0]!["ref_id"], "same node_key → restored, ref_id preserved");
+    assert.deepEqual((await ws.listSteps()).map((s) => [s.type, s.description]), [["s", "again"]]);
+    assert.deepEqual(await ws.listStepVersions("s"), { active: "v1", versions: ["v1"] });
+  });
+
+  it("is persistent: a second store over the same backend sees everything, and materialization prunes stale files", async () => {
+    await ws.publishStep("keep", STEP("keep"));
+    await ws.publishStep("drop", STEP("drop"));
+    const dir = await ws.materializeCustomSteps();
+    const other = new Neo4jWorkspaceStore(backend, { materializeDir: join(scratch, "steps") });
+    assert.deepEqual((await other.listSteps()).map((s) => s.type), ["drop", "keep"]);
+    await other.deleteStep("drop");
+    assert.equal(await ws.materializeCustomSteps(), dir);
+    const { readdir } = await import("node:fs/promises");
+    assert.deepEqual((await readdir(dir)).sort(), ["keep.ts"]);
+  });
+
+  it("helpers (_-prefixed) are stored and materialized but not listed", async () => {
+    await ws.publishStep("ns/_shared", "export const x = 1;");
+    await ws.publishStep("ns/real", STEP("ns/real"));
+    assert.deepEqual((await ws.listSteps()).map((s) => s.type), ["ns/real"]);
+    const dir = await ws.materializeCustomSteps();
+    const { readdir } = await import("node:fs/promises");
+    assert.deepEqual((await readdir(join(dir, "ns"))).sort(), ["_shared.ts", "real.ts"]);
+  });
+});

--- a/vein/src/graph/workspace-store.ts
+++ b/vein/src/graph/workspace-store.ts
@@ -1,0 +1,699 @@
+/**
+ * `Neo4jWorkspaceStore` — the graph-backed `WorkspaceStore`
+ * (plans/generic-storage.md §7). Workflows, versions, steps, and step
+ * versions are nodes in vein's own Neo4j domain (`VeinWorkflow`,
+ * `VeinWorkflowVersion`, `VeinStep`, `VeinStepVersion` — the label registry
+ * in `vein-schemas.ts`), linked by `VERSION_OF`, `ACTIVE_VERSION`,
+ * `USES_STEP`, and `DEPENDS_ON` edges. Every write goes through the
+ * jarvis-dialect node/edge writers, so a jarvis mounted on the same database
+ * sees native data.
+ *
+ * Semantics mirror `FileWorkspaceStore` (the conformance suite in
+ * `src/test-util/workspace-conformance.ts` is the contract), with one
+ * deliberate difference: versions are CONTENT-ADDRESSED. A version node is
+ * keyed by `(name, content_hash)`, and the user-facing `v1`/`v2` label is a
+ * property on it. Publishing content that already exists under another
+ * label re-labels that version instead of duplicating it.
+ *
+ * Custom step code is executable, so the store also materializes every
+ * active custom step into a scratch directory (`materializeCustomSteps`) for
+ * the module loader; the graph stays the record.
+ *
+ * Deletion is soft (`is_deleted = true`) — nothing is ever DETACH DELETEd.
+ */
+import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import yaml from "js-yaml";
+import type { Flow } from "../core.js";
+import {
+  assertValidWorkflowYaml,
+  flowFromYaml,
+  renderWorkflowYaml,
+  validateStepName,
+  type StepListEntry,
+  type StepVersionsResult,
+  type WorkflowListEntry,
+  type WorkflowMetadata,
+  type WorkspaceStore,
+} from "../workspace.js";
+import { readStepSourceFromDisk, type StepSource } from "../steps/registry.js";
+import { contentHash, nextVersionLabel } from "../version.js";
+import type { GraphBackend } from "./backend.js";
+import type { Row } from "./bolt.js";
+
+export interface Neo4jWorkspaceStoreOptions {
+  /** Where active custom steps are written for the module loader. Default:
+   *  a per-(uri, namespace) dir under the OS temp dir. */
+  materializeDir?: string;
+}
+
+const NOT_DELETED = (v: string) => `(${v}.is_deleted IS NULL OR ${v}.is_deleted = false)`;
+
+interface WorkflowRow {
+  ref_id: string;
+  name: string;
+  description?: string;
+  category?: string;
+  publisher?: string;
+  active_version?: string;
+}
+
+interface VersionRow {
+  ref_id: string;
+  name: string;
+  content_hash: string;
+  version_label: string;
+  description?: string;
+  created_at: number; // epoch seconds
+  source: string;
+  publisher?: string;
+}
+
+interface StepRow {
+  ref_id: string;
+  step_type: string;
+  description?: string;
+  publisher?: string;
+  active_version?: string;
+}
+
+interface StepVersionRow {
+  ref_id: string;
+  step_type: string;
+  content_hash: string;
+  version_label: string;
+  description?: string;
+  created_at: number;
+  source: string;
+  publisher?: string;
+}
+
+const isoFromSeconds = (s: number | undefined): string =>
+  new Date((s ?? 0) * 1000).toISOString();
+
+/** Drop undefined/null values so the writer sees only real attributes. */
+function compact(o: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(o)) if (v !== undefined && v !== null) out[k] = v;
+  return out;
+}
+
+/** A patch that makes a node's attributes equal `desired` for the given
+ *  keys: set the defined ones, remove the ones now undefined. */
+function patchFor(
+  current: Record<string, unknown>,
+  desired: Record<string, unknown>,
+): { set: Record<string, unknown>; remove: string[] } | null {
+  const set: Record<string, unknown> = {};
+  const remove: string[] = [];
+  for (const [k, v] of Object.entries(desired)) {
+    if (v === undefined || v === null || v === "") {
+      if (current[k] !== undefined && current[k] !== null) remove.push(k);
+    } else if (current[k] !== v) {
+      set[k] = v;
+    }
+  }
+  return Object.keys(set).length || remove.length ? { set, remove } : null;
+}
+
+/** Every `{ type, config }` step object in a parsed workflow, at any depth
+ *  (loop/if/foreach bodies nest steps inside config). */
+function collectStepRefs(node: unknown, out: Array<{ type: string; config: Record<string, unknown> }> = []) {
+  if (Array.isArray(node)) {
+    for (const x of node) collectStepRefs(x, out);
+  } else if (node && typeof node === "object") {
+    const o = node as Record<string, unknown>;
+    if (typeof o["type"] === "string" && typeof o["id"] === "string") {
+      out.push({ type: o["type"], config: (o["config"] as Record<string, unknown>) ?? {} });
+    }
+    for (const v of Object.values(o)) if (v && typeof v === "object") collectStepRefs(v, out);
+  }
+  return out;
+}
+
+export class Neo4jWorkspaceStore implements WorkspaceStore {
+  private readonly ns: string;
+  private readonly materializeDir: string;
+
+  constructor(
+    private readonly backend: GraphBackend,
+    opts: Neo4jWorkspaceStoreOptions = {},
+  ) {
+    this.ns = backend.cfg.namespace;
+    this.materializeDir =
+      opts.materializeDir ??
+      join(
+        tmpdir(),
+        "vein-graph-steps",
+        createHash("sha256").update(`${backend.cfg.uri}|${backend.cfg.database ?? ""}|${this.ns}`).digest("hex").slice(0, 16),
+      );
+  }
+
+  // ── Reads: workflows ───────────────────────────────────────────────────
+
+  private async workflowRow(name: string): Promise<WorkflowRow | null> {
+    const rows = await this.backend.bolt.run(
+      `MATCH (w:VeinWorkflow {namespace: $ns, name: $name}) WHERE ${NOT_DELETED("w")}
+       RETURN properties(w) AS p LIMIT 1`,
+      { ns: this.ns, name },
+    );
+    return rows.length ? (rows[0]!["p"] as WorkflowRow) : null;
+  }
+
+  private async versionRows(name: string): Promise<VersionRow[]> {
+    const rows = await this.backend.bolt.run(
+      `MATCH (v:VeinWorkflowVersion {namespace: $ns, name: $name}) WHERE ${NOT_DELETED("v")}
+       RETURN properties(v) AS p ORDER BY v.created_at, v.date_added_to_graph`,
+      { ns: this.ns, name },
+    );
+    return rows.map((r: Row) => r["p"] as VersionRow);
+  }
+
+  async listWorkflows(): Promise<WorkflowListEntry[]> {
+    const rows = await this.backend.bolt.run(
+      `MATCH (w:VeinWorkflow {namespace: $ns}) WHERE ${NOT_DELETED("w")}
+       OPTIONAL MATCH (v:VeinWorkflowVersion {namespace: $ns, name: w.name}) WHERE ${NOT_DELETED("v")}
+       WITH w, v ORDER BY v.created_at, v.date_added_to_graph
+       RETURN properties(w) AS w, collect(properties(v)) AS versions ORDER BY w.name`,
+      { ns: this.ns },
+    );
+    const out: WorkflowListEntry[] = [];
+    for (const r of rows) {
+      const w = r["w"] as WorkflowRow;
+      const versions = (r["versions"] as VersionRow[]).filter((v) => v && v.version_label);
+      const active = versions.find((v) => v.content_hash === w.active_version);
+      out.push({
+        name: w.name,
+        activeVersion: active?.version_label ?? "",
+        versions: versions.map((v) => v.version_label),
+        description: active?.description,
+        ...(w.category ? { category: w.category } : {}),
+        ...(w.publisher ? { publisher: w.publisher } : {}),
+      });
+    }
+    return out;
+  }
+
+  async getWorkflowMetadata(name: string): Promise<WorkflowMetadata | null> {
+    const w = await this.workflowRow(name);
+    if (!w) return null;
+    const versions = await this.versionRows(name);
+    const active = versions.find((v) => v.content_hash === w.active_version);
+    const meta: WorkflowMetadata = { active: active?.version_label ?? "", versions: {} };
+    for (const v of versions) {
+      meta.versions[v.version_label] = {
+        createdAt: isoFromSeconds(v.created_at),
+        ...(v.description !== undefined ? { description: v.description } : {}),
+        hash: v.content_hash,
+      };
+    }
+    if (w.category) meta.category = w.category;
+    if (w.publisher) meta.publisher = w.publisher;
+    return meta;
+  }
+
+  private async versionByLabel(name: string, label: string): Promise<VersionRow | null> {
+    return (await this.versionRows(name)).find((v) => v.version_label === label) ?? null;
+  }
+
+  private async activeVersion(name: string): Promise<VersionRow> {
+    const w = await this.workflowRow(name);
+    if (!w) throw new Error(`Workflow "${name}" not found`);
+    const v = (await this.versionRows(name)).find((x) => x.content_hash === w.active_version);
+    if (!v) throw new Error(`Workflow "${name}" has no active version`);
+    return v;
+  }
+
+  async getWorkflow(name: string): Promise<Flow> {
+    const v = await this.activeVersion(name);
+    return flowFromYaml(name, v.version_label, v.source);
+  }
+
+  async getWorkflowVersion(name: string, version: string): Promise<Flow> {
+    return flowFromYaml(name, version, await this.getWorkflowSource(name, version));
+  }
+
+  async getWorkflowSource(name: string, version: string): Promise<string> {
+    const v = await this.versionByLabel(name, version);
+    if (!v) throw new Error(`Version "${version}" of workflow "${name}" not found`);
+    return v.source;
+  }
+
+  async getWorkflowHash(name: string, version?: string): Promise<string | null> {
+    try {
+      const v = version ? await this.versionByLabel(name, version) : await this.activeVersion(name);
+      return v?.content_hash ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  // ── Writes: workflows ──────────────────────────────────────────────────
+
+  async createWorkflow(
+    name: string,
+    content: { steps: any[]; params?: Record<string, unknown> } | string,
+    description?: string,
+    category?: string,
+    publisher?: string,
+  ): Promise<{ name: string; version: string }> {
+    let finalName = name;
+    let n = 2;
+    while (await this.workflowRow(finalName)) finalName = `${name}-${n++}`;
+    let resolvedContent = content;
+    if (finalName !== name && typeof content === "string") {
+      const parsed = yaml.load(content) as any;
+      if (parsed && typeof parsed === "object") {
+        parsed.name = finalName;
+        resolvedContent = yaml.dump(parsed, { lineWidth: 120, noRefs: true });
+      }
+    }
+    await this.publishWorkflow(finalName, "v1", resolvedContent, description, category, publisher);
+    return { name: finalName, version: "v1" };
+  }
+
+  async publishWorkflow(
+    name: string,
+    version: string,
+    content: { steps: any[]; params?: Record<string, unknown>; promotes?: unknown[] } | string,
+    description?: string,
+    category?: string,
+    publisher?: string,
+  ): Promise<void> {
+    const yamlStr = renderWorkflowYaml(name, content);
+    assertValidWorkflowYaml(yamlStr);
+    await this.writeVersion(name, version, yamlStr, description, category, publisher);
+  }
+
+  /** The one write path behind publish/publishByContent/setParam: ensure the
+   *  version node exists (creating, restoring, or re-labeling it), then
+   *  point the workflow at it. */
+  private async writeVersion(
+    name: string,
+    label: string,
+    yamlStr: string,
+    description: string | undefined,
+    category: string | undefined,
+    publisher: string | undefined,
+  ): Promise<VersionRow> {
+    const hash = contentHash(yamlStr);
+    const { nodes } = this.backend;
+    const existing = (await this.versionRows(name)).find((v) => v.content_hash === hash);
+    let versionRef: string;
+    if (existing) {
+      // Content-addressed: same content under a new label re-labels.
+      const patch = patchFor(existing as unknown as Record<string, unknown>, {
+        version_label: label,
+        ...(description !== undefined ? { description } : {}),
+      });
+      if (patch) await nodes.update(existing.ref_id, patch);
+      versionRef = existing.ref_id;
+    } else {
+      const parsed = (yaml.load(yamlStr) as Record<string, unknown> | null) ?? {};
+      const r = await nodes.write({
+        type: "VeinWorkflowVersion",
+        data: compact({
+          name,
+          content_hash: hash,
+          version_label: label,
+          description,
+          created_at: new Date().toISOString(),
+          source: yamlStr,
+          params_json: parsed["params"] != null ? JSON.stringify(parsed["params"]) : undefined,
+          publisher,
+        }),
+      });
+      versionRef = r.ref_id;
+    }
+    await this.activate(name, { ref_id: versionRef, hash, description }, category, publisher);
+    await this.linkVersionDeps(versionRef, yamlStr);
+    return (await this.versionRows(name)).find((v) => v.ref_id === versionRef)!;
+  }
+
+  /** Point the workflow node (creating it if needed) at a version: mirror the
+   *  version's description onto the workflow, swap the ACTIVE_VERSION edge. */
+  private async activate(
+    name: string,
+    version: { ref_id: string; hash: string; description: string | undefined },
+    category?: string,
+    publisher?: string,
+  ): Promise<void> {
+    const { nodes, edges, bolt } = this.backend;
+    const w = await this.workflowRow(name);
+    let wfRef: string;
+    if (!w) {
+      const r = await nodes.write({
+        type: "VeinWorkflow",
+        data: compact({ name, description: version.description, category, publisher, active_version: version.hash }),
+      });
+      wfRef = r.ref_id;
+    } else {
+      wfRef = w.ref_id;
+      const desired: Record<string, unknown> = { active_version: version.hash, description: version.description };
+      if (category !== undefined) desired["category"] = category;
+      if (publisher !== undefined) desired["publisher"] = publisher;
+      const patch = patchFor(w as unknown as Record<string, unknown>, desired);
+      if (patch) await nodes.update(wfRef, patch);
+    }
+    await edges.write({ edge: "VERSION_OF", source_ref_id: version.ref_id, target_ref_id: wfRef });
+    await bolt.run(
+      `MATCH (w:VeinWorkflow {ref_id: $w})-[r:ACTIVE_VERSION]->(v) WHERE v.ref_id <> $v DELETE r`,
+      { w: wfRef, v: version.ref_id },
+    );
+    await edges.write({ edge: "ACTIVE_VERSION", source_ref_id: wfRef, target_ref_id: version.ref_id });
+  }
+
+  /** USES_STEP → every custom step the version references; DEPENDS_ON →
+   *  every workflow its subflow steps call. Only targets that exist are
+   *  linked (the graph pays off in "which workflows use step X"). */
+  private async linkVersionDeps(versionRef: string, yamlStr: string): Promise<void> {
+    let parsed: unknown;
+    try {
+      parsed = yaml.load(yamlStr);
+    } catch {
+      return;
+    }
+    const refs = collectStepRefs((parsed as Record<string, unknown> | null)?.["steps"]);
+    const stepTypes = [...new Set(refs.filter((r) => r.type !== "subflow").map((r) => r.type))];
+    const subflows = [
+      ...new Set(refs.filter((r) => r.type === "subflow" && typeof r.config["workflow"] === "string").map((r) => r.config["workflow"] as string)),
+    ];
+    const inputs: Array<{ edge: string; source_ref_id: string; target_ref_id: string }> = [];
+    if (stepTypes.length) {
+      const rows = await this.backend.bolt.run(
+        `MATCH (s:VeinStep {namespace: $ns}) WHERE s.step_type IN $types AND ${NOT_DELETED("s")} RETURN s.ref_id AS ref_id`,
+        { ns: this.ns, types: stepTypes },
+      );
+      for (const r of rows) inputs.push({ edge: "USES_STEP", source_ref_id: versionRef, target_ref_id: r["ref_id"] as string });
+    }
+    if (subflows.length) {
+      const rows = await this.backend.bolt.run(
+        `MATCH (w:VeinWorkflow {namespace: $ns}) WHERE w.name IN $names AND ${NOT_DELETED("w")} RETURN w.ref_id AS ref_id`,
+        { ns: this.ns, names: subflows },
+      );
+      for (const r of rows) inputs.push({ edge: "DEPENDS_ON", source_ref_id: versionRef, target_ref_id: r["ref_id"] as string });
+    }
+    if (inputs.length) await this.backend.edges.writeMany(inputs);
+  }
+
+  async publishWorkflowByContent(
+    name: string,
+    yamlStr: string,
+    description?: string,
+    category?: string,
+    publisher?: string,
+  ): Promise<{ version: string; changed: boolean }> {
+    const hash = contentHash(yamlStr);
+    const w = await this.workflowRow(name);
+    if (w) {
+      if (category !== undefined && (w.category ?? undefined) !== category) {
+        await this.setWorkflowCategory(name, category);
+      }
+      const match = (await this.versionRows(name)).find((v) => v.content_hash === hash);
+      if (match) {
+        if (w.active_version === hash) return { version: match.version_label, changed: false };
+        await this.setActiveVersion(name, match.version_label);
+        return { version: match.version_label, changed: true };
+      }
+    }
+    const next = nextVersionLabel((await this.versionRows(name)).map((v) => v.version_label));
+    assertValidWorkflowYaml(yamlStr);
+    await this.writeVersion(name, next, yamlStr, description, category, publisher);
+    return { version: next, changed: true };
+  }
+
+  async setWorkflowCategory(name: string, category: string | null): Promise<void> {
+    const w = await this.workflowRow(name);
+    if (!w) throw new Error(`Workflow "${name}" not found`);
+    const patch = patchFor(w as unknown as Record<string, unknown>, { category: category || undefined });
+    if (patch) await this.backend.nodes.update(w.ref_id, patch);
+  }
+
+  async setActiveVersion(name: string, version: string): Promise<void> {
+    const w = await this.workflowRow(name);
+    if (!w) throw new Error(`Workflow "${name}" not found`);
+    const versions = await this.versionRows(name);
+    const v = versions.find((x) => x.version_label === version);
+    if (!v) {
+      throw new Error(
+        `Version "${version}" not found for workflow "${name}". Available: ${versions.map((x) => x.version_label).join(", ")}`,
+      );
+    }
+    await this.activate(name, { ref_id: v.ref_id, hash: v.content_hash, description: v.description });
+  }
+
+  async setParam(
+    name: string,
+    param: string,
+    value: unknown,
+  ): Promise<{ version: string; before: unknown; after: unknown }> {
+    const active = await this.activeVersion(name);
+    const obj = (yaml.load(active.source) as Record<string, unknown>) ?? {};
+    if (!obj["name"]) obj["name"] = name;
+    const params =
+      obj["params"] && typeof obj["params"] === "object" ? (obj["params"] as Record<string, unknown>) : {};
+    const before = params[param];
+    params[param] = value;
+    obj["params"] = params;
+    const yamlStr = yaml.dump(obj, { lineWidth: 120, noRefs: true });
+    const next = nextVersionLabel((await this.versionRows(name)).map((v) => v.version_label));
+    await this.publishWorkflow(name, next, yamlStr);
+    return { version: next, before, after: value };
+  }
+
+  // ── Reads: steps ───────────────────────────────────────────────────────
+
+  private async stepRow(type: string): Promise<StepRow | null> {
+    const rows = await this.backend.bolt.run(
+      `MATCH (s:VeinStep {namespace: $ns, step_type: $type}) WHERE ${NOT_DELETED("s")} RETURN properties(s) AS p LIMIT 1`,
+      { ns: this.ns, type },
+    );
+    return rows.length ? (rows[0]!["p"] as StepRow) : null;
+  }
+
+  private async stepVersionRows(type: string): Promise<StepVersionRow[]> {
+    const rows = await this.backend.bolt.run(
+      `MATCH (v:VeinStepVersion {namespace: $ns, step_type: $type}) WHERE ${NOT_DELETED("v")}
+       RETURN properties(v) AS p ORDER BY v.created_at, v.date_added_to_graph`,
+      { ns: this.ns, type },
+    );
+    return rows.map((r: Row) => r["p"] as StepVersionRow);
+  }
+
+  /** Every visible step with its active version's row (null when the
+   *  pointer dangles). Helpers (`_`-prefixed segments) included. */
+  private async stepsWithActive(): Promise<Array<{ step: StepRow; active: StepVersionRow | null }>> {
+    const rows = await this.backend.bolt.run(
+      `MATCH (s:VeinStep {namespace: $ns}) WHERE ${NOT_DELETED("s")}
+       OPTIONAL MATCH (v:VeinStepVersion {namespace: $ns, step_type: s.step_type, content_hash: s.active_version})
+       WHERE ${NOT_DELETED("v")}
+       RETURN properties(s) AS s, properties(v) AS v ORDER BY s.step_type`,
+      { ns: this.ns },
+    );
+    return rows.map((r) => ({ step: r["s"] as StepRow, active: (r["v"] as StepVersionRow | null) ?? null }));
+  }
+
+  private static isHelper(type: string): boolean {
+    return type.split("/").some((seg) => seg.startsWith("_"));
+  }
+
+  async listSteps(filter?: { publisher?: string }): Promise<StepListEntry[]> {
+    const out: StepListEntry[] = [];
+    for (const { step, active } of await this.stepsWithActive()) {
+      if (Neo4jWorkspaceStore.isHelper(step.step_type)) continue;
+      if (filter?.publisher && step.publisher !== filter.publisher) continue;
+      out.push({
+        type: step.step_type,
+        description: active?.description,
+        createdAt: active ? isoFromSeconds(active.created_at) : undefined,
+        publisher: step.publisher,
+      });
+    }
+    return out;
+  }
+
+  async listStepVersions(name: string): Promise<StepVersionsResult> {
+    validateStepName(name);
+    const s = await this.stepRow(name);
+    if (!s) throw new Error(`Step "${name}" not found`);
+    const versions = await this.stepVersionRows(name);
+    return {
+      active: versions.find((v) => v.content_hash === s.active_version)?.version_label ?? "",
+      versions: versions.map((v) => v.version_label),
+    };
+  }
+
+  async getStepVersionSource(name: string, version: string): Promise<string> {
+    validateStepName(name);
+    const v = (await this.stepVersionRows(name)).find((x) => x.version_label === version);
+    if (!v) throw new Error(`Version "${version}" of step "${name}" not found`);
+    return v.source;
+  }
+
+  // ── Writes: steps ──────────────────────────────────────────────────────
+
+  async publishStep(
+    name: string,
+    code: string,
+    description?: string,
+    publisher?: string,
+  ): Promise<{ version: string; changed: boolean }> {
+    validateStepName(name);
+    const hash = contentHash(code);
+    const { nodes } = this.backend;
+    const existing = await this.stepRow(name);
+    const versions = existing ? await this.stepVersionRows(name) : [];
+
+    if (existing) {
+      const match = versions.find((v) => v.content_hash === hash);
+      if (match) {
+        let changed = false;
+        const desired: Record<string, unknown> = {};
+        if (existing.active_version !== hash) {
+          desired["active_version"] = hash;
+          desired["description"] = match.description;
+          changed = true;
+        }
+        if (publisher !== undefined && existing.publisher !== publisher) desired["publisher"] = publisher;
+        const patch = patchFor(existing as unknown as Record<string, unknown>, desired);
+        if (patch) await nodes.update(existing.ref_id, patch);
+        if (changed) await this.swapActiveStepEdge(existing.ref_id, match.ref_id);
+        return { version: match.version_label, changed };
+      }
+    }
+
+    const vid = nextVersionLabel(versions.map((v) => v.version_label));
+    const v = await nodes.write({
+      type: "VeinStepVersion",
+      data: compact({
+        step_type: name,
+        content_hash: hash,
+        version_label: vid,
+        description,
+        created_at: new Date().toISOString(),
+        source: code,
+        publisher: publisher ?? existing?.publisher,
+      }),
+    });
+    let stepRef: string;
+    if (!existing) {
+      const s = await nodes.write({
+        type: "VeinStep",
+        data: compact({ step_type: name, description, publisher, active_version: hash }),
+      });
+      stepRef = s.ref_id;
+    } else {
+      stepRef = existing.ref_id;
+      const desired: Record<string, unknown> = { active_version: hash, description };
+      if (publisher !== undefined) desired["publisher"] = publisher;
+      const patch = patchFor(existing as unknown as Record<string, unknown>, desired);
+      if (patch) await nodes.update(stepRef, patch);
+    }
+    await this.backend.edges.write({ edge: "VERSION_OF", source_ref_id: v.ref_id, target_ref_id: stepRef });
+    await this.swapActiveStepEdge(stepRef, v.ref_id);
+    return { version: vid, changed: true };
+  }
+
+  private async swapActiveStepEdge(stepRef: string, versionRef: string): Promise<void> {
+    await this.backend.bolt.run(
+      `MATCH (s:VeinStep {ref_id: $s})-[r:ACTIVE_VERSION]->(v) WHERE v.ref_id <> $v DELETE r`,
+      { s: stepRef, v: versionRef },
+    );
+    await this.backend.edges.write({ edge: "ACTIVE_VERSION", source_ref_id: stepRef, target_ref_id: versionRef });
+  }
+
+  async setActiveStepVersion(name: string, version: string): Promise<void> {
+    validateStepName(name);
+    const s = await this.stepRow(name);
+    if (!s) throw new Error(`Step "${name}" not found`);
+    const versions = await this.stepVersionRows(name);
+    const v = versions.find((x) => x.version_label === version);
+    if (!v) {
+      throw new Error(
+        `Version "${version}" not found for step "${name}". Available: ${versions.map((x) => x.version_label).join(", ")}`,
+      );
+    }
+    const patch = patchFor(s as unknown as Record<string, unknown>, { active_version: v.content_hash, description: v.description });
+    if (patch) await this.backend.nodes.update(s.ref_id, patch);
+    await this.swapActiveStepEdge(s.ref_id, v.ref_id);
+  }
+
+  async deleteStep(name: string): Promise<boolean> {
+    validateStepName(name);
+    const s = await this.stepRow(name);
+    if (!s) return false;
+    for (const v of await this.stepVersionRows(name)) await this.backend.nodes.softDelete(v.ref_id);
+    await this.backend.nodes.softDelete(s.ref_id);
+    return true;
+  }
+
+  async deleteStepsByPublisher(publisher: string): Promise<string[]> {
+    const names = (await this.stepsWithActive())
+      .filter(({ step }) => step.publisher === publisher)
+      .map(({ step }) => step.step_type);
+    for (const n of names) await this.deleteStep(n);
+    return names;
+  }
+
+  // ── Step source + code loading ─────────────────────────────────────────
+
+  async getStepSource(type: string): Promise<{ code: string; origin: StepSource } | null> {
+    const s = await this.stepRow(type);
+    if (s) {
+      const v = (await this.stepVersionRows(type)).find((x) => x.content_hash === s.active_version);
+      if (v) return { code: v.source, origin: "custom" };
+    }
+    // Core + lib ship with the engine; a non-existent custom dir keeps the
+    // disk reader from ever serving a stale materialized file as "custom".
+    return readStepSourceFromDisk(type, join(this.materializeDir, ".none"));
+  }
+
+  /**
+   * Write every active custom step (helpers included) to the scratch dir as
+   * `<name>.ts`, skipping unchanged files and deleting files for steps that
+   * are no longer in the graph, so the loader never imports a stale step.
+   * Cheap to call on every registry rebuild.
+   */
+  async materializeCustomSteps(): Promise<string> {
+    const dir = this.materializeDir;
+    await mkdir(dir, { recursive: true });
+    const wanted = new Map<string, string>();
+    for (const { step, active } of await this.stepsWithActive()) {
+      if (active) wanted.set(join(dir, `${step.step_type}.ts`), active.source);
+    }
+    for (const [file, code] of wanted) {
+      let current: string | null = null;
+      try {
+        current = await readFile(file, "utf-8");
+      } catch {
+        // absent
+      }
+      if (current !== code) {
+        await mkdir(dirname(file), { recursive: true });
+        await writeFile(file, code, "utf-8");
+      }
+    }
+    for (const file of await walkTs(dir)) {
+      if (!wanted.has(file)) await rm(file, { force: true });
+    }
+    return dir;
+  }
+}
+
+async function walkTs(dir: string): Promise<string[]> {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  const out: string[] = [];
+  for (const e of entries) {
+    const full = join(dir, e.name);
+    if (e.isDirectory()) out.push(...(await walkTs(full)));
+    else if (e.isFile() && e.name.endsWith(".ts")) out.push(full);
+  }
+  return out;
+}

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -57,11 +57,14 @@ export {
 // Persistence
 export {
   type RunStore,
+  type TailOpts,
   type PartialRunSummary,
   FileRunStore,
   MemoryRunStore,
   generateRunId,
   tailJsonl,
+  tailFromPolling,
+  lastRunAtFromIds,
   summarizeFromEvents,
 } from "./store.js";
 

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -258,7 +258,7 @@ export {
 } from "./graph/backend.js";
 // Graph-backed workspace + the run/chat projector (plans/generic-storage.md §7).
 export { Neo4jWorkspaceStore, type Neo4jWorkspaceStoreOptions } from "./graph/workspace-store.js";
-export { graphWorkspaceFromEnv, graphWorkspaceRequested } from "./graph/wiring.js";
+export { graphWorkspaceFromEnv, graphWorkspaceRequested, graphMaterializeDir } from "./graph/wiring.js";
 export {
   projectRuns,
   projectChats,

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -95,6 +95,8 @@ export {
 
 // Workspace
 export {
+  type WorkspaceStore,
+  FileWorkspaceStore,
   WorkspaceManager,
   type WorkflowMetadata,
   type WorkflowVersionInfo,

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -256,3 +256,14 @@ export {
   type GraphBackend,
   type GraphBackendOptions,
 } from "./graph/backend.js";
+// Graph-backed workspace + the run/chat projector (plans/generic-storage.md §7).
+export { Neo4jWorkspaceStore, type Neo4jWorkspaceStoreOptions } from "./graph/workspace-store.js";
+export { graphWorkspaceFromEnv, graphWorkspaceRequested } from "./graph/wiring.js";
+export {
+  projectRuns,
+  projectChats,
+  projectAll,
+  projectRunEvents,
+  type ProjectRunsOptions,
+  type ProjectReport,
+} from "./graph/projector.js";

--- a/vein/src/run-step.ts
+++ b/vein/src/run-step.ts
@@ -102,8 +102,9 @@ export async function runSingleStep(
   };
 }
 
-/** Default on-disk location for a step's cassette, under the workspace. */
-export function cassettePath(workspacePath: string, name: string): string {
+/** Default on-disk location for a step's cassette, under the server's local
+ *  data dir (`dataDir` — the workspace root for file-backed deployments). */
+export function cassettePath(dataDir: string, name: string): string {
   // `name` may contain slashes (namespaced step types) — they become subdirs.
-  return `${workspacePath}/steps/_cassettes/${name}.json`;
+  return `${dataDir}/steps/_cassettes/${name}.json`;
 }

--- a/vein/src/server.ts
+++ b/vein/src/server.ts
@@ -1,6 +1,8 @@
 // Default vein server — a thin wrapper over createVein() that boots
 // vein with its filesystem-backed defaults (FileRunStore, workspace
-// loaded from VEIN_WORKSPACE, registry built by scanning steps/).
+// loaded from VEIN_WORKSPACE, registry built by scanning steps/), or —
+// with VEIN_WORKSPACE_BACKEND=graph — keeps workflows/steps in Neo4j
+// (see src/graph/wiring.ts) while runs/chats/blobs stay under VEIN_WORKSPACE.
 //
 // This file is the canonical "library usage" example: anything you
 // see here, your own consumer code can do too. Pass your own
@@ -9,6 +11,10 @@
 // behind Express, or just call `vein.listen(port)`).
 
 import { createVein, type Vein } from "./createVein.js";
+import { FileRunStore } from "./store.js";
+import { FileChatStore } from "./chat-store.js";
+import { FileSecretStore } from "./secret-store.js";
+import { graphWorkspaceRequested } from "./graph/wiring.js";
 
 let veinInstance: Vein | null = null;
 
@@ -16,7 +22,23 @@ let veinInstance: Vein | null = null;
  *  module doesn't kick off filesystem I/O at module-load time. */
 async function getDefault(): Promise<Vein> {
   if (!veinInstance) {
-    veinInstance = await createVein();
+    if (graphWorkspaceRequested()) {
+      const { graphWorkspaceFromEnv } = await import("./graph/wiring.js");
+      const { workspace } = await graphWorkspaceFromEnv();
+      // dataDir keeps its file default (VEIN_WORKSPACE / ./workspace): runs,
+      // chats, secrets, artifacts, and cassettes stay local. Explicit file
+      // stores, since a non-file workspace would otherwise default to memory.
+      const dataDir = process.env["VEIN_WORKSPACE"] ?? "./workspace";
+      veinInstance = await createVein({
+        workspace,
+        dataDir,
+        store: new FileRunStore(dataDir),
+        chatStore: new FileChatStore(dataDir),
+        secretStore: new FileSecretStore(dataDir),
+      });
+    } else {
+      veinInstance = await createVein();
+    }
   }
   return veinInstance;
 }

--- a/vein/src/server.ts
+++ b/vein/src/server.ts
@@ -24,11 +24,12 @@ async function getDefault(): Promise<Vein> {
   if (!veinInstance) {
     if (graphWorkspaceRequested()) {
       const { graphWorkspaceFromEnv } = await import("./graph/wiring.js");
-      const { workspace } = await graphWorkspaceFromEnv();
       // dataDir keeps its file default (VEIN_WORKSPACE / ./workspace): runs,
-      // chats, secrets, artifacts, and cassettes stay local. Explicit file
-      // stores, since a non-file workspace would otherwise default to memory.
+      // chats, secrets, artifacts, cassettes, and the materialized custom
+      // steps stay local. Explicit file stores, since a non-file workspace
+      // would otherwise default to memory.
       const dataDir = process.env["VEIN_WORKSPACE"] ?? "./workspace";
+      const { workspace } = await graphWorkspaceFromEnv(process.env, { dataDir });
       veinInstance = await createVein({
         workspace,
         dataDir,

--- a/vein/src/steps/lib/graph/graph-steps.test.ts
+++ b/vein/src/steps/lib/graph/graph-steps.test.ts
@@ -193,3 +193,59 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
     assert.equal(steps.length, 1, "inline VeinStep created once");
   });
 });
+
+// ── graph/project: the run/chat projector as a step ─────────────────────────
+
+describe("graph/project step", () => {
+  it("is discovered by the registry, sourced from lib", async () => {
+    const { registry, sources } = await buildRegistry();
+    assert.ok(registry["graph/project"]);
+    assert.equal(sources["graph/project"], "lib");
+  });
+
+  it("projects a file workspace's runs into the graph (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4J_URI not set" }, async () => {
+    const { mkdtemp, rm } = await import("node:fs/promises");
+    const { tmpdir } = await import("node:os");
+    const { join } = await import("node:path");
+    const { FileWorkspaceStore } = await import("../../../workspace.js");
+    const { FileRunStore } = await import("../../../store.js");
+    const { openGraphBackend } = await import("../../../graph/backend.js");
+
+    const dataDir = await mkdtemp(join(tmpdir(), "vein-project-step-"));
+    try {
+      const ws = new FileWorkspaceStore(dataDir);
+      await ws.publishWorkflow("wf", "v1", { steps: [{ id: "a", type: "log", config: { message: "x" } }] });
+      const store = new FileRunStore(dataDir);
+      const base = { runId: "1700000000000", path: "wf" };
+      await store.append("wf", base.runId, { ...base, ts: new Date().toISOString(), type: "run.start", input: {} });
+      await store.append("wf", base.runId, { ...base, ts: new Date().toISOString(), type: "run.end", output: "ok" });
+
+      const bolt = new Bolt(cfg!);
+      await wipeGraph(bolt);
+      await bolt.close();
+      const secrets: Record<string, string> = {
+        NEO4J_URI: cfg!.uri, NEO4J_USER: cfg!.user, NEO4J_PASSWORD: cfg!.password,
+        VEIN_GRAPH_NAMESPACE: cfg!.namespace, VEIN_GRAPH_EMBEDDINGS: "off",
+      };
+      const ctx = {
+        runId: "test", path: "test", scope: {}, input: undefined, emit: async () => {},
+        services: { secrets: { get: async (n: string) => secrets[n] } },
+      } as unknown as StepContext;
+      const { registry } = await buildRegistry();
+      const def = registry["graph/project"] as unknown as { input: { parse(v: unknown): unknown }; run(cfg: unknown, ctx: StepContext): Promise<any> };
+
+      const out = await def.run(def.input.parse({ dataDir }), ctx);
+      assert.ok(typeof out !== "string", out);
+      assert.deepEqual([out.workflows, out.runs, out.chats, out.skipped], [["wf"], 1, 0, 0]);
+      const again = await def.run(def.input.parse({ dataDir }), ctx);
+      assert.deepEqual([again.runs, again.skipped], [0, 1], "settled run skipped on re-run");
+
+      const b = await openGraphBackend({ ...cfg!, namespace: cfg!.namespace }, { embeddings: false, skipBoot: true });
+      const rows = await b.bolt.run(`MATCH (r:VeinRun) RETURN r.run_id AS id, r.status AS s`);
+      assert.deepEqual(rows, [{ id: base.runId, s: "success" }]);
+    } finally {
+      await closeGraphBackends();
+      await rm(dataDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/vein/src/steps/lib/graph/project.ts
+++ b/vein/src/steps/lib/graph/project.ts
@@ -1,0 +1,54 @@
+import { z } from "zod";
+import { defineStep, type StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+import { graphCtx, errText } from "./_shared.js";
+
+export default defineStep({
+  type: "graph/project",
+  description:
+    "Project vein's own run and chat history into the knowledge graph (VeinRun / VeinAgentSession / " +
+    "VeinToolCall / VeinChat / VeinTurn nodes with EXECUTED, IN_RUN, IN_SESSION, SPAWNED, IN_CHAT edges), " +
+    "reading the raw logs under the server's data dir. Idempotent — re-run any time; settled runs are " +
+    "skipped unless skipSettled is false. This is what makes 'which runs executed this version' and " +
+    "'which chat launched this run' one-hop graph questions.",
+  input: z.object({
+    dataDir: z
+      .string()
+      .optional()
+      .describe("Local data dir holding workflows/<name>/runs and chats/ (default: VEIN_WORKSPACE, else ./workspace)."),
+    workflows: z
+      .array(z.string())
+      .optional()
+      .describe("Workflows whose runs to project (default: every workflow the workspace lists)."),
+    limitPerWorkflow: z.number().int().positive().optional().describe("Newest N runs per workflow (default: all)."),
+    skipSettled: z.boolean().optional().describe("Skip runs already in the graph with a terminal status (default true)."),
+    chats: z.boolean().optional().describe("Also project chats + turns (default true)."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    try {
+      const b = await graphCtx(ctx as StepContext<VeinCapabilities>);
+      const dataDir = cfg.dataDir ?? process.env["VEIN_WORKSPACE"] ?? "./workspace";
+      const [{ FileRunStore }, { FileChatStore }, { FileWorkspaceStore }, { Neo4jWorkspaceStore }, { projectAll }, { graphWorkspaceRequested }] =
+        await Promise.all([
+          import("../../../store.js"),
+          import("../../../chat-store.js"),
+          import("../../../workspace.js"),
+          import("../../../graph/workspace-store.js"),
+          import("../../../graph/projector.js"),
+          import("../../../graph/wiring.js"),
+        ]);
+      const workflows =
+        cfg.workflows ??
+        (await (graphWorkspaceRequested() ? new Neo4jWorkspaceStore(b) : new FileWorkspaceStore(dataDir)).listWorkflows()).map((w) => w.name);
+      const report = await projectAll(
+        b,
+        { store: new FileRunStore(dataDir), chatStore: cfg.chats === false ? undefined : new FileChatStore(dataDir), workflows },
+        { limitPerWorkflow: cfg.limitPerWorkflow, skipSettled: cfg.skipSettled },
+      );
+      return { dataDir, workflows, ...report };
+    } catch (e) {
+      return errText("graph/project", e);
+    }
+  },
+});

--- a/vein/src/steps/registry.test.ts
+++ b/vein/src/steps/registry.test.ts
@@ -22,14 +22,14 @@ describe("buildRegistry", () => {
   });
 
   it("returns a registry and a parallel sources map", async () => {
-    const { registry, sources } = await buildRegistry(tempDir);
+    const { registry, sources } = await buildRegistry(join(tempDir, "steps", "custom"));
 
     assert.ok(typeof registry === "object" && registry !== null);
     assert.ok(typeof sources === "object" && sources !== null);
   });
 
   it("tags every core step with source: core", async () => {
-    const { sources } = await buildRegistry(tempDir);
+    const { sources } = await buildRegistry(join(tempDir, "steps", "custom"));
 
     for (const type of CORE_STEP_TYPES) {
       assert.equal(
@@ -41,7 +41,7 @@ describe("buildRegistry", () => {
   });
 
   it("tags lib steps (shipped under src/steps/lib) with source: lib", async () => {
-    const { registry, sources } = await buildRegistry(tempDir);
+    const { registry, sources } = await buildRegistry(join(tempDir, "steps", "custom"));
 
     // Shipped lib steps live under src/steps/lib (e.g. github/fetch-pr,
     // gdrive/export-file). If lib steps change, this test should adapt —
@@ -81,7 +81,7 @@ describe("buildRegistry", () => {
   it("tags user-published custom steps with source: custom", async () => {
     await ws.publishStep("my-custom", minimalStep("my-custom"));
 
-    const { registry, sources } = await buildRegistry(tempDir);
+    const { registry, sources } = await buildRegistry(join(tempDir, "steps", "custom"));
 
     assert.ok(registry["my-custom"], "custom step should be in registry");
     assert.equal(sources["my-custom"], "custom");
@@ -97,7 +97,7 @@ describe("buildRegistry", () => {
       minimalStep("gitree/save-feature"),
     );
 
-    const { registry, sources } = await buildRegistry(tempDir);
+    const { registry, sources } = await buildRegistry(join(tempDir, "steps", "custom"));
 
     assert.ok(
       registry["gitree/save-feature"],
@@ -113,7 +113,7 @@ describe("buildRegistry", () => {
   it("does not register helper files (_-prefixed)", async () => {
     await ws.publishStep("gitree/_shared", "export const HELPER = 1;");
 
-    const { registry, sources } = await buildRegistry(tempDir);
+    const { registry, sources } = await buildRegistry(join(tempDir, "steps", "custom"));
     assert.equal(registry["gitree/_shared"], undefined);
     assert.equal(sources["gitree/_shared"], undefined);
   });

--- a/vein/src/steps/registry.ts
+++ b/vein/src/steps/registry.ts
@@ -60,7 +60,7 @@ export const CORE_DIR = join(dirname(fileURLToPath(import.meta.url)), "core");
  */
 export async function readStepSourceFromDisk(
   type: string,
-  workspacePath: string,
+  customDir: string,
 ): Promise<{ code: string; origin: StepSource } | null> {
   const parts = type.split("/");
   const leaf = parts.at(-1)!;
@@ -72,7 +72,7 @@ export async function readStepSourceFromDisk(
   }
   candidates.push({ base: join(LIB_DIR, ...nested, leaf), origin: "lib" });
   candidates.push({
-    base: join(workspacePath, "steps", "custom", ...nested, leaf),
+    base: join(customDir, ...nested, leaf),
     origin: "custom",
   });
 
@@ -200,7 +200,8 @@ export async function stepLoadError(filePath: string): Promise<string | null> {
 /**
  * Build the complete step registry by merging core steps (statically
  * imported) with lib steps (dynamically imported from `src/steps/lib/`)
- * and custom steps (dynamically imported from `<workspace>/steps/custom/`).
+ * and custom steps (dynamically imported from `customDir` — the directory
+ * `WorkspaceStore.materializeCustomSteps()` returns; omit for core+lib only).
  *
  * Resolution order: core/ → lib/ → custom/. Higher tiers cannot shadow
  * lower ones — a name collision is skipped with a warning.
@@ -213,7 +214,7 @@ export async function stepLoadError(filePath: string): Promise<string | null> {
  * Returns both the registry and a parallel `sources` map so callers can
  * report which tier each step came from without guessing from the name.
  */
-export async function buildRegistry(workspacePath?: string): Promise<RegistryBundle> {
+export async function buildRegistry(customDir?: string): Promise<RegistryBundle> {
   const registry: StepRegistry = { ...CORE_STEPS };
   const sources: StepSources = {};
 
@@ -223,13 +224,8 @@ export async function buildRegistry(workspacePath?: string): Promise<RegistryBun
 
   await loadStepsFrom(LIB_DIR, registry, sources, "lib");
 
-  if (workspacePath) {
-    await loadStepsFrom(
-      join(workspacePath, "steps", "custom"),
-      registry,
-      sources,
-      "custom",
-    );
+  if (customDir) {
+    await loadStepsFrom(customDir, registry, sources, "custom");
   }
 
   return { registry, sources };
@@ -285,9 +281,8 @@ export function coreRegistry(): StepRegistry {
  *     See AGENTS.md "Lib step dependency convention".
  *   - whatever you pass in `steps`
  *
- * Workspace **custom/** steps live on disk and are loaded via
- * `buildRegistry(workspacePath)` instead — they're never included
- * here.
+ * Workspace **custom/** steps are loaded via `buildRegistry(customDir)`
+ * instead — they're never included here.
  *
  * Each step is keyed by its `type` field. Duplicates among `steps`
  * throw. A user step whose `type` collides with a core or lib step

--- a/vein/src/storage-conformance.test.ts
+++ b/vein/src/storage-conformance.test.ts
@@ -1,13 +1,14 @@
 import { describe, it, beforeEach, afterEach } from "node:test";
 import assert from "node:assert/strict";
-import { mkdir, rm, stat } from "node:fs/promises";
+import { mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { RunEvent, RunSummary } from "./core.js";
 import { FileRunStore, MemoryRunStore, summarizeFromEvents, type RunStore } from "./store.js";
-import { FileWorkspaceStore, type WorkspaceStore } from "./workspace.js";
+import { FileWorkspaceStore } from "./workspace.js";
 import { pathlessWorkspace } from "./test-util/pathless-workspace.js";
+import { workspaceConformance } from "./test-util/workspace-conformance.js";
 import { FileChatStore, MemoryChatStore, type ChatStore, type ChatEvent } from "./chat-store.js";
 import { FileSecretStore, MemorySecretStore, type SecretStore } from "./secret-store.js";
 
@@ -18,136 +19,8 @@ import { FileSecretStore, MemorySecretStore, type SecretStore } from "./secret-s
  * a different assertion here is a backend that changed the contract.
  */
 
-const STEP_SRC = (type: string, desc: string) => `import { z } from "zod";
-import { defineStep } from "vein";
-export default defineStep({
-  type: ${JSON.stringify(type)},
-  description: ${JSON.stringify(desc)},
-  input: z.object({}),
-  output: z.any(),
-  async run() { return ${JSON.stringify(desc)}; },
-});
-`;
-
-// ── Workspace store ────────────────────────────────────────────────────────
-
-const workspaceImpls: Array<{ name: string; make: (dir: string) => WorkspaceStore }> = [
-  { name: "FileWorkspaceStore", make: (dir) => new FileWorkspaceStore(dir) },
-  { name: "path-less WorkspaceStore", make: (dir) => pathlessWorkspace(new FileWorkspaceStore(dir)) },
-];
-
-for (const impl of workspaceImpls) {
-  describe(`WorkspaceStore conformance: ${impl.name}`, () => {
-    let dir: string;
-    let ws: WorkspaceStore;
-    beforeEach(async () => {
-      dir = join(tmpdir(), `vein-conf-ws-${randomUUID()}`);
-      await mkdir(dir, { recursive: true });
-      ws = impl.make(dir);
-    });
-    afterEach(() => rm(dir, { recursive: true, force: true }));
-
-    const steps = [{ id: "a", type: "log", config: { message: "hi" } }];
-
-    it("workflow publish → list → metadata → source → hash round-trip", async () => {
-      await ws.publishWorkflow("wf", "v1", { steps }, "first", "exp", "me");
-      const list = await ws.listWorkflows();
-      assert.deepEqual(
-        list.map((w) => [w.name, w.activeVersion, w.versions, w.description, w.category, w.publisher]),
-        [["wf", "v1", ["v1"], "first", "exp", "me"]],
-      );
-      assert.equal("lastRunAt" in list[0]!, false, "runs are the run store's — never listed here");
-      const meta = await ws.getWorkflowMetadata("wf");
-      assert.equal(meta?.active, "v1");
-      assert.equal(meta?.publisher, "me");
-      assert.equal(await ws.getWorkflowMetadata("nope"), null);
-      const src = await ws.getWorkflowSource("wf", "v1");
-      assert.ok(src.includes("type: log"));
-      assert.equal(typeof (await ws.getWorkflowHash("wf")), "string");
-      assert.equal(await ws.getWorkflowHash("nope"), null);
-      assert.equal((await ws.getWorkflow("wf")).steps.length, 1);
-      assert.equal((await ws.getWorkflowVersion("wf", "v1")).steps.length, 1);
-      await assert.rejects(() => ws.getWorkflow("nope"), /not found/);
-    });
-
-    it("versions, active switching, content dedup, category, params", async () => {
-      await ws.publishWorkflow("wf", "v1", { steps, params: { greeting: "old" } });
-      const first = await ws.publishWorkflowByContent("wf", await ws.getWorkflowSource("wf", "v1"));
-      assert.equal(first.changed, false, "same content → no new version");
-      assert.equal(first.version, "v1");
-      const second = await ws.publishWorkflowByContent(
-        "wf",
-        (await ws.getWorkflowSource("wf", "v1")).replace("old", "new"),
-      );
-      assert.equal(second.changed, true);
-      assert.notEqual(second.version, "v1");
-      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, second.version);
-      await ws.setActiveVersion("wf", "v1");
-      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, "v1");
-      await assert.rejects(() => ws.setActiveVersion("wf", "v99"));
-      await ws.setWorkflowCategory("wf", "cat");
-      assert.equal((await ws.getWorkflowMetadata("wf"))?.category, "cat");
-      const p = await ws.setParam("wf", "greeting", "newer");
-      assert.deepEqual([p.before, p.after], ["old", "newer"]);
-      assert.equal((await ws.getWorkflow("wf")).params?.["greeting"], "newer");
-    });
-
-    it("createWorkflow allocates a fresh name/version and returns it", async () => {
-      const a = await ws.createWorkflow("made", { steps });
-      const b = await ws.createWorkflow("made", { steps });
-      assert.equal(a.name, "made");
-      assert.notEqual(b.name, a.name, "a second create under the same name is renamed, not clobbered");
-    });
-
-    it("step publish → list → versions → source → active switching → delete", async () => {
-      const v1 = await ws.publishStep("my-step", STEP_SRC("my-step", "one"), "one", "svc");
-      const again = await ws.publishStep("my-step", STEP_SRC("my-step", "one"), "one", "svc");
-      assert.equal(again.changed, false, "same source → no new version");
-      const v2 = await ws.publishStep("my-step", STEP_SRC("my-step", "two"), "two", "svc");
-      assert.equal(v2.changed, true);
-      assert.deepEqual(
-        (await ws.listSteps()).map((s) => [s.type, s.description, s.publisher]),
-        [["my-step", "two", "svc"]],
-      );
-      assert.deepEqual(await ws.listSteps({ publisher: "other" }), []);
-      const versions = await ws.listStepVersions("my-step");
-      assert.equal(versions.active, v2.version);
-      assert.deepEqual(new Set(versions.versions), new Set([v1.version, v2.version]));
-      assert.ok((await ws.getStepVersionSource("my-step", v1.version)).includes('"one"'));
-      await ws.setActiveStepVersion("my-step", v1.version);
-      assert.equal((await ws.listStepVersions("my-step")).active, v1.version);
-      assert.equal((await ws.getStepSource("my-step"))?.code.includes('"one"'), true);
-      assert.equal(await ws.deleteStep("my-step"), true);
-      assert.equal(await ws.deleteStep("my-step"), false);
-      assert.deepEqual(await ws.listSteps(), []);
-    });
-
-    it("deleteStepsByPublisher removes exactly that publisher's steps", async () => {
-      await ws.publishStep("a", STEP_SRC("a", "a"), "a", "svc-1");
-      await ws.publishStep("ns/b", STEP_SRC("ns/b", "b"), "b", "svc-1");
-      await ws.publishStep("c", STEP_SRC("c", "c"), "c", "svc-2");
-      assert.deepEqual((await ws.deleteStepsByPublisher("svc-1")).sort(), ["a", "ns/b"]);
-      assert.deepEqual((await ws.listSteps()).map((s) => s.type), ["c"]);
-    });
-
-    it("getStepSource spans tiers: custom from the store, lib + core from the engine, null otherwise", async () => {
-      await ws.publishStep("ns/custom", STEP_SRC("ns/custom", "x"));
-      assert.equal((await ws.getStepSource("ns/custom"))?.origin, "custom");
-      assert.equal((await ws.getStepSource("log"))?.origin, "core");
-      assert.equal((await ws.getStepSource("github/fetch-pr"))?.origin, "lib");
-      assert.equal(await ws.getStepSource("no/such/step"), null);
-    });
-
-    it("materializeCustomSteps returns a directory holding every active custom step as a file", async () => {
-      await ws.publishStep("flat", STEP_SRC("flat", "f"));
-      await ws.publishStep("ns/nested", STEP_SRC("ns/nested", "n"));
-      const root = await ws.materializeCustomSteps();
-      assert.ok((await stat(join(root, "flat.ts"))).isFile());
-      assert.ok((await stat(join(root, "ns", "nested.ts"))).isFile());
-      assert.equal(await ws.materializeCustomSteps(), root, "idempotent");
-    });
-  });
-}
+workspaceConformance({ name: "FileWorkspaceStore", make: (dir) => new FileWorkspaceStore(dir) });
+workspaceConformance({ name: "path-less WorkspaceStore", make: (dir) => pathlessWorkspace(new FileWorkspaceStore(dir)) });
 
 // ── Run store ──────────────────────────────────────────────────────────────
 

--- a/vein/src/storage-conformance.test.ts
+++ b/vein/src/storage-conformance.test.ts
@@ -1,0 +1,365 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import type { RunEvent, RunSummary } from "./core.js";
+import { FileRunStore, MemoryRunStore, summarizeFromEvents, type RunStore } from "./store.js";
+import { FileWorkspaceStore, type WorkspaceStore } from "./workspace.js";
+import { pathlessWorkspace } from "./test-util/pathless-workspace.js";
+import { FileChatStore, MemoryChatStore, type ChatStore, type ChatEvent } from "./chat-store.js";
+import { FileSecretStore, MemorySecretStore, type SecretStore } from "./secret-store.js";
+
+/**
+ * The storage boundary's spec, as tests: one behavioral suite per layer,
+ * parameterized over implementations. Every backend — file, memory, and a
+ * future graph-backed one — passes the same cases. A backend that needs
+ * a different assertion here is a backend that changed the contract.
+ */
+
+const STEP_SRC = (type: string, desc: string) => `import { z } from "zod";
+import { defineStep } from "vein";
+export default defineStep({
+  type: ${JSON.stringify(type)},
+  description: ${JSON.stringify(desc)},
+  input: z.object({}),
+  output: z.any(),
+  async run() { return ${JSON.stringify(desc)}; },
+});
+`;
+
+// ── Workspace store ────────────────────────────────────────────────────────
+
+const workspaceImpls: Array<{ name: string; make: (dir: string) => WorkspaceStore }> = [
+  { name: "FileWorkspaceStore", make: (dir) => new FileWorkspaceStore(dir) },
+  { name: "path-less WorkspaceStore", make: (dir) => pathlessWorkspace(new FileWorkspaceStore(dir)) },
+];
+
+for (const impl of workspaceImpls) {
+  describe(`WorkspaceStore conformance: ${impl.name}`, () => {
+    let dir: string;
+    let ws: WorkspaceStore;
+    beforeEach(async () => {
+      dir = join(tmpdir(), `vein-conf-ws-${randomUUID()}`);
+      await mkdir(dir, { recursive: true });
+      ws = impl.make(dir);
+    });
+    afterEach(() => rm(dir, { recursive: true, force: true }));
+
+    const steps = [{ id: "a", type: "log", config: { message: "hi" } }];
+
+    it("workflow publish → list → metadata → source → hash round-trip", async () => {
+      await ws.publishWorkflow("wf", "v1", { steps }, "first", "exp", "me");
+      const list = await ws.listWorkflows();
+      assert.deepEqual(
+        list.map((w) => [w.name, w.activeVersion, w.versions, w.description, w.category, w.publisher]),
+        [["wf", "v1", ["v1"], "first", "exp", "me"]],
+      );
+      assert.equal("lastRunAt" in list[0]!, false, "runs are the run store's — never listed here");
+      const meta = await ws.getWorkflowMetadata("wf");
+      assert.equal(meta?.active, "v1");
+      assert.equal(meta?.publisher, "me");
+      assert.equal(await ws.getWorkflowMetadata("nope"), null);
+      const src = await ws.getWorkflowSource("wf", "v1");
+      assert.ok(src.includes("type: log"));
+      assert.equal(typeof (await ws.getWorkflowHash("wf")), "string");
+      assert.equal(await ws.getWorkflowHash("nope"), null);
+      assert.equal((await ws.getWorkflow("wf")).steps.length, 1);
+      assert.equal((await ws.getWorkflowVersion("wf", "v1")).steps.length, 1);
+      await assert.rejects(() => ws.getWorkflow("nope"), /not found/);
+    });
+
+    it("versions, active switching, content dedup, category, params", async () => {
+      await ws.publishWorkflow("wf", "v1", { steps, params: { greeting: "old" } });
+      const first = await ws.publishWorkflowByContent("wf", await ws.getWorkflowSource("wf", "v1"));
+      assert.equal(first.changed, false, "same content → no new version");
+      assert.equal(first.version, "v1");
+      const second = await ws.publishWorkflowByContent(
+        "wf",
+        (await ws.getWorkflowSource("wf", "v1")).replace("old", "new"),
+      );
+      assert.equal(second.changed, true);
+      assert.notEqual(second.version, "v1");
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, second.version);
+      await ws.setActiveVersion("wf", "v1");
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, "v1");
+      await assert.rejects(() => ws.setActiveVersion("wf", "v99"));
+      await ws.setWorkflowCategory("wf", "cat");
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.category, "cat");
+      const p = await ws.setParam("wf", "greeting", "newer");
+      assert.deepEqual([p.before, p.after], ["old", "newer"]);
+      assert.equal((await ws.getWorkflow("wf")).params?.["greeting"], "newer");
+    });
+
+    it("createWorkflow allocates a fresh name/version and returns it", async () => {
+      const a = await ws.createWorkflow("made", { steps });
+      const b = await ws.createWorkflow("made", { steps });
+      assert.equal(a.name, "made");
+      assert.notEqual(b.name, a.name, "a second create under the same name is renamed, not clobbered");
+    });
+
+    it("step publish → list → versions → source → active switching → delete", async () => {
+      const v1 = await ws.publishStep("my-step", STEP_SRC("my-step", "one"), "one", "svc");
+      const again = await ws.publishStep("my-step", STEP_SRC("my-step", "one"), "one", "svc");
+      assert.equal(again.changed, false, "same source → no new version");
+      const v2 = await ws.publishStep("my-step", STEP_SRC("my-step", "two"), "two", "svc");
+      assert.equal(v2.changed, true);
+      assert.deepEqual(
+        (await ws.listSteps()).map((s) => [s.type, s.description, s.publisher]),
+        [["my-step", "two", "svc"]],
+      );
+      assert.deepEqual(await ws.listSteps({ publisher: "other" }), []);
+      const versions = await ws.listStepVersions("my-step");
+      assert.equal(versions.active, v2.version);
+      assert.deepEqual(new Set(versions.versions), new Set([v1.version, v2.version]));
+      assert.ok((await ws.getStepVersionSource("my-step", v1.version)).includes('"one"'));
+      await ws.setActiveStepVersion("my-step", v1.version);
+      assert.equal((await ws.listStepVersions("my-step")).active, v1.version);
+      assert.equal((await ws.getStepSource("my-step"))?.code.includes('"one"'), true);
+      assert.equal(await ws.deleteStep("my-step"), true);
+      assert.equal(await ws.deleteStep("my-step"), false);
+      assert.deepEqual(await ws.listSteps(), []);
+    });
+
+    it("deleteStepsByPublisher removes exactly that publisher's steps", async () => {
+      await ws.publishStep("a", STEP_SRC("a", "a"), "a", "svc-1");
+      await ws.publishStep("ns/b", STEP_SRC("ns/b", "b"), "b", "svc-1");
+      await ws.publishStep("c", STEP_SRC("c", "c"), "c", "svc-2");
+      assert.deepEqual((await ws.deleteStepsByPublisher("svc-1")).sort(), ["a", "ns/b"]);
+      assert.deepEqual((await ws.listSteps()).map((s) => s.type), ["c"]);
+    });
+
+    it("getStepSource spans tiers: custom from the store, lib + core from the engine, null otherwise", async () => {
+      await ws.publishStep("ns/custom", STEP_SRC("ns/custom", "x"));
+      assert.equal((await ws.getStepSource("ns/custom"))?.origin, "custom");
+      assert.equal((await ws.getStepSource("log"))?.origin, "core");
+      assert.equal((await ws.getStepSource("github/fetch-pr"))?.origin, "lib");
+      assert.equal(await ws.getStepSource("no/such/step"), null);
+    });
+
+    it("materializeCustomSteps returns a directory holding every active custom step as a file", async () => {
+      await ws.publishStep("flat", STEP_SRC("flat", "f"));
+      await ws.publishStep("ns/nested", STEP_SRC("ns/nested", "n"));
+      const root = await ws.materializeCustomSteps();
+      assert.ok((await stat(join(root, "flat.ts"))).isFile());
+      assert.ok((await stat(join(root, "ns", "nested.ts"))).isFile());
+      assert.equal(await ws.materializeCustomSteps(), root, "idempotent");
+    });
+  });
+}
+
+// ── Run store ──────────────────────────────────────────────────────────────
+
+const runImpls: Array<{ name: string; make: (dir: string) => RunStore }> = [
+  { name: "FileRunStore", make: (dir) => new FileRunStore(dir) },
+  { name: "MemoryRunStore", make: () => new MemoryRunStore() },
+];
+
+const WF = "wf";
+const ev = (runId: string, type: RunEvent["type"], extra: Partial<RunEvent> = {}): RunEvent => ({
+  ts: new Date().toISOString(),
+  runId,
+  path: WF,
+  type,
+  ...extra,
+});
+const summaryFor = (runId: string): RunSummary => ({
+  runId,
+  workflow: WF,
+  startedAt: "s",
+  finishedAt: "f",
+  durationMs: 1,
+  status: "success",
+  input: { q: 1 },
+  output: { answer: 42 },
+});
+
+for (const impl of runImpls) {
+  describe(`RunStore conformance: ${impl.name}`, () => {
+    let dir: string;
+    let store: RunStore;
+    beforeEach(async () => {
+      dir = join(tmpdir(), `vein-conf-run-${randomUUID()}`);
+      await mkdir(dir, { recursive: true });
+      store = impl.make(dir);
+    });
+    afterEach(() => rm(dir, { recursive: true, force: true }));
+
+    it("append → getRunEvents → finalize → getRunSummary; unknown runs are empty/null", async () => {
+      await store.append(WF, "1000", ev("1000", "run.start", { input: { q: 1 } }));
+      await store.append(WF, "1000", ev("1000", "run.end"));
+      assert.deepEqual((await store.getRunEvents(WF, "1000")).map((e) => e.type), ["run.start", "run.end"]);
+      assert.equal(await store.getRunSummary(WF, "1000"), null);
+      await store.finalize(WF, "1000", summaryFor("1000"));
+      assert.deepEqual(await store.getRunSummary(WF, "1000"), summaryFor("1000"));
+      assert.deepEqual(await store.getRunEvents(WF, "nope"), []);
+      assert.equal(await store.getRunSummary(WF, "nope"), null);
+    });
+
+    it("listRuns is per-workflow, newest first; lastRunAt is the newest run's start", async () => {
+      await store.append(WF, "1000", ev("1000", "run.start"));
+      await store.append(WF, "3000", ev("3000", "run.start"));
+      await store.append(WF, "2000", ev("2000", "run.start"));
+      await store.append("other", "9000", ev("9000", "run.start"));
+      assert.deepEqual(await store.listRuns(WF), ["3000", "2000", "1000"]);
+      assert.deepEqual(await store.listRuns("never"), []);
+      assert.equal(await store.lastRunAt(WF), 3000);
+      assert.equal(await store.lastRunAt("never"), null);
+    });
+
+    it("a finalize-less log yields a partial summary (crash / in-flight)", async () => {
+      await store.append(WF, "1", ev("1", "run.start", { input: { q: 1 } }));
+      await store.append(WF, "1", ev("1", "step.end", { path: `${WF}/a`, output: "A" }));
+      await store.append(WF, "1", ev("1", "step.error", { path: `${WF}/b`, error: { message: "boom" } }));
+      const partial = summarizeFromEvents(WF, "1", await store.getRunEvents(WF, "1"));
+      assert.equal(partial?.partial, true);
+      assert.deepEqual(partial?.steps, { a: "A" });
+      assert.equal(partial?.lastError?.message, "boom");
+      assert.equal(summarizeFromEvents(WF, "nope", await store.getRunEvents(WF, "nope")), null);
+    });
+
+    it("tailEvents: history, then live follow, closing at the terminal event", async () => {
+      await store.append(WF, "1", ev("1", "run.start"));
+      const seen: string[] = [];
+      const tail = (async () => {
+        for await (const e of store.tailEvents(WF, "1", { intervalMs: 5 })) seen.push(e.type);
+      })();
+      await new Promise((r) => setTimeout(r, 25));
+      await store.append(WF, "1", ev("1", "step.start", { path: `${WF}/a` }));
+      await store.append(WF, "1", ev("1", "run.end"));
+      await tail;
+      assert.deepEqual(seen, ["run.start", "step.start", "run.end"]);
+    });
+
+    it("tailEvents: a run.resumed past a terminal event reopens the log", async () => {
+      for (const t of ["run.start", "run.cancelled", "run.resumed", "run.end"] as const) {
+        await store.append(WF, "1", ev("1", t));
+      }
+      const seen: string[] = [];
+      for await (const e of store.tailEvents(WF, "1", { intervalMs: 5 })) seen.push(e.type);
+      assert.deepEqual(seen, ["run.start", "run.cancelled", "run.resumed", "run.end"]);
+    });
+
+    it("tailEvents: stillLive keeps following after a terminal event; abort stops it", async () => {
+      await store.append(WF, "1", ev("1", "run.start"));
+      await store.append(WF, "1", ev("1", "run.error", { error: { message: "x" } }));
+      let live = true;
+      const seen: string[] = [];
+      const tail = (async () => {
+        for await (const e of store.tailEvents(WF, "1", { intervalMs: 5, stillLive: () => live })) {
+          seen.push(e.type);
+        }
+      })();
+      await new Promise((r) => setTimeout(r, 25));
+      await store.append(WF, "1", ev("1", "run.resumed"));
+      await store.append(WF, "1", ev("1", "run.end"));
+      live = false;
+      await tail;
+      assert.deepEqual(seen, ["run.start", "run.error", "run.resumed", "run.end"]);
+
+      const ac = new AbortController();
+      const aborted: string[] = [];
+      const t2 = (async () => {
+        for await (const e of store.tailEvents(WF, "2", { intervalMs: 5, signal: ac.signal })) {
+          aborted.push(e.type);
+        }
+      })();
+      await new Promise((r) => setTimeout(r, 15));
+      ac.abort();
+      await t2;
+      assert.deepEqual(aborted, [], "no events yet and aborted → nothing, and it returns");
+    });
+  });
+}
+
+// ── Chat store ─────────────────────────────────────────────────────────────
+
+const chatImpls: Array<{ name: string; make: (dir: string) => ChatStore }> = [
+  { name: "FileChatStore", make: (dir) => new FileChatStore(dir) },
+  { name: "MemoryChatStore", make: () => new MemoryChatStore() },
+];
+
+const cev = (chatId: string, turn: number, type: ChatEvent["type"], extra: Partial<ChatEvent> = {}): ChatEvent => ({
+  ts: new Date().toISOString(),
+  chatId,
+  turn,
+  type,
+  ...extra,
+});
+
+for (const impl of chatImpls) {
+  describe(`ChatStore conformance: ${impl.name}`, () => {
+    let dir: string;
+    let store: ChatStore;
+    beforeEach(async () => {
+      dir = join(tmpdir(), `vein-conf-chat-${randomUUID()}`);
+      await mkdir(dir, { recursive: true });
+      store = impl.make(dir);
+    });
+    afterEach(() => rm(dir, { recursive: true, force: true }));
+
+    it("create → meta → list → messages → delete", async () => {
+      const meta = await store.createChat({ id: "c1", title: "t" });
+      assert.equal(meta.id, "c1");
+      assert.equal((await store.getMeta("c1"))?.title, "t");
+      assert.equal(await store.getMeta("nope"), null);
+      await store.setMeta("c1", { status: "done" });
+      assert.equal((await store.getMeta("c1"))?.status, "done");
+      assert.deepEqual((await store.listChats()).map((c) => c.id), ["c1"]);
+      await store.appendMessages("c1", [{ role: "user", content: "hi" } as never]);
+      assert.equal((await store.loadMessages("c1")).length, 1);
+      await store.deleteChat("c1");
+      assert.equal(await store.getMeta("c1"), null);
+    });
+
+    it("tailEvents yields one turn's events (history → live) and stops at its terminal", async () => {
+      await store.createChat({ id: "c1" });
+      await store.appendEvent("c1", cev("c1", 0, "text-delta", { delta: "a" }));
+      await store.appendEvent("c1", cev("c1", 0, "chat.end"));
+      await store.appendEvent("c1", cev("c1", 1, "text-delta", { delta: "b" }));
+      const seen: ChatEvent[] = [];
+      const tail = (async () => {
+        for await (const e of store.tailEvents("c1", 1, { intervalMs: 5 })) seen.push(e);
+      })();
+      await new Promise((r) => setTimeout(r, 25));
+      await store.appendEvent("c1", cev("c1", 1, "chat.end"));
+      await tail;
+      assert.deepEqual(seen.map((e) => [e.turn, e.type]), [[1, "text-delta"], [1, "chat.end"]]);
+    });
+  });
+}
+
+// ── Secret store ───────────────────────────────────────────────────────────
+
+const secretImpls: Array<{ name: string; make: (dir: string) => SecretStore }> = [
+  { name: "FileSecretStore", make: (dir) => new FileSecretStore(dir) },
+  { name: "MemorySecretStore", make: () => new MemorySecretStore() },
+];
+
+for (const impl of secretImpls) {
+  describe(`SecretStore conformance: ${impl.name}`, () => {
+    let dir: string;
+    let store: SecretStore;
+    beforeEach(async () => {
+      dir = join(tmpdir(), `vein-conf-secret-${randomUUID()}`);
+      await mkdir(dir, { recursive: true });
+      store = impl.make(dir);
+    });
+    afterEach(() => rm(dir, { recursive: true, force: true }));
+
+    it("set → get → list (names only, never values) → overwrite → delete", async () => {
+      assert.equal(await store.get("API_KEY"), undefined);
+      await store.set("API_KEY", "s3cret");
+      assert.equal(await store.get("API_KEY"), "s3cret");
+      const listed = await store.list();
+      assert.deepEqual(listed.map((s) => s.name), ["API_KEY"]);
+      assert.equal(JSON.stringify(listed).includes("s3cret"), false, "list never carries values");
+      await store.set("API_KEY", "rotated");
+      assert.equal(await store.get("API_KEY"), "rotated");
+      assert.equal(await store.delete("API_KEY"), true);
+      assert.equal(await store.delete("API_KEY"), false);
+      assert.equal(await store.get("API_KEY"), undefined);
+    });
+  });
+}

--- a/vein/src/store.test.ts
+++ b/vein/src/store.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 import { tmpdir } from "node:os";
 import { randomUUID } from "node:crypto";
 import type { RunEvent, RunSummary } from "./core.js";
-import { FileRunStore, MemoryRunStore, summarizeFromEvents } from "./store.js";
+import { FileRunStore, MemoryRunStore, summarizeFromEvents, tailFromPolling, lastRunAtFromIds } from "./store.js";
 
 const WF = "test-workflow";
 
@@ -398,5 +398,122 @@ describe("summarizeFromEvents", () => {
   it("threads a caller-supplied live status through", () => {
     const s = summarizeFromEvents(WF, "r1", [ev({ type: "run.start" })], "running");
     assert.equal(s?.status, "running");
+  });
+});
+
+// ── MemoryRunStore reads + polling tail ────────────────────────────────────
+
+describe("MemoryRunStore reads", () => {
+  const ev = (runId: string, type: RunEvent["type"], ts = new Date().toISOString()): RunEvent => ({
+    ts,
+    runId,
+    path: WF,
+    type,
+  });
+
+  it("lists runs newest first, reads events + summary, reports lastRunAt", async () => {
+    const store = new MemoryRunStore();
+    await store.append(WF, "1000", ev("1000", "run.start"));
+    await store.append(WF, "2000", ev("2000", "run.start"));
+    await store.append(WF, "2000", ev("2000", "run.end"));
+    const summary: RunSummary = {
+      runId: "2000",
+      workflow: WF,
+      startedAt: "a",
+      finishedAt: "b",
+      durationMs: 1,
+      status: "success",
+      input: {},
+    };
+    await store.finalize(WF, "2000", summary);
+
+    assert.deepEqual(await store.listRuns(WF), ["2000", "1000"]);
+    assert.deepEqual(await store.listRuns("other"), []);
+    assert.equal((await store.getRunEvents(WF, "2000")).length, 2);
+    assert.deepEqual(await store.getRunEvents(WF, "nope"), []);
+    assert.deepEqual(await store.getRunSummary(WF, "2000"), summary);
+    assert.equal(await store.getRunSummary(WF, "1000"), null);
+    assert.equal(await store.lastRunAt(WF), 2000);
+    assert.equal(await store.lastRunAt("other"), null);
+  });
+
+  it("getRunEvents returns a copy (callers can't mutate the log)", async () => {
+    const store = new MemoryRunStore();
+    await store.append(WF, "r", ev("r", "run.start"));
+    const got = await store.getRunEvents(WF, "r");
+    got.push(ev("r", "run.end"));
+    assert.equal((await store.getRunEvents(WF, "r")).length, 1);
+  });
+
+  it("tailEvents drains history then follows appends until terminal", async () => {
+    const store = new MemoryRunStore();
+    await store.append(WF, "r", ev("r", "run.start"));
+    const seen: string[] = [];
+    const tail = (async () => {
+      for await (const e of store.tailEvents(WF, "r", { intervalMs: 5 })) seen.push(e.type);
+    })();
+    await new Promise((r) => setTimeout(r, 20));
+    await store.append(WF, "r", ev("r", "step.start"));
+    await store.append(WF, "r", ev("r", "run.end"));
+    await tail;
+    assert.deepEqual(seen, ["run.start", "step.start", "run.end"]);
+  });
+
+  it("tailEvents scans past a terminal event when a run.resumed reopens the log", async () => {
+    const store = new MemoryRunStore();
+    for (const t of ["run.start", "run.error", "run.resumed", "run.end"] as const) {
+      await store.append(WF, "r", ev("r", t));
+    }
+    const seen: string[] = [];
+    for await (const e of store.tailEvents(WF, "r", { intervalMs: 5 })) seen.push(e.type);
+    assert.deepEqual(seen, ["run.start", "run.error", "run.resumed", "run.end"]);
+  });
+
+  it("tailEvents keeps following after a terminal event while stillLive", async () => {
+    const store = new MemoryRunStore();
+    await store.append(WF, "r", ev("r", "run.start"));
+    await store.append(WF, "r", ev("r", "run.cancelled"));
+    let live = true;
+    const seen: string[] = [];
+    const tail = (async () => {
+      for await (const e of store.tailEvents(WF, "r", { intervalMs: 5, stillLive: () => live })) {
+        seen.push(e.type);
+      }
+    })();
+    await new Promise((r) => setTimeout(r, 20));
+    await store.append(WF, "r", ev("r", "run.resumed"));
+    await store.append(WF, "r", ev("r", "run.end"));
+    live = false;
+    await tail;
+    assert.deepEqual(seen, ["run.start", "run.cancelled", "run.resumed", "run.end"]);
+  });
+
+  it("tailEvents stops on abort", async () => {
+    const store = new MemoryRunStore();
+    await store.append(WF, "r", ev("r", "run.start"));
+    const ac = new AbortController();
+    const seen: string[] = [];
+    const tail = (async () => {
+      for await (const e of store.tailEvents(WF, "r", { intervalMs: 5, signal: ac.signal })) {
+        seen.push(e.type);
+      }
+    })();
+    await new Promise((r) => setTimeout(r, 20));
+    ac.abort();
+    await tail;
+    assert.deepEqual(seen, ["run.start"]);
+  });
+
+  it("tailFromPolling works over any getRunEvents source", async () => {
+    const log: RunEvent[] = [ev("r", "run.start"), ev("r", "run.end")];
+    const seen: string[] = [];
+    for await (const e of tailFromPolling({ getRunEvents: async () => log }, WF, "r")) seen.push(e.type);
+    assert.deepEqual(seen, ["run.start", "run.end"]);
+  });
+
+  it("lastRunAtFromIds picks the max numeric id and ignores non-numeric", () => {
+    assert.equal(lastRunAtFromIds(["10", "abc", "30", "20"]), 30);
+    assert.equal(lastRunAtFromIds(["abc"]), null);
+    assert.equal(lastRunAtFromIds([]), null);
   });
 });

--- a/vein/src/store.ts
+++ b/vein/src/store.ts
@@ -117,9 +117,93 @@ export async function* tailJsonl<T>(
 
 // ── Interface ──────────────────────────────────────────────────────────────
 
+/** Options for `RunStore.tailEvents`. */
+export interface TailOpts {
+  /** Poll interval while following a live log (default 250ms). */
+  intervalMs?: number;
+  /** Stop the tail early (e.g. on client disconnect). */
+  signal?: AbortSignal;
+  /** Consulted at EOF after a terminal event: a live producer (the server's
+   *  registered run controller) means a resume is in flight — keep following
+   *  instead of closing. Default: close at EOF. */
+  stillLive?: () => boolean;
+}
+
+/**
+ * The persistence boundary for runs — the full contract, writes AND reads.
+ * Every backend (filesystem, memory, a database) implements all of it; the
+ * server capability-gates on nothing else. `tailEvents` has a generic
+ * polling implementation (`tailFromPolling`) built on `getRunEvents`, so a
+ * backend without a native tail implements the five data methods and
+ * delegates.
+ *
+ * Tail contract (RUN_CONTROL_SPEC §5.2): yield the run's history from event
+ * 0, then follow appends until a terminal event (`run.end` / `run.error` /
+ * `run.cancelled`). A terminal event doesn't close the tail immediately — a
+ * later `run.resumed` REOPENS the log (durable resume appends past the old
+ * terminal event), so the tail scans ahead and only closes at EOF, or keeps
+ * following if `opts.stillLive()` reports a resume in flight.
+ */
 export interface RunStore {
   append(workflow: string, runId: string, event: RunEvent): Promise<void>;
   finalize(workflow: string, runId: string, summary: RunSummary): Promise<void>;
+  /** Run ids for a workflow, newest first. */
+  listRuns(workflow: string): Promise<string[]>;
+  /** The finalized summary, or null while the run is in flight / if it never
+   *  finalized (crash) — callers fall back to `summarizeFromEvents`. */
+  getRunSummary(workflow: string, runId: string): Promise<RunSummary | null>;
+  /** The full event log (empty for an unknown run). */
+  getRunEvents(workflow: string, runId: string): Promise<RunEvent[]>;
+  /** History → live tail; see the interface doc for terminality. */
+  tailEvents(workflow: string, runId: string, opts?: TailOpts): AsyncGenerator<RunEvent>;
+  /** Start time (epoch ms) of the most recent run, or null if never run. */
+  lastRunAt(workflow: string): Promise<number | null>;
+}
+
+/**
+ * Generic `tailEvents` for backends without a native append-following
+ * primitive: re-read the run's events on each poll and yield past the index
+ * cursor. Same terminal / reopen / `stillLive` semantics as the file tail
+ * (`tailJsonl`), which `FileRunStore` keeps because a byte-offset read is
+ * cheaper than a full re-read per poll.
+ */
+export async function* tailFromPolling(
+  store: Pick<RunStore, "getRunEvents">,
+  workflow: string,
+  runId: string,
+  opts: TailOpts = {},
+): AsyncGenerator<RunEvent> {
+  const intervalMs = opts.intervalMs ?? 250;
+  let cursor = 0;
+  let sawTerminal = false;
+  while (true) {
+    if (opts.signal?.aborted) return;
+    const events = await store.getRunEvents(workflow, runId);
+    const fresh = events.slice(cursor);
+    cursor = events.length;
+    for (const event of fresh) {
+      yield event;
+      if (isTerminal(event)) sawTerminal = true;
+      else if (sawTerminal && reopensRun(event)) sawTerminal = false;
+    }
+    if (sawTerminal) {
+      if (fresh.length > 0) continue; // drain immediately, no poll delay
+      if (!(opts.stillLive?.() ?? false)) return;
+    }
+    await sleep(intervalMs);
+  }
+}
+
+/** Newest run's start time from the run-id list — run ids are millisecond
+ *  timestamps (`generateRunId`), so the max parseable id is the latest.
+ *  Shared by backends whose ids follow that convention. */
+export function lastRunAtFromIds(runIds: string[]): number | null {
+  let max: number | null = null;
+  for (const id of runIds) {
+    const t = parseInt(id, 10);
+    if (!isNaN(t) && (max == null || t > max)) max = t;
+  }
+  return max;
 }
 
 // ── Partial summary (reconstructed from events) ────────────────────────────
@@ -280,7 +364,7 @@ export class FileRunStore implements RunStore {
   async *tailEvents(
     workflow: string,
     runId: string,
-    opts: { intervalMs?: number; signal?: AbortSignal; stillLive?: () => boolean } = {},
+    opts: TailOpts = {},
   ): AsyncGenerator<RunEvent> {
     const file = join(this.runDir(workflow, runId), "events.jsonl");
     // `run.error`/`run.cancelled` are no longer unconditionally terminal: a
@@ -315,16 +399,49 @@ export class FileRunStore implements RunStore {
     }
     return events;
   }
+
+  async lastRunAt(workflow: string): Promise<number | null> {
+    return lastRunAtFromIds(await this.listRuns(workflow));
+  }
 }
 
-// ── In-memory implementation (for testing) ─────────────────────────────────
+// ── In-memory implementation ───────────────────────────────────────────────
 
+/**
+ * A complete ephemeral backend (not just a write-only test stub): run
+ * history, SSE reattach, durable resume, and promotions all work over it —
+ * the records just don't survive the process.
+ */
 export class MemoryRunStore implements RunStore {
   events: Map<string, RunEvent[]> = new Map();
   summaries: Map<string, RunSummary> = new Map();
 
   private key(workflow: string, runId: string): string {
     return `${workflow}/${runId}`;
+  }
+
+  async listRuns(workflow: string): Promise<string[]> {
+    const prefix = `${workflow}/`;
+    const ids = new Set<string>();
+    for (const k of this.events.keys()) if (k.startsWith(prefix)) ids.add(k.slice(prefix.length));
+    for (const k of this.summaries.keys()) if (k.startsWith(prefix)) ids.add(k.slice(prefix.length));
+    return [...ids].sort((a, b) => b.localeCompare(a));
+  }
+
+  async getRunSummary(workflow: string, runId: string): Promise<RunSummary | null> {
+    return this.summaries.get(this.key(workflow, runId)) ?? null;
+  }
+
+  async getRunEvents(workflow: string, runId: string): Promise<RunEvent[]> {
+    return [...(this.events.get(this.key(workflow, runId)) ?? [])];
+  }
+
+  tailEvents(workflow: string, runId: string, opts: TailOpts = {}): AsyncGenerator<RunEvent> {
+    return tailFromPolling(this, workflow, runId, opts);
+  }
+
+  async lastRunAt(workflow: string): Promise<number | null> {
+    return lastRunAtFromIds(await this.listRuns(workflow));
   }
 
   async append(workflow: string, runId: string, event: RunEvent): Promise<void> {

--- a/vein/src/test-util/pathless-workspace.ts
+++ b/vein/src/test-util/pathless-workspace.ts
@@ -1,0 +1,15 @@
+import { FileWorkspaceStore, type WorkspaceStore } from "../workspace.js";
+
+/** A `WorkspaceStore` that is NOT a `FileWorkspaceStore` and has no `path`:
+ *  the file impl's methods bound onto a plain object. It stands in for a
+ *  non-file backend, proving nothing reaches through to a directory. */
+export function pathlessWorkspace(inner: FileWorkspaceStore): WorkspaceStore {
+  const out: Record<string, unknown> = {};
+  for (const k of Object.getOwnPropertyNames(FileWorkspaceStore.prototype)) {
+    if (k === "constructor") continue;
+    const v = (inner as unknown as Record<string, unknown>)[k];
+    if (typeof v === "function") out[k] = v.bind(inner);
+  }
+  return out as unknown as WorkspaceStore;
+}
+

--- a/vein/src/test-util/workspace-conformance.ts
+++ b/vein/src/test-util/workspace-conformance.ts
@@ -1,0 +1,150 @@
+import { describe, it, beforeEach, afterEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdir, rm, stat } from "node:fs/promises";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { randomUUID } from "node:crypto";
+import type { WorkspaceStore } from "../workspace.js";
+
+/**
+ * The `WorkspaceStore` contract as tests — one behavioral suite every
+ * backend (file, path-less wrapper, graph) must pass. A backend that needs
+ * a different assertion here is a backend that changed the contract.
+ */
+
+const STEP_SRC = (type: string, desc: string) => `import { z } from "zod";
+import { defineStep } from "vein";
+export default defineStep({
+  type: ${JSON.stringify(type)},
+  description: ${JSON.stringify(desc)},
+  input: z.object({}),
+  output: z.any(),
+  async run() { return ${JSON.stringify(desc)}; },
+});
+`;
+
+// ── Workspace store ────────────────────────────────────────────────────────
+
+export interface WorkspaceImpl {
+  name: string;
+  /** Build a fresh, empty store. `dir` is a fresh temp dir the case owns. */
+  make: (dir: string) => Promise<WorkspaceStore> | WorkspaceStore;
+  /** Reset backend state between cases (graph wipe, …). */
+  reset?: () => Promise<void>;
+  /** `describe` skip reason (e.g. no live database configured). */
+  skip?: string | false;
+}
+
+export function workspaceConformance(impl: WorkspaceImpl): void {
+  describe(`WorkspaceStore conformance: ${impl.name}`, { skip: impl.skip ?? false }, () => {
+    let dir: string;
+    let ws: WorkspaceStore;
+    beforeEach(async () => {
+      dir = join(tmpdir(), `vein-conf-ws-${randomUUID()}`);
+      await mkdir(dir, { recursive: true });
+      await impl.reset?.();
+      ws = await impl.make(dir);
+    });
+    afterEach(() => rm(dir, { recursive: true, force: true }));
+
+    const steps = [{ id: "a", type: "log", config: { message: "hi" } }];
+
+    it("workflow publish → list → metadata → source → hash round-trip", async () => {
+      await ws.publishWorkflow("wf", "v1", { steps }, "first", "exp", "me");
+      const list = await ws.listWorkflows();
+      assert.deepEqual(
+        list.map((w) => [w.name, w.activeVersion, w.versions, w.description, w.category, w.publisher]),
+        [["wf", "v1", ["v1"], "first", "exp", "me"]],
+      );
+      assert.equal("lastRunAt" in list[0]!, false, "runs are the run store's — never listed here");
+      const meta = await ws.getWorkflowMetadata("wf");
+      assert.equal(meta?.active, "v1");
+      assert.equal(meta?.publisher, "me");
+      assert.equal(await ws.getWorkflowMetadata("nope"), null);
+      const src = await ws.getWorkflowSource("wf", "v1");
+      assert.ok(src.includes("type: log"));
+      assert.equal(typeof (await ws.getWorkflowHash("wf")), "string");
+      assert.equal(await ws.getWorkflowHash("nope"), null);
+      assert.equal((await ws.getWorkflow("wf")).steps.length, 1);
+      assert.equal((await ws.getWorkflowVersion("wf", "v1")).steps.length, 1);
+      await assert.rejects(() => ws.getWorkflow("nope"), /not found/);
+    });
+
+    it("versions, active switching, content dedup, category, params", async () => {
+      await ws.publishWorkflow("wf", "v1", { steps, params: { greeting: "old" } });
+      const first = await ws.publishWorkflowByContent("wf", await ws.getWorkflowSource("wf", "v1"));
+      assert.equal(first.changed, false, "same content → no new version");
+      assert.equal(first.version, "v1");
+      const second = await ws.publishWorkflowByContent(
+        "wf",
+        (await ws.getWorkflowSource("wf", "v1")).replace("old", "new"),
+      );
+      assert.equal(second.changed, true);
+      assert.notEqual(second.version, "v1");
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, second.version);
+      await ws.setActiveVersion("wf", "v1");
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, "v1");
+      await assert.rejects(() => ws.setActiveVersion("wf", "v99"));
+      await ws.setWorkflowCategory("wf", "cat");
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.category, "cat");
+      const p = await ws.setParam("wf", "greeting", "newer");
+      assert.deepEqual([p.before, p.after], ["old", "newer"]);
+      assert.equal((await ws.getWorkflow("wf")).params?.["greeting"], "newer");
+    });
+
+    it("createWorkflow allocates a fresh name/version and returns it", async () => {
+      const a = await ws.createWorkflow("made", { steps });
+      const b = await ws.createWorkflow("made", { steps });
+      assert.equal(a.name, "made");
+      assert.notEqual(b.name, a.name, "a second create under the same name is renamed, not clobbered");
+    });
+
+    it("step publish → list → versions → source → active switching → delete", async () => {
+      const v1 = await ws.publishStep("my-step", STEP_SRC("my-step", "one"), "one", "svc");
+      const again = await ws.publishStep("my-step", STEP_SRC("my-step", "one"), "one", "svc");
+      assert.equal(again.changed, false, "same source → no new version");
+      const v2 = await ws.publishStep("my-step", STEP_SRC("my-step", "two"), "two", "svc");
+      assert.equal(v2.changed, true);
+      assert.deepEqual(
+        (await ws.listSteps()).map((s) => [s.type, s.description, s.publisher]),
+        [["my-step", "two", "svc"]],
+      );
+      assert.deepEqual(await ws.listSteps({ publisher: "other" }), []);
+      const versions = await ws.listStepVersions("my-step");
+      assert.equal(versions.active, v2.version);
+      assert.deepEqual(new Set(versions.versions), new Set([v1.version, v2.version]));
+      assert.ok((await ws.getStepVersionSource("my-step", v1.version)).includes('"one"'));
+      await ws.setActiveStepVersion("my-step", v1.version);
+      assert.equal((await ws.listStepVersions("my-step")).active, v1.version);
+      assert.equal((await ws.getStepSource("my-step"))?.code.includes('"one"'), true);
+      assert.equal(await ws.deleteStep("my-step"), true);
+      assert.equal(await ws.deleteStep("my-step"), false);
+      assert.deepEqual(await ws.listSteps(), []);
+    });
+
+    it("deleteStepsByPublisher removes exactly that publisher's steps", async () => {
+      await ws.publishStep("a", STEP_SRC("a", "a"), "a", "svc-1");
+      await ws.publishStep("ns/b", STEP_SRC("ns/b", "b"), "b", "svc-1");
+      await ws.publishStep("c", STEP_SRC("c", "c"), "c", "svc-2");
+      assert.deepEqual((await ws.deleteStepsByPublisher("svc-1")).sort(), ["a", "ns/b"]);
+      assert.deepEqual((await ws.listSteps()).map((s) => s.type), ["c"]);
+    });
+
+    it("getStepSource spans tiers: custom from the store, lib + core from the engine, null otherwise", async () => {
+      await ws.publishStep("ns/custom", STEP_SRC("ns/custom", "x"));
+      assert.equal((await ws.getStepSource("ns/custom"))?.origin, "custom");
+      assert.equal((await ws.getStepSource("log"))?.origin, "core");
+      assert.equal((await ws.getStepSource("github/fetch-pr"))?.origin, "lib");
+      assert.equal(await ws.getStepSource("no/such/step"), null);
+    });
+
+    it("materializeCustomSteps returns a directory holding every active custom step as a file", async () => {
+      await ws.publishStep("flat", STEP_SRC("flat", "f"));
+      await ws.publishStep("ns/nested", STEP_SRC("ns/nested", "n"));
+      const root = await ws.materializeCustomSteps();
+      assert.ok((await stat(join(root, "flat.ts"))).isFile());
+      assert.ok((await stat(join(root, "ns", "nested.ts"))).isFile());
+      assert.equal(await ws.materializeCustomSteps(), root, "idempotent");
+    });
+  });
+}

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -26,7 +26,7 @@ const PARAM_SELF_REF = /\{\{\s*(params(?:\.[\w$]+|\[[^\]]+\])+)\s*\}\}/g;
  * positive on `{{ }}` inside block-scalar message bodies) and throw a clear,
  * actionable error pointing at the fix: quote the template.
  */
-function assertValidWorkflowYaml(yamlStr: string): void {
+export function assertValidWorkflowYaml(yamlStr: string): void {
   let parsed: unknown;
   try {
     parsed = yaml.load(yamlStr);
@@ -82,6 +82,44 @@ function resolveParamSelfReferences(params: Record<string, unknown>): Record<str
     return v;
   };
   return walk(params) as Record<string, unknown>;
+}
+
+/** Parse a stored workflow version's YAML into a runnable `Flow` — the one
+ *  loader every `WorkspaceStore` backend shares (param self-references are
+ *  resolved once here, at load). */
+export function flowFromYaml(name: string, version: string, raw: string): Flow {
+  const data = yaml.load(raw) as any;
+  if (!data || !data.steps) {
+    throw new Error(`Invalid workflow YAML for "${name}" version "${version}"`);
+  }
+  return {
+    name: data.name ?? name,
+    input: z.any(),
+    steps: data.steps,
+    // Resolve param-to-param references (`{{ params.* }}` nested inside another
+    // param) once at load, so a shared value can be factored into one knob.
+    ...(data.params != null ? { params: resolveParamSelfReferences(data.params) } : {}),
+    ...(Array.isArray(data.promotes) ? { promotes: data.promotes } : {}),
+  };
+}
+
+/** Render publish content (a steps object or raw YAML) to the YAML string
+ *  that gets stored — shared by every backend so hashes agree. */
+export function renderWorkflowYaml(
+  name: string,
+  content: { steps: any[]; params?: Record<string, unknown>; promotes?: unknown[] } | string,
+): string {
+  return typeof content === "string"
+    ? content
+    : yaml.dump(
+        {
+          name,
+          steps: content.steps,
+          ...(content.params != null ? { params: content.params } : {}),
+          ...(content.promotes != null ? { promotes: content.promotes } : {}),
+        },
+        { lineWidth: 120, noRefs: true },
+      );
 }
 
 // ── Types ──────────────────────────────────────────────────────────────────
@@ -330,23 +368,7 @@ export class FileWorkspaceStore implements WorkspaceStore {
   private async loadFlowYaml(name: string, version: string): Promise<Flow> {
     const dir = join(this.root, "workflows", name);
     const raw = await readFile(join(dir, `${version}.yaml`), "utf-8");
-    const data = yaml.load(raw) as any;
-
-    if (!data || !data.steps) {
-      throw new Error(
-        `Invalid workflow YAML for "${name}" version "${version}"`,
-      );
-    }
-
-    return {
-      name: data.name ?? name,
-      input: z.any(),
-      steps: data.steps,
-      // Resolve param-to-param references (`{{ params.* }}` nested inside another
-      // param) once at load, so a shared value can be factored into one knob.
-      ...(data.params != null ? { params: resolveParamSelfReferences(data.params) } : {}),
-      ...(Array.isArray(data.promotes) ? { promotes: data.promotes } : {}),
-    };
+    return flowFromYaml(name, version, raw);
   }
 
   /**
@@ -401,20 +423,7 @@ export class FileWorkspaceStore implements WorkspaceStore {
     const dir = join(this.root, "workflows", name);
     await mkdir(dir, { recursive: true });
 
-    // Write YAML
-    const yamlStr =
-      typeof content === "string"
-        ? content
-        : yaml.dump(
-            {
-              name,
-              steps: content.steps,
-              ...(content.params != null ? { params: content.params } : {}),
-              ...(content.promotes != null ? { promotes: content.promotes } : {}),
-            },
-            { lineWidth: 120, noRefs: true },
-          );
-
+    const yamlStr = renderWorkflowYaml(name, content);
     assertValidWorkflowYaml(yamlStr);
 
     await writeFile(join(dir, `${version}.yaml`), yamlStr, "utf-8");
@@ -877,7 +886,7 @@ async function pathExists(p: string): Promise<boolean> {
  * (e.g. `gitree/save-feature`) and helper names with leading underscores
  * (e.g. `gitree/_shared`). Rejects path traversal and absolute paths.
  */
-function validateStepName(name: string): void {
+export function validateStepName(name: string): void {
   if (!name) {
     throw new Error("Step name cannot be empty");
   }

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -146,9 +146,9 @@ export interface WorkflowListEntry {
   category?: string;
   /** Provenance stamp, if any (see WorkflowMetadata.publisher). */
   publisher?: string;
-  /** Start time (epoch ms) of the most recent run, if any. Run ids are
-   *  millisecond timestamps (FileRunStore), so this is just the max entry
-   *  in the workflow's `runs/` dir — no run.json reads. */
+  /** Start time (epoch ms) of the most recent run, if any. Not produced by
+   *  the workspace itself (runs are the run store's records) — the server's
+   *  `GET /workflows` decorates entries from `RunStore.lastRunAt`. */
   lastRunAt?: number;
 }
 
@@ -184,7 +184,6 @@ export class WorkspaceManager {
       const meta = await this.readWorkflowMetadata(entry.name);
       if (meta) {
         const activeDesc = meta.versions[meta.active]?.description;
-        const lastRunAt = await this.lastRunAt(entry.name);
         results.push({
           name: entry.name,
           activeVersion: meta.active,
@@ -192,24 +191,11 @@ export class WorkspaceManager {
           description: activeDesc,
           ...(meta.category ? { category: meta.category } : {}),
           ...(meta.publisher ? { publisher: meta.publisher } : {}),
-          ...(lastRunAt != null ? { lastRunAt } : {}),
         });
       }
     }
 
     return results;
-  }
-
-  /** Most recent run's start time (epoch ms), or null if never run. Run ids
-   *  are millisecond-timestamp dir names, so the max entry is the latest. */
-  private async lastRunAt(name: string): Promise<number | null> {
-    const entries = await safeReaddir(join(this.root, "workflows", name, "runs"));
-    let max: number | null = null;
-    for (const e of entries) {
-      const t = parseInt(e.name, 10);
-      if (!isNaN(t) && (max == null || t > max)) max = t;
-    }
-    return max;
   }
 
   /** Load the active version of a workflow. */

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -3,6 +3,8 @@ import { dirname, join, relative, sep } from "node:path";
 import yaml from "js-yaml";
 import { z } from "zod";
 import type { Flow } from "./core.js";
+import type { SubflowResolver } from "./runner.js";
+import { readStepSourceFromDisk, type StepSource } from "./steps/registry.js";
 import { contentHash, nextVersionLabel } from "./version.js";
 import { evaluateExpr } from "./expr.js";
 
@@ -159,15 +161,100 @@ export interface StepListEntry {
   publisher?: string;
 }
 
-// ── Workspace Manager ──────────────────────────────────────────────────────
+// ── Workspace store boundary ───────────────────────────────────────────────
 
-export class WorkspaceManager {
+/**
+ * The persistence boundary for workflows and steps — everything the server,
+ * the authoring capability, and the chat builder need from "the workspace",
+ * with no filesystem in the contract. `FileWorkspaceStore` is the default
+ * implementation; a graph-backed one implements the same surface.
+ *
+ * Two things a workspace deliberately does NOT own: run records (the
+ * `RunStore`) and local scratch (artifacts, cassettes, shell cwd — the
+ * server's `dataDir`). Custom steps are executable code, so the boundary
+ * exposes them two ways: as source text (`getStepSource`) and as an
+ * importable directory (`materializeCustomSteps`) for the module loader.
+ */
+export interface WorkspaceStore extends SubflowResolver {
+  // ── Workflows ──
+  /** Every workflow with its version list. `lastRunAt` is NOT populated
+   *  here (runs belong to the run store — the server composes it). */
+  listWorkflows(): Promise<WorkflowListEntry[]>;
+  getWorkflow(name: string): Promise<Flow>;
+  getWorkflowVersion(name: string, version: string): Promise<Flow>;
+  /** Raw YAML source of a workflow version (throws when missing). */
+  getWorkflowSource(name: string, version: string): Promise<string>;
+  /** Content hash of a version's source (active when omitted), or null. */
+  getWorkflowHash(name: string, version?: string): Promise<string | null>;
+  /** The workflow's metadata record (active version, versions, category,
+   *  publisher), or null when the workflow doesn't exist. */
+  getWorkflowMetadata(name: string): Promise<WorkflowMetadata | null>;
+  createWorkflow(
+    name: string,
+    content: { steps: any[]; params?: Record<string, unknown> } | string,
+    description?: string,
+    category?: string,
+    publisher?: string,
+  ): Promise<{ name: string; version: string }>;
+  publishWorkflow(
+    name: string,
+    version: string,
+    content: { steps: any[]; params?: Record<string, unknown>; promotes?: unknown[] } | string,
+    description?: string,
+    category?: string,
+    publisher?: string,
+  ): Promise<void>;
+  publishWorkflowByContent(
+    name: string,
+    yamlStr: string,
+    description?: string,
+    category?: string,
+    publisher?: string,
+  ): Promise<{ version: string; changed: boolean }>;
+  setWorkflowCategory(name: string, category: string | null): Promise<void>;
+  setActiveVersion(name: string, version: string): Promise<void>;
+  setParam(
+    name: string,
+    param: string,
+    value: unknown,
+  ): Promise<{ version: string; before: unknown; after: unknown }>;
+
+  // ── Steps (custom tier) ──
+  listSteps(filter?: { publisher?: string }): Promise<StepListEntry[]>;
+  publishStep(
+    name: string,
+    code: string,
+    description?: string,
+    publisher?: string,
+  ): Promise<{ version: string; changed: boolean }>;
+  listStepVersions(name: string): Promise<StepVersionsResult>;
+  getStepVersionSource(name: string, version: string): Promise<string>;
+  setActiveStepVersion(name: string, version: string): Promise<void>;
+  deleteStep(name: string): Promise<boolean>;
+  deleteStepsByPublisher(publisher: string): Promise<string[]>;
+
+  // ── Step source + code loading ──
+  /** A step's source text across all tiers (core / lib ship with the
+   *  engine; custom is this store's), or null when none is on record. */
+  getStepSource(type: string): Promise<{ code: string; origin: StepSource } | null>;
+  /** Ensure every ACTIVE custom step exists as an importable file and
+   *  return the directory root — what `buildRegistry(customDir)` loads. A
+   *  file-backed store already has it; other backends write to scratch. */
+  materializeCustomSteps(): Promise<string>;
+}
+
+// ── Filesystem implementation ──────────────────────────────────────────────
+
+export class FileWorkspaceStore implements WorkspaceStore {
   private root: string;
 
   constructor(root?: string) {
     this.root = root ?? process.env["VEIN_WORKSPACE"] ?? "./workspace";
   }
 
+  /** The filesystem root — an implementation detail of THIS store, not part
+   *  of `WorkspaceStore`. The server's local scratch (`dataDir`) defaults to
+   *  it so file-backed deployments keep one directory. */
   get path(): string {
     return this.root;
   }
@@ -196,6 +283,10 @@ export class WorkspaceManager {
     }
 
     return results;
+  }
+
+  async getWorkflowMetadata(name: string): Promise<WorkflowMetadata | null> {
+    return this.readWorkflowMetadata(name);
   }
 
   /** Load the active version of a workflow. */
@@ -715,6 +806,22 @@ export class WorkspaceManager {
     return toDelete;
   }
 
+  // ── Step source + code loading ─────────────────────────────────────────
+
+  async getStepSource(type: string): Promise<{ code: string; origin: StepSource } | null> {
+    return readStepSourceFromDisk(type, this.customStepsDir());
+  }
+
+  /** Publishing already writes each active custom step to
+   *  `<root>/steps/custom/<name>.ts`, so the store IS the materialization. */
+  async materializeCustomSteps(): Promise<string> {
+    return this.customStepsDir();
+  }
+
+  private customStepsDir(): string {
+    return join(this.root, "steps", "custom");
+  }
+
   // ── Private helpers ────────────────────────────────────────────────────
 
   private async readWorkflowMetadata(
@@ -742,6 +849,9 @@ export class WorkspaceManager {
     }
   }
 }
+
+/** Back-compat name for `FileWorkspaceStore` (embedders and docs). */
+export { FileWorkspaceStore as WorkspaceManager };
 
 // ── Utilities ──────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Implements `vein/plans/generic-storage.md` §1–§7, stacked on #1629 (the graph backend branch). Four commits: the three storage-boundary phases, then §7 on top.

## Storage boundary (§1–§6)

**Step 1 — `RunStore` is the full contract.** The interface gains `listRuns` / `getRunSummary` / `getRunEvents` / `tailEvents` / `lastRunAt`. `tailFromPolling` is the generic tail (re-read + index cursor) for backends without a byte-offset primitive; `FileRunStore` keeps `tailJsonl`. `MemoryRunStore` implements everything, so memory-mode vein has run history, SSE reattach, durable resume, and promotions. All `instanceof FileRunStore` capability gates and their 501 branches are gone; the `RunReadStore` / `asReadStore` feature-detect shim in authoring + ai is gone. `lastRunAt` moved from `WorkspaceManager` (which read the run store's dir layout) to the store; `GET /workflows` composes the two.

**Steps 2–5 — `WorkspaceStore` boundary, step-source seam, `dataDir`, default wiring, conformance suite.**
- `WorkspaceStore` interface extracted; class renamed `FileWorkspaceStore` (`WorkspaceManager` kept as an alias). `getWorkflowMetadata` replaces the raw `_metadata.json` read in `GET /workflows/:name`. Every consumer is typed to the interface.
- Custom step code crosses the boundary two ways: `getStepSource(type)` (text, all tiers) and `materializeCustomSteps()` (importable dir). `buildRegistry(customDir)` takes the custom dir, not a workspace root.
- `dataDir` (`VeinOptions.dataDir`, `Vein.dataDir`) is the explicit local root for artifacts, cassettes, and the chat shell cwd. Defaults to the file workspace's root, so file-backed deployments see no change. Nothing outside `workspace.ts` reads `workspace.path`. `/health` reports `dataDir` instead of `workspace`.
- Default store selection keys off one resolved mode (file-backed workspace → file stores under `dataDir`; any other impl → memory). No capability is gated on a concrete class.
- `src/storage-conformance.test.ts` + `src/test-util/workspace-conformance.ts`: one behavioral suite per layer, run over file + memory impls and a path-less workspace wrapper. `MemoryChatStore.tailEvents` now follows live turns (the suite caught that it didn't).

## Graph backend (§7)

- **`Neo4jWorkspaceStore`** (`src/graph/workspace-store.ts`): workflows, versions, steps, and step versions as `VeinWorkflow` / `VeinWorkflowVersion` / `VeinStep` / `VeinStepVersion` nodes with `VERSION_OF`, `ACTIVE_VERSION`, `USES_STEP`, `DEPENDS_ON` edges, written through the jarvis-dialect writers from #1629. Deletes are soft. Active custom steps are materialized into a scratch dir for the module loader (stale files pruned). Passes the same workspace conformance suite as the file store, live. One deliberate deviation: versions are content-addressed, so identical content published under a new label re-labels the existing version node instead of duplicating it.
- **Projector** (`src/graph/projector.ts`, `graph/project` lib step): a post-hoc consumer of any `RunStore` / `ChatStore` that writes `VeinRun` / `VeinAgentSession` / `VeinToolCall` / `VeinChat` / `VeinTurn` with `EXECUTED` / `IN_RUN` / `IN_SESSION` / `SPAWNED` / `IN_CHAT` edges — summaries and `log_ref` pointers only, idempotent upserts, settled runs skipped on re-run. Makes "which runs executed this version" and "which chat launched this run" one-hop queries.
- **Wiring** (`src/graph/wiring.ts`): `VEIN_WORKSPACE_BACKEND=graph` switches the default server's workflows/steps to Neo4j; runs, chats, secrets, and blobs stay local under `VEIN_WORKSPACE`.

Not projected yet: `ACCESSED` (needs the plan's v2 provenance convention) and `PROMOTED_FROM` (promotion doesn't record its source run).

## Testing
- `npm test` (vein/): 612 pass, 0 fail (569 on the base branch).
- `npm run test:graph` against the throwaway Neo4j container: 115 pass, 0 fail, 0 skipped — includes the graph store's conformance run, graph-specific cases (edges, soft delete, re-labeling, persistence, materialization pruning), the projector (nodes, edges, idempotency, settled-skip, chat→run→session→tool chain), and the `graph/project` step end to end.
- `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)