### PR TITLE
mcp: npm overrides for onnxruntime-node + Dockerfile duplicate guard

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -152,7 +152,18 @@ COPY ./src/gitsee/agent/package.json ./src/gitsee/agent/package.json
 RUN yarn
 
 # Install linux x64 tokenizer bindings (required for fastembed in Docker)
+#
+# This is an `npm install` on top of a yarn tree, so npm re-resolves
+# package.json here and ignores yarn's `resolutions`. Without a matching npm
+# `overrides` entry it re-nests fastembed's declared onnxruntime-node 1.21.0
+# under node_modules/fastembed/node_modules, and at runtime that older
+# libonnxruntime.so.1 loads first and vein's 1.24.3 binding (same soname)
+# fails with "version VERS_1.24.3 not found". package.json carries both
+# `resolutions` (yarn) and `overrides` (npm) pinned to the same version; the
+# check below fails the build, not /lab at runtime, if a second copy sneaks in.
 RUN npm install --force --os=linux --cpu=x64 @anush008/tokenizers-linux-x64-gnu@0.0.0
+RUN extra="$(find node_modules -mindepth 2 -type d -name onnxruntime-node -not -path 'node_modules/onnxruntime-node' -not -path 'node_modules/vein/*')"; \
+    if [ -n "$extra" ]; then echo "duplicate onnxruntime-node copies (soname clash with vein):"; echo "$extra"; exit 1; fi
 
 # Copy the rest of your application code
 COPY ./tsconfig.json ./tsconfig.json

--- a/mcp/package.json
+++ b/mcp/package.json
@@ -22,6 +22,9 @@
     "@ai-sdk/xai": "3.0.88",
     "onnxruntime-node": "1.24.3"
   },
+  "overrides": {
+    "onnxruntime-node": "1.24.3"
+  },
   "scripts": {
     "dev": "([ -n \"$CI\" ] || npm run refresh-vein); tsx src/index.ts",
     "build": "tsc && node scripts/copy-lab-assets.mjs",


### PR DESCRIPTION
## Summary
- Prod \`/lab\` still failed after #1633 with \`libonnxruntime.so.1: version VERS_1.24.3 not found\`, now from \`node_modules/fastembed/node_modules/onnxruntime-node\` (1.21.0).
- Cause: the Dockerfile's \`npm install --force ... @anush008/tokenizers-linux-x64-gnu\` step runs after \`yarn\`; npm ignores yarn \`resolutions\` and re-nests fastembed's pinned 1.21.0. Its \`libonnxruntime.so.1\` shares a soname with vein's 1.24.3, so whichever loads first wins and vein's binding fails.
- Fix: add npm \`overrides\` for \`onnxruntime-node@1.24.3\` alongside the yarn resolution, and a Dockerfile check that fails the build if a second copy appears.

## Test plan
- [x] Reproduced in a scratch project: yarn + npm step nests 1.21.0 without \`overrides\`; with \`overrides\` a single top-level 1.24.3 remains.
- [x] fastembed embeds correctly against onnxruntime-node 1.24.3 (verified in #1633).
- [ ] After image build, \`/lab\` on prod loads without the onnxruntime error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)