### PR TITLE
aieo: provider-agnostic web_search (Exa shim off Anthropic) + aieo@0.1.36

### DIFF
--- a/mcp/src/aieo/package.json
+++ b/mcp/src/aieo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aieo",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "main": "./dist/index.js",
   "type": "module",
   "module": "./dist/index.mjs",
@@ -12,11 +12,13 @@
   "repository": "https://github.com/stakwork/stakgraph",
   "scripts": {
     "build": "tsup",
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "tsx ./src/__tests__/search.test.ts && tsx ./src/__tests__/provider.test.ts",
     "try": "ts-node ./src/test/try.ts",
     "try-anthropic": "ts-node ./src/test/try-anthropic.ts",
     "try-kimi": "ts-node ./src/test/try-kimi.ts",
-    "try-grok": "tsx ./src/test/try-grok.ts"
+    "try-grok": "tsx ./src/test/try-grok.ts",
+    "try-search": "tsx ./src/test/try-search.ts",
+    "cite-rate": "tsx ./src/test/cite-rate.ts"
   },
   "keywords": [
     "llm",

--- a/mcp/src/aieo/src/__tests__/search.test.ts
+++ b/mcp/src/aieo/src/__tests__/search.test.ts
@@ -1,0 +1,255 @@
+import {
+  createWebSearch,
+  stripCitations,
+  linkifyCitations,
+  resolveSearchBackend,
+  captureNativeResults,
+  WEB_SEARCH_TOOL_NAME,
+  type WebSearchResult,
+} from "../search.js";
+
+type TestCase = { label: string; run: () => Promise<void> | void };
+
+function assert(cond: unknown, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+/** Stub Exa's HTTP endpoint with a fixed page of results. */
+function stubExa(pages: Array<Array<{ url: string; title?: string }>>) {
+  let call = 0;
+  (globalThis as any).fetch = async () => ({
+    ok: true,
+    json: async () => ({
+      results: (pages[call++] ?? []).map((r) => ({
+        url: r.url,
+        title: r.title ?? null,
+        publishedDate: null,
+        text: "body text",
+      })),
+    }),
+  });
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const exec = (t: any, input: any) => t.execute(input, { toolCallId: "t", messages: [] });
+
+const tests: TestCase[] = [
+  {
+    label: "anthropic keeps the native tool; others fall to exa",
+    run() {
+      assert(resolveSearchBackend("anthropic") === "anthropic", "anthropic → anthropic");
+      for (const p of ["openai", "google", "openrouter", "xai"] as const) {
+        assert(resolveSearchBackend(p) === "exa", `${p} → exa`);
+      }
+    },
+  },
+  {
+    label: "no EXA key → tool is undefined, not a throw",
+    run() {
+      delete process.env.EXA_API_KEY;
+      const ws = createWebSearch({ provider: "openai" });
+      assert(ws.tool === undefined, "tool should be undefined");
+      assert(ws.backend === undefined, "backend should be undefined");
+      assert(ws.promptSnippet === "", "no snippet without a tool");
+    },
+  },
+  {
+    label: "exa path assigns flat 1-based indices across successive calls",
+    async run() {
+      process.env.EXA_API_KEY = "test-key";
+      stubExa([
+        [{ url: "https://a.com" }, { url: "https://b.com" }],
+        [{ url: "https://c.com" }],
+      ]);
+      const ws = createWebSearch({ provider: "openai", citations: true });
+      const first = (await exec(ws.tool, { query: "one" })) as WebSearchResult[];
+      const second = (await exec(ws.tool, { query: "two" })) as WebSearchResult[];
+      assert(first.map((r) => r.index).join() === "1,2", `first indices: ${first.map((r) => r.index)}`);
+      assert(second[0].index === 3, `second index: ${second[0].index}`);
+      assert(ws.results.length === 3, `results length: ${ws.results.length}`);
+      assert(ws.results[2].url === "https://c.com", "results in citation order");
+      assert(ws.native === false, "exa path is not native");
+      assert(ws.promptSnippet.includes("index"), "shim ships citation instructions");
+    },
+  },
+  {
+    label: "capture() is a no-op on the exa path (no double-count)",
+    async run() {
+      process.env.EXA_API_KEY = "test-key";
+      stubExa([[{ url: "https://a.com" }]]);
+      const ws = createWebSearch({ provider: "openai" });
+      await exec(ws.tool, { query: "one" });
+      ws.capture([
+        { type: "tool-result", toolName: WEB_SEARCH_TOOL_NAME, output: [{ url: "https://a.com" }] },
+      ]);
+      assert(ws.results.length === 1, `expected 1 result, got ${ws.results.length}`);
+    },
+  },
+  {
+    label: "maxUses is enforced in-process on the exa path",
+    async run() {
+      process.env.EXA_API_KEY = "test-key";
+      stubExa([[{ url: "https://a.com" }], [{ url: "https://b.com" }]]);
+      const ws = createWebSearch({ provider: "openai", maxUses: 1 });
+      await exec(ws.tool, { query: "one" });
+      const blocked = (await exec(ws.tool, { query: "two" })) as { error?: string };
+      assert(!!blocked.error, "second call should be refused");
+      assert(ws.results.length === 1, "refused call adds no results");
+    },
+  },
+  {
+    label: "search failures return an error to the model, not a throw",
+    async run() {
+      process.env.EXA_API_KEY = "test-key";
+      (globalThis as any).fetch = async () => ({ ok: false, status: 429, text: async () => "slow down" });
+      const ws = createWebSearch({ provider: "openai" });
+      const out = (await exec(ws.tool, { query: "one" })) as { error?: string };
+      assert(out.error?.includes("429"), `expected 429 in error, got: ${out.error}`);
+    },
+  },
+  {
+    label: "captureNativeResults walks both output and result shapes, skips junk",
+    run() {
+      const target: WebSearchResult[] = [];
+      captureNativeResults(
+        [
+          { type: "tool-result", toolName: WEB_SEARCH_TOOL_NAME, output: [{ url: "https://a.com", title: "A" }] },
+          { type: "tool-result", toolName: WEB_SEARCH_TOOL_NAME, result: [{ url: "https://b.com" }] },
+          { type: "tool-result", toolName: "other_tool", output: [{ url: "https://nope.com" }] },
+          { type: "tool-result", toolName: WEB_SEARCH_TOOL_NAME, output: { notAnArray: true } },
+          { type: "text", text: "hi" },
+        ],
+        target,
+      );
+      assert(target.length === 2, `expected 2, got ${target.length}`);
+      assert(target[0].title === "A" && target[1].title === null, "title normalized to null");
+      assert(target[0].index === 1 && target[1].index === 2, "native results get indices too");
+    },
+  },
+  {
+    label: "both backends ship citation instructions when asked",
+    run() {
+      process.env.EXA_API_KEY = "test-key";
+      const native = createWebSearch({ provider: "anthropic", apiKey: "sk-ant-fake", citations: true });
+      assert(native.native === true, "anthropic is native");
+      assert(native.promptSnippet.includes("cite index"), "native needs instructions too");
+      const shim = createWebSearch({ provider: "xai", searchApiKey: "exa-fake", citations: true });
+      assert(shim.promptSnippet.includes("index"), "shim needs instructions");
+      assert(shim.promptSnippet.includes("REQUIRED"), "anchor text is demanded");
+    },
+  },
+  {
+    label: "citations off by default: no instructions, output is plain prose",
+    run() {
+      process.env.EXA_API_KEY = "test-key";
+      const ws = createWebSearch({ provider: "xai" });
+      assert(ws.promptSnippet === "", "no citation instructions by default");
+      const out = ws.formatOutput(
+        'Sphinx runs on Lightning. <cite index="1">per the docs</cite> Also fast. <cite index="2"></cite>',
+      );
+      assert(
+        out.content === "Sphinx runs on Lightning. per the docs Also fast.",
+        `got: ${out.content}`,
+      );
+      assert(!out.content.includes("cite"), "no markup survives");
+    },
+  },
+  {
+    label: "citations: true restores instructions and markdown links",
+    run() {
+      process.env.EXA_API_KEY = "test-key";
+      const ws = createWebSearch({ provider: "xai", citations: true });
+      assert(ws.promptSnippet.includes("cite index"), "instructions restored");
+      ws.results.push({
+        url: "https://a.com",
+        title: "A",
+        pageAge: null,
+        index: 1,
+        type: "web_search_result",
+      });
+      const out = ws.formatOutput('claim <cite index="1">source</cite>');
+      assert(out.content === "claim [source](https://a.com)", `got: ${out.content}`);
+      assert(out.converted === 1, "counted");
+    },
+  },
+  {
+    label: "stripCitations handles empty markers, anchors and truncated tags",
+    run() {
+      // Trailing empty marker takes its leading space with it.
+      assert(
+        stripCitations('a claim. <cite index="4"></cite>') === "a claim.",
+        "empty marker leaves no trailing space",
+      );
+      // Anthropic's multi-part index form.
+      assert(
+        stripCitations('<cite index="2-1,3-4">the words</cite> rest') === "the words rest",
+        "multi-part anchor collapses",
+      );
+      // Stream cut mid-tag: no half-tag survives.
+      assert(
+        stripCitations('a claim <cite index="3">trailing') === "a claim trailing",
+        "orphan open tag swept",
+      );
+      assert(stripCitations("plain text") === "plain text", "untouched when no tags");
+    },
+  },
+  {
+    label: "empty anchor degrades to a [N] footnote, not an empty link",
+    run() {
+      const results: WebSearchResult[] = [
+        { url: "https://a.com", title: "A", pageAge: null, type: "web_search_result" },
+        { url: "https://b.com", title: "B", pageAge: null, type: "web_search_result" },
+      ];
+      // grok-4 emits exactly this shape: a trailing marker, no anchor.
+      const out = linkifyCitations('a claim. <cite index="2"></cite>', results);
+      assert(out.content === "a claim. [[2]](https://b.com)", `got: ${out.content}`);
+      assert(out.converted === 1, "still counts as converted");
+    },
+  },
+  {
+    label: "linkifyCitations handles shim and anthropic multi-part indices",
+    run() {
+      const results: WebSearchResult[] = [
+        { url: "https://a.com", title: "A", pageAge: null, type: "web_search_result" },
+        { url: "https://b.com", title: "B", pageAge: null, type: "web_search_result" },
+      ];
+      const out = linkifyCitations(
+        'see <cite index="1">first</cite> and <cite index="2-1,3-4">second</cite> and <cite index="9">gone</cite>',
+        results,
+      );
+      assert(out.content.includes("[first](https://a.com)"), `shim form: ${out.content}`);
+      assert(out.content.includes("[second](https://b.com)"), `multi-part form: ${out.content}`);
+      assert(out.content.includes(" and gone"), "out-of-range collapses to anchor");
+      assert(!out.content.includes("<cite"), "no raw cite markup survives");
+      assert(out.converted === 2 && out.skipped === 1, `counts: ${out.converted}/${out.skipped}`);
+    },
+  },
+  {
+    label: "linkifyCitations escapes ] in model-generated anchor text",
+    run() {
+      const results: WebSearchResult[] = [
+        { url: "https://a.com", title: "A", pageAge: null, type: "web_search_result" },
+      ];
+      const out = linkifyCitations('<cite index="1">a]b</cite>', results);
+      assert(out.content === "[a\\]b](https://a.com)", `got: ${out.content}`);
+    },
+  },
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const tc of tests) {
+  try {
+    await tc.run();
+    console.log(`✅ PASS: ${tc.label}`);
+    passed++;
+  } catch (err: any) {
+    console.error(`❌ FAIL: ${tc.label}`);
+    console.error(`   ${err.message}`);
+    failed++;
+  }
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/mcp/src/aieo/src/index.ts
+++ b/mcp/src/aieo/src/index.ts
@@ -4,6 +4,7 @@ export * from "./stream.js";
 export * from "./usage.js";
 export * from "./prompt.js";
 export * from "./tools.js";
+export * from "./search.js";
 
 export type { ModelMessage } from "ai";
 export type { Tool, ToolSet } from "ai";

--- a/mcp/src/aieo/src/search.ts
+++ b/mcp/src/aieo/src/search.ts
@@ -1,0 +1,487 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { Provider, getGatewayBaseURL, normalizeApiKey } from "./provider.js";
+
+/**
+ * Web search, uniform across providers.
+ *
+ * Anthropic ships a server-executed `web_search` tool: the search loop
+ * runs inside their API, results never round-trip through us, and the
+ * model emits `<cite index="N-M">` tags referencing a flat, 1-based list
+ * of every result returned across the whole turn. It's the best option
+ * when it's available — no extra model hop, no per-search bill on us.
+ *
+ * Nobody else has an equivalent we can drop in. OpenAI, Google,
+ * OpenRouter and xAI each expose *some* server-side search, but every
+ * one has a different tool name, a different result shape, and a
+ * different citation mechanism (Google's sources arrive as
+ * `groundingMetadata`, OpenRouter's as message `annotations` — neither
+ * is a tool-result at all). Adapting four of those into one pipeline is
+ * four adapters and four citation normalizers.
+ *
+ * So: keep Anthropic on its native tool, and give every other provider a
+ * client-executed tool of the same name, backed by Exa, that returns the
+ * same shape. Consumers see one `web_search` tool, one result type, one
+ * citation convention, regardless of which model is driving.
+ *
+ * Usage:
+ *
+ *   const ws = createWebSearch({ provider, apiKey });
+ *   const tools = { ...(ws.tool ? { [WEB_SEARCH_TOOL_NAME]: ws.tool } : {}) };
+ *   const system = basePrompt + ws.promptSnippet;
+ *   // in onStepFinish:  ws.capture(step.content)
+ *   // when writing up:  linkifyCitations(markdown, ws.results)
+ *
+ * `ws.results` ends the run holding every result in citation order on
+ * both paths, so downstream code never branches on the backend.
+ */
+
+/** Tool name registered with the model. Load-bearing: consumers key UI
+ *  and step-walking off this exact string. */
+export const WEB_SEARCH_TOOL_NAME = "web_search";
+
+/** Which implementation backs the tool. */
+export type SearchBackend = "anthropic" | "exa";
+
+/**
+ * One search hit. Field-compatible with Anthropic's
+ * `web_search_result` output (`url` / `title` / `pageAge` / `type`), so
+ * code that walks Anthropic tool-results parses Exa results unchanged.
+ */
+export interface WebSearchResult {
+  url: string;
+  title: string | null;
+  /** Publish date when the backend reports one. */
+  pageAge: string | null;
+  /**
+   * Extracted page text. Exa path only — Anthropic returns
+   * `encryptedContent` that only their model can read, so on the native
+   * path the text is never visible to us (or to this process).
+   */
+  text?: string;
+  /**
+   * 1-based citation index, flat across every `web_search` call in the
+   * run — the number the model is told to cite. Exa path only; on the
+   * Anthropic path the model derives indices itself.
+   */
+  index?: number;
+  type: "web_search_result";
+}
+
+export interface WebSearchOptions {
+  /** Max `web_search` calls per run. Default 3, matching the previous
+   *  Anthropic-only default. Enforced in-process on the Exa path. */
+  maxUses?: number;
+  /** Results per call on the Exa path. Default 5. */
+  numResults?: number;
+  /** Per-result text budget on the Exa path. Default 4000. Raise for
+   *  research writeups, lower for quick factual lookups. */
+  maxCharacters?: number;
+  allowedDomains?: string[];
+  blockedDomains?: string[];
+}
+
+export interface CreateWebSearchOptions extends WebSearchOptions {
+  /** LLM provider driving the run — decides the backend. */
+  provider: Provider;
+  /** LLM API key. Only used on the Anthropic path. Falls back to env. */
+  apiKey?: string;
+  /** Exa key. Falls back to `EXA_API_KEY`. */
+  searchApiKey?: string;
+  /**
+   * Force a backend regardless of provider. `"exa"` is how you A/B the
+   * shim against Anthropic's native tool on identical prompts.
+   */
+  backend?: SearchBackend;
+  /**
+   * Ask the model to cite sources as `<cite index="N">` tags, so
+   * `formatOutput` can turn them into markdown links. Default `false`:
+   * no citation instructions go out, and any tag the model emits anyway
+   * is stripped to plain prose.
+   *
+   * Only turn this on for surfaces that actually render source links
+   * (a research writeup). Claude honors the instruction unreliably —
+   * measured 0/3 runs against claude-sonnet-5, which writes bare
+   * parentheticals like `(Bitcoin Magazine)` instead — so a chat reply
+   * asking for citations tends to get prose with no links either way.
+   * See `npm run cite-rate`.
+   */
+  citations?: boolean;
+  abortSignal?: AbortSignal;
+}
+
+export interface WebSearchHandle {
+  /** Register under {@link WEB_SEARCH_TOOL_NAME}. `undefined` when no
+   *  key is configured for the chosen backend — drop the tool rather
+   *  than failing the request. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tool: any | undefined;
+  backend: SearchBackend | undefined;
+  /** True when the model runs the search server-side (Anthropic). */
+  native: boolean;
+  /** Every result from the run, in citation order. */
+  results: WebSearchResult[];
+  /**
+   * Feed each step's content here (AI SDK `onStepFinish`). Walks
+   * Anthropic tool-results into `results`; a no-op on the Exa path,
+   * where `execute` already appended them. Safe to call either way.
+   */
+  capture(stepContent: unknown): void;
+  /** Citation instructions to append to the system prompt. Empty unless
+   *  `citations: true` was requested. */
+  promptSnippet: string;
+  /**
+   * Run the model's final text through the right citation treatment for
+   * this handle: markdown links when `citations` is on, plain prose when
+   * it isn't. Either way no raw `<cite>` markup survives — a leftover
+   * tag renders as literal text in any GFM viewer.
+   */
+  formatOutput(markdown: string): { content: string; converted: number; skipped: number };
+}
+
+const EXA_SEARCH_URL = "https://api.exa.ai/search";
+const DEFAULT_MAX_USES = 3;
+const DEFAULT_NUM_RESULTS = 5;
+const DEFAULT_MAX_CHARACTERS = 4000;
+
+export function getSearchApiKey(): string | undefined {
+  return normalizeApiKey(process.env.EXA_API_KEY);
+}
+
+export function hasSearchApiKey(): boolean {
+  return !!getSearchApiKey();
+}
+
+/**
+ * Which backend a provider gets. Anthropic keeps its native tool;
+ * everything else falls to Exa.
+ */
+export function resolveSearchBackend(provider: Provider): SearchBackend {
+  return provider === "anthropic" ? "anthropic" : "exa";
+}
+
+interface ExaResult {
+  url?: string;
+  title?: string | null;
+  publishedDate?: string | null;
+  text?: string;
+}
+
+/**
+ * Raw Exa search. Exposed for callers that want results without an LLM
+ * in the loop (a research pre-fetch, a URL enrichment pass).
+ *
+ * Throws on transport/HTTP failure — {@link createWebSearch} catches and
+ * hands the model a readable error instead of failing the whole turn.
+ */
+export async function searchWeb(
+  query: string,
+  opts: WebSearchOptions & { apiKey?: string; abortSignal?: AbortSignal } = {},
+): Promise<WebSearchResult[]> {
+  const apiKey = normalizeApiKey(opts.apiKey) || getSearchApiKey();
+  if (!apiKey) throw new Error("EXA_API_KEY not configured");
+
+  const res = await fetch(EXA_SEARCH_URL, {
+    method: "POST",
+    headers: { "content-type": "application/json", "x-api-key": apiKey },
+    signal: opts.abortSignal,
+    body: JSON.stringify({
+      query,
+      type: "auto",
+      numResults: opts.numResults ?? DEFAULT_NUM_RESULTS,
+      contents: {
+        text: { maxCharacters: opts.maxCharacters ?? DEFAULT_MAX_CHARACTERS },
+      },
+      ...(opts.allowedDomains?.length
+        ? { includeDomains: opts.allowedDomains }
+        : {}),
+      ...(opts.blockedDomains?.length
+        ? { excludeDomains: opts.blockedDomains }
+        : {}),
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Exa search failed (${res.status}): ${body.slice(0, 300)}`);
+  }
+
+  const json = (await res.json()) as { results?: ExaResult[] };
+  const results = Array.isArray(json.results) ? json.results : [];
+  return results
+    .filter((r): r is ExaResult & { url: string } => typeof r.url === "string")
+    .map((r) => ({
+      url: r.url,
+      title: r.title ?? null,
+      pageAge: r.publishedDate ?? null,
+      ...(r.text ? { text: r.text } : {}),
+      type: "web_search_result" as const,
+    }));
+}
+
+/**
+ * Citation instructions.
+ *
+ * Both backends need these. Claude does NOT reliably emit `<cite>` tags
+ * for `web_search` results unprompted — a live run against
+ * claude-sonnet-5 produced ten captured results and zero citation tags,
+ * writing bare parentheticals instead. So the native path gets the
+ * instructions too; it just describes Anthropic's own `N-M` index form
+ * rather than the shim's flat `N`.
+ *
+ * On the Exa path the model also can't *compute* `N` — it's a global
+ * offset across every search call in the turn, which the model can't
+ * see. So the tool hands the number back with each result and the
+ * prompt says to reuse it verbatim. One format across both backends is
+ * what lets {@link linkifyCitations} stay backend-agnostic.
+ */
+function citationSnippet(backend: SearchBackend): string {
+  const indexRule =
+    backend === "exa"
+      ? "Every result carries an `index` field. Use that number exactly as returned — never invent or renumber one. Indices are global across all searches in this conversation."
+      : "Use the index Anthropic assigns to the search result you are citing.";
+  return `
+
+## Citing web search results
+When you use information from a \`${WEB_SEARCH_TOOL_NAME}\` result, cite it inline as \`<cite index="N">anchor text</cite>\`. ${indexRule}
+
+The anchor text is REQUIRED and becomes the link text — put the words being sourced inside the tag, e.g. \`<cite index="3">runs on the Lightning Network</cite>\`. Never emit an empty tag like \`<cite index="3"></cite>\`; a trailing marker with no anchor produces a broken link.
+
+Do NOT name sources parenthetically (e.g. \`(Bitcoin Magazine)\`) or as bare URLs — observed models fall back to that style and it produces no link. Every source reference must be a cite tag.`;
+}
+
+/**
+ * Build the `web_search` tool for a run, plus the citation bookkeeping
+ * that goes with it. See the module header for the usage shape.
+ */
+export function createWebSearch(
+  opts: CreateWebSearchOptions,
+): WebSearchHandle {
+  const results: WebSearchResult[] = [];
+  const backend = opts.backend ?? resolveSearchBackend(opts.provider);
+  const maxUses = opts.maxUses ?? DEFAULT_MAX_USES;
+
+  if (backend === "anthropic") {
+    const apiKey =
+      normalizeApiKey(opts.apiKey) || normalizeApiKey(process.env.ANTHROPIC_API_KEY);
+    if (!apiKey) {
+      return emptyHandle(results);
+    }
+    const baseURL = getGatewayBaseURL("anthropic");
+    const anthropic = createAnthropic({ apiKey, ...(baseURL && { baseURL }) });
+    return {
+      tool: anthropic.tools.webSearch_20250305({
+        maxUses,
+        ...(opts.allowedDomains?.length
+          ? { allowedDomains: opts.allowedDomains }
+          : {}),
+        ...(opts.blockedDomains?.length
+          ? { blockedDomains: opts.blockedDomains }
+          : {}),
+      }),
+      backend,
+      native: true,
+      results,
+      capture: (stepContent) => captureNativeResults(stepContent, results),
+      promptSnippet: opts.citations ? citationSnippet("anthropic") : "",
+      formatOutput: (markdown) => formatOutput(markdown, results, !!opts.citations),
+    };
+  }
+
+  const searchApiKey = normalizeApiKey(opts.searchApiKey) || getSearchApiKey();
+  if (!searchApiKey) {
+    return emptyHandle(results);
+  }
+
+  let uses = 0;
+  return {
+    tool: tool({
+      description:
+        "Search the web for current information. Returns numbered results with page text. " +
+        "Prefer one specific query per call over broad multi-topic queries.",
+      inputSchema: z.object({
+        query: z.string().describe("The search query."),
+        num_results: z
+          .number()
+          .int()
+          .min(1)
+          .max(10)
+          .optional()
+          .describe("How many results to return. Default 5."),
+      }),
+      execute: async ({
+        query,
+        num_results,
+      }: {
+        query: string;
+        num_results?: number;
+      }) => {
+        if (uses >= maxUses) {
+          return {
+            error: `web_search budget exhausted (${maxUses} calls). Answer with what you have.`,
+          };
+        }
+        uses++;
+        try {
+          const hits = await searchWeb(query, {
+            numResults: num_results ?? opts.numResults,
+            maxCharacters: opts.maxCharacters,
+            allowedDomains: opts.allowedDomains,
+            blockedDomains: opts.blockedDomains,
+            apiKey: searchApiKey,
+            abortSignal: opts.abortSignal,
+          });
+          // Indices are assigned HERE, at append time, so they're the
+          // true global offset even with concurrent tool calls in one
+          // step. The model gets the number it must cite; it never has
+          // to compute one.
+          return hits.map((hit) => {
+            const indexed: WebSearchResult = { ...hit, index: results.length + 1 };
+            results.push(indexed);
+            return indexed;
+          });
+        } catch (err) {
+          return {
+            error: `Search failed: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    }),
+    backend,
+    native: false,
+    results,
+    // Exa results are appended by `execute` above; walking the step
+    // would double-count them.
+    capture: () => {},
+    promptSnippet: opts.citations ? citationSnippet("exa") : "",
+    formatOutput: (markdown) => formatOutput(markdown, results, !!opts.citations),
+  };
+}
+
+function emptyHandle(results: WebSearchResult[]): WebSearchHandle {
+  return {
+    tool: undefined,
+    backend: undefined,
+    native: false,
+    results,
+    capture: () => {},
+    promptSnippet: "",
+    formatOutput: (markdown) => formatOutput(markdown, results, false),
+  };
+}
+
+function formatOutput(
+  markdown: string,
+  results: WebSearchResult[],
+  citations: boolean,
+): { content: string; converted: number; skipped: number } {
+  return citations
+    ? linkifyCitations(markdown, results)
+    : { content: stripCitations(markdown), converted: 0, skipped: 0 };
+}
+
+/**
+ * Walk one AI SDK step's content for `web_search` tool-results and
+ * append each hit to `target`, in order.
+ *
+ * Order is load-bearing: Anthropic's `<cite index="N-M">` tags index
+ * this flat list 1-based across the entire turn.
+ *
+ * Tolerates both result shapes (`output` and `result`) and skips any
+ * non-array body — adapters vary across AI SDK versions, and a shape we
+ * don't recognize should cost us citations, not the run.
+ */
+export function captureNativeResults(
+  stepContent: unknown,
+  target: WebSearchResult[],
+): void {
+  if (!Array.isArray(stepContent)) return;
+  for (const content of stepContent) {
+    if (content?.type !== "tool-result") continue;
+    if (content?.toolName !== WEB_SEARCH_TOOL_NAME) continue;
+    const body = content.output ?? content.result ?? null;
+    if (!Array.isArray(body)) continue;
+    for (const r of body) {
+      if (r && typeof r === "object" && typeof r.url === "string") {
+        target.push({
+          url: r.url,
+          title: r.title ?? null,
+          pageAge: r.pageAge ?? null,
+          // Assigned here too, so `results` is shape-identical to the
+          // Exa path. Anthropic's model derives its own indices from
+          // the same ordering, so these agree by construction.
+          index: target.length + 1,
+          type: "web_search_result",
+        });
+      }
+    }
+  }
+}
+
+
+/**
+ * Remove citation markup, leaving readable prose.
+ *
+ * The default treatment when `citations` is off. Models emit `<cite`
+ * tags unprompted often enough that we can't just hope: Claude produces
+ * them spontaneously with server-side search, and a raw tag renders as
+ * literal text in any GFM viewer, which looks broken.
+ *
+ * Three shapes, in order:
+ *   1. Empty markers — `a claim. <cite index="4"></cite>` — are
+ *      trailing footnotes with nothing to say. They take their leading
+ *      whitespace with them, so the sentence closes up cleanly.
+ *   2. Anchored tags collapse to their anchor text, which is the words
+ *      the model was sourcing and reads as normal prose.
+ *   3. Any orphan `<cite ...>` or `</cite>` left by a truncated stream
+ *      is swept, so no half-tag survives a cut-off response.
+ */
+export function stripCitations(markdown: string): string {
+  return markdown
+    .replace(/[ \t]*<cite\b[^>]*>\s*<\/cite>/g, "")
+    .replace(/<cite\b[^>]*>(.*?)<\/cite>/g, "$1")
+    .replace(/<\/?cite\b[^>]*>/g, "");
+}
+
+/**
+ * Replace `<cite index="N">anchor</cite>` tags with markdown links into
+ * `results`. Handles Anthropic's multi-part form (`index="2-1"`,
+ * `index="2-1,3-4"`) by keying off the leading number, which is the
+ * flat result index.
+ *
+ * Out-of-range or unresolvable indices collapse to the bare anchor
+ * text. That span loses its link, but no raw `<cite>` markup survives
+ * into the output — persisted markdown is usually rendered as plain
+ * GFM, where a leftover tag shows up as literal text.
+ *
+ * Models regularly ignore the "anchor text is required" instruction and
+ * emit a trailing `<cite index="4"></cite>` marker instead (grok-4 does
+ * it consistently). An empty anchor would linkify to `[](url)` — a
+ * broken, invisible link — so it falls back to a `[N]` footnote marker.
+ */
+export function linkifyCitations(
+  markdown: string,
+  results: WebSearchResult[],
+): { content: string; converted: number; skipped: number } {
+  let converted = 0;
+  let skipped = 0;
+  const content = markdown.replace(
+    /<cite index="(\d+)(?:-\d+(?:,\d+-\d+)*)?">(.*?)<\/cite>/g,
+    (_match, indexStr: string, anchor: string) => {
+      const index = parseInt(indexStr, 10);
+      const hit = results[index - 1];
+      if (!hit || typeof hit.url !== "string") {
+        skipped++;
+        return anchor;
+      }
+      converted++;
+      // Anchor text is model-generated; a stray `]` would break the
+      // markdown link, and an empty one would render as an invisible
+      // link, so degrade to a numbered footnote marker.
+      const text = anchor.trim() ? anchor.replace(/\]/g, "\\]") : `[${index}]`;
+      return `[${text}](${hit.url})`;
+    },
+  );
+  return { content, converted, skipped };
+}

--- a/mcp/src/aieo/src/test/cite-rate.ts
+++ b/mcp/src/aieo/src/test/cite-rate.ts
@@ -1,0 +1,39 @@
+import { generateText, stepCountIs } from "ai";
+import * as dotenv from "dotenv";
+import { getModelDetails, getProviderOptions } from "../provider.js";
+import { createWebSearch, linkifyCitations, WEB_SEARCH_TOOL_NAME } from "../search.js";
+
+dotenv.config({ path: "../../.env" });
+
+const PROMPT =
+  "Search the web for what the Sphinx Chat project is and who builds it. " +
+  "Then write exactly 3 short bullet points summarizing what you found. Cite a source in every bullet.";
+
+async function once(modelName: string) {
+  const { model, provider, apiKey, modelId } = getModelDetails(modelName);
+  const ws = createWebSearch({ provider, apiKey });
+  const res = await generateText({
+    model,
+    tools: { [WEB_SEARCH_TOOL_NAME]: ws.tool },
+    system: "You are a concise research assistant." + ws.promptSnippet,
+    prompt: PROMPT,
+    stopWhen: stepCountIs(6),
+    providerOptions: getProviderOptions(provider, "fast", modelId) as any,
+    onStepFinish: (s) => ws.capture(s.content),
+  });
+  const { converted, skipped } = linkifyCitations(res.text, ws.results);
+  return { converted, skipped, captured: ws.results.length };
+}
+
+for (const [label, m] of [["anthropic/sonnet", "sonnet"], ["xai/grok", "grok"]] as const) {
+  const rows: string[] = [];
+  for (let i = 0; i < 3; i++) {
+    try {
+      const r = await once(m);
+      rows.push(`converted=${r.converted} skipped=${r.skipped} captured=${r.captured}`);
+    } catch (e: any) {
+      rows.push(`ERROR ${e?.message?.slice(0, 60)}`);
+    }
+  }
+  console.log(`\n### ${label}\n  ` + rows.join("\n  "));
+}

--- a/mcp/src/aieo/src/test/try-search.ts
+++ b/mcp/src/aieo/src/test/try-search.ts
@@ -1,0 +1,73 @@
+import { generateText, stepCountIs } from "ai";
+import * as dotenv from "dotenv";
+import { getModelDetails, getProviderOptions } from "../provider.js";
+import { createWebSearch, WEB_SEARCH_TOOL_NAME } from "../search.js";
+
+dotenv.config({ path: "../../.env" });
+
+// `npm run try-search -- --citations` to exercise the linkifying mode.
+const CITATIONS = process.argv.includes("--citations");
+
+// One prompt, both backends: forces at least one search, then a writeup
+// that must carry citations — which is what exercises the index plumbing.
+const PROMPT =
+  "Search the web for what the Sphinx Chat project is and who builds it. " +
+  "Then write exactly 3 short bullet points summarizing what you found. " +
+  "Cite a source in every bullet.";
+
+async function run(label: string, modelName: string) {
+  console.log(`\n${"=".repeat(70)}\n${label}\n${"=".repeat(70)}`);
+  const { model, provider, apiKey, modelId } = getModelDetails(modelName);
+  const ws = createWebSearch({ provider, apiKey, citations: CITATIONS });
+  console.log(
+    `backend=${ws.backend} native=${ws.native} hasTool=${!!ws.tool} snippet=${ws.promptSnippet.length}b`,
+  );
+  if (!ws.tool) {
+    console.error("no tool — missing key for this backend");
+    return;
+  }
+
+  const started = Date.now();
+  const res = await generateText({
+    model,
+    tools: { [WEB_SEARCH_TOOL_NAME]: ws.tool },
+    system: "You are a concise research assistant." + ws.promptSnippet,
+    prompt: PROMPT,
+    stopWhen: stepCountIs(6),
+    providerOptions: getProviderOptions(provider, "fast", modelId) as any,
+    onStepFinish: (step) => {
+      const calls = step.content
+        .filter((c: any) => c.type === "tool-call")
+        .map((c: any) => `${c.toolName}(${JSON.stringify(c.input)?.slice(0, 60)})`);
+      if (calls.length) console.log(`  step: ${calls.join(", ")}`);
+      ws.capture(step.content);
+    },
+  });
+  const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+
+  console.log(`\nsteps=${res.steps.length} elapsed=${elapsed}s captured=${ws.results.length}`);
+  for (const r of ws.results.slice(0, 6)) {
+    console.log(
+      `  [${r.index ?? "-"}] ${r.url}  ${r.text ? `(${r.text.length}b text)` : "(no text)"}`,
+    );
+  }
+
+  console.log(`\n--- raw model text ---\n${res.text}`);
+  const link = ws.formatOutput(res.text);
+  console.log(
+    `\n--- formatted (citations=${CITATIONS} converted=${link.converted} skipped=${link.skipped}) ---\n${link.content}`,
+  );
+  const leftover = /<cite/.test(link.content);
+  console.log(`\nraw <cite> markup left behind: ${leftover}`);
+}
+
+async function main() {
+  await run("ANTHROPIC (native web_search)", "sonnet").catch((e) =>
+    console.error("anthropic failed:", e?.message || e),
+  );
+  await run("XAI / GROK (exa shim)", "grok").catch((e) =>
+    console.error("grok failed:", e?.message || e),
+  );
+}
+
+main();

--- a/mcp/src/aieo/src/tools.ts
+++ b/mcp/src/aieo/src/tools.ts
@@ -1,13 +1,31 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { Provider, getGatewayBaseURL } from "./provider.js";
+import { createWebSearch } from "./search.js";
 
 export type ProviderTool = "webSearch" | "bash";
 
+/**
+ * Provider-native tool by name.
+ *
+ * `webSearch` is special: only Anthropic has a native one, so every
+ * other provider gets the Exa-backed shim from `./search.js` instead of
+ * an exception. That keeps the tool available (and named `web_search`)
+ * on any model. This entry point returns the bare tool — for citation
+ * indices and the matching prompt snippet, call `createWebSearch`
+ * directly.
+ *
+ * Returns `undefined` for `webSearch` when the chosen backend has no key
+ * configured; callers should drop the tool rather than fail the request.
+ * Non-`webSearch` tools still throw for unsupported providers.
+ */
 export function getProviderTool(
   provider: Provider,
   apiKey: string,
   toolName: ProviderTool
 ): any {
+  if (toolName === "webSearch") {
+    return createWebSearch({ provider, apiKey }).tool;
+  }
   switch (provider) {
     case "anthropic":
       return getAnthropicTool(apiKey, toolName);


### PR DESCRIPTION
## Problem

Only Anthropic ships a native `web_search` tool. `getProviderTool` threw for every other provider, so any non-Anthropic model silently lost web search entirely — Hive works around this today by deleting the tool from the toolset when `provider !== "anthropic"`.

The other providers do have server-side search (OpenAI, Google, OpenRouter, xAI), but each has a different tool name, result shape, and citation mechanism — Google's sources arrive as `groundingMetadata`, OpenRouter's as message `annotations`, neither as a tool-result at all. Adapting four of those into one pipeline is four adapters.

## Approach

Keep Anthropic on its native server-executed tool. Give every other provider a client-executed tool of the **same name** backed by Exa, returning the **same shape**. Consumers see one `web_search` tool and one result type regardless of which model is driving.

```ts
const ws = createWebSearch({ provider, apiKey });
// tools:        { [WEB_SEARCH_TOOL_NAME]: ws.tool }
// system:       base + ws.promptSnippet
// onStepFinish: ws.capture(step.content)
// final text:   ws.formatOutput(res.text)
```

`ws.results` ends a run holding every hit in citation order on **both** paths (native fills it by walking tool-results, Exa fills it inside `execute`), so downstream code never branches on the backend.

Exa rather than Brave because the key is already provisioned across our services as `searchApiKey`, and Exa returns page text in the same call — Brave is snippet-only, which would need a second fetch/extract pass.

## Citations are off by default

No instructions go out, and any tag a model emits anyway is stripped to plain prose. `citations: true` opts into markdown links for surfaces that render them (research writeups).

## Findings from live testing

Tested against `claude-sonnet-5` and `grok-4` with real keys.

- **Claude does not reliably emit `<cite>` markup for its own web_search results** — 0/3 runs with citations on, writing bare parentheticals like `(Bitcoin Magazine)` instead. Strengthening the instruction to 674 bytes made no difference. Documented on the option; `npm run cite-rate` measures it. Relevant to Hive, whose research linkifier assumes the opposite.
- **grok-4 emits trailing empty markers** (`<cite index="4"></cite>` with no anchor), which would linkify to an invisible `[](url)`. Empty anchors now degrade to a `[N]` footnote.
- **Exa returns 1.2–4KB of real page text per result**; Anthropic returns `encryptedContent` only its model can read. On the native path we can't see, store, or re-rank what the model read.

## Compatibility

`getProviderTool(provider, key, "webSearch")` now delegates instead of throwing, so existing callers gain search on any model just by upgrading. It returns `undefined` when the chosen backend has no key — callers drop the tool rather than fail the request. Non-`webSearch` tools still throw for unsupported providers.

## Testing

- 14 new unit tests (`npm test`, which was previously a stub — now also runs the existing provider tests)
- `npm run try-search` — live end-to-end against both backends; `-- --citations` for the linkifying mode
- `npm run cite-rate` — 3× per backend, measures citation conversion
- `tsc` and `tsup` clean

## Not included

Hive-side wiring (four call sites in `src/lib/ai/`) is a follow-up. Publishing `aieo@0.1.36` to npm is left to @Evanfeenstra.

🤖 Generated with [Claude Code](https://claude.com/claude-code)