### PR TITLE
evolve loop: evidence-only briefing + schema-mode author nudge

### DIFF
--- a/mcp/src/lab/eval/steps/evolve-loop.ts
+++ b/mcp/src/lab/eval/steps/evolve-loop.ts
@@ -1,44 +1,48 @@
 import { z, defineStep, type RunEvent } from "vein";
 
 /**
- * The GENERIC hill-climb over workflow versions (EVOLVE_SPEC §5.3.3 — the
- * generalization §9.5 called for; promoted from the harvey instance): run a
- * one-generation workflow up to maxGenerations times, feeding each
- * generation a BRIEFING composed from the baseline digest plus every
- * previous attempt's version, fitness, approach summary, and failure
- * digest — anchored to the best-so-far (never the latest, which may have
- * regressed; the same guarantee eval/optimize makes for prompts).
+ * The GENERIC loop over workflow versions (EVOLVE_SPEC §5.3.3 — promoted
+ * from the harvey instance): run a one-generation workflow up to
+ * maxGenerations times, briefing each generation with the EVIDENCE so far
+ * and letting the author decide what to build on.
  *
- * Domain-agnostic on purpose: the loop knows nothing about rubrics or
- * scorers. A domain plugs in via
+ * The briefing is deliberately just evidence, laid out once:
+ *   - the TASK LIST (id, level, question) — the only place questions appear;
+ *   - a task × version GRID of every version graded in this run, baseline
+ *     first (✓ / ✗ / ∅ empty / ! error, or the per-task score where the
+ *     domain grades on a gradient), with the fitness row underneath;
+ *   - per attempt: version, fitness, the author's approach summary, and
+ *     its MISSES only (task → wrong answer / failed criteria / error).
+ *
+ * There is NO best-so-far anchor, noise margin, or exploit/explore
+ * directive any more. One run of one version wobbles by a task or two on
+ * sampling luck alone, so every one of those mechanisms was a decision made
+ * on noise — and the author, which can read any version with
+ * meta/get-workflow, is better placed to weigh the grid than the loop is.
+ *
+ * Domain-agnostic on purpose: a domain plugs in via
  *   - `genWorkflow`: its one-generation workflow (author → run candidate
  *     over tasks → digest), invoked with
  *     { tasks, mission, candidateName, generation, briefing } and returning
- *     { version?, summary?, changes?, missingSecrets?, authorCost?, digest }
- *   - the digest's FITNESS: the loop reads `digest.fitness` (falling back
- *     to `digest.meanPassRate`, the harvey digest's field) — a number in
- *     [0,1] that MUST have a gradient (harvey: criteria pass-rate, since
- *     binary all-pass has none; gaia: plain accuracy — binary per task is
- *     fine there because the set supplies the gradient).
- *   - `fitnessName`: how briefings name that number ("pass-rate",
- *     "accuracy", …) so authors read the right thing.
- *
- * EXPLOIT vs EXPLORE: while attempts keep beating the best, the directive
- * says refine the best version. After `exploreAfter` consecutive
- * non-improving attempts, it flips: try a GENUINELY DIFFERENT approach,
- * with the already-tried approaches listed so "different" is checkable.
- *
- * Noise: an improvement must clear `improveMargin` to count; smaller
- * deltas are ties. What the margin answers is per-domain — judge noise for
- * LLM-judged benchmarks (harvey: 0.02 ≈ one criterion at n=50), produce-
- * sampling noise for deterministic scorers (gaia: 0, any task flip counts,
- * but the same caveat rides: validate on held-out tasks).
+ *     { version?, summary?, changes?, missingSecrets?, authorCost?, digest,
+ *       noop? }
+ *   - the digest's FITNESS: `digest.fitness` (falling back to
+ *     `digest.meanPassRate`, the harvey digest's field), a number in [0,1];
+ *   - the digest's `results`: one entry per task, read through
+ *     normalizeVerdicts (gaia: taskId/correct/answer/question; harvey:
+ *     task/passRate/failed[]) — the grid and miss lines are built from it;
+ *   - `fitnessName`: how briefings name the fitness ("accuracy",
+ *     "pass-rate", …).
  *
  * Runs generations through `services.optimizer` (vein.run — same capability
  * eval/optimize uses), each as its own persisted run linked from this
  * step's per-generation progress events. Stops on: stopFitness reached,
- * generations exhausted, or two consecutive generation-run failures (a
- * broken harness should not burn ten generations of budget).
+ * generations exhausted, a cost/time cap, or two consecutive generation-run
+ * failures (a broken harness should not burn ten generations of budget).
+ *
+ * The report names EVERY version that reached the top fitness (ties are
+ * ties — one noisy run is no reason to hide one of them); `bestVersion` is
+ * the oldest of them, kept for callers that want a single field.
  *
  * TRAIN-SET caveat rides on the output: every generation tunes against the
  * same tasks; the final fitness is a train score (EVOLVE_SPEC §7).
@@ -69,18 +73,26 @@ function excerpt(s: unknown, max: number): string {
   return t.length > max ? t.slice(0, max) + " […]" : t;
 }
 
+function oneLine(s: unknown, max: number): string {
+  if (typeof s !== "string") return "";
+  const t = s.replace(/\s+/g, " ").trim();
+  return t.length > max ? t.slice(0, max) + " […]" : t;
+}
+
 function num(v: unknown): number | undefined {
   return typeof v === "number" && Number.isFinite(v) ? v : undefined;
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === "string" && v.trim() ? v : undefined;
 }
 
 /**
  * Authors occasionally end schema mode on a bare text turn, echoing filler
  * ("placeholder", "") into `summary`. Junk there poisons every later
- * briefing — the EXPLORE directive's "pick an approach that is none of the
- * above" is only checkable against real summaries — and the report the
- * human reads. Replace it with an honest marker instead of passing it
- * through. (The version echo has its own fallback in the gen workflows;
- * this is the summary-channel counterpart.)
+ * briefing and the report the human reads. Replace it with an honest marker
+ * instead of passing it through. (The version echo has its own fallback in
+ * the gen workflows; this is the summary-channel counterpart.)
  */
 const NO_SUMMARY =
   "(no usable approach summary reported by this generation's author — read this version's YAML diff to see what it changed)";
@@ -92,35 +104,92 @@ function usableSummary(v: unknown): string | undefined {
   return t;
 }
 
+/** How much of an author's approach summary the next generation sees. It
+ *  is the only record of what a generation tried, so it is roomy. */
+const SUMMARY_CHARS = 3000;
+const QUESTION_CHARS = 300;
+const ANSWER_CHARS = 200;
+const FAILED_CHARS = 600;
+
 /**
- * A generation only becomes the new best if it BEAT the bar by more than the
- * noise margin AND it is a version this run has not already scored.
- *
- * The second half matters because fitness is resampled: re-running an
- * already-graded version can land above its own recorded score by produce-
- * sampling luck alone. The gen workflows' `published` gate stops the common
- * cause (an author that ships nothing, so the version fallback resolves to
- * the previous generation's publish), but a *deliberate* republish of
- * identical YAML under a new version string is indistinguishable from here —
- * this is the backstop for the case the gate cannot see, and it keeps the
- * reported best pinned to the run where that version was first measured.
+ * One task's verdict inside one measurement, normalized across the gaia
+ * digest (taskId, correct boolean, answer, question) and the harvey digest
+ * (task, passRate, all_pass, failed[]). Unknown shapes yield no verdict —
+ * the grid shows "?" rather than inventing one.
  */
-function isNewBest(
-  version: string | undefined,
-  fitness: number,
-  best: { fitness: number },
-  margin: number,
-  scored: Map<string, number>,
-): boolean {
-  if (!(fitness > best.fitness + margin)) return false;
-  return version == null || !scored.has(version);
+export interface TaskVerdict {
+  taskId: string;
+  level?: number | null;
+  question?: string;
+  /** binary verdict, when the domain has one */
+  correct?: boolean;
+  /** graded score in [0,1], when the domain grades on a gradient */
+  score?: number;
+  answer?: string;
+  error?: string;
+  failed?: string[];
 }
 
-function indent(s: string, pad: string): string {
-  return s
-    .split("\n")
-    .map((l) => pad + l)
-    .join("\n");
+export function normalizeVerdicts(digest: unknown): TaskVerdict[] {
+  const d = (digest ?? {}) as AnyRec;
+  const arr = Array.isArray(d["results"]) ? (d["results"] as unknown[]) : [];
+  const out: TaskVerdict[] = [];
+  for (const raw of arr) {
+    if (!raw || typeof raw !== "object") continue;
+    const r = raw as AnyRec;
+    const taskId = str(r["taskId"]) ?? str(r["task"]) ?? str(r["label"]);
+    if (!taskId) continue;
+    const correct =
+      typeof r["correct"] === "boolean"
+        ? (r["correct"] as boolean)
+        : typeof r["all_pass"] === "boolean"
+          ? (r["all_pass"] as boolean)
+          : undefined;
+    // harvey's `score` is the binary all-pass — passRate is the gradient.
+    const score = num(r["passRate"]);
+    const err = r["error"];
+    const failed = Array.isArray(r["failed"])
+      ? (r["failed"] as unknown[]).filter((f): f is string => typeof f === "string" && f.trim() !== "")
+      : [];
+    out.push({
+      taskId,
+      ...(typeof r["level"] === "number" ? { level: r["level"] as number } : {}),
+      ...(str(r["question"]) ? { question: r["question"] as string } : {}),
+      ...(correct != null ? { correct } : {}),
+      ...(score != null ? { score } : {}),
+      ...(typeof r["answer"] === "string" ? { answer: r["answer"] as string } : {}),
+      ...(typeof err === "string" && err.trim()
+        ? { error: err }
+        : err && typeof err === "object" && str((err as AnyRec)["message"])
+          ? { error: (err as AnyRec)["message"] as string }
+          : {}),
+      ...(failed.length ? { failed } : {}),
+    });
+  }
+  return out;
+}
+
+/** A task counts as a MISS when it was not fully solved. */
+function isMiss(v: TaskVerdict): boolean {
+  if (v.correct != null) return !v.correct;
+  if (v.score != null) return v.score < 1;
+  return false;
+}
+
+/** The grid cell for one verdict. */
+function cell(v: TaskVerdict | undefined): string {
+  if (!v) return "·";
+  if (v.score != null && v.correct !== true) return String(v.score);
+  if (v.correct === true) return "✓";
+  if (v.correct === false) return v.error ? "!" : (v.answer ?? "").trim() === "" ? "∅" : "✗";
+  return "?";
+}
+
+/** One graded version — the baseline or a completed generation. */
+interface Measured {
+  label: string;
+  fitness: number;
+  verdicts: TaskVerdict[];
 }
 
 /** One completed generation, as both output record and briefing material. */
@@ -133,106 +202,139 @@ interface GenEntry {
   summary?: string;
   changes?: unknown;
   missingSecrets?: unknown;
-  digestText?: string;
+  /** per-task verdicts (normalized) — the grid column + miss lines */
+  verdicts?: TaskVerdict[];
   authorCost?: number;
   produceCost?: number;
-  explore: boolean;
   error?: string;
   /** The author published nothing — nothing was graded, so there is no
    *  fitness datapoint here (see the gen workflows' `published` gate). */
   noop?: boolean;
 }
 
+function missLine(v: TaskVerdict): string {
+  const parts: string[] = [];
+  if (v.error) parts.push(`ERROR: ${oneLine(v.error, ANSWER_CHARS)}`);
+  else if (v.correct === false && v.answer != null) {
+    // Only domains with an answer channel (gaia) get the answer phrase; a
+    // harvey entry has criteria, not an answer.
+    parts.push(v.answer.trim() === "" ? "EMPTY answer" : `answered "${oneLine(v.answer, ANSWER_CHARS)}"`);
+  }
+  if (v.score != null && v.correct !== true) parts.push(`score ${v.score}`);
+  if (v.failed?.length) parts.push(`failed: ${oneLine(v.failed.join(" | "), FAILED_CHARS)}`);
+  return `${v.taskId} → ${parts.join("; ") || "not solved"}`;
+}
+
+function renderGrid(taskIds: string[], columns: Measured[]): string[] {
+  const idW = Math.min(12, Math.max(4, ...taskIds.map((t) => t.length)));
+  const short = (t: string) => (t.length > idW ? t.slice(0, idW) : t.padEnd(idW));
+  const colW = Math.max(4, ...columns.map((c) => c.label.length));
+  const pad = (s: string) => s.padStart(colW);
+  const lines: string[] = [];
+  lines.push(`${"task".padEnd(idW)} | ${columns.map((c) => pad(c.label)).join(" | ")}`);
+  lines.push(`${"-".repeat(idW)}-+-${columns.map(() => "-".repeat(colW)).join("-+-")}`);
+  for (const t of taskIds) {
+    const cells = columns.map((c) => pad(cell(c.verdicts.find((v) => v.taskId === t))));
+    lines.push(`${short(t)} | ${cells.join(" | ")}`);
+  }
+  lines.push(`${"fitness".padEnd(idW)} | ${columns.map((c) => pad(String(c.fitness))).join(" | ")}`);
+  return lines;
+}
+
 export function composeBriefing(args: {
   baseWorkflow: string;
   candidateName: string;
   fitnessName: string;
-  baselineText: string;
-  baselineFitness: number;
+  tasks: string[];
+  baseline: Measured;
   generations: GenEntry[];
-  best: { gen: number; version?: string; fitness: number; digestText: string };
-  explore: boolean;
-  sinceImprove: number;
-  improveMargin: number;
 }): string {
-  const { generations, best, fitnessName } = args;
+  const { baseline, generations, fitnessName, candidateName } = args;
   const lines: string[] = [];
 
+  // Every version graded in this run, oldest → newest, baseline first.
+  const columns: Measured[] = [baseline];
+  for (const g of generations) {
+    if (g.error || g.noop || !g.verdicts) continue;
+    columns.push({ label: g.version ?? `gen${g.gen}`, fitness: g.fitness, verdicts: g.verdicts });
+  }
+
+  // Row order: the configured task list, then anything the digests know
+  // that the list does not. Task metadata (level, question) comes from the
+  // first measurement that carries it.
+  const taskIds = [...args.tasks];
+  const meta = new Map<string, { level?: number | null; question?: string }>();
+  for (const c of columns) {
+    for (const v of c.verdicts) {
+      if (!taskIds.includes(v.taskId)) taskIds.push(v.taskId);
+      const m = meta.get(v.taskId) ?? {};
+      if (m.level == null && v.level != null) m.level = v.level;
+      if (!m.question && v.question) m.question = v.question;
+      meta.set(v.taskId, m);
+    }
+  }
+
   lines.push(
-    `BASELINE — the seeded produce workflow "${args.baseWorkflow}" was run on every task and graded (mean ${fitnessName} ${args.baselineFitness}):`,
+    `BASELINE — the seeded produce workflow "${args.baseWorkflow}" was run once over the task set: mean ${fitnessName} ${baseline.fitness}.`,
   );
-  lines.push(indent(args.baselineText, "  "));
+  const baseMisses = baseline.verdicts.filter(isMiss);
+  if (baseMisses.length) {
+    lines.push("  misses:");
+    for (const v of baseMisses) lines.push(`    - ${missLine(v)}`);
+  }
   lines.push("");
 
-  lines.push("PREVIOUS ATTEMPTS in this evolution run (oldest → newest):");
+  lines.push("TASKS:");
+  for (const t of taskIds) {
+    const m = meta.get(t);
+    const lvl = m?.level != null ? ` (L${m.level})` : "";
+    lines.push(`- ${t}${lvl}${m?.question ? `: ${oneLine(m.question, QUESTION_CHARS)}` : ""}`);
+  }
+  lines.push("");
+
+  lines.push(
+    `RESULTS GRID — every version graded in this run, oldest → newest (${fitnessName} in the last row). ` +
+      "✓ solved, ✗ wrong, ∅ empty answer, ! produce error, · not run; a number is that task's graded score.",
+  );
+  lines.push(...renderGrid(taskIds, columns));
+  lines.push("");
+
+  lines.push("ATTEMPTS in this evolution run (oldest → newest):");
   if (!generations.length) {
     lines.push("  (none — this is the first attempt)");
-  } else {
-    for (const g of generations) {
-      if (g.error) {
-        lines.push(`- attempt ${g.gen}: FAILED to complete (${excerpt(g.error, 200)})`);
-        continue;
-      }
-      // A no-op attempt has no score to compare — saying "mean accuracy 0"
-      // here would read as a catastrophic approach rather than an author
-      // that never shipped, and would push later generations to explore
-      // away from a strategy that was never actually tried.
-      if (g.noop) {
-        lines.push(
-          `- attempt ${g.gen}: NO CANDIDATE PUBLISHED — its author finished without publishing a new ` +
-            `version, so nothing was graded. Do not read this as evidence about any approach.`,
-        );
-        continue;
-      }
-      const delta = Math.round((g.fitness - args.baselineFitness) * 1000) / 1000;
+  }
+  for (const g of generations) {
+    if (g.error) {
+      lines.push(`- attempt ${g.gen}: FAILED to complete (${excerpt(g.error, 200)})`);
+      continue;
+    }
+    // A no-op attempt has no score — saying "fitness 0" here would read as
+    // a catastrophic approach rather than an author that never shipped.
+    if (g.noop) {
       lines.push(
-        `- attempt ${g.gen} → published ${args.candidateName}@${g.version ?? "?"}: mean ${fitnessName} ${g.fitness} (${delta >= 0 ? "+" : ""}${delta} vs baseline)`,
+        `- attempt ${g.gen}: NO CANDIDATE PUBLISHED — its author finished without publishing a new ` +
+          `version, so nothing was graded. Do not read this as evidence about any approach.`,
       );
-      // The approach summary is the ONLY channel telling the EXPLORE
-      // directive what has already been tried — keep it roomy enough that
-      // "pick an approach that is none of the above" stays checkable.
-      if (g.summary) lines.push(`  approach: ${excerpt(g.summary, 1200)}`);
-      if (g.digestText) lines.push(indent(excerpt(g.digestText, 700), "    "));
+      continue;
+    }
+    lines.push(`- attempt ${g.gen} → ${candidateName}@${g.version ?? "?"}: ${fitnessName} ${g.fitness}`);
+    if (g.summary) lines.push(`  approach: ${excerpt(g.summary, SUMMARY_CHARS)}`);
+    const misses = (g.verdicts ?? []).filter(isMiss);
+    if (misses.length) {
+      lines.push("  misses:");
+      for (const v of misses) lines.push(`    - ${missLine(v)}`);
+    } else if (g.verdicts?.length) {
+      lines.push("  misses: none");
     }
   }
   lines.push("");
 
-  if (best.gen < 0) {
-    lines.push(
-      `BEST SO FAR: the baseline itself (mean ${fitnessName} ${best.fitness}) — no attempt has beaten it yet.`,
-    );
-  } else {
-    lines.push(
-      `BEST SO FAR: attempt ${best.gen} → ${args.candidateName}@${best.version} (mean ${fitnessName} ${best.fitness}). Its result digest:`,
-    );
-    lines.push(indent(excerpt(best.digestText, 900), "  "));
-  }
-  lines.push("");
-
-  if (args.explore) {
-    lines.push(
-      `DIRECTIVE — EXPLORE. The last ${args.sinceImprove} attempt(s) did NOT beat the best. ` +
-        `Do NOT keep refining the same approach. Choose a GENUINELY DIFFERENT strategy this ` +
-        `generation: a different structure (e.g. sub-agent split vs single agent, a fresh-eyes ` +
-        `verification pass vs a research phase), a different method, a different allocation of the ` +
-        `step budget. Every approach summarized above has been tried — pick one that is none of ` +
-        `them. A regression from a distinct attempt is worth more than a marginal tweak that ` +
-        `changes nothing.`,
-    );
-  } else if (best.gen < 0) {
-    lines.push(
-      `DIRECTIVE — EXPLOIT. Start from the base workflow "${args.baseWorkflow}" (read its YAML with ` +
-        `meta/get-workflow) and fix exactly what the baseline failures above show.`,
-    );
-  } else {
-    lines.push(
-      `DIRECTIVE — EXPLOIT. Improve FROM the best attempt: read ${args.candidateName}@${best.version} ` +
-        `(meta/get-workflow with that EXACT version — the active version may be a worse later ` +
-        `attempt) and refine it: keep what worked, fix exactly what its failures show.`,
-    );
-  }
   lines.push(
-    `Deltas within ±${args.improveMargin} are noise — treat them as ties, not as signal to chase.`,
+    `Every version above is readable with meta/get-workflow ("${candidateName}" + the exact version; the base ` +
+      `workflow is "${args.baseWorkflow}"). Choose your own starting point from this evidence: build on whichever ` +
+      "version the grid shows solving the most, or take a different route when the same misses keep recurring " +
+      "across versions. One run of the same YAML can flip a task or two by sampling luck alone — read patterns " +
+      "across columns, not single cells.",
   );
 
   return lines.join("\n");
@@ -241,13 +343,13 @@ export function composeBriefing(args: {
 export default defineStep({
   type: "eval/evolve-loop",
   description:
-    "GENERIC hill-climb of candidate produce workflows over generations: repeatedly run a domain's one-generation workflow (author → run candidate over tasks → digest), composing each generation's briefing from the baseline digest + all previous attempts, anchored to the best-so-far, flipping to an explore directive after `exploreAfter` non-improving attempts. Fitness is the generation digest's `fitness` (fallback `meanPassRate`). Requires services.optimizer. Config: tasks, mission, baseline (a digest object with fitness/meanPassRate + text), candidateName, baseWorkflow, genWorkflow, fitnessName? (default 'pass-rate'), maxGenerations? (default 5, max 20), stopFitness? (default 1), improveMargin? (default 0.02), exploreAfter? (default 2), genParams? (paramOverrides for the generation workflow). Output: { candidate, baselineFitness, bestGen, bestVersion, bestFitness, improved, generations, totalKnownCost, stopReason }.",
+    "GENERIC loop over candidate produce workflow versions: repeatedly run a domain's one-generation workflow (author → run candidate over tasks → digest), briefing each generation with the evidence so far — the task list, a task×version grid of every version graded (baseline first), and each attempt's approach summary + misses — and letting the author choose what to build on. Fitness is the generation digest's `fitness` (fallback `meanPassRate`); per-task verdicts come from the digest's `results`. Requires services.optimizer. Config: tasks, mission, baseline (a digest object with fitness/meanPassRate + results), candidateName, baseWorkflow, genWorkflow, fitnessName? (default 'pass-rate'), maxGenerations? (default 5, max 20), stopFitness? (default 1), genParams? (paramOverrides for the generation workflow), maxCost?, maxMinutes?. Output: { candidate, baselineFitness, topFitness, topVersions, bestGen, bestVersion, bestFitness, improved, generations, totalKnownCost, stopReason }.",
   input: z.object({
     tasks: z.array(z.string()).min(1).describe("task ids the loop optimizes against (the TRAIN set)"),
     mission: z.string().describe("the standing gap statement handed to every generation's author"),
     baseline: z
       .any()
-      .describe("the baseline digest object ({ fitness | meanPassRate, text, … }) — generation 0's anchor"),
+      .describe("the baseline digest object ({ fitness | meanPassRate, results, … }) — the grid's first column"),
     candidateName: z.string().describe("the candidate workflow name every generation publishes to (versioned lineage)"),
     baseWorkflow: z.string().describe("the seeded produce workflow the baseline ran"),
     genWorkflow: z.string().describe("the domain's one-generation workflow the loop runs"),
@@ -257,28 +359,15 @@ export default defineStep({
       .describe("how briefings name the fitness number ('pass-rate', 'accuracy', …)"),
     maxGenerations: z.number().int().min(1).max(20).default(5),
     stopFitness: z.number().min(0).max(1).default(1).describe("stop early once a generation's fitness reaches this"),
-    improveMargin: z
-      .number()
-      .min(0)
-      .default(0.02)
-      .describe("an attempt must beat the best by MORE than this to count as an improvement (noise floor — judge noise for LLM-judged domains, produce-sampling noise for deterministic scorers)"),
-    exploreAfter: z
-      .number()
-      .int()
-      .min(1)
-      .default(2)
-      .describe("consecutive non-improving attempts before the directive flips from exploit to explore"),
     genParams: z
       .record(z.string(), z.any())
       .optional()
       .describe("param overrides for the generation workflow (e.g. { authorModel, authorMaxSteps }) — applied via paramOverrides keyed by genWorkflow"),
     // Generation COUNT is a poor budget: each generation costs whatever the
     // architecture the authors evolved costs, and authors reliably evolve
-    // toward more expensive shapes (redundant attempts, reconcilers, extra
-    // verification passes). A 10-generation run that started at ~1h/gen can
-    // finish at ~2.5h/gen. These caps bound the run in the units a human
-    // actually budgets in. Both are checked BETWEEN generations, so the cap
-    // is a floor on when the loop stops, never a mid-generation kill.
+    // toward more expensive shapes. These caps bound the run in the units a
+    // human actually budgets in. Both are checked BETWEEN generations, so
+    // the cap is a floor on when the loop stops, never a mid-generation kill.
     maxCost: z
       .number()
       .positive()
@@ -297,19 +386,11 @@ export default defineStep({
       throw new Error("eval/evolve-loop requires a `services.optimizer` capability (injected in createLabVein).");
     }
 
-    const baseline = (cfg.baseline ?? {}) as AnyRec;
-    const baselineFitness = num(baseline["fitness"]) ?? num(baseline["meanPassRate"]) ?? 0;
-    const baselineText =
-      typeof baseline["text"] === "string" && baseline["text"]
-        ? (baseline["text"] as string)
-        : excerpt(JSON.stringify(baseline), 800);
+    const baselineDigest = (cfg.baseline ?? {}) as AnyRec;
+    const baselineFitness = num(baselineDigest["fitness"]) ?? num(baselineDigest["meanPassRate"]) ?? 0;
+    const baseline: Measured = { label: "base", fitness: baselineFitness, verdicts: normalizeVerdicts(baselineDigest) };
 
-    let best = { gen: -1, version: undefined as string | undefined, fitness: baselineFitness, digestText: baselineText };
-    // version → the fitness it was FIRST measured at, so a later re-score of
-    // the same version cannot be promoted as an improvement (see isNewBest).
-    const scored = new Map<string, number>();
     const loopStart = Date.now();
-    let sinceImprove = 0;
     let consecutiveFailures = 0;
     let totalKnownCost = 0;
     let stopReason = "maxGenerations exhausted";
@@ -347,8 +428,8 @@ export default defineStep({
 
       // Durable resume (§5, iterative code steps): a generation whose
       // synthetic `#gen` step.end is journaled replays — its run is NOT
-      // re-launched. State (best / sinceImprove / stop logic) is rebuilt
-      // from the journaled output so the loop continues where it left off.
+      // re-launched. State is rebuilt from the journaled output so the loop
+      // continues where it left off.
       const journaled = ctx.journal?.[`${ctx.path}#${gen}`] as AnyRec | undefined;
       if (journaled) {
         const noop = journaled["noop"] === true;
@@ -359,20 +440,11 @@ export default defineStep({
           version: typeof journaled["version"] === "string" ? (journaled["version"] as string) : undefined,
           fitness,
           summary: usableSummary(journaled["summary"]) ?? NO_SUMMARY,
-          digestText: typeof journaled["digestText"] === "string" ? (journaled["digestText"] as string) : undefined,
-          explore: journaled["directive"] === "explore",
-          ...(noop ? { noop: true } : {}),
+          ...(noop ? { noop: true } : { verdicts: normalizeVerdicts({ results: journaled["verdicts"] }) }),
         };
         generations.push(entry);
         consecutiveFailures = 0;
         totalKnownCost += num(journaled["knownCost"]) ?? 0;
-        if (!noop && isNewBest(entry.version, fitness, best, cfg.improveMargin, scored)) {
-          best = { gen, version: entry.version, fitness, digestText: entry.digestText ?? "" };
-          sinceImprove = 0;
-        } else {
-          sinceImprove++;
-        }
-        if (!noop && entry.version && !scored.has(entry.version)) scored.set(entry.version, fitness);
         await emitGen(gen, { type: "step.replayed", output: journaled });
         if (!noop && fitness >= cfg.stopFitness) {
           stopReason = `stopFitness ${cfg.stopFitness} reached`;
@@ -381,23 +453,18 @@ export default defineStep({
         continue;
       }
 
-      const explore = sinceImprove >= cfg.exploreAfter;
       const briefing = composeBriefing({
         baseWorkflow: cfg.baseWorkflow,
         candidateName: cfg.candidateName,
         fitnessName: cfg.fitnessName,
-        baselineText,
-        baselineFitness,
+        tasks: cfg.tasks,
+        baseline,
         generations,
-        best,
-        explore,
-        sinceImprove,
-        improveMargin: cfg.improveMargin,
       });
       const genStart = Date.now();
       await emitGen(gen, {
         type: "step.start",
-        input: { gen, directive: explore ? "explore" : "exploit", bestFitness: best.fitness, briefing: excerpt(briefing, 2000) },
+        input: { gen, briefing: excerpt(briefing, 4000) },
       });
 
       const run = await opt.run(
@@ -415,13 +482,12 @@ export default defineStep({
 
       if (run.status !== "success") {
         const message = run.error?.message ?? "unknown";
-        generations.push({ gen, genRunId: run.runId, fitness: 0, explore, error: message });
+        generations.push({ gen, genRunId: run.runId, fitness: 0, error: message });
         await emitGen(gen, {
           type: "step.error",
           durationMs: Date.now() - genStart,
           error: { message: `gen ${gen}: ${message}` },
         });
-        sinceImprove++;
         if (++consecutiveFailures >= 2) {
           stopReason = "two consecutive generation failures";
           break;
@@ -435,8 +501,7 @@ export default defineStep({
       // NO-OP generation: the gen workflow's `published` gate found that this
       // generation's author shipped no new version, so it skipped grading
       // rather than re-running an already-scored version over the whole task
-      // set. Record the wasted author budget, leave `best` alone, and let the
-      // non-improvement push the directive toward explore — but never write a
+      // set. Record the wasted author budget and move on — never write a
       // fitness of 0, which would libel an approach that was never tried.
       if (out["noop"] === true) {
         const authorOnly = num(out["authorCost"]) ?? 0;
@@ -446,21 +511,16 @@ export default defineStep({
           genRunId: run.runId,
           fitness: 0,
           noop: true,
-          explore,
           authorCost: authorOnly,
           summary: usableSummary(out["summary"]) ?? NO_SUMMARY,
         });
-        sinceImprove++;
         await emitGen(gen, {
           type: "step.end",
           durationMs: Date.now() - genStart,
           output: {
             gen,
-            directive: explore ? "explore" : "exploit",
             noop: true,
             note: "author published no new candidate version — grading skipped, no fitness recorded",
-            bestFitness: best.fitness,
-            bestGen: best.gen,
             knownCost: Math.round(authorOnly * 10000) / 10000,
             runs: [{ label: `generation ${gen} (no-op)`, workflow: cfg.genWorkflow, runId: run.runId }],
           },
@@ -484,41 +544,25 @@ export default defineStep({
         summary: usableSummary(out["summary"]) ?? NO_SUMMARY,
         changes: out["changes"],
         missingSecrets: out["missingSecrets"],
-        digestText: typeof digest["text"] === "string" ? (digest["text"] as string) : undefined,
+        verdicts: normalizeVerdicts(digest),
         authorCost,
         produceCost: Math.round(produceCost * 10000) / 10000,
-        explore,
       };
       generations.push(entry);
-
-      const rescored = entry.version != null && scored.has(entry.version);
-      if (isNewBest(entry.version, fitness, best, cfg.improveMargin, scored)) {
-        best = { gen, version: entry.version, fitness, digestText: entry.digestText ?? "" };
-        sinceImprove = 0;
-      } else {
-        sinceImprove++;
-      }
-      if (entry.version && !rescored) scored.set(entry.version, fitness);
 
       await emitGen(gen, {
         type: "step.end",
         durationMs: Date.now() - genStart,
         output: {
           gen,
-          directive: explore ? "explore" : "exploit",
           version: entry.version,
           fitness,
-          bestFitness: best.fitness,
-          bestGen: best.gen,
-          // A version this run already scored — its fitness here is a
-          // resample, not a hill-climb step, and cannot become the best.
-          ...(rescored ? { rescoredVersion: true } : {}),
           knownCost: Math.round((authorCost + produceCost) * 10000) / 10000,
           runs: [{ label: `generation ${gen}`, workflow: cfg.genWorkflow, runId: run.runId }],
           // Carried so a durable resume can rebuild later generations'
-          // briefings (approach summaries + best digest) from the journal.
-          ...(entry.summary ? { summary: excerpt(entry.summary, 1200) } : {}),
-          ...(entry.digestText ? { digestText: excerpt(entry.digestText, 900) } : {}),
+          // briefings (grid column + approach summary) from the journal.
+          ...(entry.summary ? { summary: excerpt(entry.summary, SUMMARY_CHARS) } : {}),
+          verdicts: entry.verdicts,
         },
       });
 
@@ -528,17 +572,28 @@ export default defineStep({
       }
     }
 
+    // The top: every graded generation that reached the highest fitness,
+    // oldest first. Ties stay ties. The baseline is not a candidate version,
+    // so it never appears here; `improved` says whether anything beat it.
+    const graded = generations.filter((g) => !g.error && !g.noop);
+    const topFitness = graded.length ? Math.max(...graded.map((g) => g.fitness)) : baselineFitness;
+    const top = graded.filter((g) => g.fitness === topFitness);
+    const topVersions = top.map((g) => ({ gen: g.gen, version: g.version, fitness: g.fitness }));
+    const oldest = top[0];
+
     return {
       candidate: cfg.candidateName,
       baselineFitness,
-      bestGen: best.gen,
-      bestVersion: best.version,
-      bestFitness: best.fitness,
-      improved: best.gen >= 0,
+      topFitness,
+      topVersions,
+      bestGen: oldest?.gen ?? -1,
+      bestVersion: oldest?.version,
+      bestFitness: topFitness,
+      improved: graded.length > 0 && topFitness > baselineFitness,
       generations,
       totalKnownCost: Math.round(totalKnownCost * 10000) / 10000,
       stopReason,
-      note: "TRAIN scores — every generation tuned against the same tasks (EVOLVE_SPEC §7). Validate the best version on held-out tasks before promoting. totalKnownCost = author + produce costs; grading cost (where the benchmark bills it) is additional.",
+      note: "TRAIN scores — every generation tuned against the same tasks (EVOLVE_SPEC §7). Validate the top version(s) on held-out tasks before promoting. Each version was graded ONCE; a one-task difference is within sampling noise. totalKnownCost = author + produce costs; grading cost (where the benchmark bills it) is additional.",
     };
   },
 });

--- a/mcp/src/lab/gaia/evolve-smoke.ts
+++ b/mcp/src/lab/gaia/evolve-smoke.ts
@@ -35,7 +35,7 @@ async function main() {
     }
 
     // step types referenced by the workflows all exist in the registry
-    const { registry } = await buildRegistry(workspace.path);
+    const { registry } = await buildRegistry(await workspace.materializeCustomSteps());
     const wanted = [
       "gaia/list-tasks", "gaia/get-task", "gaia/evaluate", "gaia/pack-result",
       "gaia/summarize-batch", "gaia/digest-results", "eval/evolve-loop",
@@ -183,7 +183,7 @@ async function main() {
     assert.equal(out.results[0].correct, true);
     assert.equal(out.results[0].cost, 0.5); // unpacked from runResult.output in code
     assert.equal(out.results[0].steps, 12);
-    assert.equal(out.results[0].question, undefined); // question excerpts ride on MISSES only
+    assert.equal(typeof out.results[0].question, "string"); // question rides on EVERY entry (the loop's task list)
     assert.equal(out.results[1].correct, false); // count+results normalization
     assert.equal(out.results[1].miss, "wrong-answer");
     assert.equal(out.results[2].miss, "produce-error");
@@ -195,12 +195,17 @@ async function main() {
     assert.ok(out.text.includes("ERROR: AI_NoObjectGeneratedError"));
     console.log("✔ gaia/digest-results: shape normalization, miss taxonomy, fitness, text");
 
-    // 5. the generic loop climbs the gaia digest's `fitness` field (accuracy)
-    //    with improveMargin 0 — any task flip counts — and names the fitness
-    //    "accuracy" in briefings.
+    // 5. the generic loop climbs the gaia digest's `fitness` field (accuracy),
+    //    names it "accuracy" in briefings, and briefs each generation with
+    //    the EVIDENCE: task list once, a task×version grid, per-attempt
+    //    misses only. No best-so-far anchor, no margin, no directive.
     const loop = registry["eval/evolve-loop"]!;
     const genCalls: any[] = [];
     const rates = [0.4, 0.6];
+    const verdicts = (g: number) => [
+      { taskId: "t-1", level: 1, correct: true, answer: "42", question: "Q one", cost: 2 },
+      { taskId: "t-2", level: 2, correct: g === 1, answer: g === 1 ? "ok" : "nope", question: "Q two", cost: 0 },
+    ];
     const fakeOpt = {
       run: async (_name: string, input: any) => {
         genCalls.push(input);
@@ -215,118 +220,98 @@ async function main() {
             // loop must replace it with the honest no-summary marker.
             summary: g === 0 ? "placeholder" : `approach ${g}`,
             authorCost: 1,
-            digest: { fitness: rates[g], text: `digest ${g}`, results: [{ cost: 2 }] },
+            digest: { fitness: rates[g], text: `digest ${g}`, results: verdicts(g) },
           },
         };
       },
     };
+    const baseDigest = {
+      fitness: 0.4,
+      text: "baseline digest",
+      results: [
+        { taskId: "t-1", level: 1, correct: true, answer: "42", question: "Q one" },
+        { taskId: "t-2", level: 2, correct: false, answer: "", question: "Q two" },
+      ],
+    };
+    const loopBase = {
+      tasks: ["t-1", "t-2"],
+      mission: "m",
+      baseline: baseDigest,
+      candidateName: "gaia-produce-ai",
+      baseWorkflow: "gaia-produce",
+      genWorkflow: "gaia-evolve-gen",
+      fitnessName: "accuracy",
+    };
     const loopOut: any = await loop.run(
-      loop.input.parse({
-        tasks: ["t-1", "t-2"],
-        mission: "m",
-        baseline: { fitness: 0.4, text: "baseline digest" },
-        candidateName: "gaia-produce-ai",
-        baseWorkflow: "gaia-produce",
-        genWorkflow: "gaia-evolve-gen",
-        fitnessName: "accuracy",
-        maxGenerations: 5,
-        stopFitness: 0.6,
-        improveMargin: 0,
-        exploreAfter: 2,
-      }),
+      loop.input.parse({ ...loopBase, maxGenerations: 5, stopFitness: 0.6 }),
       { ...ctxStub, services: { optimizer: fakeOpt } },
     );
     assert.equal(genCalls.length, 2); // gen 1 hit stopFitness 0.6
     assert.equal(loopOut.stopReason, "stopFitness 0.6 reached");
+    assert.deepEqual(loopOut.topVersions, [{ gen: 1, version: "v2", fitness: 0.6 }]);
     assert.equal(loopOut.bestGen, 1);
     assert.equal(loopOut.bestVersion, "v2");
     assert.equal(loopOut.bestFitness, 0.6);
     assert.equal(loopOut.baselineFitness, 0.4);
     assert.equal(loopOut.improved, true);
-    assert.ok(genCalls[0].briefing.includes("mean accuracy 0.4"));
-    assert.ok(genCalls[1].briefing.includes('the seeded produce workflow "gaia-produce"'));
-    // margin 0 semantics: a TIE (0.4 vs baseline 0.4) does not become best
-    assert.ok(genCalls[1].briefing.includes("BEST SO FAR: the baseline itself"));
+    const b0 = genCalls[0].briefing as string;
+    const b1 = genCalls[1].briefing as string;
+    assert.ok(b0.includes("mean accuracy 0.4"));
+    assert.ok(b0.includes('the seeded produce workflow "gaia-produce"'));
+    assert.ok(b0.includes("none — this is the first attempt"));
+    // the task list appears ONCE, with level + question from the baseline digest
+    assert.ok(b1.includes("- t-2 (L2): Q two"));
+    assert.equal(b1.split("Q two").length - 1, 1, "questions are listed once, never repeated per attempt");
+    // the grid: baseline column first, then v1; ∅ for the baseline's empty answer
+    assert.ok(b1.includes("RESULTS GRID"));
+    assert.match(b1, /task\s+\|\s+base \|\s+v1/);
+    assert.match(b1, /t-2\s+\|\s+∅ \|\s+✗/);
+    assert.match(b1, /fitness\s+\|\s+0\.4 \|\s+0\.4/); // fitness row
+    // per attempt: misses only, with the wrong answer
+    assert.ok(b1.includes("attempt 0 → gaia-produce-ai@v1: accuracy 0.4"));
+    assert.ok(b1.includes('- t-2 → answered "nope"'));
+    assert.ok(!b1.includes("t-1 → "), "solved tasks are not listed under misses");
+    // no anchor / directive machinery left
+    assert.ok(!b1.includes("BEST SO FAR") && !b1.includes("DIRECTIVE"));
     // junk-summary guard: gen 0's "placeholder" echo must NOT reach the next
     // briefing or the report — both carry the honest no-summary marker.
-    assert.ok(!genCalls[1].briefing.includes("placeholder"));
-    assert.ok(genCalls[1].briefing.includes("no usable approach summary"));
-    assert.equal(
-      loopOut.generations[0].summary.includes("no usable approach summary"),
-      true,
-    );
+    assert.ok(!b1.includes("placeholder"));
+    assert.ok(b1.includes("no usable approach summary"));
+    assert.equal(loopOut.generations[0].summary.includes("no usable approach summary"), true);
     assert.equal(loopOut.generations[1].summary, "approach 1");
-    console.log("✔ eval/evolve-loop: climbs gaia `fitness`, accuracy naming, margin-0 tie handling, junk-summary guard");
+    console.log("✔ eval/evolve-loop: climbs gaia `fitness`, evidence briefing (tasks once, grid, misses only), junk-summary guard");
 
-    // 6. the capture stage (Phase 1 wiring): a k-sample baseline folded by
-    //    eval/matrix plugs into the loop AS the baseline object, and the
-    //    measured noise floor feeds improveMargin via the yaml's fallback
-    //    expression.
-    const matrixStep = registry["eval/matrix"]!;
-    // Two identical-YAML baseline samples, one task flipping between them —
-    // gaia-run result shape (correct as 0/1 count with total 1).
-    const bSample = (flip: boolean) => [
-      { taskId: "t-1", level: 2, correct: 1, total: 1, answer: "42", question: "Q1" },
-      { taskId: "t-2", level: 2, correct: flip ? 1 : 0, total: 1, answer: flip ? "ok" : "no", question: "Q2" },
-    ];
-    const basematrix: any = await matrixStep.run(
-      matrixStep.input.parse({ version: "gaia-produce", samples: [bSample(true), bSample(false)] }),
-      ctxStub,
-    );
-    assert.equal(basematrix.fitness, 1); // MAX sample (2/2) — the conservative bar
-    assert.equal(basematrix.noise.floorKnown, true);
-    assert.equal(basematrix.noise.suggestedMargin, 0.5); // 1 flip on n=2
-    assert.ok(basematrix.text.includes("question: Q2"), "stuck-task question in the baseline text");
-    // the yaml's margin expression: measured floor wins, fallback when unmeasured
-    const mScope = { basematrix, params: { improveMargin: 0 } };
-    assert.equal((resolveConfig as any)("{{ basematrix.noise.suggestedMargin || params.improveMargin }}", mScope), 0.5);
-    const mScopeUnknown = { basematrix: { noise: { floorKnown: false } }, params: { improveMargin: 0 } };
-    assert.equal(
-      (resolveConfig as any)("{{ basematrix.noise.suggestedMargin || params.improveMargin }}", mScopeUnknown),
-      0,
-    );
-    // the matrix object IS a valid loop baseline: fitness + text read through
-    const mLoopCalls: any[] = [];
-    const mLoopOut: any = await loop.run(
-      loop.input.parse({
-        tasks: ["t-1", "t-2"],
-        mission: "m",
-        baseline: basematrix,
-        candidateName: "gaia-produce-ai",
-        baseWorkflow: "gaia-produce",
-        genWorkflow: "gaia-evolve-gen",
-        fitnessName: "accuracy",
-        maxGenerations: 1,
-        stopFitness: 1,
-        improveMargin: 0.5,
-        exploreAfter: 2,
-      }),
-      {
-        ...ctxStub,
-        services: {
-          optimizer: {
-            run: async (_n: string, input: any) => {
-              mLoopCalls.push(input);
-              return {
-                runId: "genrun-m",
-                status: "success",
-                output: { version: "v1", summary: "an approach", digest: { fitness: 1, text: "d", results: [] } },
-              };
-            },
-          },
+    // 6. TIES stay ties: two versions at the top are BOTH reported; the
+    //    single-field `bestVersion` is the oldest of them.
+    const tieOpt = {
+      run: async (_name: string, input: any) => ({
+        runId: `genrun-${input.generation}`,
+        status: "success",
+        output: {
+          candidate: input.candidateName,
+          version: `v${input.generation + 1}`,
+          summary: `approach ${input.generation}`,
+          authorCost: 1,
+          digest: { fitness: 0.5, text: "d", results: verdicts(0) },
         },
-      },
+      }),
+    };
+    const tieOut: any = await loop.run(
+      loop.input.parse({ ...loopBase, maxGenerations: 2, stopFitness: 1 }),
+      { ...ctxStub, services: { optimizer: tieOpt } },
     );
-    assert.equal(mLoopOut.baselineFitness, 1); // read from basematrix.fitness
-    assert.ok(mLoopCalls[0].briefing.includes("TASK×VERSION MATRIX"), "matrix text is the baseline briefing block");
-    // fitness 1 vs baseline 1 with margin 0.5: a tie, not an improvement
-    assert.equal(mLoopOut.improved, false);
-    console.log("✔ capture wiring: k-sample matrix as loop baseline, measured-margin fallback expression");
+    assert.deepEqual(tieOut.topVersions, [
+      { gen: 0, version: "v1", fitness: 0.5 },
+      { gen: 1, version: "v2", fitness: 0.5 },
+    ]);
+    assert.equal(tieOut.bestVersion, "v1");
+    assert.equal(tieOut.improved, true); // 0.5 > baseline 0.4
+    console.log("✔ eval/evolve-loop: tied top versions are all reported");
 
-    // 6. NO-OP generation: the gen workflow's `published` gate reports that an
+    // 7. NO-OP generation: the gen workflow's `published` gate reports that an
     //    author shipped nothing, so nothing was graded. The loop must record
-    //    it without a fitness, leave `best` untouched, spend only the author
-    //    cost, and tell the next generation not to read it as evidence.
+    //    it without a fitness, spend only the author cost, keep it out of the
+    //    grid, and tell the next generation not to read it as evidence.
     const noopCalls: any[] = [];
     const noopOpt = {
       run: async (_name: string, input: any) => {
@@ -343,64 +328,28 @@ async function main() {
                   version: `v${g + 1}`,
                   summary: `approach ${g}`,
                   authorCost: 1,
-                  digest: { fitness: 0.6, text: `digest ${g}`, results: [{ cost: 2 }] },
+                  digest: { fitness: 0.6, text: `digest ${g}`, results: verdicts(1) },
                 },
         };
       },
     };
-    const noopBase = {
-      tasks: ["t-1", "t-2"],
-      mission: "m",
-      baseline: { fitness: 0.4, text: "baseline digest" },
-      candidateName: "gaia-produce-ai",
-      baseWorkflow: "gaia-produce",
-      genWorkflow: "gaia-evolve-gen",
-      fitnessName: "accuracy",
-      stopFitness: 1,
-      improveMargin: 0,
-      exploreAfter: 2,
-    };
+    const noopBase = { ...loopBase, stopFitness: 1 };
     const noopOut: any = await loop.run(
       loop.input.parse({ ...noopBase, maxGenerations: 3 }),
       { ...ctxStub, services: { optimizer: noopOpt } },
     );
     assert.equal(noopOut.generations[1].noop, true);
-    assert.equal(noopOut.bestGen, 0); // gen 1 did not displace gen 0's v1
+    assert.equal(noopOut.bestGen, 0); // oldest of the tied v1 / v3
     assert.equal(noopOut.bestVersion, "v1");
     assert.equal(noopOut.bestFitness, 0.6);
+    assert.equal(noopOut.topVersions.length, 2);
     // no-op spends the author budget only — never the 2 tasks × cost 2 produce
     assert.equal(noopOut.totalKnownCost, 3 + 1 + 3);
     // the briefing must not libel an approach that was never tried
     assert.ok(noopCalls[2].briefing.includes("NO CANDIDATE PUBLISHED"));
-    assert.ok(!noopCalls[2].briefing.includes("attempt 1 → published"));
+    assert.ok(!noopCalls[2].briefing.includes("attempt 1 → "));
+    assert.ok(!noopCalls[2].briefing.includes("gen1"), "a no-op gets no grid column");
     console.log("✔ eval/evolve-loop: no-op generation records no fitness, spends only the author budget");
-
-    // 7. RE-SCORE guard: the same version graded twice cannot be promoted on
-    //    the luckier sample — the run's best stays pinned to first measurement.
-    const dupOpt = {
-      run: async (_name: string, input: any) => {
-        const g = input.generation as number;
-        return {
-          runId: `genrun-${g}`,
-          status: "success",
-          output: {
-            candidate: input.candidateName,
-            version: "v1", // gen 1 re-runs gen 0's version…
-            summary: `approach ${g}`,
-            authorCost: 1,
-            digest: { fitness: g === 0 ? 0.6 : 0.9, text: `digest ${g}`, results: [{ cost: 2 }] }, // …and gets lucky
-          },
-        };
-      },
-    };
-    const dupOut: any = await loop.run(
-      loop.input.parse({ ...noopBase, maxGenerations: 2 }),
-      { ...ctxStub, services: { optimizer: dupOpt } },
-    );
-    assert.equal(dupOut.bestGen, 0);
-    assert.equal(dupOut.bestFitness, 0.6); // NOT 0.9 — a resample, not a climb
-    assert.equal(dupOut.generations[1].fitness, 0.9); // still reported honestly
-    console.log("✔ eval/evolve-loop: a re-scored version cannot become the best on sampling luck");
 
     // 8. BUDGET caps stop the loop between generations.
     const costOpt = {

--- a/mcp/src/lab/gaia/seed.ts
+++ b/mcp/src/lab/gaia/seed.ts
@@ -70,7 +70,7 @@ const SEED_WORKFLOWS: Array<{ name: string; description: string }> = [
   {
     name: "gaia-evolve",
     description:
-      "GAIA authoring harness (hill-climb): baseline gaia-run over the task set -> digest -> eval/evolve-loop over gaia-evolve-gen generations (accuracy fitness, exact-match so improveMargin 0) -> report with best version vs baseline. TRAIN scores — validate the best version on held-out tasks before promoting. Input: { tasks: [taskId, …], mission, generations? }.",
+      "GAIA authoring harness (hill-climb): baseline gaia-run over the task set -> digest -> eval/evolve-loop over gaia-evolve-gen generations (accuracy fitness) -> report with the top version(s) vs baseline. TRAIN scores — validate a top version on held-out tasks before promoting. Input: { tasks: [taskId, …], mission, generations? }.",
   },
 ];
 

--- a/mcp/src/lab/gaia/steps/digest-results.ts
+++ b/mcp/src/lab/gaia/steps/digest-results.ts
@@ -67,7 +67,7 @@ function correctOf(r: AnyRec): boolean {
 export default defineStep({
   type: "gaia/digest-results",
   description:
-    "Aggregate an array of graded GAIA results (gaia-run / gaia-candidate-run outputs) into a compact digest: accuracy as `fitness` (what eval/evolve-loop reads), per-task correct/wrong with the produced answer excerpt, miss tags (wrong-answer / empty-answer / produce-error), question excerpts for misses, and a preformatted `text` block for an LLM prompt. Gold never enters or leaves this step. Config: results (array), maxAnswerChars? (default 160), maxQuestionChars? (default 240). Output: { n, correctCount, accuracy, fitness, byLevel, results, text }.",
+    "Aggregate an array of graded GAIA results (gaia-run / gaia-candidate-run outputs) into a compact digest: accuracy as `fitness` (what eval/evolve-loop reads), per-task correct/wrong with the produced answer excerpt, miss tags (wrong-answer / empty-answer / produce-error), question excerpts, and a preformatted `text` block for an LLM prompt. Gold never enters or leaves this step. Config: results (array), maxAnswerChars? (default 160), maxQuestionChars? (default 240). Output: { n, correctCount, accuracy, fitness, byLevel, results, text }.",
   input: z.object({
     results: z.array(z.any()).describe("graded results, one per task (gaia-run / gaia-candidate-run outputs)"),
     maxAnswerChars: z.number().int().positive().default(160).describe("max characters of the produced answer per task"),
@@ -76,7 +76,7 @@ export default defineStep({
       .int()
       .positive()
       .default(240)
-      .describe("max characters of the question excerpt shown for missed tasks"),
+      .describe("max characters of the question excerpt per task"),
   }),
   output: z.any(),
   async run(cfg) {
@@ -104,7 +104,9 @@ export default defineStep({
         correct,
         answer: truncate(answer, cfg.maxAnswerChars),
         ...(miss ? { miss } : {}),
-        ...(correct ? {} : { question: truncate(str(r["question"]) ?? "", cfg.maxQuestionChars) }),
+        // Task-visible text (every producer sees it); the loop's briefing
+        // builds its task list from here, so every entry carries it.
+        question: truncate(str(r["question"]) ?? "", cfg.maxQuestionChars),
         ...(cost != null ? { cost } : {}),
         ...(steps != null ? { steps } : {}),
         ...(error ? { error: truncate(error, 240) } : {}),

--- a/mcp/src/lab/gaia/workflows/gaia-evolve-gen.yaml
+++ b/mcp/src/lab/gaia/workflows/gaia-evolve-gen.yaml
@@ -2,10 +2,11 @@ name: gaia-evolve-gen
 # ONE GENERATION of the gaia evolution loop: author a candidate → run it
 # over the task set → digest the scores. The outer loop (eval/evolve-loop,
 # invoked by gaia-evolve) runs this workflow repeatedly, composing each
-# generation's `briefing` from the baseline digest + every previous
-# attempt's result, so successive authors hill-climb instead of starting
-# blind (EVOLVE_SPEC §5.2's reflect beat, §5.3.3's loop-over-versions —
-# the gaia instance, mirroring harvey-evolve-gen).
+# generation's `briefing` from the baseline + every previous attempt's
+# result — a task×version grid plus each attempt's approach and misses —
+# so successive authors build on evidence instead of starting blind
+# (EVOLVE_SPEC §5.2's reflect beat, §5.3.3's loop-over-versions — the gaia
+# instance, mirroring harvey-evolve-gen).
 #
 # The author is the standard meta/* authoring agent (§5.3.2 grants: meta/*
 # and the editor tool, never bash, never graders). It sees correct/wrong
@@ -14,9 +15,9 @@ name: gaia-evolve-gen
 #
 # Input:  { tasks, mission, candidateName, generation, briefing }
 #   tasks:    GAIA taskIds (the TRAIN set)
-#   briefing: composed by eval/evolve-loop — baseline digest, previous
-#             attempts (version, accuracy, approach, misses), best-so-far
-#             anchor, and the exploit-or-explore directive.
+#   briefing: composed by eval/evolve-loop — the task list, a task×version
+#             grid of every version graded so far (baseline first), and
+#             each previous attempt's approach summary and misses.
 # Output: { candidate, generation, version, summary, changes,
 #           missingSecrets, authorCost, authorSteps, digest }
 #   digest: the gaia/digest-results object for this generation's candidate
@@ -58,7 +59,7 @@ steps:
         {{ input.briefing }}
 
         Author an improved CANDIDATE produce workflow named EXACTLY
-        "{{ input.candidateName }}", following the DIRECTIVE above. Address
+        "{{ input.candidateName }}", using the evidence above. Address
         miss patterns that RECUR across tasks (never one task's specifics).
         Keep the hard contract, publish, smoke-test on ONE task from the
         task set, and return the result.
@@ -81,7 +82,7 @@ steps:
             description: "EXACT version string of the final healthy publish (from meta/publish-workflow)"
           summary:
             type: string
-            description: "the APPROACH this generation took and why — tied to the directive and the recurring miss patterns; the next generation reads this to know what has been tried"
+            description: "the APPROACH this generation took and why — tied to the recurring miss patterns; the next generation reads this to know what has been tried"
           changes:
             type: array
             items: { type: string }
@@ -216,9 +217,11 @@ params:
 
     You are ONE GENERATION in a hill-climbing loop: earlier generations'
     attempts and results are in your task prompt, and your published version
-    and summary will be handed to the next generation. Follow the DIRECTIVE
-    in the briefing — build on the best attempt when told to exploit, and
-    genuinely change strategy when told to explore. The fitness is exact-
+    and summary will be handed to the next generation. The briefing is
+    EVIDENCE only — the task list, a task×version grid of every version
+    graded so far, and each attempt's approach and misses. Nothing in the
+    harness picks a winner: YOU choose which version to build on, or
+    whether to change strategy, by reading the grid. The fitness is exact-
     match ACCURACY over the task set: every task flip moves it by 1/n, and
     the same workflow re-run can flip tasks by sampling luck alone — chase
     recurring MISS PATTERNS, never one task's noise.
@@ -251,11 +254,12 @@ params:
     for available credential NAMES.
 
     METHOD
-    1. Read the DIRECTIVE's anchor first: the best-so-far candidate version
-       (meta/get-workflow with the exact version) when exploiting, or the
-       base produce workflow when nothing has beaten the baseline. Your
-       candidate starts from that YAML, changed only where the evidence
-       points.
+    1. Pick your anchor from the grid: read the version that solved the
+       most (meta/get-workflow with the exact version), or the base produce
+       workflow when nothing has beaten the baseline. Your candidate starts
+       from that YAML, changed where the evidence points — and when the
+       same misses recur across every column, change approach instead of
+       adding another rule to the same prompt.
     2. PUBLISH EARLY. Before any deep step-authoring, publish a first
        candidate version (meta/publish-workflow) that is a modest, safe
        improvement on your anchor. The harness grades whatever your FINAL
@@ -274,8 +278,8 @@ params:
        healthy. Runs cost real money: one task, at most two smoke runs.
     5. Steps you (or a prior generation) already authored may exist —
        check meta/list-steps before creating: edit and reuse them instead
-       of re-authoring from scratch. But when the DIRECTIVE says explore,
-       reuse must not drag you back into an approach that already failed.
+       of re-authoring from scratch. But reuse must not drag you back into
+       an approach the grid shows already failed.
 
     WORKFLOW DESIGN PATTERNS — vocabulary, not prescription. A candidate
     may be ANY shape that honors the hard contract: compose these, adapt

--- a/mcp/src/lab/gaia/workflows/gaia-evolve.yaml
+++ b/mcp/src/lab/gaia/workflows/gaia-evolve.yaml
@@ -1,58 +1,46 @@
 name: gaia-evolve
-# The AUTHORING HARNESS (EVOLVE_SPEC §5.2 / §9.4) for GAIA — a HILL-CLIMB
-# (§5.3.3, gaia instance of the generic eval/evolve-loop): baseline once,
-# then up to maxGenerations author→run→grade cycles, each generation
-# briefed with every previous attempt's version, accuracy, approach, and
-# misses — anchored to the best-so-far, flipping to an explicit "try a
-# genuinely different approach" directive after `exploreAfter`
-# non-improving attempts.
+# The AUTHORING HARNESS (EVOLVE_SPEC §5.2 / §9.4) for GAIA — the gaia
+# instance of the generic eval/evolve-loop: baseline once, then up to
+# maxGenerations author→run→grade cycles. Each generation's author is
+# briefed with the EVIDENCE so far — the task list, a task×version grid of
+# every version graded in this run (baseline first), and each attempt's
+# approach summary and misses — and chooses for itself which version to
+# build on (it can read any of them with meta/get-workflow).
 #
-#   capture   run the BASELINE produce workflow over the task set
-#             `baselineSamples` times (identical YAML re-runs — the noise
-#             instrument), score each with the real leaderboard scorer, and
-#             fold the samples into the eval/matrix task×version view:
-#             bands, per-task wrong answers + questions, and the MEASURED
-#             produce-sampling floor that becomes the loop's improveMargin
+#   capture   run the BASELINE produce workflow once over the task set,
+#             score it with the real leaderboard scorer, digest it — the
+#             grid's first column
 #   loop      eval/evolve-loop runs gaia-evolve-gen per generation: an
 #             authoring agent (meta/* only — §5.3.2) publishes a new
 #             version of the candidate, the harness runs it pinned over the
-#             same tasks and digests the scores; the loop composes the next
-#             generation's briefing and directive from the results
-#   promote   the report: best version + its accuracy vs baseline, the
+#             same tasks and digests the scores; the loop folds the result
+#             into the next generation's briefing
+#   promote   the report: the top version(s) + accuracy vs baseline, the
 #             full generation history, costs. Promotion stays a HUMAN act —
-#             point gaia-run's input.produceWorkflow at the best version,
-#             or fold its diff into the seeded gaia-produce, after review.
+#             point gaia-run's input.produceWorkflow at a top version, or
+#             fold its diff into the seeded gaia-produce, after review.
 #             Review must also check the candidate never embeds
 #             gaia/evaluate (produce-time oracle access — §6).
 #
-# MEASUREMENT DISCIPLINE (EVOLVE_SPEC §6/§7; the plan doc's Phase 1):
-#   - Scoring is exact-match, so there is no judge noise. What remains is
-#     PRODUCE-SAMPLING noise: the same workflow re-run flips tasks by luck
-#     (observed live: identical YAML re-measured 0.76 vs 0.80). The k
-#     baseline samples MEASURE that floor — eval/matrix reports the max
-#     fitness delta between same-version re-runs, and the loop's
-#     improveMargin defaults to it, so a challenger must beat the
-#     baseline's best draw by more than identical YAML wobbles on its own.
-#     params.improveMargin is only the fallback if the floor is unmeasured
-#     (baselineSamples: 1).
-#   - Every score in this report is a TRAIN score on the very tasks the
-#     candidates were tuned against. Validate the best version on held-out
-#     tasks (gaia-batch over a different slice) before believing the delta.
-#   - Authors cannot grade: grading happens in the harness after each
-#     author finishes, and candidates run under their OWN runIds via
-#     meta/run-workflow (gaia-candidate-run).
+# MEASUREMENT (EVOLVE_SPEC §6/§7): scoring is exact-match, so there is no
+# judge noise, but the same YAML re-run flips a task or two by produce-
+# sampling luck alone. Every version here is graded ONCE — there is no
+# noise margin or best-so-far machinery trying to outguess that; the grid
+# shows the author every column and the author reads patterns across them.
+# Every score is a TRAIN score on the very tasks the candidates were tuned
+# against: validate a top version on held-out tasks (gaia-batch over a
+# different slice) before believing the delta.
 #
-# COST: roughly (baselineSamples + generations) × |tasks| × produce + each
-# generation's author (incl. its ≤2 smoke runs). Scoring is a local python
-# subprocess — free. produceConcurrency shrinks wall-clock, not dollars.
-# Start small; raise input.generations (cap 20) to let it rip.
+# COST: roughly (1 + generations) × |tasks| × produce + each generation's
+# author (incl. its ≤2 smoke runs). Scoring is a local python subprocess —
+# free. produceConcurrency shrinks wall-clock, not dollars.
 #
 # Needs: ANTHROPIC_API_KEY, HF_TOKEN (or a populated GAIA_DIR checkout;
 # git-lfs for attachments).
 # Input:  { tasks: [taskId, …], mission, generations? }
 #   mission:     the standing gap statement handed to every generation's
-#                author (the digest evidence rides alongside it and, per
-#                the author method, outranks it).
+#                author (the grid evidence rides alongside it and, per the
+#                author method, outranks it).
 #   generations: override params.maxGenerations for this run (e.g. 10).
 #   maxCost:     dollar ceiling (author + produce) — the loop stops before
 #                starting the generation that would cross it.
@@ -60,67 +48,48 @@ name: gaia-evolve
 #                Both default to params (null = uncapped). Prefer these over
 #                guessing a generation count: cost and time per generation
 #                GROW as authors evolve more expensive architectures.
-# Output: { candidate, bestGen, bestVersion, bestAccuracy,
+# Output: { candidate, topVersions, bestGen, bestVersion, bestAccuracy,
 #           baselineAccuracy, improved, generations, totalKnownCost,
 #           stopReason, baseline, … }
 steps:
-  # ── capture: k baseline samples over the task set ──────────────────────
-  # Outer foreach counts 0..baselineSamples-1 (numeric items — the
-  # parameterized-repeat form); each sample is a full pass over the tasks.
-  # Identical YAML re-runs are the noise instrument: their score spread IS
-  # the produce-sampling floor, measured for free before the loop spends
-  # anything on generations.
+  # ── capture: the baseline over the task set ────────────────────────────
   - id: baseline
     type: foreach
     config:
-      items: "{{ params.baselineSamples }}"
+      items: "{{ input.tasks }}"
+      # Tasks hit rate-limited targets (observed 429s) — keep this low.
+      concurrency: "{{ params.produceConcurrency }}"
       body:
-        id: sample
-        type: foreach
+        id: one
+        type: subflow
         config:
-          items: "{{ input.tasks }}"
-          # Tasks hit rate-limited targets (observed 429s) — keep this low.
-          concurrency: "{{ params.produceConcurrency }}"
-          body:
-            id: one
-            type: subflow
-            config:
-              workflow: gaia-run
-              input:
-                taskId: "{{ $current }}"
+          workflow: gaia-run
+          input:
+            taskId: "{{ $current }}"
 
-  # The task×version matrix over the samples (single-version mode). Output
-  # carries `fitness` (MAX sample — the baseline's best observed draw, the
-  # conservative bar), `noise.suggestedMargin` (the measured floor), bands,
-  # and a `text` block with per-task wrong answers + questions — it IS the
-  # loop's baseline object.
-  - id: basematrix
-    type: eval/matrix
+  # The same digest every generation produces — per-task verdicts, the
+  # produced answers, and the questions — so the baseline is just the
+  # grid's first column.
+  - id: basedigest
+    type: gaia/digest-results
     depends: baseline
     config:
-      version: "{{ params.baseWorkflow }}"
-      samples: "{{ baseline }}"
+      results: "{{ baseline }}"
 
-  # ── the hill-climb: author → run → grade, up to N generations ──────────
+  # ── the loop: author → run → grade, up to N generations ────────────────
   - id: evolve
     type: eval/evolve-loop
-    depends: basematrix
+    depends: basedigest
     config:
       tasks: "{{ input.tasks }}"
       mission: "{{ input.mission }}"
-      baseline: "{{ basematrix }}"
+      baseline: "{{ basedigest }}"
       candidateName: "{{ params.candidateName }}"
       baseWorkflow: "{{ params.baseWorkflow }}"
       genWorkflow: "{{ params.genWorkflow }}"
       fitnessName: accuracy
       maxGenerations: "{{ input.generations || params.maxGenerations }}"
       stopFitness: "{{ params.stopAccuracy }}"
-      # The MEASURED produce-sampling floor (max fitness delta between the
-      # identical-YAML baseline samples); params.improveMargin only when
-      # unmeasured (baselineSamples: 1). A measured 0 also falls through —
-      # indistinguishable here, and the fallback is 0 anyway.
-      improveMargin: "{{ basematrix.noise.suggestedMargin || params.improveMargin }}"
-      exploreAfter: "{{ params.exploreAfter }}"
       genParams: "{{ params.genParams }}"
       maxCost: "{{ input.maxCost || params.maxCost }}"
       maxMinutes: "{{ input.maxMinutes || params.maxMinutes }}"
@@ -133,6 +102,9 @@ steps:
       mission: "{{ input.mission }}"
       tasks: "{{ input.tasks }}"
       candidate: "{{ evolve.candidate }}"
+      # Every version that reached the top accuracy, oldest first — a tie on
+      # one noisy run is no reason to hide one of them.
+      topVersions: "{{ evolve.topVersions }}"
       bestGen: "{{ evolve.bestGen }}"
       bestVersion: "{{ evolve.bestVersion }}"
       bestAccuracy: "{{ evolve.bestFitness }}"
@@ -142,11 +114,9 @@ steps:
       generations: "{{ evolve.generations }}"
       totalKnownCost: "{{ evolve.totalKnownCost }}"
       stopReason: "{{ evolve.stopReason }}"
-      # The per-task matrix rows (bands, flips, wrong answers, questions)
-      # and the measured noise floor — the report's evidence base.
-      baseline: "{{ basematrix.tasks }}"
-      baselineNoise: "{{ basematrix.noise }}"
-      baselineSamples: "{{ params.baselineSamples }}"
+      # The baseline's per-task verdicts, answers, and questions — the
+      # report's evidence base.
+      baseline: "{{ basedigest.results }}"
       note: "{{ evolve.note }}"
 
 params:
@@ -155,7 +125,7 @@ params:
   baseWorkflow: gaia-produce
   # The candidate's name. Every generation republishes it — a NEW VERSION
   # each time, so one evolve run leaves a versioned lineage (and the report
-  # pins the best version, which may not be the latest).
+  # names the top version(s), which may not be the latest).
   candidateName: gaia-produce-ai
   # The one-generation workflow the loop runs (author → candidate eval →
   # digest). Its own params (authorModel, authorMaxSteps, authorSystem, …)
@@ -165,21 +135,9 @@ params:
   # Stop early once a generation's accuracy reaches this (1 = every task —
   # reachable on tuned-against train sets; generations are the real cap).
   stopAccuracy: 1
-  # How many identical baseline passes to run — ≥2 measures the
-  # produce-sampling noise floor (eval/matrix's suggestedMargin) that
-  # becomes the loop's improveMargin. 1 = old single-sample behavior with
-  # an UNKNOWN floor; the fallback margin below applies then.
-  baselineSamples: 2
   # Parallel produce runs per pass (foreach concurrency). Tasks hit
   # rate-limited targets (metmuseum/NIST 429s observed) — keep low.
   produceConcurrency: 3
-  # FALLBACK margin, used only when the floor is unmeasured
-  # (baselineSamples: 1) or measured exactly 0. Exact-match scoring has no
-  # judge noise, so 0 = any task flip counts — the pre-Phase-1 behavior.
-  improveMargin: 0
-  # Consecutive non-improving attempts before the directive flips from
-  # "refine the best" to "try a genuinely different approach".
-  exploreAfter: 2
   # Param overrides for gaia-evolve-gen (e.g. { authorModel: "...",
   # authorMaxSteps: 120, authorGuidance: "..." }). Empty = its defaults.
   genParams: {}

--- a/mcp/src/lab/harvey/evolve-smoke.ts
+++ b/mcp/src/lab/harvey/evolve-smoke.ts
@@ -34,7 +34,7 @@ async function main() {
     }
 
     // step types referenced by the workflows all exist in the registry
-    const { registry } = await buildRegistry(workspace.path);
+    const { registry } = await buildRegistry(await workspace.materializeCustomSteps());
     const wanted = [
       "harvey/get-task", "harvey/evaluate", "harvey/pack-result", "harvey/digest-results",
       "eval/evolve-loop", "artifacts/dir", "meta/run-workflow", "agent", "subflow", "foreach",
@@ -134,10 +134,10 @@ async function main() {
     await assert.rejects(() => dirStep.run(dirStep.input.parse({ sub: "/abs" }), dirCtx), /relative path/);
     console.log("✔ artifacts/dir sub: create + traversal guards");
 
-    // 5. the hill-climb loop, driven by a fake optimizer:
-    //    rates 0.85, 0.86, 0.86, 0.95 vs baseline 0.90 (improveMargin 0.02,
-    //    exploreAfter 2) → gens 0-1 exploit and fail to improve, gens 2-3
-    //    get the EXPLORE directive, gen 3 beats best and hits stopFitness.
+    // 5. the loop, driven by a fake optimizer: pass-rates 0.85, 0.86, 0.86,
+    //    0.95 vs baseline 0.90 → gen 3 hits stopFitness 0.94. Each
+    //    generation is briefed with the grid (harvey's per-task pass-rate as
+    //    the cell) and the failed-criteria miss lines.
     const loop = registry["eval/evolve-loop"]!;
     const genCalls: any[] = [];
     const rates = [0.85, 0.86, 0.86, 0.95];
@@ -153,7 +153,12 @@ async function main() {
             version: `v${g + 1}`,
             summary: `approach ${g}`,
             authorCost: 1,
-            digest: { meanPassRate: rates[g], allPassCount: 0, text: `digest ${g}`, results: [{ cost: 2 }] },
+            digest: {
+              meanPassRate: rates[g],
+              allPassCount: 0,
+              text: `digest ${g}`,
+              results: [{ task: "a/b", passRate: rates[g], all_pass: false, failed: [`c${g}: missing`], cost: 2 }],
+            },
           },
         };
       },
@@ -163,37 +168,40 @@ async function main() {
       loop.input.parse({
         tasks: ["a/b"],
         mission: "m",
-        baseline: { meanPassRate: 0.9, text: "baseline digest" },
+        baseline: {
+          meanPassRate: 0.9,
+          text: "baseline digest",
+          results: [{ task: "a/b", passRate: 0.9, all_pass: false, failed: ["c9: missing"] }],
+        },
         candidateName: "harvey-produce-ai",
         baseWorkflow: "harvey-produce",
         genWorkflow: "harvey-evolve-gen",
         maxGenerations: 6,
         stopFitness: 0.94,
-        improveMargin: 0.02,
-        exploreAfter: 2,
       }),
       loopCtx,
     );
     assert.equal(genCalls.length, 4); // stopped at gen 3 (0.95 ≥ 0.94), not 6
     assert.equal(loopOut.stopReason, "stopFitness 0.94 reached");
+    assert.deepEqual(loopOut.topVersions, [{ gen: 3, version: "v4", fitness: 0.95 }]);
     assert.equal(loopOut.bestGen, 3);
     assert.equal(loopOut.bestVersion, "v4");
     assert.equal(loopOut.bestFitness, 0.95);
     assert.equal(loopOut.baselineFitness, 0.9);
     assert.equal(loopOut.improved, true);
     assert.equal(loopOut.totalKnownCost, 12); // 4 gens × (author 1 + produce 2)
-    // directive flip: gens 0-1 exploit, gens 2-3 explore
-    assert.ok(!genCalls[0].briefing.includes("GENUINELY DIFFERENT"));
-    assert.ok(!genCalls[1].briefing.includes("GENUINELY DIFFERENT"));
-    assert.ok(genCalls[2].briefing.includes("GENUINELY DIFFERENT"));
-    assert.ok(genCalls[3].briefing.includes("GENUINELY DIFFERENT"));
-    // history accumulates: gen 3's briefing lists all prior attempts + baseline anchor
+    // history accumulates: gen 3's briefing lists every prior attempt, the
+    // grid carries a column per version with the pass-rate as the cell, and
+    // the miss lines carry the failed criteria.
     assert.ok(genCalls[0].briefing.includes("none — this is the first attempt"));
-    assert.ok(genCalls[3].briefing.includes("attempt 0"));
-    assert.ok(genCalls[3].briefing.includes("attempt 2"));
-    assert.ok(genCalls[3].briefing.includes("harvey-produce-ai@v3"));
-    assert.ok(genCalls[3].briefing.includes("BEST SO FAR: the baseline itself"));
-    console.log("✔ eval/evolve-loop: best-anchoring, explore flip, history, early stop");
+    const b3 = genCalls[3].briefing as string;
+    assert.ok(b3.includes("attempt 0") && b3.includes("attempt 2"));
+    assert.ok(b3.includes("harvey-produce-ai@v3: pass-rate 0.86"));
+    assert.match(b3, /task\s+\|\s+base \|\s+v1 \|\s+v2 \|\s+v3/);
+    assert.match(b3, /a\/b\s+\|\s+0\.9 \|\s+0\.85 \|\s+0\.86 \|\s+0\.86/);
+    assert.ok(b3.includes("a/b → score 0.86; failed: c2: missing"));
+    assert.ok(!b3.includes("GENUINELY DIFFERENT") && !b3.includes("BEST SO FAR"));
+    console.log("✔ eval/evolve-loop: evidence briefing (grid + failed criteria), history, early stop");
 
     // two consecutive generation failures abort the loop
     const failOpt = { run: async () => ({ runId: "x", status: "failed", error: { message: "boom" } }) };

--- a/mcp/src/lab/harvey/workflows/harvey-evolve-gen.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve-gen.yaml
@@ -13,8 +13,8 @@ name: harvey-evolve-gen
 #
 # Input:  { tasks, mission, candidateName, generation, briefing }
 #   briefing: composed by eval/evolve-loop — baseline digest, previous
-#             attempts (version, pass-rate, approach, failures), best-so-far
-#             anchor, and the exploit-or-explore directive.
+#             attempts (version, pass-rate, approach, failures) as a
+#             task×version grid plus per-attempt miss lines.
 # Output: { candidate, generation, version, summary, changes,
 #           missingSecrets, authorCost, authorSteps, digest }
 #   digest: the harvey/digest-results object for this generation's candidate
@@ -56,7 +56,7 @@ steps:
         {{ input.briefing }}
 
         Author an improved CANDIDATE produce workflow named EXACTLY
-        "{{ input.candidateName }}", following the DIRECTIVE above. Address
+        "{{ input.candidateName }}", using the evidence above. Address
         failure patterns that RECUR across tasks (never one task's
         specifics). Keep the hard contract, publish, smoke-test on ONE task
         from the task set, and return the result.
@@ -79,7 +79,7 @@ steps:
             description: "EXACT version string of the final healthy publish (from meta/publish-workflow)"
           summary:
             type: string
-            description: "the APPROACH this generation took and why — tied to the directive and the recurring failure patterns; the next generation reads this to know what has been tried"
+            description: "the APPROACH this generation took and why — tied to the recurring failure patterns; the next generation reads this to know what has been tried"
           changes:
             type: array
             items: { type: string }
@@ -211,9 +211,11 @@ params:
 
     You are ONE GENERATION in a hill-climbing loop: earlier generations'
     attempts and results are in your task prompt, and your published version
-    and summary will be handed to the next generation. Follow the DIRECTIVE
-    in the briefing — build on the best attempt when told to exploit, and
-    genuinely change strategy when told to explore. Deltas within ±0.02
+    and summary will be handed to the next generation. The briefing is
+    EVIDENCE only — the task list, a task×version grid of every version
+    graded so far, and each attempt's approach and misses. Nothing in the
+    harness picks a winner: YOU choose which version to build on, or
+    whether to change strategy, by reading the grid. Deltas within ±0.02
     (one criterion on a 50-criterion task) are judge noise — treat them as
     ties, not signal.
 
@@ -228,11 +230,12 @@ params:
     for available credential NAMES.
 
     METHOD
-    1. Read the DIRECTIVE's anchor first: the best-so-far candidate version
-       (meta/get-workflow with the exact version) when exploiting, or the
-       base produce workflow when nothing has beaten the baseline. Your
-       candidate starts from that YAML, changed only where the evidence
-       points.
+    1. Pick your anchor from the grid: read the version that solved the
+       most (meta/get-workflow with the exact version), or the base produce
+       workflow when nothing has beaten the baseline. Your candidate starts
+       from that YAML, changed where the evidence points — and when the
+       same misses recur across every column, change approach instead of
+       adding another rule to the same prompt.
     2. PUBLISH EARLY. Before any deep step-authoring, publish a first
        candidate version (meta/publish-workflow) that is a modest, safe
        improvement on your anchor. The harness grades whatever your FINAL
@@ -255,8 +258,8 @@ params:
        cost real money: one task, at most two smoke runs.
     5. Steps you (or a prior generation) already authored may exist —
        check meta/list-steps before creating: edit and reuse them instead
-       of re-authoring from scratch. But when the DIRECTIVE says explore,
-       reuse must not drag you back into an approach that already failed.
+       of re-authoring from scratch. But reuse must not drag you back into
+       an approach the grid shows already failed.
 
     WORKFLOW DESIGN PATTERNS — vocabulary, not prescription. A candidate
     may be ANY shape that honors the hard contract: compose these, adapt

--- a/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-evolve.yaml
@@ -1,21 +1,21 @@
 name: harvey-evolve
-# The AUTHORING HARNESS (EVOLVE_SPEC §5.2 / §9.4), now a HILL-CLIMB
-# (§5.3.3, harvey instance): baseline once, then up to maxGenerations
-# author→run→grade cycles, each generation briefed with every previous
-# attempt's version, pass-rate, approach, and failures — anchored to the
-# best-so-far, flipping to an explicit "try a genuinely different
-# approach" directive after `exploreAfter` non-improving attempts.
+# The AUTHORING HARNESS (EVOLVE_SPEC §5.2 / §9.4), harvey instance of the
+# generic eval/evolve-loop (§5.3.3): baseline once, then up to
+# maxGenerations author→run→grade cycles, each generation briefed with the
+# EVIDENCE so far — the task list, a task×version grid of every version
+# graded (baseline first), and each attempt's approach and failed criteria.
+# The author chooses for itself which version to build on.
 #
 #   capture   run the BASELINE produce workflow over the task set, grade it
 #             with the real benchmark eval, digest the aggregate misses
 #   loop      eval/evolve-loop (generic) runs harvey-evolve-gen per generation:
 #             an authoring agent (meta/* only — §5.3.2) publishes a new
 #             version of the candidate, the harness runs it pinned over the
-#             same tasks and digests the grades; the loop composes the next
-#             generation's briefing and directive from the results
-#   promote   the report: best version + its pass-rate vs baseline, the
+#             same tasks and digests the grades; the loop folds the result
+#             into the next generation's briefing
+#   promote   the report: the top version(s) + pass-rate vs baseline, the
 #             full generation history, costs. Promotion stays a HUMAN act —
-#             point harvey-run's input.produceWorkflow at the best version,
+#             point harvey-run's input.produceWorkflow at a top version,
 #             or fold its diff into the seeded harvey-produce, after review.
 #
 # MEASUREMENT DISCIPLINE (EVOLVE_SPEC §6/§7):
@@ -25,8 +25,10 @@ name: harvey-evolve
 #     very tasks the candidates were tuned against. Validate the best
 #     version on held-out tasks before believing the delta.
 #   - The fitness is criteria pass-RATE (harvey/digest-results) — the
-#     benchmark's binary all-pass score has no gradient. Improvements must
-#     clear `improveMargin` (judge-noise floor) to count.
+#     benchmark's binary all-pass score has no gradient. Every version is
+#     graded ONCE; ±0.02 (one criterion on a 50-criterion task) is judge
+#     noise — the grid shows the author every column and the author reads
+#     patterns across them, no margin machinery tries to outguess it.
 #   - Authors cannot grade: grading happens in the harness after each
 #     author finishes, and candidates run under their OWN runIds via
 #     meta/run-workflow (harvey-candidate-run).
@@ -48,7 +50,7 @@ name: harvey-evolve
 #                Both default to params (null = uncapped). Prefer these over
 #                guessing a generation count: cost and time per generation
 #                GROW as authors evolve more expensive architectures.
-# Output: { candidate, bestGen, bestVersion, bestPassRate,
+# Output: { candidate, topVersions, bestGen, bestVersion, bestPassRate,
 #           baselinePassRate, improved, generations, totalKnownCost,
 #           stopReason, baseline, … }
 steps:
@@ -89,8 +91,6 @@ steps:
       fitnessName: pass-rate
       maxGenerations: "{{ input.generations || params.maxGenerations }}"
       stopFitness: "{{ params.stopPassRate }}"
-      improveMargin: "{{ params.improveMargin }}"
-      exploreAfter: "{{ params.exploreAfter }}"
       genParams: "{{ params.genParams }}"
       maxCost: "{{ input.maxCost || params.maxCost }}"
       maxMinutes: "{{ input.maxMinutes || params.maxMinutes }}"
@@ -103,6 +103,8 @@ steps:
       mission: "{{ input.mission }}"
       tasks: "{{ input.tasks }}"
       candidate: "{{ evolve.candidate }}"
+      # Every version that reached the top pass-rate, oldest first.
+      topVersions: "{{ evolve.topVersions }}"
       bestGen: "{{ evolve.bestGen }}"
       bestVersion: "{{ evolve.bestVersion }}"
       bestPassRate: "{{ evolve.bestFitness }}"
@@ -131,12 +133,6 @@ params:
   # Stop early once a generation's mean pass-rate reaches this (1 = every
   # criterion on every task — rarely reached; generations are the real cap).
   stopPassRate: 1
-  # Judge-noise floor: an attempt must beat the best by MORE than this to
-  # count as an improvement (0.02 ≈ one criterion on a 50-criterion task).
-  improveMargin: 0.02
-  # Consecutive non-improving attempts before the directive flips from
-  # "refine the best" to "try a genuinely different approach".
-  exploreAfter: 2
   digestMaxCriteria: 6
   # Param overrides for harvey-evolve-gen (e.g. { authorModel: "...",
   # authorMaxSteps: 120, authorGuidance: "..." }). Empty = its defaults.

--- a/vein/src/steps/core/agent.test.ts
+++ b/vein/src/steps/core/agent.test.ts
@@ -17,6 +17,7 @@ import agent, {
   maskDeep,
   wrapToolsWithMask,
   classifyFinalAnswerStop,
+  degenerateSchemaFields,
   isTransientStreamError,
 } from "./agent.js";
 
@@ -552,6 +553,58 @@ describe("classifyFinalAnswerStop (premature text-only stop vs exhausted budget)
   });
 });
 
+describe("degenerateSchemaFields (schema-mode premature stop)", () => {
+  const schema = {
+    type: "object",
+    properties: {
+      candidate: { type: "string" },
+      version: { type: "string" },
+      summary: { type: "string" },
+      changes: { type: "array", items: { type: "string" } },
+      score: { type: "number" },
+    },
+    required: ["candidate", "version", "summary", "changes"],
+  };
+
+  it("flags required strings that are empty, whitespace, or filler", () => {
+    // The live incident: 3 of 8 authoring generations ended on a bare text
+    // turn like this at a handful of steps into a 200-step budget.
+    assert.deepEqual(
+      degenerateSchemaFields(schema, { candidate: "gaia-produce-ai", version: "", summary: "  " }),
+      ["version", "summary"],
+    );
+    assert.deepEqual(
+      degenerateSchemaFields(schema, { candidate: "x", version: "v3", summary: "placeholder" }),
+      ["summary"],
+    );
+    assert.deepEqual(degenerateSchemaFields(schema, { candidate: "x", version: "TBD.", summary: "n/a" }), [
+      "version",
+      "summary",
+    ]);
+  });
+
+  it("returns nothing for a usable object", () => {
+    assert.deepEqual(
+      degenerateSchemaFields(schema, { candidate: "gaia-produce-ai", version: "v6", summary: "split research and format" }),
+      [],
+    );
+  });
+
+  it("only judges required STRING properties — arrays, numbers, optionals are not its business", () => {
+    // `changes` is required but an array; `score` is a number; a missing
+    // optional string is fine. None of those may trigger a nudge.
+    assert.deepEqual(degenerateSchemaFields(schema, { candidate: "x", version: "v1", summary: "real", changes: [] }), []);
+    const optionalOnly = { type: "object", properties: { note: { type: "string" } } };
+    assert.deepEqual(degenerateSchemaFields(optionalOnly, { note: "" }), []);
+  });
+
+  it("treats a missing object as every required string missing, and a malformed schema as nothing to check", () => {
+    assert.deepEqual(degenerateSchemaFields(schema, undefined), ["candidate", "version", "summary"]);
+    assert.deepEqual(degenerateSchemaFields(undefined, { summary: "" }), []);
+    assert.deepEqual(degenerateSchemaFields({ required: "summary" }, { summary: "" }), []);
+  });
+});
+
 describe("isTransientStreamError (resume a severed stream, not a real failure)", () => {
   it("treats undici's bare `terminated` as transient", () => {
     // The live incident: a 34-tool-call case-law step died ~12 minutes in when
@@ -750,6 +803,83 @@ describe("mid-stream socket death is resumed, not lost", () => {
       await assert.rejects(run(), /terminated/);
       // 1 good call + the first sever + MAX_STREAM_ERROR_CONTINUATIONS resumes.
       assert.equal(s.calls(), 7);
+    } finally {
+      s.close();
+    }
+  });
+
+  // Schema (structured-output) mode: the provider sends the JSON as plain
+  // assistant text (output_format json_schema), so a "final answer" is a
+  // text turn that ends the loop.
+  const textTurn = (text: string) =>
+    sse({ type: "content_block_start", index: 0, content_block: { type: "text", text: "" } }) +
+    sse({ type: "content_block_delta", index: 0, delta: { type: "text_delta", text } }) +
+    sse({ type: "content_block_stop", index: 0 }) +
+    sse({ type: "message_delta", delta: { stop_reason: "end_turn", stop_sequence: null }, usage: { output_tokens: 20 } }) +
+    sse({ type: "message_stop" });
+  const schema = {
+    type: "object",
+    properties: { candidate: { type: "string" }, version: { type: "string" }, summary: { type: "string" } },
+    required: ["candidate", "version", "summary"],
+    additionalProperties: false,
+  };
+  const runSchema = (maxSteps = 10) =>
+    agent.run(
+      (agent.input as any).parse({
+        cwd, system: "sys", prompt: "author and publish the candidate",
+        model: "claude-sonnet-4-5", maxSteps, schema, toolFilter: ["bash"],
+      }),
+      { runId: "r", path: "p", scope: {}, input: undefined, emit: async () => {}, services: {}, registry: {} } as any,
+    ) as Promise<any>;
+
+  it("schema mode: a premature degenerate answer is nudged, and the continuation's work + object win", async () => {
+    // The live incident: an author ended on a bare text turn at 6/200 steps
+    // with summary "" and a version it never published.
+    const s = await serve((call, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write(msgStart());
+      if (call === 1) res.write(textTurn(JSON.stringify({ candidate: "gaia-produce-ai", version: "v11", summary: "" })));
+      else if (call === 2) res.write(toolUse("toolu_1", "bash", { command: "echo v11 > published.txt" }));
+      else res.write(textTurn(JSON.stringify({ candidate: "gaia-produce-ai", version: "v11", summary: "dual attempt + reconcile" })));
+      res.end();
+    });
+    process.env["ANTHROPIC_BASE_URL"] = `http://127.0.0.1:${s.port}`;
+    try {
+      const out = await runSchema();
+      assert.equal(out.object.summary, "dual attempt + reconcile");
+      assert.equal(out.object.version, "v11");
+      // The nudged loop ran a REAL tool call before answering.
+      assert.equal(readFileSync(join(cwd, "published.txt"), "utf8").trim(), "v11");
+      // 1 original turn + 2 continuation turns; usage summed across all three.
+      assert.equal(out.steps, 3);
+      assert.equal(out.usage.inputTokens, 300);
+      const nudge = s.bodies[1] ?? "";
+      assert.ok(nudge.includes("empty or filler: summary"), "nudge must name the empty field(s)");
+      assert.ok(nudge.includes("author and publish the candidate"), "nudge must restate the task");
+    } finally {
+      s.close();
+    }
+  });
+
+  it("schema mode: a usable answer is returned without a nudge, and an exhausted budget is never nudged", async () => {
+    let body = JSON.stringify({ candidate: "gaia-produce-ai", version: "v6", summary: "" });
+    const s = await serve((_call, res) => {
+      res.writeHead(200, { "content-type": "text/event-stream" });
+      res.write(msgStart());
+      res.write(textTurn(body));
+      res.end();
+    });
+    process.env["ANTHROPIC_BASE_URL"] = `http://127.0.0.1:${s.port}`;
+    try {
+      // Degenerate but the step budget is already spent: hand it back as-is.
+      const exhausted = await runSchema(1);
+      assert.equal(exhausted.object.summary, "");
+      assert.equal(s.calls(), 1);
+      body = JSON.stringify({ candidate: "gaia-produce-ai", version: "v6", summary: "curl not html/extract" });
+      const fine = await runSchema();
+      assert.equal(fine.object.summary, "curl not html/extract");
+      assert.equal(fine.steps, 1);
+      assert.equal(s.calls(), 2, "a complete answer must not trigger a continuation");
     } finally {
       s.close();
     }

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -406,6 +406,33 @@ export function classifyFinalAnswerStop(
 }
 
 /**
+ * Schema-mode counterpart of that check. In structured mode the SDK loop
+ * ends on ANY tool-less turn and parses that turn AS the object, so a model
+ * that narrates or bails early hands back a schema-valid object whose
+ * required strings are empty or filler. Observed live in a hill-climb: 3 of
+ * 8 authoring generations returned `summary: ""` at 5-8 of 200 steps, and
+ * one of them echoed a version it never got round to publishing — the
+ * finalAnswer-mode nudge would have caught all three, but it never ran in
+ * schema mode. Returns the names of top-level REQUIRED string properties
+ * whose value is missing, blank, or a filler token; empty when the object
+ * is usable (or the schema declares no required strings to check).
+ */
+const FILLER_VALUE = /^(placeholder|todo|tbd|n\/?a|none|null|unknown|string|\.\.\.|-+)[.!]?$/i;
+export function degenerateSchemaFields(schema: unknown, output: unknown): string[] {
+  const s = schema as { properties?: Record<string, { type?: unknown }>; required?: unknown } | null;
+  if (!s || typeof s !== "object" || !Array.isArray(s.required)) return [];
+  const props = s.properties ?? {};
+  const obj = (output && typeof output === "object" ? output : {}) as Record<string, unknown>;
+  const bad: string[] = [];
+  for (const key of s.required as unknown[]) {
+    if (typeof key !== "string" || props[key]?.type !== "string") continue;
+    const v = obj[key];
+    if (typeof v !== "string" || !v.trim() || FILLER_VALUE.test(v.trim())) bad.push(key);
+  }
+  return bad;
+}
+
+/**
  * How many times a mid-stream CONNECTION failure may be resumed before the
  * step gives up. Each continuation replays the whole conversation so far, so
  * this is bounded work, not a spin: the step budget (`maxSteps`) still caps
@@ -1052,8 +1079,76 @@ export default defineStep({
 
     // Structured mode: return the typed object.
     if (useSchema) {
-      console.log(`[agent] completed in ${Date.now() - startTime}ms (${steps.length} steps, structured)`);
-      return { result: res.text, object: res.output, steps: steps.length, ...maybeMessages, usage, cost };
+      let object = res.output;
+      let text = res.text;
+      // PREMATURE stop, schema flavour: the loop ended on a tool-less turn
+      // with budget remaining and the parsed object has required strings
+      // that are empty or filler. Same remedy as the finalAnswer nudge
+      // below — resume the REAL tool loop once (it can still publish or
+      // verify whatever it skipped) and demand a complete structured
+      // answer. A second degenerate stop is returned as-is: the caller's
+      // own fallbacks (usableSummary, version resolution) take it from there.
+      const bad = degenerateSchemaFields(cfg.schema, object);
+      if (bad.length && stepsUsed < cfg.maxSteps) {
+        console.warn(
+          `[agent] Structured answer left required field(s) empty/filler (${bad.join(", ")}) at ${stepsUsed}/${cfg.maxSteps} steps; nudging the loop once.`,
+        );
+        try {
+          const nudger = new ToolLoopAgent({
+            model,
+            instructions: cfg.system,
+            tools,
+            maxOutputTokens,
+            // At least a few turns even when the stop came near the cap.
+            stopWhen: [stepCountIs(Math.max(4, cfg.maxSteps - stepsUsed))],
+            ...(providerOptions ? { providerOptions } : {}),
+            output: Output.object({ schema: jsonSchema(cfg.schema) }),
+            prepareStep,
+            onStepFinish,
+          });
+          const nudged = await nudger.stream({
+            messages: [
+              // response.messages holds only generated turns — the task leads.
+              { role: "user", content: basePrompt },
+              ...(messages as any[]),
+              {
+                role: "user",
+                content:
+                  "Your last message ended your run and was parsed as your FINAL structured answer, but it left " +
+                  `required field(s) empty or filler: ${bad.join(", ")}. That answer is what the harness harvests — ` +
+                  "an empty field there wastes the whole run. If work remains (something you still had to publish, " +
+                  "create, or verify), continue it with tool calls now. Then finish with a complete structured answer " +
+                  "that fills EVERY required field with real values: never a placeholder, never an empty string.",
+              },
+            ] as any,
+          });
+          let nudgeError: unknown;
+          await nudged.consumeStream({ onError: (e: unknown) => { nudgeError = e; } });
+          if (nudgeError) throw nudgeError;
+          const nudgedSteps = (await nudged.steps) ?? [];
+          stepsUsed += nudgedSteps.length;
+          messages.push(...(((await nudged.response)?.messages ?? []) as any[]));
+          const nu = usageFromResult(await nudged.totalUsage);
+          usage = addUsage(usage, nu);
+          cost += computeCost(provider, nu);
+          // The continuation may have done real work (a publish) before
+          // answering, so its object is the fresher one — keep it unless it
+          // is WORSE than what we already had.
+          const nudgedObject = await (nudged as any).output;
+          const stillBad = degenerateSchemaFields(cfg.schema, nudgedObject);
+          if (stillBad.length <= bad.length) {
+            object = nudgedObject;
+            text = await nudged.text;
+          }
+          if (stillBad.length) {
+            console.warn(`[agent] nudged structured answer still has empty/filler field(s): ${stillBad.join(", ")}`);
+          }
+        } catch (e) {
+          console.warn("[agent] schema nudge continuation failed:", (e as Error).message);
+        }
+      }
+      console.log(`[agent] completed in ${Date.now() - startTime}ms (${stepsUsed} steps, structured)`);
+      return { result: text, object, steps: stepsUsed, ...maybeMessages, usage, cost };
     }
 
     // finalAnswer / text mode: extract the final_answer tool output, else last text.


### PR DESCRIPTION
Two fixes from reviewing gaia-evolve run 1788383322040 (10 generations on a mixed 10-task set: best 0.9, most 0.6–0.8, three no-summary generations, one no-op).

## 1. Schema-mode nudge in the `agent` step (vein)

In structured-output mode the AI SDK loop ends on ANY tool-less turn and parses it as the object. An author that narrates or bails early returns a schema-valid object with empty/filler required strings, and nothing caught it: the premature-stop nudge lives in the `finalAnswer` branch, below the early `if (useSchema) return`. Live: gens 1, 5, 7 returned `summary: ""` at 5–8 of 200 steps; gen 7 also echoed a version it never published.

- `degenerateSchemaFields(schema, output)`: required top-level strings that are missing, blank, or filler.
- When it flags fields with budget remaining, resume the tool loop once with a nudge naming them; keep the continuation's object unless it is worse.
- Unit tests + mock-provider tests (the gen-7 shape, a complete answer left alone, an exhausted budget left alone).

## 2. Evidence-only briefing in `eval/evolve-loop` (mcp)

The old briefing repeated the full task list per attempt and cut each copy at 700 chars, so the tasks that actually move (at the end of the list) were invisible to later authors. It also built a best-so-far anchor, a noise margin, and an exploit/explore directive on single noisy runs: the two baseline samples both scored 0.7 while two tasks flipped, so the "measured" margin was 0 and a lucky 0.9 became the anchor.

Now each generation gets the evidence once:

```
TASKS:
- <id> (L1): <question>
RESULTS GRID
task         | base |   v1 |   v2
-------------+------+------+-----
f918266a-b3e |    ✓ |    ✓ |    ✓
0a3cd321-3e7 |    ✗ |    ✗ |    ✓
384d0dd8-e8a |    ∅ |    ∅ |    ✗
fitness      |  0.6 |  0.4 |  0.8
ATTEMPTS
- attempt 0 → gaia-produce-ai@v1: accuracy 0.4
  approach: …(cap 3000)
  misses:
    - cf106601… → answered "MLT"
```

The author picks what to build on (it can read any version with `meta/get-workflow`). The report names every version that tied for the top (`topVersions`); `bestVersion` is the oldest of them.

- `gaia-evolve`: single baseline pass digested like a generation; drops `eval/matrix` wiring, `baselineSamples`, `improveMargin`, `exploreAfter`.
- `harvey-evolve`: drops `improveMargin`/`exploreAfter`, adds `topVersions`.
- `gaia/digest-results`: question on every entry (the task list reads it).
- Gen author prompts: "follow the DIRECTIVE" → choose from the grid.
- Smoke tests rewritten; they also now pass `workspace.materializeCustomSteps()` to `buildRegistry` (they were stale vs the workspace refactor and failed on `main` before this change).

Verification: vein `tsc` + full suite green; mcp `tsc` clean; `gaia/evolve-smoke.ts` and `harvey/evolve-smoke.ts` pass with `VEIN_WORKSPACE_BACKEND=fs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)