### PR TITLE
vein: ACCESSED provenance — graph-touching steps report the nodes they touch

### DIFF
--- a/mcp/package.json
+++ b/mcp/package.json
@@ -19,7 +19,8 @@
     "@ai-sdk/openai": "3.0.61",
     "@ai-sdk/gateway": "3.0.110",
     "ai": "6.0.175",
-    "@ai-sdk/xai": "3.0.88"
+    "@ai-sdk/xai": "3.0.88",
+    "onnxruntime-node": "1.24.3"
   },
   "scripts": {
     "dev": "([ -n \"$CI\" ] || npm run refresh-vein); tsx src/index.ts",

--- a/mcp/src/lab/jarvis/steps/create-batch-triplet.ts
+++ b/mcp/src/lab/jarvis/steps/create-batch-triplet.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -182,6 +182,10 @@ export default defineStep({
     }
 
     const failed = results.filter((r) => r.error).length;
-    return { requested: cfg.triplets.length, succeeded: results.length - failed, failed, results };
+    return withAccessedNodes(
+      { requested: cfg.triplets.length, succeeded: results.length - failed, failed, results },
+      // Provenance: both endpoints of every edge that was written.
+      results.filter((r) => !r.error).flatMap((r) => [{ ref_id: r.source_ref_id as string }, { ref_id: r.target_ref_id as string }]),
+    );
   },
 });

--- a/mcp/src/lab/jarvis/steps/create-node.ts
+++ b/mcp/src/lab/jarvis/steps/create-node.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -60,14 +60,17 @@ export default defineStep({
     if (!refId) {
       return `jarvis/create-node failed — HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
     }
-    return {
-      // "Warning" here means the node already existed (idempotent merge).
-      status: body?.status ?? "Success",
-      ref_id: refId,
-      node_type: cfg.node_type,
-      ...(Array.isArray(body?.status_messages) && body.status_messages.length > 0
-        ? { messages: body.status_messages }
-        : {}),
-    };
+    return withAccessedNodes(
+      {
+        // "Warning" here means the node already existed (idempotent merge).
+        status: body?.status ?? "Success",
+        ref_id: refId,
+        node_type: cfg.node_type,
+        ...(Array.isArray(body?.status_messages) && body.status_messages.length > 0
+          ? { messages: body.status_messages }
+          : {}),
+      },
+      [{ ref_id: refId, node_type: cfg.node_type }],
+    );
   },
 });

--- a/mcp/src/lab/jarvis/steps/create-triplet.ts
+++ b/mcp/src/lab/jarvis/steps/create-triplet.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -184,17 +184,21 @@ export default defineStep({
           `but the edge write failed — HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`
         );
       }
-      return {
-        // "Warning" here means the edge already existed (idempotent merge).
-        status: body?.status ?? "Success",
-        source_ref_id: sourceRef,
-        target_ref_id: targetRef,
-        edge_ref_id: edgeRef,
-        edge_type: cfg.edge_type,
-        ...(Array.isArray(body?.status_messages) && body.status_messages.length > 0
-          ? { messages: body.status_messages }
-          : {}),
-      };
+      return withAccessedNodes(
+        {
+          // "Warning" here means the edge already existed (idempotent merge).
+          status: body?.status ?? "Success",
+          source_ref_id: sourceRef,
+          target_ref_id: targetRef,
+          edge_ref_id: edgeRef,
+          edge_type: cfg.edge_type,
+          ...(Array.isArray(body?.status_messages) && body.status_messages.length > 0
+            ? { messages: body.status_messages }
+            : {}),
+        },
+        // Provenance: both endpoints (the edge itself is not a node).
+        [{ ref_id: sourceRef, node_type: cfg.source_type }, { ref_id: targetRef, node_type: cfg.target_type }],
+      );
     } catch (err: any) {
       return `jarvis/create-triplet failed: ${err?.message ?? String(err)}`;
     }

--- a/mcp/src/lab/jarvis/steps/edit-node.ts
+++ b/mcp/src/lab/jarvis/steps/edit-node.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -86,12 +86,15 @@ export default defineStep({
     }
     // Compact confirmation — deliberately NOT the full updated node, whose
     // properties include bulky derived fields. jarvis_graph_get to verify.
-    return {
-      status: "Success",
-      ref_id: cfg.ref_id,
-      ...(hasSet ? { updated: Object.keys(cfg.node_data!) } : {}),
-      ...(hasDelete ? { deleted: cfg.properties_to_be_deleted } : {}),
-      ...(cfg.node_type ? { node_type: cfg.node_type } : {}),
-    };
+    return withAccessedNodes(
+      {
+        status: "Success",
+        ref_id: cfg.ref_id,
+        ...(hasSet ? { updated: Object.keys(cfg.node_data!) } : {}),
+        ...(hasDelete ? { deleted: cfg.properties_to_be_deleted } : {}),
+        ...(cfg.node_type ? { node_type: cfg.node_type } : {}),
+      },
+      [{ ref_id: cfg.ref_id, node_type: cfg.node_type }],
+    );
   },
 });

--- a/mcp/src/lab/jarvis/steps/graph-get-batched.ts
+++ b/mcp/src/lab/jarvis/steps/graph-get-batched.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -132,12 +132,16 @@ export default defineStep({
       nodes.push(...(await Promise.all(wave.map(fetchNode))));
     }
 
-    return {
-      requested: cfg.ref_ids.length,
-      returned: nodes.length,
-      truncated: omitted.length > 0,
-      omitted_ref_ids: omitted,
-      nodes,
-    };
+    return withAccessedNodes(
+      {
+        requested: cfg.ref_ids.length,
+        returned: nodes.length,
+        truncated: omitted.length > 0,
+        omitted_ref_ids: omitted,
+        nodes,
+      },
+      // Provenance: the nodes that resolved (an `error` entry touched nothing).
+      nodes.filter((n) => !n["error"]).map((n) => ({ ref_id: n["ref_id"] as string, node_type: n["node_type"] as string })),
+    );
   },
 });

--- a/mcp/src/lab/jarvis/steps/graph-get.ts
+++ b/mcp/src/lab/jarvis/steps/graph-get.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -100,12 +100,15 @@ export default defineStep({
       // best effort — edges stays {}
     }
 
-    return {
-      ref_id: raw.ref_id,
-      node_type: raw.node_type,
-      name: deriveNodeName(raw, properties),
-      properties: raw.properties,
-      edges,
-    };
+    return withAccessedNodes(
+      {
+        ref_id: raw.ref_id,
+        node_type: raw.node_type,
+        name: deriveNodeName(raw, properties),
+        properties: raw.properties,
+        edges,
+      },
+      [{ ref_id: raw.ref_id, node_type: raw.node_type }],
+    );
   },
 });

--- a/mcp/src/lab/jarvis/steps/graph-neighbors.ts
+++ b/mcp/src/lab/jarvis/steps/graph-neighbors.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -125,6 +125,10 @@ export default defineStep({
       if (neighbors.length >= NEIGHBOR_CAP) break;
     }
 
-    return neighbors;
+    // Provenance: the expanded node plus every neighbor returned.
+    return withAccessedNodes(neighbors, [
+      { ref_id: cfg.ref_id },
+      ...neighbors.map((n) => ({ ref_id: n.ref_id as string, node_type: n.node_type as string })),
+    ]);
   },
 });

--- a/mcp/src/lab/jarvis/steps/graph-search.ts
+++ b/mcp/src/lab/jarvis/steps/graph-search.ts
@@ -1,4 +1,4 @@
-import { z, defineStep, type StepContext, type VeinCapabilities } from "vein";
+import { z, defineStep, type StepContext, type VeinCapabilities, withAccessedNodes } from "vein";
 
 /** Resolve the Jarvis base URL + auth via the secrets capability (secret
  *  store → env fallback). Duplicated in every jarvis/* step — see _shared.ts. */
@@ -82,7 +82,7 @@ export default defineStep({
     if (!res.ok) return `HTTP ${res.status}: ${typeof res.body === "string" ? res.body : JSON.stringify(res.body)}`;
     const data = res.body as any;
     const nodes: any[] = Array.isArray(data) ? data : (data?.nodes ?? []);
-    return nodes.map((n: any) => ({
+    const hits = nodes.map((n: any) => ({
       ref_id: n.ref_id ?? n.properties?.ref_id,
       name:
         n.properties?.name ??
@@ -96,5 +96,7 @@ export default defineStep({
       ...(n.properties?.workflow_id !== undefined ? { workflow_id: n.properties.workflow_id } : {}),
       ...(n.properties?.skill_id !== undefined ? { skill_id: n.properties.skill_id } : {}),
     }));
+    // Provenance: every hit is a node this call touched.
+    return withAccessedNodes(hits, hits.map((h: any) => ({ ref_id: h.ref_id, node_type: h.node_type })));
   },
 });

--- a/mcp/yarn.lock
+++ b/mcp/yarn.lock
@@ -1475,13 +1475,6 @@
     wrap-ansi "^8.1.0"
     wrap-ansi-cjs "npm:wrap-ansi@^7.0.0"
 
-"@isaacs/fs-minipass@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/@isaacs/fs-minipass/-/fs-minipass-4.0.1.tgz"
-  integrity sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==
-  dependencies:
-    minipass "^7.0.4"
-
 "@jridgewell/gen-mapping@^0.3.2":
   version "0.3.13"
   resolved "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz"
@@ -3156,11 +3149,6 @@ chownr@^2.0.0:
   version "2.0.0"
   resolved "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
-
-chownr@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.npmjs.org/chownr/-/chownr-3.0.0.tgz"
-  integrity sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==
 
 chrome-launcher@^1.2.0:
   version "1.2.1"
@@ -5059,7 +5047,7 @@ minipass@^5.0.0:
   resolved "https://registry.npmjs.org/minipass/-/minipass-5.0.0.tgz"
   integrity sha512-3FnjYuehv9k6ovOEbyOswadCDPX1piCfhV8ncmYtHOjuPwylVWsghTLo7rabjC3Rx5xD4HDx8Wm1xnMF7S5qFQ==
 
-"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.0.4, minipass@^7.1.2:
+"minipass@^5.0.0 || ^6.0.2 || ^7.0.0", minipass@^7.1.2:
   version "7.1.2"
   resolved "https://registry.npmjs.org/minipass/-/minipass-7.1.2.tgz"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
@@ -5071,13 +5059,6 @@ minizlib@^2.1.1:
   dependencies:
     minipass "^3.0.0"
     yallist "^4.0.0"
-
-minizlib@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.npmjs.org/minizlib/-/minizlib-3.1.0.tgz"
-  integrity sha512-KZxYo1BUkWD2TVFLr0MQoM8vUUigWD3LlD83a/75BqC+4qE0Hb1Vo5v1FgcfaNXvfXzr+5EhQ6ing/CaBijTlw==
-  dependencies:
-    minipass "^7.1.2"
 
 mitt@3.0.1:
   version "3.0.1"
@@ -5245,11 +5226,6 @@ onetime@^6.0.0:
   dependencies:
     mimic-fn "^4.0.0"
 
-onnxruntime-common@1.21.0:
-  version "1.21.0"
-  resolved "https://registry.npmjs.org/onnxruntime-common/-/onnxruntime-common-1.21.0.tgz"
-  integrity sha512-Q632iLLrtCAVOTO65dh2+mNbQir/QNTVBG3h/QdZBpns7mZ0RYbLRBgGABPbpU9351AgYy7SJf1WaeVwMrBFPQ==
-
 onnxruntime-common@1.24.0-dev.20251116-b39e144322:
   version "1.24.0-dev.20251116-b39e144322"
   resolved "https://registry.yarnpkg.com/onnxruntime-common/-/onnxruntime-common-1.24.0-dev.20251116-b39e144322.tgz#6edecf4e5178f9d76907d5abbe241c3635e528dd"
@@ -5260,16 +5236,7 @@ onnxruntime-common@1.24.3:
   resolved "https://registry.yarnpkg.com/onnxruntime-common/-/onnxruntime-common-1.24.3.tgz#fb93319a2d041fc9fe2a209167ba6ef2f1a47fee"
   integrity sha512-GeuPZO6U/LBJXvwdaqHbuUmoXiEdeCjWi/EG7Y1HNnDwJYuk6WUbNXpF6luSUY8yASul3cmUlLGrCCL1ZgVXqA==
 
-onnxruntime-node@1.21.0:
-  version "1.21.0"
-  resolved "https://registry.npmjs.org/onnxruntime-node/-/onnxruntime-node-1.21.0.tgz"
-  integrity sha512-NeaCX6WW2L8cRCSqy3bInlo5ojjQqu2fD3D+9W5qb5irwxhEyWKXeH2vZ8W9r6VxaMPUan+4/7NDwZMtouZxEw==
-  dependencies:
-    global-agent "^3.0.0"
-    onnxruntime-common "1.21.0"
-    tar "^7.0.1"
-
-onnxruntime-node@1.24.3:
+onnxruntime-node@1.21.0, onnxruntime-node@1.24.3:
   version "1.24.3"
   resolved "https://registry.yarnpkg.com/onnxruntime-node/-/onnxruntime-node-1.24.3.tgz#ec8da99c335aa5ea95559a3ac1ae915a89541d5e"
   integrity sha512-JH7+czbc8ALA819vlTgcV+Q214/+VjGeBHDjX81+ZCD0PCVCIFGFNtT0V4sXG/1JXypKPgScQcB3ij/hk3YnTg==
@@ -6338,17 +6305,6 @@ tar@^6.2.0:
     mkdirp "^1.0.3"
     yallist "^4.0.0"
 
-tar@^7.0.1:
-  version "7.5.7"
-  resolved "https://registry.npmjs.org/tar/-/tar-7.5.7.tgz"
-  integrity sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==
-  dependencies:
-    "@isaacs/fs-minipass" "^4.0.0"
-    chownr "^3.0.0"
-    minipass "^7.1.2"
-    minizlib "^3.1.0"
-    yallist "^5.0.0"
-
 text-decoder@^1.1.0:
   version "1.2.3"
   resolved "https://registry.npmjs.org/text-decoder/-/text-decoder-1.2.3.tgz"
@@ -6729,11 +6685,6 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
-
-yallist@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.npmjs.org/yallist/-/yallist-5.0.0.tgz"
-  integrity sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==
 
 yargs-parser@^21.1.1:
   version "21.1.1"

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -292,7 +292,14 @@ services bag can override it, same as `http`/`secrets`).
   projects them into `VeinRun`/`VeinAgentSession`/`VeinToolCall`/
   `VeinChat`/`VeinTurn` with `EXECUTED`/`IN_RUN`/`IN_SESSION`/`SPAWNED`/
   `IN_CHAT` edges — summaries + `log_ref` pointers, never payloads,
-  idempotent upserts.
+  idempotent upserts. **Provenance convention:** a graph-touching step
+  marks its output with `withAccessedNodes(output, [{ ref_id, node_type? }])`
+  (`core.ts`; a non-enumerable marker — invisible to the model, `{{ }}`
+  expressions, and JSON). `wrapToolsWithEmit` lifts it onto the tool call's
+  `step.end` event as `nodes`, untruncated, and the projector writes one
+  `ACCESSED` edge per ref the graph holds (`VeinToolCall → any node`). Every
+  `graph/*` (and mcp `jarvis/*`) node-touching step does this; a step that
+  reports nothing gets no edges — never inferred from prose.
   `server.ts` is a thin wrapper (`getApp`/`startServer`) over
   `createVein()` — graph workspace by default, file stores for the rest.
 

--- a/vein/plans/generic-storage.md
+++ b/vein/plans/generic-storage.md
@@ -10,9 +10,11 @@
 > `src/graph/projector.ts` (post-hoc run/chat projector, idempotent
 > upserts) + the `graph/project` lib step, and `src/graph/wiring.ts`
 > (graph is the default server's workspace; `VEIN_WORKSPACE_BACKEND=fs`
-opts out). Not projected
-> yet: `ACCESSED` (needs the v2 provenance convention below) and
-> `PROMOTED_FROM` (promotion doesn't record its source run). One deliberate
+opts out). The v2 provenance convention below landed 2026-09-02
+> (`withAccessedNodes` in `core.ts`, `nodes` on `step.end`, `ACCESSED`
+> in the projector; every `graph/*` + mcp `jarvis/*` node-touching step
+> reports). Not projected yet: `PROMOTED_FROM` (promotion doesn't record
+> its source run). One deliberate
 > deviation from the file store: graph versions are content-addressed —
 > publishing identical content under a new label re-labels the existing
 > version node instead of duplicating it.
@@ -375,6 +377,15 @@ backend-independent and unaffected.
 6. (Follow-up plan) `Neo4jWorkspaceStore` against the conformance suite.
 
 ## v2: Provenance convention (the gap the projection can't close alone)
+
+> **Status (2026-09-02):** implemented. The marker is `withAccessedNodes`
+> / `accessedNodesOf` in `core.ts` (a NON-enumerable `_nodes` property, so
+> it rides with the value in-process but never reaches the model, `{{ }}`
+> expressions, or JSON — which also lets array-shaped outputs carry it);
+> `wrapToolsWithEmit` lifts it onto `step.end` as `RunEvent.nodes`;
+> `maskDeep` carries it across masking; the projector writes `ACCESSED`
+> for refs the graph holds and counts the rest as `unresolved`. Chat-mode
+> agents expose no graph tools today, so nothing to capture there yet.
 
 Storage backends are not what blocks "which prompts touch which parts of
 the graph" — **provenance capture is**. Today a graph-touching tool call

--- a/vein/src/core.test.ts
+++ b/vein/src/core.test.ts
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 import { z } from "zod";
-import { flow, step, defineStep } from "./core.js";
+import { flow, step, defineStep, withAccessedNodes, accessedNodesOf } from "./core.js";
 
 // ── step() ─────────────────────────────────────────────────────────────────
 
@@ -187,5 +187,34 @@ describe("defineStep()", () => {
     // Invalid input
     assert.throws(() => def.input.parse({ name: "Alice" }));
     assert.throws(() => def.input.parse({ name: 123, age: 30 }));
+  });
+});
+
+// ── Provenance marker (withAccessedNodes / accessedNodesOf) ────────────────
+
+describe("withAccessedNodes()", () => {
+  it("marks objects and arrays with a non-enumerable, deduplicated node list", () => {
+    const obj = withAccessedNodes({ ref_id: "a" }, [{ ref_id: "a", node_type: "Concept" }, { ref_id: "a" }, { ref_id: "b" }]);
+    assert.deepEqual(accessedNodesOf(obj), [{ ref_id: "a", node_type: "Concept" }, { ref_id: "b" }]);
+    // Invisible to enumeration, JSON, spreads, and deep-equality.
+    assert.deepEqual(Object.keys(obj), ["ref_id"]);
+    assert.equal(JSON.stringify(obj), '{"ref_id":"a"}');
+    assert.equal(accessedNodesOf({ ...obj }), undefined);
+    assert.deepEqual(obj, { ref_id: "a" });
+
+    const arr = withAccessedNodes([{ ref_id: "x" }], [{ ref_id: "x" }]);
+    assert.deepEqual(accessedNodesOf(arr), [{ ref_id: "x" }]);
+    assert.equal(JSON.stringify(arr), '[{"ref_id":"x"}]');
+    assert.equal(arr.length, 1);
+  });
+
+  it("leaves primitives, empty lists, and junk refs unmarked", () => {
+    assert.equal(withAccessedNodes("error text", [{ ref_id: "a" }]), "error text");
+    assert.equal(accessedNodesOf("error text"), undefined);
+    assert.equal(accessedNodesOf(withAccessedNodes({}, [])), undefined);
+    assert.equal(accessedNodesOf(withAccessedNodes({}, [null, undefined, { ref_id: "" }, { ref_id: 1 as any }])), undefined);
+    assert.equal(accessedNodesOf(null), undefined);
+    // node_type is optional and dropped when empty.
+    assert.deepEqual(accessedNodesOf(withAccessedNodes({}, [{ ref_id: "a", node_type: "" }])), [{ ref_id: "a" }]);
   });
 });

--- a/vein/src/core.ts
+++ b/vein/src/core.ts
@@ -169,6 +169,52 @@ export interface RunEvent {
    *  re-executes steps with the SAME knob values the original run used. */
   params?: Record<string, unknown>;
   paramOverrides?: Record<string, Record<string, unknown>>;
+  /** Graph nodes this step reported touching (the provenance convention,
+   *  plans/generic-storage.md "v2") — lifted verbatim from the output's
+   *  `_nodes` marker on `step.end`, exempt from any truncation. The graph
+   *  projector turns them into `ACCESSED` edges. */
+  nodes?: AccessedNode[];
+}
+
+// ── Provenance convention: which graph nodes did a step touch? ─────────────
+
+/** One graph node a step read or wrote, by its stable `ref_id`. */
+export interface AccessedNode {
+  ref_id: string;
+  node_type?: string;
+}
+
+const ACCESSED_NODES_KEY = "_nodes";
+
+/**
+ * Mark a step's output with the graph nodes it touched. The marker is a
+ * NON-enumerable own property of the output value (object or array), so it
+ * rides along in-process — to `wrapToolsWithEmit`, which lifts it onto the
+ * `step.end` event — but never reaches the model, downstream `{{ }}`
+ * expressions, or a JSON serializer. Refs are deduplicated by `ref_id`;
+ * empty lists and non-object outputs (error strings) are left unmarked.
+ * Returns `output` for chaining: `return withAccessedNodes(result, refs)`.
+ */
+export function withAccessedNodes<T>(output: T, nodes: Array<AccessedNode | null | undefined>): T {
+  if (output === null || typeof output !== "object") return output;
+  const seen = new Set<string>();
+  const list: AccessedNode[] = [];
+  for (const n of nodes) {
+    if (!n || typeof n.ref_id !== "string" || !n.ref_id || seen.has(n.ref_id)) continue;
+    seen.add(n.ref_id);
+    list.push(typeof n.node_type === "string" && n.node_type ? { ref_id: n.ref_id, node_type: n.node_type } : { ref_id: n.ref_id });
+  }
+  if (list.length === 0) return output;
+  Object.defineProperty(output, ACCESSED_NODES_KEY, { value: list, enumerable: false, configurable: true, writable: true });
+  return output;
+}
+
+/** The nodes a step output was marked with (see `withAccessedNodes`), else
+ *  undefined. */
+export function accessedNodesOf(output: unknown): AccessedNode[] | undefined {
+  if (output === null || typeof output !== "object") return undefined;
+  const v = (output as Record<string, unknown>)[ACCESSED_NODES_KEY];
+  return Array.isArray(v) && v.length > 0 ? (v as AccessedNode[]) : undefined;
 }
 
 /** Result of running a workflow. */

--- a/vein/src/graph/projector.test.ts
+++ b/vein/src/graph/projector.test.ts
@@ -15,6 +15,8 @@ let backend: GraphBackend;
 const WF = "harvey-deliver";
 const RUN = "1788307097627";
 const T0 = Date.parse("2026-09-01T20:00:00Z");
+const CONCEPT_A = "11111111-1111-4111-8111-111111111111";
+const CONCEPT_B = "22222222-2222-4222-8222-222222222222";
 const ts = (i: number) => new Date(T0 + i * 1000).toISOString();
 const ev = (i: number, type: RunEvent["type"], path: string, extra: Partial<RunEvent> = {}): RunEvent => ({
   ts: ts(i),
@@ -30,7 +32,14 @@ function sampleEvents(workflowHash: string): RunEvent[] {
     ev(0, "run.start", WF, { input: { q: "deliver" }, workflowHash, params: { model: "m" } }),
     ev(1, "step.start", `${WF}/plan`, { stepType: "agent", input: { prompt: "Plan the delivery", model: "claude" } }),
     ev(2, "step.start", `${WF}/plan/001-search`, { stepType: "tool:graph/graph-search", input: { query: "docs" } }),
-    ev(3, "step.end", `${WF}/plan/001-search`, { stepType: "tool:graph/graph-search", output: { hits: 3 }, durationMs: 800 }),
+    ev(3, "step.end", `${WF}/plan/001-search`, {
+      stepType: "tool:graph/graph-search",
+      output: { hits: 3 },
+      durationMs: 800,
+      // Provenance marker lifted by wrapToolsWithEmit: two concepts, one
+      // repeated, one ref this graph will not hold.
+      nodes: [{ ref_id: CONCEPT_A, node_type: "Concept" }, { ref_id: CONCEPT_B }, { ref_id: CONCEPT_A }, { ref_id: "not-in-this-graph" }],
+    }),
     ev(4, "step.start", `${WF}/plan/002-read`, { stepType: "tool:read", input: { id: "x" } }),
     ev(5, "step.error", `${WF}/plan/002-read`, { stepType: "tool:read", error: { message: "not found" }, durationMs: 10 }),
     ev(6, "step.end", `${WF}/plan`, { stepType: "agent", output: "Plan: ship it", durationMs: 5000 }),
@@ -64,6 +73,12 @@ describe("projectRunEvents (pure)", () => {
         [2, "read", "not found", `${WF}/plan`],
       ],
     );
+    // Accessed refs come from the end event's `nodes`, deduplicated.
+    assert.deepEqual(
+      p.toolCalls.map((t) => t.accessed.map((n) => n.ref_id)),
+      [[CONCEPT_A, CONCEPT_B, "not-in-this-graph"], []],
+    );
+    assert.equal(p.toolCalls[0]!.accessed[0]!.node_type, "Concept");
   });
 
   it("uses the summary when present, and marks a finalize-less log stale", () => {
@@ -132,8 +147,16 @@ describe("projector (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4J_URI no
       runId: RUN, workflow: WF, startedAt: ts(0), finishedAt: ts(9), durationMs: 9000, status: "success", input: { q: "deliver" }, output: { delivered: 60 },
     });
 
+    // Two jarvis-style Concept nodes (no Vein label) the search step reported touching.
+    for (const [r, name] of [[CONCEPT_A, "a"], [CONCEPT_B, "b"]]) {
+      await backend.bolt.run(`CREATE (:Concept:Node:Data_Bank:Domain_general {ref_id: $r, node_key: $k, namespace: "default", name: $n})`, { r, k: `concept-${name}`, n: name });
+    }
+
     const report = await projectRuns(backend, store, { workflows: [WF] });
-    assert.deepEqual([report.runs, report.sessions, report.toolCalls, report.edges, report.skipped], [1, 1, 2, 4, 0]);
+    assert.deepEqual(
+      [report.runs, report.sessions, report.toolCalls, report.edges, report.accessed, report.unresolved, report.skipped],
+      [1, 1, 2, 6, 2, 1, 0],
+    );
     assert.equal(await count("VeinRun"), 1);
     assert.equal(await count("VeinAgentSession"), 1);
     assert.equal(await count("VeinToolCall"), 2);
@@ -153,6 +176,20 @@ describe("projector (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4J_URI no
       `MATCH (r:VeinRun)-[:EXECUTED]->(v:VeinWorkflowVersion)<-[:ACTIVE_VERSION]-(w:VeinWorkflow) RETURN w.name AS wf, r.run_id AS run`,
     );
     assert.deepEqual(rows, [{ wf: WF, run: RUN }]);
+
+    // ACCESSED: the search call → each concept it reported (the unknown ref
+    // is skipped, never an error); the full provenance chain is queryable.
+    assert.equal(await edges("ACCESSED"), 2);
+    const touched = await backend.bolt.run(
+      `MATCH (r:VeinRun)<-[:IN_RUN]-(:VeinAgentSession)<-[:IN_SESSION]-(t:VeinToolCall)-[:ACCESSED]->(c:Concept) RETURN r.run_id AS run, t.tool_name AS tool, c.name AS concept ORDER BY concept`,
+    );
+    assert.deepEqual(touched, [
+      { run: RUN, tool: "graph/graph-search", concept: "a" },
+      { run: RUN, tool: "graph/graph-search", concept: "b" },
+    ]);
+    // Re-projection does not duplicate the edges.
+    await projectRuns(backend, store, { workflows: [WF], skipSettled: false });
+    assert.equal(await edges("ACCESSED"), 2);
   });
 
   it("is idempotent, skips settled runs, and re-projects an unsettled run once it finalizes", async () => {

--- a/vein/src/graph/projector.ts
+++ b/vein/src/graph/projector.ts
@@ -12,12 +12,17 @@
  * edge vocabulary grows — every write is an idempotent `upsert` keyed by
  * the node's identity (`unique_source_id` stamped for cheap reconciliation).
  *
- * Not projected (v2, "provenance convention"): `ACCESSED` edges from tool
- * calls to the domain nodes they touched — the log has no structured record
- * of those yet. `PROMOTED_FROM` likewise: promotions publish a new version
- * without recording the source run.
+ * Provenance: a tool call whose `step.end` carries `nodes` (the convention
+ * in plans/generic-storage.md "v2" — graph-touching steps mark their output
+ * with `withAccessedNodes`, and `wrapToolsWithEmit` lifts the marker onto
+ * the event untruncated) gets one `ACCESSED` edge per node that exists in
+ * this graph. Refs the graph doesn't hold (another database, a deleted
+ * node) are counted as `unresolved`, never written — explicit over clever.
+ *
+ * Not projected: `PROMOTED_FROM` — promotions publish a new version without
+ * recording the source run.
  */
-import type { RunEvent, RunSummary } from "../core.js";
+import type { AccessedNode, RunEvent, RunSummary } from "../core.js";
 import type { RunStore } from "../store.js";
 import type { ChatStore, StoredMessage } from "../chat-store.js";
 import type { GraphBackend } from "./backend.js";
@@ -42,11 +47,16 @@ export interface ProjectReport {
   toolCalls: number;
   chats: number;
   turns: number;
+  /** Every edge written, `ACCESSED` included. */
   edges: number;
+  /** `ACCESSED` edges written (tool call → node it touched). */
+  accessed: number;
+  /** Node refs tool calls reported that this graph does not hold — no edge. */
+  unresolved: number;
   skipped: number;
 }
 
-const emptyReport = (): ProjectReport => ({ runs: 0, sessions: 0, toolCalls: 0, chats: 0, turns: 0, edges: 0, skipped: 0 });
+const emptyReport = (): ProjectReport => ({ runs: 0, sessions: 0, toolCalls: 0, chats: 0, turns: 0, edges: 0, accessed: 0, unresolved: 0, skipped: 0 });
 
 /** A bounded text preview of any value — the only shape of payload that
  *  reaches the graph. */
@@ -86,7 +96,7 @@ function runStatus(summary: RunSummary | null, events: RunEvent[]): string {
 interface RunProjection {
   run: NodeInput;
   sessions: NodeInput[];
-  toolCalls: Array<{ node: NodeInput; sessionPath: string }>;
+  toolCalls: Array<{ node: NodeInput; sessionPath: string; accessed: AccessedNode[] }>;
   workflowHash?: string;
 }
 
@@ -156,7 +166,8 @@ export function projectRunEvents(workflow: string, runId: string, events: RunEve
   }
 
   // Tool calls: `tool:<name>` steps nested under a session path, numbered
-  // per session in log order.
+  // per session in log order. `accessed` is the end event's `nodes` list
+  // (the provenance marker), deduplicated by ref_id.
   const toolCalls: RunProjection["toolCalls"] = [];
   const seqBySession = new Map<string, number>();
   const toolEnds = new Map<string, RunEvent>();
@@ -168,8 +179,16 @@ export function projectRunEvents(workflow: string, runId: string, events: RunEve
     const seq = (seqBySession.get(session) ?? 0) + 1;
     seqBySession.set(session, seq);
     const end = toolEnds.get(keyOf(e));
+    const accessed: AccessedNode[] = [];
+    const seenRef = new Set<string>();
+    for (const n of end?.nodes ?? []) {
+      if (!n || typeof n.ref_id !== "string" || !n.ref_id || seenRef.has(n.ref_id)) continue;
+      seenRef.add(n.ref_id);
+      accessed.push(n);
+    }
     toolCalls.push({
       sessionPath: session,
+      accessed,
       node: {
         type: "VeinToolCall",
         data: compact({
@@ -234,10 +253,26 @@ export async function projectRuns(backend: GraphBackend, store: RunStore, opts: 
         const ref = sessionRef.get(String(s.data["path"]).replace(/#\d+$/, ""))!;
         edges.push({ edge: "IN_RUN", source_ref_id: ref, target_ref_id: runRef });
       });
+      const toolRef = (i: number) => written[1 + p.sessions.length + i]!.ref_id;
       p.toolCalls.forEach((t, i) => {
-        const ref = written[1 + p.sessions.length + i]!.ref_id;
-        edges.push({ edge: "IN_SESSION", source_ref_id: ref, target_ref_id: sessionRef.get(t.sessionPath)! });
+        edges.push({ edge: "IN_SESSION", source_ref_id: toolRef(i), target_ref_id: sessionRef.get(t.sessionPath)! });
       });
+      // ACCESSED: only toward nodes this graph actually holds (the edge
+      // writer treats a missing endpoint as an error, and a ref may point
+      // at another database or a since-deleted node).
+      const wanted = new Set(p.toolCalls.flatMap((t) => t.accessed.map((n) => n.ref_id)));
+      if (wanted.size) {
+        const rows = await backend.bolt.run(`MATCH (n:Data_Bank) WHERE n.ref_id IN $ids RETURN DISTINCT n.ref_id AS ref_id`, { ids: [...wanted] });
+        const present = new Set(rows.map((r) => r["ref_id"] as string));
+        p.toolCalls.forEach((t, i) => {
+          for (const n of t.accessed) {
+            if (present.has(n.ref_id)) {
+              edges.push({ edge: "ACCESSED", source_ref_id: toolRef(i), target_ref_id: n.ref_id });
+              report.accessed++;
+            } else report.unresolved++;
+          }
+        });
+      }
       if (p.workflowHash) {
         const rows = await backend.bolt.run(
           `MATCH (v:VeinWorkflowVersion {namespace: $ns, name: $wf, content_hash: $h}) RETURN v.ref_id AS ref_id LIMIT 1`,
@@ -373,6 +408,8 @@ export async function projectAll(
     chats: a.chats + b.chats,
     turns: a.turns + b.turns,
     edges: a.edges + b.edges,
+    accessed: a.accessed + b.accessed,
+    unresolved: a.unresolved + b.unresolved,
     skipped: a.skipped + b.skipped,
   };
 }

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -22,6 +22,9 @@ export {
   type RunResult,
   type RunSummary,
   type RunEventType,
+  type AccessedNode,
+  withAccessedNodes,
+  accessedNodesOf,
 } from "./core.js";
 
 // Runner

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -6,7 +6,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { z } from "zod";
 import { coreRegistry } from "../registry.js";
-import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
+import { withAccessedNodes, accessedNodesOf, defineStep, type StepContext, type StepRegistry } from "../../core.js";
 import agent, {
   repoTree,
   textEdit,
@@ -282,6 +282,40 @@ describe("wrapToolsWithEmit (per-call nested run events)", () => {
     const orig = tools.bash.execute;
     wrapToolsWithEmit(tools, undefined);
     assert.equal(tools.bash.execute, orig, "execute is left untouched");
+  });
+
+  it("lifts the provenance marker onto step.end as `nodes`, untruncated, without touching the tool result", async () => {
+    const events: any[] = [];
+    const big = "x".repeat(5000);
+    const refs = Array.from({ length: 40 }, (_, i) => ({ ref_id: `ref-${i}`, node_type: "Concept" }));
+    const tools: Record<string, any> = {
+      search: { execute: async () => withAccessedNodes([{ ref_id: "ref-0", text: big }], refs) },
+      plain: { execute: async () => ({ ok: true }) },
+    };
+    wrapToolsWithEmit(tools, makeCtx(events));
+
+    const out = await tools.search.execute({});
+    assert.deepEqual(accessedNodesOf(out), refs, "the model-facing result keeps the marker (invisible to JSON)");
+    assert.equal(JSON.stringify(out), JSON.stringify([{ ref_id: "ref-0", text: big }]));
+    const end = events.find((e) => e.type === "step.end" && e.path.endsWith("-search"));
+    assert.deepEqual(end.nodes, refs, "all 40 refs survive even though output was truncated");
+    assert.ok(end.output.length < big.length, "output itself is still summarized");
+
+    await tools.plain.execute({});
+    const plainEnd = events.find((e) => e.type === "step.end" && e.path.endsWith("-plain"));
+    assert.ok(!("nodes" in plainEnd), "unmarked results emit no nodes field");
+  });
+});
+
+describe("maskDeep keeps the provenance marker", () => {
+  it("carries `_nodes` across the rebuilt object/array", () => {
+    const refs = [{ ref_id: "r1" }];
+    const obj = maskDeep(withAccessedNodes({ key: "sk-123", nested: ["sk-123"] }, refs), ["sk-123"]) as any;
+    assert.deepEqual(obj, { key: "[MASKED_SECRET]", nested: ["[MASKED_SECRET]"] });
+    assert.deepEqual(accessedNodesOf(obj), refs);
+    const arr = maskDeep(withAccessedNodes(["sk-123"], refs), ["sk-123"]) as any;
+    assert.deepEqual(arr, ["[MASKED_SECRET]"]);
+    assert.deepEqual(accessedNodesOf(arr), refs);
   });
 });
 

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -1,6 +1,6 @@
 import { z } from "zod";
 import type { Provider as AieoProvider } from "aieo";
-import { defineStep, type StepContext, type StepRegistry } from "../../core.js";
+import { accessedNodesOf, defineStep, type StepContext, type StepRegistry, withAccessedNodes } from "../../core.js";
 import { isCancelledError } from "../../run-control.js";
 import { usageFromResult, computeCost, addUsage, emptyUsage, maxOutputTokensFor } from "../../pricing.js";
 import { existsSync, readdirSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
@@ -541,7 +541,11 @@ export function buildRegistryTools(
  * No-op when there's no runner ctx (in-code/test) or no path. Skips
  * `final_answer` (terminal, noisy) and any tool with no function `execute`
  * (provider-executed tools like anthropic `web_search`). Output is truncated in
- * the event only (the model still sees the full result).
+ * the event only (the model still sees the full result) — except the
+ * provenance marker: a result marked with `withAccessedNodes` gets its node
+ * refs lifted verbatim onto the `step.end` event as `nodes`, the one part of
+ * tool output that must survive into the log untruncated because it is data
+ * for the graph projector (`ACCESSED` edges), not a preview for humans.
  */
 /** Replace every occurrence of each secret value in `text` with a marker.
  *  Plain string splitting (no regex) — values are opaque tokens. */
@@ -557,11 +561,13 @@ export function maskSecretValues(text: string, values: string[]): string {
 export function maskDeep(value: unknown, values: string[]): unknown {
   if (!values.length) return value;
   if (typeof value === "string") return maskSecretValues(value, values);
-  if (Array.isArray(value)) return value.map((x) => maskDeep(x, values));
+  // Rebuilding a container drops its non-enumerable provenance marker
+  // (`withAccessedNodes`) — carry it over; node refs are ids, not secrets.
+  if (Array.isArray(value)) return withAccessedNodes(value.map((x) => maskDeep(x, values)), accessedNodesOf(value) ?? []);
   if (value && typeof value === "object") {
     const out: Record<string, unknown> = {};
     for (const [k, v] of Object.entries(value)) out[k] = maskDeep(v, values);
-    return out;
+    return withAccessedNodes(out, accessedNodesOf(value) ?? []);
   }
   return value;
 }
@@ -610,12 +616,14 @@ export function wrapToolsWithEmit(tools: Record<string, any>, ctx: StepContext |
             ? { ...(opts as Record<string, unknown>), veinToolPath: path }
             : { veinToolPath: path };
         const out = await (orig as (i: unknown, o: unknown) => Promise<unknown>)(input, optsWithPath);
+        const nodes = accessedNodesOf(out);
         await emit({
           type: "step.end",
           path,
           stepType: `tool:${name}`,
           output: summarizeForEvent(out),
           durationMs: Date.now() - startedAt,
+          ...(nodes ? { nodes } : {}),
         });
         return out;
       } catch (e) {

--- a/vein/src/steps/lib/graph/create-batch-triplet.ts
+++ b/vein/src/steps/lib/graph/create-batch-triplet.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { graphCtx, errText, graphErrorCode, writeEdge, type GraphBackend } from "./_shared.js";
 /** Validate one side of a triplet: either ref_id XOR (type + data). */
@@ -136,6 +136,10 @@ export default defineStep({
     }
 
     const failed = results.filter((r) => r.error).length;
-    return { requested: cfg.triplets.length, succeeded: results.length - failed, failed, results };
+    return withAccessedNodes(
+      { requested: cfg.triplets.length, succeeded: results.length - failed, failed, results },
+      // Provenance: both endpoints of every edge that was written.
+      results.filter((r) => !r.error).flatMap((r) => [{ ref_id: r.source_ref_id as string }, { ref_id: r.target_ref_id as string }]),
+    );
   },
 });

--- a/vein/src/steps/lib/graph/create-node.ts
+++ b/vein/src/steps/lib/graph/create-node.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { graphCtx, errText } from "./_shared.js";
 export default defineStep({
@@ -32,14 +32,17 @@ export default defineStep({
       const namespace = await b.reader.resolveNamespace(cfg.namespace);
       const r = await b.nodes.write({ type: cfg.node_type, data: cfg.node_data }, "create", { namespace });
       const existed = r.outcome === "existing";
-      return {
-        // "Warning" here means the node already existed (idempotent merge).
-        status: existed ? "Warning" : "Success",
-        ref_id: r.ref_id,
-        node_type: cfg.node_type,
-        ...(existed ? { messages: [`Node already exists in the graph with node_key: ${r.node_key}`] } : {}),
-        ...(r.outcome === "restored" ? { messages: ["Node restored"] } : {}),
-      };
+      return withAccessedNodes(
+        {
+          // "Warning" here means the node already existed (idempotent merge).
+          status: existed ? "Warning" : "Success",
+          ref_id: r.ref_id,
+          node_type: cfg.node_type,
+          ...(existed ? { messages: [`Node already exists in the graph with node_key: ${r.node_key}`] } : {}),
+          ...(r.outcome === "restored" ? { messages: ["Node restored"] } : {}),
+        },
+        [{ ref_id: r.ref_id, node_type: cfg.node_type }],
+      );
     } catch (e) {
       return errText("graph/create-node", e);
     }

--- a/vein/src/steps/lib/graph/create-triplet.ts
+++ b/vein/src/steps/lib/graph/create-triplet.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { graphCtx, errText, graphErrorCode, writeEdge } from "./_shared.js";
 /** Validate one side of a triplet: either ref_id XOR (type + data). */
@@ -126,15 +126,19 @@ export default defineStep({
           `but the edge write failed — ${graphErrorCode(e) ? `${graphErrorCode(e)}: ` : ""}${e instanceof Error ? e.message : String(e)}`
         );
       }
-      return {
-        // "Warning" here means the edge already existed (idempotent merge).
-        status: edge.created ? "Success" : "Warning",
-        source_ref_id: edge.source_ref_id,
-        target_ref_id: edge.target_ref_id,
-        edge_ref_id: edge.ref_id,
-        edge_type: cfg.edge_type.toUpperCase().replace(/ /g, "_"),
-        ...(edge.created ? {} : { messages: ["Edge already exists in the graph"] }),
-      };
+      return withAccessedNodes(
+        {
+          // "Warning" here means the edge already existed (idempotent merge).
+          status: edge.created ? "Success" : "Warning",
+          source_ref_id: edge.source_ref_id,
+          target_ref_id: edge.target_ref_id,
+          edge_ref_id: edge.ref_id,
+          edge_type: cfg.edge_type.toUpperCase().replace(/ /g, "_"),
+          ...(edge.created ? {} : { messages: ["Edge already exists in the graph"] }),
+        },
+        // Provenance: both endpoints (the edge itself is not a node).
+        [{ ref_id: edge.source_ref_id, node_type: cfg.source_type }, { ref_id: edge.target_ref_id, node_type: cfg.target_type }],
+      );
     } catch (e) {
       return errText("graph/create-triplet", e);
     }

--- a/vein/src/steps/lib/graph/edit-node.ts
+++ b/vein/src/steps/lib/graph/edit-node.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { graphCtx, errText } from "./_shared.js";
 export default defineStep({
@@ -52,12 +52,15 @@ export default defineStep({
       await b.nodes.update(cfg.ref_id, { set: cfg.node_data ?? {}, remove: cfg.properties_to_be_deleted ?? [] });
       // Compact confirmation — deliberately NOT the full updated node.
       // graph_graph_get to verify.
-      return {
-        status: "Success",
-        ref_id: cfg.ref_id,
-        ...(hasSet ? { updated: Object.keys(cfg.node_data!) } : {}),
-        ...(hasDelete ? { deleted: cfg.properties_to_be_deleted } : {}),
-      };
+      return withAccessedNodes(
+        {
+          status: "Success",
+          ref_id: cfg.ref_id,
+          ...(hasSet ? { updated: Object.keys(cfg.node_data!) } : {}),
+          ...(hasDelete ? { deleted: cfg.properties_to_be_deleted } : {}),
+        },
+        [{ ref_id: cfg.ref_id }],
+      );
     } catch (e) {
       return errText("graph/edit-node", e);
     }

--- a/vein/src/steps/lib/graph/graph-get-batched.ts
+++ b/vein/src/steps/lib/graph/graph-get-batched.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { graphCtx, errText, type GraphBackend } from "./_shared.js";
 const LABEL_MAX = 160;
@@ -98,12 +98,16 @@ export default defineStep({
       nodes.push(...(await Promise.all(wave.map(fetchNode))));
     }
 
-    return {
-      requested: cfg.ref_ids.length,
-      returned: nodes.length,
-      truncated: omitted.length > 0,
-      omitted_ref_ids: omitted,
-      nodes,
-    };
+    return withAccessedNodes(
+      {
+        requested: cfg.ref_ids.length,
+        returned: nodes.length,
+        truncated: omitted.length > 0,
+        omitted_ref_ids: omitted,
+        nodes,
+      },
+      // Provenance: the nodes that resolved (an `error` entry touched nothing).
+      nodes.filter((n) => !n["error"]).map((n) => ({ ref_id: n["ref_id"] as string, node_type: n["node_type"] as string })),
+    );
   },
 });

--- a/vein/src/steps/lib/graph/graph-get.ts
+++ b/vein/src/steps/lib/graph/graph-get.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { graphCtx, errText } from "./_shared.js";
 const LABEL_MAX = 160;
@@ -66,13 +66,16 @@ export default defineStep({
       } catch {
         // edges stays {}
       }
-      return {
-        ref_id: raw.ref_id,
-        node_type: raw.node_type,
-        name: deriveNodeName(raw, properties),
-        properties: raw.properties,
-        edges,
-      };
+      return withAccessedNodes(
+        {
+          ref_id: raw.ref_id,
+          node_type: raw.node_type,
+          name: deriveNodeName(raw, properties),
+          properties: raw.properties,
+          edges,
+        },
+        [{ ref_id: raw.ref_id, node_type: raw.node_type }],
+      );
     } catch (e) {
       return errText("graph/graph-get", e);
     }

--- a/vein/src/steps/lib/graph/graph-neighbors.ts
+++ b/vein/src/steps/lib/graph/graph-neighbors.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { graphCtx, errText } from "./_shared.js";
 const LABEL_MAX = 160;
@@ -101,7 +101,11 @@ export default defineStep({
         if (neighbors.length >= NEIGHBOR_CAP) break;
       }
 
-      return neighbors;
+      // Provenance: the expanded node plus every neighbor returned.
+      return withAccessedNodes(neighbors, [
+        { ref_id: cfg.ref_id },
+        ...neighbors.map((n) => ({ ref_id: n.ref_id as string, node_type: n.node_type as string })),
+      ]);
     } catch (e) {
       return errText("graph/graph-neighbors", e);
     }

--- a/vein/src/steps/lib/graph/graph-search.ts
+++ b/vein/src/steps/lib/graph/graph-search.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { defineStep, type StepContext } from "../../../core.js";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
 import type { VeinCapabilities } from "../../../capabilities.js";
 import { getVeinSchema } from "../../../graph/vein-schemas.js";
 import { graphCtx, errText } from "./_shared.js";
@@ -80,7 +80,7 @@ export default defineStep({
         // targets come back in one call.
         include_edge_counts: true,
       });
-      return res.nodes.map((n) => {
+      const hits = res.nodes.map((n) => {
         const p = (n.properties ?? {}) as Record<string, any>;
         return {
           ref_id: n.ref_id,
@@ -93,6 +93,8 @@ export default defineStep({
           ...(p.skill_id !== undefined ? { skill_id: p.skill_id } : {}),
         };
       });
+      // Provenance: every hit is a node this call touched.
+      return withAccessedNodes(hits, hits.map((h) => ({ ref_id: h.ref_id, node_type: h.node_type })));
     } catch (e) {
       return errText("graph/graph-search", e);
     }

--- a/vein/src/steps/lib/graph/graph-steps.test.ts
+++ b/vein/src/steps/lib/graph/graph-steps.test.ts
@@ -7,7 +7,7 @@
 import { describe, it, before, after } from "node:test";
 import assert from "node:assert/strict";
 import { buildRegistry } from "../../registry.js";
-import type { StepContext } from "../../../core.js";
+import { accessedNodesOf, type StepContext } from "../../../core.js";
 import { Bolt } from "../../../graph/bolt.js";
 import { closeGraphBackends } from "../../../graph/backend.js";
 import { testGraphConfig, wipeGraph } from "../../../graph/test-util.js";
@@ -105,6 +105,7 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
 
   it("graph-get returns the jarvis envelope", async () => {
     const out = await run("graph/graph-get", { ref_id: wfRef, namespace: NS });
+    assert.deepEqual(accessedNodesOf(out), [{ ref_id: wfRef, node_type: "VeinWorkflow" }], "provenance marker");
     assert.equal(out.ref_id, wfRef);
     assert.equal(out.node_type, "VeinWorkflow");
     assert.equal(out.name, "harvey-deliver");
@@ -129,6 +130,7 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
   it("graph-search finds the workflow (fulltext, title boost, type filter)", async () => {
     const out = await run("graph/graph-search", { q: "harvey-deliver", namespace: NS, type: "VeinWorkflow" });
     assert.ok(Array.isArray(out) && out[0].ref_id === wfRef, JSON.stringify(out));
+    assert.deepEqual(accessedNodesOf(out), [{ ref_id: wfRef, node_type: "VeinWorkflow" }], "provenance marker on an array output");
     assert.equal(out[0].name, "harvey-deliver");
     assert.equal(out[0].node_type, "VeinWorkflow");
     assert.deepEqual(out[0].edges, {});
@@ -149,6 +151,7 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
     assert.equal(out.edge_type, "VERSION_OF");
     assert.equal(out.target_ref_id, wfRef);
     wfvRef = out.source_ref_id;
+    assert.deepEqual(accessedNodesOf(out), [{ ref_id: wfvRef, node_type: "VeinWorkflowVersion" }, { ref_id: wfRef }], "both endpoints");
     out = await run("graph/create-triplet", { source_ref_id: wfvRef, target_ref_id: wfRef, edge_type: "VERSION_OF" });
     assert.equal(out.status, "Warning");
     assert.match(await run("graph/create-triplet", { source_ref_id: wfRef, target_ref_id: wfvRef, edge_type: "VERSION_OF" }), /WRONG_TYPE/);
@@ -158,6 +161,7 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
   it("graph-neighbors: direction, importance, edge filter, per-neighbor counts", async () => {
     const out = await run("graph/graph-neighbors", { ref_id: wfRef, namespace: NS });
     assert.equal(out.length, 1);
+    assert.deepEqual(accessedNodesOf(out), [{ ref_id: wfRef }, { ref_id: wfvRef, node_type: "VeinWorkflowVersion" }], "expanded node + neighbors");
     assert.deepEqual(out[0], { ref_id: wfvRef, node_type: "VeinWorkflowVersion", name: "harvey-deliver", edge_type: "VERSION_OF", direction: "reverse", edges: { VERSION_OF: 1 }, importance: 0.5 });
     assert.deepEqual(await run("graph/graph-neighbors", { ref_id: wfRef, edge_type: ["USES_STEP"] }), []);
   });
@@ -171,6 +175,7 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
     assert.match(out.nodes[1].error, /not found/);
     assert.equal(out.nodes[2].node_type, "VeinWorkflowVersion");
     assert.equal(out.truncated, false);
+    assert.deepEqual(accessedNodesOf(out), [{ ref_id: wfRef, node_type: "VeinWorkflow" }, { ref_id: wfvRef, node_type: "VeinWorkflowVersion" }], "resolved nodes only");
   });
 
   it("create-batch-triplet: per-item outcomes, inline dedupe", async () => {
@@ -189,6 +194,7 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
     assert.match(out.results[1].error, /WRONG_TYPE/);
     assert.equal(out.results[2].status, "Success");
     assert.match(out.results[3].error, /does not resolve/);
+    assert.deepEqual(accessedNodesOf(out)!.map((n) => n.ref_id).sort(), [...new Set([wfRef, wfvRef, out.results[2].target_ref_id])].sort(), "endpoints of written edges");
     const steps = await run("graph/graph-search", { q: "smoke/step", type: "VeinStep", namespace: NS });
     assert.equal(steps.length, 1, "inline VeinStep created once");
   });
@@ -212,6 +218,10 @@ describe("graph/project step", () => {
     const { openGraphBackend } = await import("../../../graph/backend.js");
 
     const dataDir = await mkdtemp(join(tmpdir(), "vein-project-step-"));
+    // The step lists workflows from the DEFAULT workspace (the graph since
+    // PR #1632); this case seeds a FILE workspace at dataDir, so pin fs.
+    const prevBackend = process.env["VEIN_WORKSPACE_BACKEND"];
+    process.env["VEIN_WORKSPACE_BACKEND"] = "fs";
     try {
       const ws = new FileWorkspaceStore(dataDir);
       await ws.publishWorkflow("wf", "v1", { steps: [{ id: "a", type: "log", config: { message: "x" } }] });
@@ -244,6 +254,8 @@ describe("graph/project step", () => {
       const rows = await b.bolt.run(`MATCH (r:VeinRun) RETURN r.run_id AS id, r.status AS s`);
       assert.deepEqual(rows, [{ id: base.runId, s: "success" }]);
     } finally {
+      if (prevBackend === undefined) delete process.env["VEIN_WORKSPACE_BACKEND"];
+      else process.env["VEIN_WORKSPACE_BACKEND"] = prevBackend;
       await closeGraphBackends();
       await rm(dataDir, { recursive: true, force: true });
     }

--- a/vein/src/steps/lib/graph/project.ts
+++ b/vein/src/steps/lib/graph/project.ts
@@ -7,7 +7,8 @@ export default defineStep({
   type: "graph/project",
   description:
     "Project vein's own run and chat history into the knowledge graph (VeinRun / VeinAgentSession / " +
-    "VeinToolCall / VeinChat / VeinTurn nodes with EXECUTED, IN_RUN, IN_SESSION, SPAWNED, IN_CHAT edges), " +
+    "VeinToolCall / VeinChat / VeinTurn nodes with EXECUTED, IN_RUN, IN_SESSION, SPAWNED, IN_CHAT edges, plus " +
+    "ACCESSED edges from each tool call to the graph nodes it reported touching), " +
     "reading the raw logs under the server's data dir. Idempotent — re-run any time; settled runs are " +
     "skipped unless skipSettled is false. This is what makes 'which runs executed this version' and " +
     "'which chat launched this run' one-hop graph questions.",


### PR DESCRIPTION
Implements the "v2 provenance convention" from `vein/plans/generic-storage.md`: the last open item on that plan besides `PROMOTED_FROM`.

## Problem
A tool call's `step.end` only carried a 1500-char preview of its output, so which graph nodes a call touched was recorded nowhere structured. The projector already declared the `ACCESSED` edge (`VeinToolCall → any node`) but had no data to write it from.

## What changes
- **`core.ts`** — `withAccessedNodes(output, [{ ref_id, node_type? }])` marks a step's output with a **non-enumerable** `_nodes` property. It rides with the value in-process but never reaches the model, `{{ }}` expressions, or JSON; that also lets array-shaped outputs (search, neighbors) carry it. `accessedNodesOf` reads it back; `RunEvent.nodes` is the lifted form. Both exported from `vein`.
- **`agent.ts`** — `wrapToolsWithEmit` lifts the marker onto the tool call's `step.end` as `nodes`, exempt from truncation. `maskDeep` carries it across the rebuilt container.
- **`projector.ts`** — one `ACCESSED` edge per reported ref the graph holds. Refs it doesn't hold (another database, a deleted node) are counted as `unresolved` in the report and skipped, never an error. Idempotent like every other edge.
- **Steps** — every node-touching `graph/*` lib step and its mcp `jarvis/*` twin reports: search hits, get/get-batched nodes, the expanded node + neighbors, the created/edited node, both endpoints of written triplets. Schema-only steps (ontology, register-namespace) report nothing.
- **Docs** — `AGENTS.md`, the plan's status headers, the `graph/project` step description.

This completes the chain the plan was after: `VeinChat→SPAWNED→VeinRun←IN_RUN←VeinAgentSession←IN_SESSION←VeinToolCall→ACCESSED→Concept`. The live projector test asserts exactly that query.

## Drive-by
`graph-steps.test.ts`'s `graph/project` case has failed on `main` since #1632 made the graph the default workspace (the step listed workflows from the wiped graph instead of the temp file dir the test seeded). It now pins `VEIN_WORKSPACE_BACKEND=fs` for its duration.

## Not in scope
- `PROMOTED_FROM` — promotion still doesn't record its source run.
- Chat-mode tool-call projection — chat exposes no graph tools today, so there is nothing to capture yet.

## Verification
- `npm test` (vein): 616 pass.
- `npm run test:graph` against the throwaway `:7688` container: 118 pass (was 117/118 on main because of the drive-by above).
- `tsc --noEmit` in mcp after a vein rebuild + resync: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
