### PR TITLE
vein: graph workspace by default (VEIN_WORKSPACE_BACKEND=fs to opt out)

### DIFF
--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -145,10 +145,11 @@ export async function createLabVein(
   // these custom steps via `workspace.materializeCustomSteps()` (and step
   // publishing is enabled).
   //
-  // VEIN_WORKSPACE_BACKEND=graph keeps workflows/steps in Neo4j
-  // (vein's Neo4jWorkspaceStore; NEO4J_HOST/USER/PASSWORD, same defaults as
-  // this host's own client). Runs, chats, secrets, artifacts, and cassettes
-  // stay on disk under `workspacePath` either way.
+  // Workflows/steps live in Neo4j by default (vein's Neo4jWorkspaceStore;
+  // NEO4J_HOST/USER/PASSWORD, same defaults as this host's own client);
+  // VEIN_WORKSPACE_BACKEND=fs keeps them on disk instead. Runs, chats,
+  // secrets, artifacts, and cassettes stay on disk under `workspacePath`
+  // either way.
   const graphBacked = graphWorkspaceRequested();
   const workspace: WorkspaceStore = graphBacked
     ? (await graphWorkspaceFromEnv(process.env, { dataDir: workspacePath })).workspace

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -283,17 +283,18 @@ services bag can override it, same as `http`/`secrets`).
   keeps workflows/steps as `VeinWorkflow`/`VeinWorkflowVersion`/`VeinStep`/
   `VeinStepVersion` nodes (content-addressed versions; soft deletes;
   `USES_STEP`/`DEPENDS_ON` edges) and passes the same conformance suite
-  (`npm run test:graph`, live). `VEIN_WORKSPACE_BACKEND=graph` switches
-  the default server to it (`src/graph/wiring.ts`; connection from
-  `NEO4J_URI` / `NEO4J_HOST` / `NEO4J_USER` / `NEO4J_PASSWORD`, defaulting
-  to localhost:7687 / neo4j / testtest like the mcp host). Runs/chats stay in
+  (`npm run test:graph`, live). It is the default server's workspace
+  (`src/graph/wiring.ts`; connection from `NEO4J_URI` / `NEO4J_HOST` /
+  `NEO4J_USER` / `NEO4J_PASSWORD`, defaulting to localhost:7687 / neo4j /
+  testtest like the mcp host — so Neo4j is a boot dependency);
+  `VEIN_WORKSPACE_BACKEND=fs` opts back into the file workspace. Runs/chats stay in
   their stores; `src/graph/projector.ts` (or the `graph/project` step)
   projects them into `VeinRun`/`VeinAgentSession`/`VeinToolCall`/
   `VeinChat`/`VeinTurn` with `EXECUTED`/`IN_RUN`/`IN_SESSION`/`SPAWNED`/
   `IN_CHAT` edges — summaries + `log_ref` pointers, never payloads,
   idempotent upserts.
   `server.ts` is a thin wrapper (`getApp`/`startServer`) over
-  `createVein()` with filesystem defaults.
+  `createVein()` — graph workspace by default, file stores for the rest.
 
 - **`services` bag** is a consumer-defined capabilities object exposed to
   every step via `ctx.services` (typed by `defineStep`, untyped at

--- a/vein/plans/generic-storage.md
+++ b/vein/plans/generic-storage.md
@@ -9,7 +9,8 @@
 > workspace conformance suite live — `npm run test:graph`),
 > `src/graph/projector.ts` (post-hoc run/chat projector, idempotent
 > upserts) + the `graph/project` lib step, and `src/graph/wiring.ts`
-> (`VEIN_WORKSPACE_BACKEND=graph` for the default server). Not projected
+> (graph is the default server's workspace; `VEIN_WORKSPACE_BACKEND=fs`
+opts out). Not projected
 > yet: `ACCESSED` (needs the v2 provenance convention below) and
 > `PROMOTED_FROM` (promotion doesn't record its source run). One deliberate
 > deviation from the file store: graph versions are content-addressed —

--- a/vein/plans/jarvis-graph-compat.md
+++ b/vein/plans/jarvis-graph-compat.md
@@ -32,7 +32,8 @@ Also on branch `vein-generic-storage`: the vein-native storage boundary
 (generic-storage §1–5) and, on top of it, `Neo4jWorkspaceStore`
 (`src/graph/workspace-store.ts`) + the run/chat projector
 (`src/graph/projector.ts`, `graph/project` step) + env wiring
-(`src/graph/wiring.ts`, `VEIN_WORKSPACE_BACKEND=graph`). Their live tests
+(`src/graph/wiring.ts`; graph by default, `VEIN_WORKSPACE_BACKEND=fs` to
+opt out). Their live tests
 run under `npm run test:graph`.
 
 **Beyond the original scope — jarvis-typed data.** The harvey lab pipeline

--- a/vein/src/graph/wiring.test.ts
+++ b/vein/src/graph/wiring.test.ts
@@ -4,9 +4,11 @@ import { graphConfigFromEnv } from "./bolt.js";
 import { DEFAULT_NEO4J_HOST, graphMaterializeDir, graphWorkspaceRequested } from "./wiring.js";
 
 describe("graph workspace wiring defaults", () => {
-  it("VEIN_WORKSPACE_BACKEND=graph is the switch (case-insensitive)", () => {
-    assert.equal(graphWorkspaceRequested({}), false);
+  it("graph by default; VEIN_WORKSPACE_BACKEND=fs opts out (case-insensitive)", () => {
+    assert.equal(graphWorkspaceRequested({}), true);
     assert.equal(graphWorkspaceRequested({ VEIN_WORKSPACE_BACKEND: "Graph" }), true);
+    assert.equal(graphWorkspaceRequested({ VEIN_WORKSPACE_BACKEND: "FS" }), false);
+    assert.equal(graphWorkspaceRequested({ VEIN_WORKSPACE_BACKEND: "file" }), false);
   });
   it("materializes custom steps inside the data dir (module resolution), apart from steps/custom", () => {
     assert.equal(graphMaterializeDir("./lab-workspace"), "lab-workspace/steps/_graph");

--- a/vein/src/graph/wiring.ts
+++ b/vein/src/graph/wiring.ts
@@ -1,8 +1,10 @@
 /**
- * Env-driven wiring for the graph-backed workspace: set
- * `VEIN_WORKSPACE_BACKEND=graph` (plus the `NEO4J_*` connection vars) and
- * the default server keeps workflows/steps in Neo4j instead of the
- * filesystem. Runs, chats, secrets, artifacts, and cassettes stay local
+ * Env-driven wiring for the graph-backed workspace. Graph is the DEFAULT:
+ * the default server keeps workflows/steps in Neo4j (connection from the
+ * `NEO4J_*` vars, defaulting to localhost:7687) unless
+ * `VEIN_WORKSPACE_BACKEND=fs` opts back into the filesystem workspace.
+ * Neo4j is therefore a boot dependency by default — `bolt.verify()` fails
+ * loudly when nothing is listening. Runs, chats, secrets, artifacts, and cassettes stay local
  * under `dataDir` (`VEIN_WORKSPACE`) — the run/chat projector
  * (`projector.ts`, or the `graph/project` step) builds their graph view.
  */
@@ -11,8 +13,12 @@ import type { GraphBackend, GraphBackendOptions } from "./backend.js";
 import { openGraphBackendFromEnv } from "./backend.js";
 import { Neo4jWorkspaceStore, type Neo4jWorkspaceStoreOptions } from "./workspace-store.js";
 
+/** Graph unless `VEIN_WORKSPACE_BACKEND=fs` (case-insensitive; `file` /
+ *  `filesystem` accepted too). Any other value — including unset or the
+ *  legacy `graph` — means graph. */
 export function graphWorkspaceRequested(env: Record<string, string | undefined> = process.env): boolean {
-  return (env["VEIN_WORKSPACE_BACKEND"] ?? "").toLowerCase() === "graph";
+  const v = (env["VEIN_WORKSPACE_BACKEND"] ?? "").toLowerCase();
+  return !(v === "fs" || v === "file" || v === "filesystem");
 }
 
 /** Same default as the mcp host's own Neo4j client and the `graph/*` steps:

--- a/vein/src/server.ts
+++ b/vein/src/server.ts
@@ -1,8 +1,9 @@
-// Default vein server — a thin wrapper over createVein() that boots
-// vein with its filesystem-backed defaults (FileRunStore, workspace
-// loaded from VEIN_WORKSPACE, registry built by scanning steps/), or —
-// with VEIN_WORKSPACE_BACKEND=graph — keeps workflows/steps in Neo4j
-// (see src/graph/wiring.ts) while runs/chats/blobs stay under VEIN_WORKSPACE.
+// Default vein server — a thin wrapper over createVein() that keeps
+// workflows/steps in Neo4j by default (see src/graph/wiring.ts; NEO4J_*
+// vars, localhost:7687 when unset) while runs/chats/blobs stay under
+// VEIN_WORKSPACE. Set VEIN_WORKSPACE_BACKEND=fs to boot with the
+// filesystem-backed defaults instead (FileRunStore, workspace loaded from
+// VEIN_WORKSPACE, registry built by scanning steps/) — no Neo4j needed.
 //
 // This file is the canonical "library usage" example: anything you
 // see here, your own consumer code can do too. Pass your own
@@ -45,7 +46,7 @@ async function getDefault(): Promise<Vein> {
 }
 
 /**
- * Hono app for the default filesystem-backed vein. Returns the same
+ * Hono app for the default vein. Returns the same
  * instance on repeated calls. Most code should call `createVein()`
  * directly and mount `vein.app` — this helper exists for ergonomic
  * scripting and backwards compatibility.
@@ -55,7 +56,7 @@ export async function getApp() {
 }
 
 /**
- * Boot the default filesystem-backed vein server on `port` (defaults to
+ * Boot the default vein server on `port` (defaults to
  * `VEIN_PORT` or `3000`). Equivalent to:
  *
  * ```ts


### PR DESCRIPTION
## Summary
- \`graphWorkspaceRequested()\` (vein/src/graph/wiring.ts) now returns true unless \`VEIN_WORKSPACE_BACKEND\` is \`fs\` / \`file\` / \`filesystem\`. Unset (or the legacy \`graph\`) means graph.
- Affects the two callers: the standalone vein server (\`src/server.ts\`) and the mcp \`/lab\` mount (\`createLabVein\`). Both keep workflows/steps in Neo4j by default; runs, chats, secrets, artifacts, cassettes stay on disk as before.
- **Neo4j is now a boot dependency by default.** Connection comes from \`NEO4J_URI\` / \`NEO4J_HOST\` / \`NEO4J_USER\` / \`NEO4J_PASSWORD\` (localhost:7687 / neo4j / testtest when unset, same as the mcp host). \`bolt.verify()\` fails loudly if nothing is listening. Set \`VEIN_WORKSPACE_BACKEND=fs\` to run without one.
- Docs updated: \`vein/AGENTS.md\`, both plan files, header comments.

## Seeding
All lab seeds go through the abstract \`WorkspaceStore\` (\`publishStep\` / \`publishWorkflowByContent\`, content-hash reconciled), so they land in the graph on first boot with no further changes. Core/lib steps remain in-code (never seeded in either backend). Hand-authored workflows in an existing on-disk \`lab-workspace\` are **not** migrated.

## Verification
- \`tsc --noEmit\` clean in vein and mcp; \`wiring.test.ts\` updated and passing.
- Against the throwaway Neo4j (\`:7688\`), no backend var set:
  - cold \`/lab\` boot → \`Neo4jWorkspaceStore\`, 106 seed lines, Neo4j holds 31 \`VeinWorkflow\` + 75 \`VeinStep\`
  - warm boot → 0 seed lines (idempotent)
  - \`VEIN_WORKSPACE_BACKEND=fs\` → \`FileWorkspaceStore\`
  - standalone vein server → graph-backed \`/workflows\` returns 200 with 31 entries; \`fs\` returns 200 with 0 (fresh dir)

🤖 Generated with [Claude Code](https://claude.com/claude-code)