### PR TITLE
vein: graph/create-schema + graph/edit-edge steps

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -311,7 +311,9 @@ read/write the Jarvis knowledge graph. **Concepts are Jarvis nodes** (filter
 - **Writes:** `jarvis/create-node`, `jarvis/edit-node`,
   `jarvis/create-triplet`, `jarvis/create-batch-triplet`. The ontology CRUD
   family is deliberately NOT ported (schema editing stays a human/setup
-  activity).
+  activity). Vein's own `graph/*` twins go one step further: vein-only
+  `graph/create-schema` (register/extend a node type) and `graph/edit-edge`
+  (patch an edge's properties) exist there, with no jarvis/* counterpart.
 - **Config is automatic:** each step resolves `JARVIS_URL` + `API_TOKEN`
   (+ optional `JARVIS_HTTP_TIMEOUT_MS`) through `ctx.services.secrets`
   (secret store → env fallback) and calls through `ctx.services.http` — so

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -48,7 +48,7 @@ vein/
 │   ├── steps/
 │   │   ├── core/          # 9 built-in steps: http, log, if, loop, foreach, subflow, llm, agent, wait (static import)
 │   │   ├── lib/           # built-in domain integrations (github/fetch-pr, ...) — file dynamic-imported at build; heavy SDKs lazy-imported in run() (see "Lib step dependency convention")
-│   │   │   └── graph/     # graph/* knowledge-graph steps over src/graph (the vein-native twins of the mcp lab's jarvis/* steps — same names, inputs, outputs); _shared.ts lazy-imports the backend; graph-steps.test.ts is a live end-to-end test
+│   │   │   └── graph/     # graph/* knowledge-graph steps over src/graph (the vein-native twins of the mcp lab's jarvis/* steps — same names, inputs, outputs — plus two vein-only ones: create-schema registers/extends a node type, edit-edge patches an edge's properties); _shared.ts lazy-imports the backend; graph-steps.test.ts is a live end-to-end test
 │   │   └── registry.ts    # auto-discovery: buildRegistry() core (static) + lib (dynamic) + workspace custom/ (dynamic); createRegistry() for in-code steps
 │   ├── ai/                # AI workflow-builder backend (used by POST /chat)
 │   │   ├── index.ts       # barrel export
@@ -63,13 +63,14 @@ vein/
 │   │   ├── vein-schemas.ts# the 9 Vein node types + 14-row edge registry (label registry in plans/generic-storage.md); author-time checks
 │   │   ├── schema-seed.ts # idempotent domain registration: Thing root, Schema nodes, CHILD_OF, constraints, vector/fulltext indexes, migration stamp
 │   │   ├── node-writer.ts # §6 validation gate + node_key composition + Data_Bank + MERGE (create/upsert/restore/update), UNWIND batches
-│   │   ├── edge-writer.ts # edge MERGE by ref_id with IS_ALIAS rewrite; closed (source, edge, target) registry
+│   │   ├── edge-writer.ts # edge MERGE by ref_id with IS_ALIAS rewrite (ON CREATE only); closed (source, edge, target) registry; update() = jarvis PATCH /v2/edges/:ref_id (stamps protected)
+│   │   ├── schema-crud.ts # createNodeSchema(): register a non-Vein node type like jarvis POST /v2/schema (parent, attribute grammar, node_key, CHILD_OF, constraint) or add-only extend an existing one
 │   │   ├── embeddings.ts  # local all-MiniLM-L6-v2 via transformers.js, tokenized like sentence-transformers (256 incl. specials); NULL-scan backfill
 │   │   ├── search.ts      # the read surface: hybrid search (RRF + title boost + usage tiebreak), get/neighbors/counts, ontology, namespaces
 │   │   ├── backend.ts     # openGraphBackend(): cached per config; runs seed + backfill on first open
 │   │   ├── test-util.ts   # live-test helpers (wipe, canonical graph snapshot) — only ever point at a throwaway Neo4j
 │   │   └── fixtures/      # Python-produced MiniLM golden vectors + jarvis sanitize_node_key parity cases
-│   └── *.test.ts          # 569 unit tests across 25 files (+ 70 live graph tests under src/graph/, opt-in)
+│   └── *.test.ts          # 622 unit tests across 25 files (+ 127 live graph tests under src/graph/ and steps/lib/graph/, opt-in)
 └── web/
     ├── package.json       # preact, system-canvas, vite
     ├── vite.config.ts     # preact preset, dev proxy to :3000 (/workflows, /steps, /chat, /health)
@@ -106,7 +107,7 @@ vein/
 # Engine
 cd vein
 npm install
-npm test                    # 569 tests, ~1s
+npm test                    # 622 tests, ~1s
 npm run dev                 # starts Hono server on :3000
 
 # Graph backend tests — LIVE, against a THROWAWAY Neo4j (they wipe it).

--- a/vein/plans/jarvis-graph-compat.md
+++ b/vein/plans/jarvis-graph-compat.md
@@ -523,6 +523,8 @@ Everything in jarvis NOT reached by these tools stays out of scope.
 | ------------------------------------------------ | ---------------------------------------- | ------------------------ |
 | `create-node`, `create-triplet`, `create-batch-triplet` | `POST /v2/nodes`, `POST /v2/edges` | already §1/§3            |
 | `edit-node`                                      | `POST /v2/nodes/:ref_id`                 | §1 upsert (reprocess semantics) |
+| `create-schema` (vein-only, no jarvis/* twin)    | `POST /v2/schema`                        | `schema-crud.ts`: register a non-Vein node type (parent must exist, jarvis attribute grammar, node_key tokens, CHILD_OF, per-type constraint), or add-only extend an existing one — the ontology CRUD the mcp lab deliberately left to humans, exposed because a workflow may need a type (e.g. `Evidence`) the seed lacks |
+| `edit-edge` (vein-only, no jarvis/* twin)        | `PATCH /v2/edges/:ref_id`                | `EdgeWriter.update()`: patch an edge's properties by ref_id or by (source, EDGE, target); identity stamps protected. The only way to change an edge after the ON-CREATE-only MERGE |
 | `register-namespace`                             | `POST/GET /namespace`                    | trivial: idempotent namespace registry (mirror jarvis's storage — verify whether it's a node or derived from distinct `n.namespace` before building) |
 | `get-ontology`, `get-ontology-type`              | `GET /v2/schema[/{type}]`                | list `:Schema` nodes + inherited attrs via `CHILD_OF` walk (read side of §4) |
 | `graph-get`, `graph-get-batched`                 | `GET /v2/nodes/:ref_id` + `/connection-counts` | fetch by ref_id; response envelope = properties minus `GENERIC_NODE_PROPERTIES`; `{EDGE_TYPE: count}` map |

--- a/vein/src/graph/edge-writer.test.ts
+++ b/vein/src/graph/edge-writer.test.ts
@@ -119,6 +119,46 @@ describe("EdgeWriter (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4J_URI n
     assert.deepEqual(await graphSnapshot(bolt), snap);
   });
 
+  it("update patches an existing edge by ref_id or by triple; stamps stay protected", async () => {
+    const a = await edges.write({ edge: "IN_RUN", source_ref_id: session, target_ref_id: run, properties: { note: "x", strength: 0.5 } });
+    const stamped = (await rel(a.ref_id))["props"] as Record<string, unknown>;
+
+    const u = await edges.update({ ref_id: a.ref_id }, { set: { strength: -0.75, weight: 3 }, remove: ["note"] });
+    assert.deepEqual(u, { ref_id: a.ref_id, edge: "IN_RUN", source_ref_id: session, target_ref_id: run, updated: ["strength", "weight"], removed: ["note"] });
+    let r = await rel(a.ref_id);
+    let p = r["props"] as Record<string, unknown>;
+    assert.equal(p["strength"], -0.75);
+    assert.equal(p["weight"], 3);
+    assert.equal(r["weightType"], "INTEGER NOT NULL", "integral weight stays an Integer");
+    assert.ok(!("note" in p));
+    for (const k of ["ref_id", "edge_key", "date_added_to_graph"]) assert.equal(p[k], stamped[k], `${k} untouched`);
+
+    // By triple (case-insensitive edge type), undefined values skipped.
+    const t = await edges.update({ edge: "in run", source_ref_id: session, target_ref_id: run }, { set: { strength: 0.4, skipped: undefined } });
+    assert.equal(t.ref_id, a.ref_id);
+    assert.deepEqual(t.updated, ["strength"]);
+    p = (await rel(a.ref_id))["props"] as Record<string, unknown>;
+    assert.equal(p["strength"], 0.4);
+
+    const cases: Array<[Parameters<EdgeWriter["update"]>, string]> = [
+      [[{ ref_id: a.ref_id }, { set: { ref_id: "y" } }], "UNKNOWN_ATTRIBUTE"],
+      [[{ ref_id: a.ref_id }, { set: { edge_key: "y" } }], "UNKNOWN_ATTRIBUTE"],
+      [[{ ref_id: a.ref_id }, { remove: ["date_added_to_graph"] }], "UNKNOWN_ATTRIBUTE"],
+      [[{ ref_id: a.ref_id }, { remove: ["weight"] }], "UNKNOWN_ATTRIBUTE"],
+      [[{ ref_id: a.ref_id }, { set: { "bad-name": 1 } }], "UNKNOWN_ATTRIBUTE"],
+      [[{ ref_id: a.ref_id }, {}], "MISSING_REQUIRED"],
+      [[{ ref_id: randomUUID() }, { set: { x: 1 } }], "NOT_FOUND"],
+      [[{ edge: "IN_RUN", source_ref_id: run, target_ref_id: session }, { set: { x: 1 } }], "NOT_FOUND"],
+      [[{ edge: "in_run!", source_ref_id: session, target_ref_id: run }, { set: { x: 1 } }], "UNKNOWN_TYPE"],
+    ];
+    for (const [args, code] of cases) {
+      await assert.rejects(edges.update(...args), (e: unknown) => e instanceof GraphValidationError && e.code === code, `${JSON.stringify(args)} → ${code}`);
+    }
+    // A muted edge is invisible to the triple lookup.
+    await edges.mute(a.ref_id);
+    await assert.rejects(edges.update({ edge: "IN_RUN", source_ref_id: session, target_ref_id: run }, { set: { x: 1 } }), (e: any) => e.code === "NOT_FOUND");
+  });
+
   it("ACCESSED may point at any node, including a jarvis-owned one; source must still be a Vein node", async () => {
     // A jarvis-style Concept node: no Vein label, plain Data_Bank ref_id.
     const concept = randomUUID();

--- a/vein/src/graph/edge-writer.ts
+++ b/vein/src/graph/edge-writer.ts
@@ -27,7 +27,7 @@
  */
 import { randomUUID } from "node:crypto";
 import type { ManagedTransaction } from "neo4j-driver";
-import { Bolt, int, txRows } from "./bolt.js";
+import { Bolt, int, txRows, type Row } from "./bolt.js";
 import { GraphValidationError } from "./node-writer.js";
 import { SchemaResolver } from "./schema-resolver.js";
 import { VEIN_EDGES, WILDCARD_TARGET_EDGES, isVeinType, typeLabelOf } from "./vein-schemas.js";
@@ -57,11 +57,32 @@ export interface EdgeWriteResult {
   target_ref_id: string;
 }
 
+/** How `update` finds its edge: by ref_id, or by the (source, EDGE, target) triple. */
+export type EdgeLocator = { ref_id: string } | { edge: string; source_ref_id: string; target_ref_id: string };
+
+export interface EdgeUpdate {
+  /** Properties to set/overwrite (`undefined` values are skipped). */
+  set?: Record<string, unknown>;
+  /** Property names to remove. */
+  remove?: string[];
+}
+
+export interface EdgeUpdateResult {
+  ref_id: string;
+  edge: string;
+  source_ref_id: string;
+  target_ref_id: string;
+  updated: string[];
+  removed: string[];
+}
+
 export interface EdgeWriterOptions {
   resolver?: SchemaResolver;
 }
 
 const STAMPS = new Set(["ref_id", "edge_key", "weight", "date_added_to_graph", "unique_source_id"]);
+/** Stamps `update` may never touch (`weight` is caller-settable, as on create). */
+const PROTECTED = new Set(["ref_id", "edge_key", "date_added_to_graph", "unique_source_id"]);
 const IDENT = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 const EDGE_TYPE = /^[A-Z][A-Z0-9_]*$/;
 
@@ -132,6 +153,73 @@ export class EdgeWriter {
       }
     });
     return results;
+  }
+
+  /**
+   * Patch an existing edge's properties — jarvis `PATCH /v2/edges/:ref_id`
+   * (`set_edge_properties`), the one way to change an edge after the
+   * ON-CREATE-only MERGE. Located by `ref_id`, or by the
+   * `(source, EDGE, target)` triple (alias-rewritten like a write; muted
+   * edges are skipped; more than one live edge of that type between the
+   * endpoints — distinct edge_keys — is an error: pass the ref_id).
+   * Identity stamps (`ref_id`, `edge_key`, `date_added_to_graph`,
+   * `unique_source_id`) cannot be set or removed; `weight` can. Numbers
+   * write as FLOAT (an integral `weight` as Integer, like create).
+   */
+  async update(where: EdgeLocator, patch: EdgeUpdate): Promise<EdgeUpdateResult> {
+    const set: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(patch.set ?? {})) {
+      if (v === undefined) continue;
+      if (PROTECTED.has(k)) throw new GraphValidationError("UNKNOWN_ATTRIBUTE", "edge", "edge stamp is system-managed", k);
+      if (!IDENT.test(k)) throw new GraphValidationError("UNKNOWN_ATTRIBUTE", "edge", "edge property is not a bare identifier", k);
+      set[k] = k === "weight" && typeof v === "number" && Number.isInteger(v) ? int(v) : v;
+    }
+    const remove = [...new Set(patch.remove ?? [])];
+    for (const k of remove) {
+      if (PROTECTED.has(k) || k === "weight") throw new GraphValidationError("UNKNOWN_ATTRIBUTE", "edge", "edge stamp is system-managed", k);
+      if (!IDENT.test(k)) throw new GraphValidationError("UNKNOWN_ATTRIBUTE", "edge", "edge property is not a bare identifier", k);
+    }
+    if (Object.keys(set).length === 0 && remove.length === 0) throw new GraphValidationError("MISSING_REQUIRED", "edge", "nothing to set or remove");
+
+    const removeClause = remove.length ? `REMOVE ${remove.map((k) => `r.\`${k}\``).join(", ")}` : "";
+    const ret = `RETURN r.ref_id AS ref_id, type(r) AS edge, s.ref_id AS source_ref_id, t.ref_id AS target_ref_id`;
+    return this.bolt.write(async (tx) => {
+      let rows: Row[];
+      if ("ref_id" in where) {
+        if (!where.ref_id) throw new GraphValidationError("MISSING_REQUIRED", "edge", "ref_id is required");
+        rows = await txRows(tx, `MATCH (s)-[r {ref_id: $ref_id}]->(t) SET r += $set ${removeClause} ${ret}`, { ref_id: where.ref_id, set });
+        if (rows.length === 0) throw new GraphValidationError("NOT_FOUND", "edge", `no edge with ref_id ${where.ref_id}`);
+      } else {
+        const edge = where.edge.toUpperCase().replace(/ /g, "_");
+        if (!EDGE_TYPE.test(edge)) throw new GraphValidationError("UNKNOWN_TYPE", edge, "edge type must match ^[A-Z][A-Z0-9_]*$");
+        if (!where.source_ref_id || !where.target_ref_id) throw new GraphValidationError("MISSING_REQUIRED", edge, "source_ref_id and target_ref_id are required");
+        const found = await txRows(
+          tx,
+          `MATCH (source:Data_Bank {ref_id: $src})
+           MATCH (target:Data_Bank {ref_id: $tgt})
+           OPTIONAL MATCH (source)-[:IS_ALIAS]->(sa)
+           OPTIONAL MATCH (target)-[:IS_ALIAS]->(ta)
+           WITH COALESCE(sa, source) AS s, COALESCE(ta, target) AS t
+           MATCH (s)-[r:\`${edge}\`]->(t)
+           WHERE r.is_muted IS NULL OR r.is_muted = false
+           RETURN r.ref_id AS ref_id`,
+          { src: where.source_ref_id, tgt: where.target_ref_id },
+        );
+        if (found.length === 0) throw new GraphValidationError("NOT_FOUND", edge, `no ${edge} edge from ${where.source_ref_id} to ${where.target_ref_id}`);
+        if (found.length > 1) throw new GraphValidationError("DUPLICATE_KEY", edge, `${found.length} ${edge} edges between those nodes — pass the edge ref_id`);
+        const ref_id = String(found[0]!["ref_id"]);
+        rows = await txRows(tx, `MATCH (s)-[r {ref_id: $ref_id}]->(t) SET r += $set ${removeClause} ${ret}`, { ref_id, set });
+      }
+      const r = rows[0]!;
+      return {
+        ref_id: String(r["ref_id"]),
+        edge: String(r["edge"]),
+        source_ref_id: String(r["source_ref_id"]),
+        target_ref_id: String(r["target_ref_id"]),
+        updated: Object.keys(set),
+        removed: remove,
+      };
+    });
   }
 
   /** Edge soft delete (`is_muted = true`), by edge ref_id. */

--- a/vein/src/graph/schema-crud.test.ts
+++ b/vein/src/graph/schema-crud.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Node-schema registration: pure planning rules, and (live) the write —
+ * a new type becomes writable through the NodeWriter, an existing jarvis
+ * type can be extended add-only, and Vein's closed registry is refused.
+ */
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert/strict";
+import { Bolt } from "./bolt.js";
+import { EdgeWriter } from "./edge-writer.js";
+import { GraphValidationError, NodeWriter } from "./node-writer.js";
+import { seedJarvisOntology } from "./ontology-seed.js";
+import { createNodeSchema, planNodeSchema } from "./schema-crud.js";
+import { SchemaResolver } from "./schema-resolver.js";
+import { seedVeinDomain } from "./schema-seed.js";
+import { GraphReader } from "./search.js";
+import { schemaObjectNames, testGraphConfig, wipeGraph } from "./test-util.js";
+
+const cfg = testGraphConfig();
+
+function code(fn: () => unknown): string {
+  try {
+    fn();
+  } catch (e) {
+    if (e instanceof GraphValidationError) return `${e.code}${e.attribute ? `:${e.attribute}` : ""}`;
+    throw e;
+  }
+  return "ok";
+}
+
+describe("planNodeSchema (pure)", () => {
+  it("normalizes: default parent/domain/index, prefixed node_key, flat props", () => {
+    const p = planNodeSchema({ type: "Evidence", attributes: { description: "string", content: "?string" }, node_key: "description" });
+    assert.equal(p.parent, "Thing");
+    assert.equal(p.domain, "entity");
+    assert.equal(p.node_key, "evidence-description");
+    assert.deepEqual(p.tokens, ["description"]);
+    assert.deepEqual(p.index, ["description"]);
+    assert.deepEqual(p.flat, { type: "Evidence", parent: "Thing", node_key: "evidence-description", index: ["description"], domain: "entity", description: "string", content: "?string" });
+    // An already-prefixed node_key is not doubled; `name` needs no declaration.
+    assert.equal(planNodeSchema({ type: "Claim", attributes: { claim_text: "string" }, node_key: "claim-claim_text-name" }).node_key, "claim-claim_text-name");
+    assert.equal(planNodeSchema({ type: "Note", attributes: {} }).node_key, "note-name");
+  });
+
+  it("rejects bad types, reserved/unknown attribute names, bad type strings, undeclared key tokens", () => {
+    assert.equal(code(() => planNodeSchema({ type: "9x", attributes: {} })), "UNKNOWN_TYPE");
+    assert.equal(code(() => planNodeSchema({ type: "Thing", attributes: {} })), "UNKNOWN_TYPE");
+    assert.equal(code(() => planNodeSchema({ type: "VeinRun", attributes: {} })), "UNKNOWN_TYPE");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { "bad-name": "string" } })), "UNKNOWN_ATTRIBUTE:bad-name");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { ref_id: "string" } })), "UNKNOWN_ATTRIBUTE:ref_id");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { node_key: "string" } })), "UNKNOWN_ATTRIBUTE:node_key");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { score: "number" } })), "WRONG_TYPE:score");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { a: "string" }, node_key: "b" })), "UNKNOWN_ATTRIBUTE:node_key");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { a: "string" }, index: ["zz"] })), "UNKNOWN_ATTRIBUTE:index");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { a: "string" }, title_key: "zz" })), "UNKNOWN_ATTRIBUTE:title_key");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: {}, node_key: "-" })), "MISSING_REQUIRED:node_key");
+    assert.equal(code(() => planNodeSchema({ type: "X", attributes: { a: "?list", b: "datetime", name: "string" } })), "ok");
+  });
+});
+
+describe("createNodeSchema (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4J_URI not set" }, () => {
+  let bolt: Bolt;
+  let resolver: SchemaResolver;
+  let nodes: NodeWriter;
+  let edges: EdgeWriter;
+  let reader: GraphReader;
+  before(async () => {
+    bolt = new Bolt(cfg!);
+    await bolt.verify();
+    await wipeGraph(bolt);
+    await seedJarvisOntology(bolt);
+    await seedVeinDomain(bolt);
+    resolver = new SchemaResolver(bolt);
+    nodes = new NodeWriter(bolt, { resolver });
+    edges = new EdgeWriter(bolt, { resolver });
+    reader = new GraphReader(bolt, { resolver });
+  });
+  after(async () => {
+    await bolt?.close();
+  });
+
+  it("a new type is writable through the NodeWriter, with constraint + index, CHILD_OF, and inherited attributes", async () => {
+    // Unknown before.
+    await assert.rejects(nodes.write({ type: "Evidence", data: { name: "e" } }, "create"), (e: any) => e.code === "UNKNOWN_TYPE");
+    const r = await createNodeSchema(bolt, resolver, {
+      type: "Evidence",
+      attributes: { description: "string", content: "?string", evidence_status: "?string", strength: "?float" },
+      node_key: "description",
+      title_key: "description",
+      description_key: "content",
+      type_description: "A planned or collected piece of evidence",
+    });
+    assert.equal(r.created, true);
+    assert.equal(r.type, "Evidence");
+    assert.equal(r.parent, "Thing");
+    assert.equal(r.node_key, "evidence-description");
+    assert.deepEqual(r.added, []);
+    // `description` is a jarvis dual-use (core) name: the resolver reports it
+    // optional, and its presence is enforced through the node_key instead.
+    assert.equal(r.attributes.description, "?string");
+    assert.equal(r.attributes.evidence_status, "?string");
+    assert.equal(r.attributes.name, "?string", "Thing's name inherited (optional, as for every jarvis type)");
+    assert.equal(r.attributes.content, "?string");
+
+    const w = await nodes.write({ type: "Evidence", data: { description: "Falkor docs mention vector indexes", evidence_status: "planned" } }, "create");
+    assert.equal(w.outcome, "created");
+    assert.equal(w.node_key, "evidence-falkordocsmentionvectorindexes");
+    const got = await reader.getNode(w.ref_id);
+    assert.equal(got?.node_type, "Evidence");
+    await assert.rejects(nodes.write({ type: "Evidence", data: { description: "x", bogus: 1 } }, "create"), (e: any) => e.code === "UNKNOWN_ATTRIBUTE");
+    await assert.rejects(nodes.write({ type: "Evidence", data: { content: "no description" } }, "create"), (e: any) => e.code === "MISSING_REQUIRED");
+
+    const names = await schemaObjectNames(bolt);
+    assert.ok(names.constraints.includes("unique_evidence_node_key"), names.constraints.join(","));
+    const chain = await bolt.run(`MATCH (s:Schema {type: "Evidence"})-[:CHILD_OF]->(p:Schema) RETURN p.type AS p, s.domain AS d, s.index AS i`);
+    assert.equal(chain[0]!["p"], "Thing");
+    assert.equal(chain[0]!["d"], "entity");
+    assert.deepEqual(chain[0]!["i"], ["description"]);
+    // The ontology read surface sees it.
+    const listed = await reader.listSchemas();
+    assert.ok(listed.schemas.some((s) => s.type === "Evidence"));
+  });
+
+  it("an edge schema between a new type and a seeded one lets the edge write through", async () => {
+    const claim = await nodes.write({ type: "Claim", data: { name: "c", claim_text: "Falkor supports vector search", speaker_name: "anon" } }, "create");
+    const ev = await nodes.write({ type: "Evidence", data: { description: "release notes" } }, "create");
+    await assert.rejects(edges.write({ edge: "EVIDENCED_BY", source_ref_id: claim.ref_id, target_ref_id: ev.ref_id }), (e: any) => e.code === "WRONG_TYPE");
+    await resolver.createEdgeSchema("Claim", "EVIDENCED_BY", "Evidence");
+    const e = await edges.write({ edge: "EVIDENCED_BY", source_ref_id: claim.ref_id, target_ref_id: ev.ref_id, properties: { strength: 0.6 } });
+    assert.equal(e.created, true);
+  });
+
+  it("extends an existing jarvis type add-only, with cache invalidation, and refuses Vein types", async () => {
+    // Claim (from the seeded ontology) has no verdict.
+    await assert.rejects(nodes.write({ type: "Claim", data: { name: "c2", claim_text: "t", speaker_name: "s", verdict: "unknown" } }, "create"), (e: any) => e.code === "UNKNOWN_ATTRIBUTE");
+    const before = await bolt.run(`MATCH (s:Schema {type: "Claim"}) RETURN s.ref_id AS r, s.node_key AS k, s.claim_text AS ct`);
+    const r = await createNodeSchema(bolt, resolver, {
+      type: "claim", // case-insensitive, adopts live casing
+      parent: "Content",
+      attributes: { verdict: "?string", confidence_score: "?float", claim_text: "?string" /* existing: left alone */ },
+      node_key: "name", // ignored on extend
+    });
+    assert.equal(r.created, false);
+    assert.equal(r.type, "Claim");
+    assert.equal(r.ref_id, before[0]!["r"]);
+    assert.deepEqual(r.added, ["confidence_score", "verdict"]);
+    assert.equal(r.node_key, before[0]!["k"], "identity untouched");
+    assert.equal(r.attributes.claim_text, "string", "existing attribute not downgraded to optional");
+    assert.equal(r.attributes.verdict, "?string");
+    const w = await nodes.write({ type: "Claim", data: { name: "c2", claim_text: "t", speaker_name: "s", verdict: "unknown", confidence_score: 0.5 } }, "create");
+    assert.equal(w.outcome, "created");
+    // Nothing to add → still not created, empty added.
+    const again = await createNodeSchema(bolt, resolver, { type: "Claim", attributes: { verdict: "?string" } });
+    assert.deepEqual([again.created, again.added], [false, []]);
+
+    await assert.rejects(createNodeSchema(bolt, resolver, { type: "VeinRun", attributes: { x: "string" } }), (e: any) => e.code === "UNKNOWN_TYPE");
+    await assert.rejects(createNodeSchema(bolt, resolver, { type: "SubRun", parent: "VeinRun", attributes: {} }), (e: any) => e.code === "UNKNOWN_TYPE" && e.attribute === "parent");
+    await assert.rejects(createNodeSchema(bolt, resolver, { type: "Orphan", parent: "NoSuchParent", attributes: {} }), (e: any) => e.code === "UNKNOWN_TYPE" && e.attribute === "parent");
+  });
+
+  it("replaces a soft-deleted schema", async () => {
+    await createNodeSchema(bolt, resolver, { type: "Draft", attributes: { body: "?string" } });
+    await bolt.run(`MATCH (s:Schema {type: "Draft"}) SET s.is_deleted = true`);
+    resolver.invalidate();
+    const r = await createNodeSchema(bolt, resolver, { type: "Draft", attributes: { text: "string" }, node_key: "text" });
+    assert.equal(r.created, true);
+    assert.equal(r.node_key, "draft-text");
+    const rows = await bolt.run(`MATCH (s:Schema {type: "Draft"}) RETURN count(s) AS c, collect(s.is_deleted) AS d`);
+    assert.equal(Number(rows[0]!["c"]), 1);
+  });
+});

--- a/vein/src/graph/schema-crud.ts
+++ b/vein/src/graph/schema-crud.ts
@@ -1,0 +1,230 @@
+/**
+ * Node-schema registration — the write side of the `:Schema` meta-graph for
+ * types that are NOT Vein's own, mirroring jarvis's `POST /v2/schema`
+ * (`schema_service.create_schema` + `schema_crud.create_schema`):
+ *
+ *   - the parent must already be a Schema (default `Thing`); the type must
+ *     not (`ERROR_SCHEMA_EXISTS`), except that a soft-deleted one is
+ *     replaced, as jarvis's service does;
+ *   - attributes are `name → type string` over jarvis's grammar
+ *     (`string | boolean | int | float | complex | datetime | list`, `?` =
+ *     optional); names are bare identifiers and may not reuse a core schema
+ *     key or a generic node property;
+ *   - `node_key` is `-`-joined attribute tokens, stored as
+ *     `<type lower>-<tokens>`; every token must be a declared attribute
+ *     (`name` is inherited from Thing and always available);
+ *   - `index` defaults to the node_key tokens and must name attributes;
+ *   - the schema is written flat (core keys + attributes as top-level
+ *     properties, like `schema-seed.ts`), linked `CHILD_OF` its parent, and
+ *     given the per-type `(node_key, namespace)` uniqueness constraint +
+ *     node_key index. The domain's search indexes are created when absent
+ *     (`ensure_indexes_for_schema`).
+ *
+ * `createNodeSchema` also EXTENDS an existing non-Vein schema — add-only,
+ * the way `seedVeinDomain` reconciles: attributes the schema lacks are
+ * added, nothing existing is changed, identity keys (`type`, `parent`,
+ * `node_key`, `index`) are never touched. That is what lets a workflow add
+ * `verdict` to a jarvis-seeded `Claim` without editing the ontology by hand.
+ *
+ * Vein's own types are a closed in-code registry (`vein-schemas.ts`) and
+ * are refused here.
+ */
+import { randomUUID } from "node:crypto";
+import type { Bolt } from "./bolt.js";
+import { txRows } from "./bolt.js";
+import { GraphValidationError } from "./node-writer.js";
+import { searchableAttributesOf } from "./ontology-seed.js";
+import type { SchemaResolver } from "./schema-resolver.js";
+import { schemaStatement } from "./schema-seed.js";
+import { GENERIC_NODE_PROPERTIES, RESERVED_ATTRIBUTE_NAMES, THING_TYPE, isVeinType } from "./vein-schemas.js";
+
+export interface NodeSchemaInput {
+  /** New type label, e.g. `Evidence`. */
+  type: string;
+  /** Parent type (must exist as a Schema). Default `Thing`. */
+  parent?: string;
+  /** Attribute name → jarvis type string (`?` prefix = optional). */
+  attributes: Record<string, string>;
+  /** `-`-joined attribute tokens that identify a node, e.g. `name` or
+   *  `claim_text-speaker_name`. Default `name`. A `<type>-` prefix is
+   *  accepted and not doubled. */
+  node_key?: string;
+  /** Searchable attributes; default = the node_key tokens. */
+  index?: string[];
+  title_key?: string;
+  description_key?: string;
+  /** Domain the type belongs to (→ `Domain_<domain>` label). Default `entity`. */
+  domain?: string;
+  type_description?: string;
+}
+
+/** A validated, normalized schema ready to write. */
+export interface NodeSchemaPlan {
+  type: string;
+  parent: string;
+  node_key: string;
+  tokens: string[];
+  index: string[];
+  domain: string;
+  attributes: Record<string, string>;
+  /** The flat `:Schema` node properties (core keys + attributes). */
+  flat: Record<string, unknown>;
+}
+
+export interface NodeSchemaResult {
+  /** True when a new Schema node was written; false when an existing one
+   *  was extended (or already had everything). */
+  created: boolean;
+  ref_id: string;
+  type: string;
+  parent: string;
+  node_key: string;
+  /** Attributes added to an existing schema (always empty on create). */
+  added: string[];
+  /** Full effective attribute map after the write (inherited included). */
+  attributes: Record<string, string>;
+}
+
+const TYPE_LABEL = /^[A-Za-z][A-Za-z0-9_]*$/;
+const IDENT = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+const TYPE_GRAMMAR = /^\??(string|boolean|int|float|complex|datetime|list)$/;
+const VECTOR_OPTIONS = "OPTIONS { indexConfig: { `vector.dimensions`: 384, `vector.similarity_function`: 'cosine' } }";
+
+/** Validate one attribute declaration. Reserved = jarvis's protected schema
+ *  keys + the generic node properties the writer stamps. Dual-use names
+ *  (`description`, `source_link`, `name`) are allowed, as in jarvis — note
+ *  the resolver treats a core-key attribute as optional regardless of its
+ *  declared type (`schema-resolver.ts` `fromDb`), so a `description:
+ *  "string"` is required only when it is a node_key token. */
+function checkAttribute(type: string, name: string, value: unknown): void {
+  if (!IDENT.test(name)) throw new GraphValidationError("UNKNOWN_ATTRIBUTE", type, "attribute name is not a bare identifier", name);
+  if (RESERVED_ATTRIBUTE_NAMES.has(name) || GENERIC_NODE_PROPERTIES.has(name)) {
+    throw new GraphValidationError("UNKNOWN_ATTRIBUTE", type, "attribute name is a reserved schema/system property", name);
+  }
+  if (typeof value !== "string" || !TYPE_GRAMMAR.test(value)) {
+    throw new GraphValidationError("WRONG_TYPE", type, `attribute type must be one of string|boolean|int|float|complex|datetime|list (optionally ?-prefixed), got ${JSON.stringify(value)}`, name);
+  }
+}
+
+/**
+ * Pure validation + normalization of a schema input (no DB). Throws a
+ * `GraphValidationError` on the first problem. Existence checks (parent,
+ * duplicate type) happen in `createNodeSchema`.
+ */
+export function planNodeSchema(input: NodeSchemaInput): NodeSchemaPlan {
+  const type = String(input.type ?? "").trim();
+  if (!TYPE_LABEL.test(type)) throw new GraphValidationError("UNKNOWN_TYPE", type || "?", "type must match ^[A-Za-z][A-Za-z0-9_]*$");
+  if (type === "*" || type === THING_TYPE) throw new GraphValidationError("UNKNOWN_TYPE", type, "cannot create the root or wildcard schema");
+  if (isVeinType(type)) throw new GraphValidationError("UNKNOWN_TYPE", type, "Vein's own types are a closed in-code registry");
+  const parent = String(input.parent ?? THING_TYPE).trim() || THING_TYPE;
+  if (!TYPE_LABEL.test(parent)) throw new GraphValidationError("UNKNOWN_TYPE", type, `parent must match ^[A-Za-z][A-Za-z0-9_]*$, got ${JSON.stringify(input.parent)}`, "parent");
+
+  const attributes: Record<string, string> = {};
+  for (const [k, v] of Object.entries(input.attributes ?? {})) {
+    checkAttribute(type, k, v);
+    attributes[k] = v as string;
+  }
+  const declared = new Set(["name", ...Object.keys(attributes)]);
+
+  const prefix = `${type.toLowerCase()}-`;
+  let rawKey = String(input.node_key ?? "name").trim();
+  if (rawKey.toLowerCase().startsWith(prefix)) rawKey = rawKey.slice(prefix.length);
+  const tokens = rawKey.split("-").map((t) => t.trim()).filter(Boolean);
+  if (tokens.length === 0) throw new GraphValidationError("MISSING_REQUIRED", type, "node_key needs at least one attribute token", "node_key");
+  for (const t of tokens) {
+    if (!declared.has(t)) throw new GraphValidationError("UNKNOWN_ATTRIBUTE", type, `node_key token ${t} is not a declared attribute`, "node_key");
+  }
+  const node_key = `${prefix}${tokens.join("-")}`;
+
+  const index = (input.index ?? tokens).map((f) => String(f).trim()).filter(Boolean);
+  for (const f of index) {
+    if (!declared.has(f)) throw new GraphValidationError("UNKNOWN_ATTRIBUTE", type, `index field ${f} is not a declared attribute`, "index");
+  }
+  for (const [key, val] of [["title_key", input.title_key], ["description_key", input.description_key]] as const) {
+    if (val !== undefined && !declared.has(val)) throw new GraphValidationError("UNKNOWN_ATTRIBUTE", type, `${key} ${val} is not a declared attribute`, key);
+  }
+  const domain = String(input.domain ?? "entity").trim() || "entity";
+  if (!IDENT.test(domain)) throw new GraphValidationError("WRONG_TYPE", type, "domain must be a bare identifier", "domain");
+
+  const flat: Record<string, unknown> = {
+    type,
+    parent,
+    node_key,
+    index,
+    domain,
+    ...(input.title_key ? { title_key: input.title_key } : {}),
+    ...(input.description_key ? { description_key: input.description_key } : {}),
+    ...(input.type_description ? { type_description: input.type_description } : {}),
+    ...attributes,
+  };
+  return { type, parent, node_key, tokens, index, domain, attributes, flat };
+}
+
+/**
+ * Create the schema (or add-only extend an existing non-Vein one). The
+ * resolver's caches are invalidated so the next write sees the new type.
+ */
+export async function createNodeSchema(bolt: Bolt, resolver: SchemaResolver, input: NodeSchemaInput): Promise<NodeSchemaResult> {
+  const plan = planNodeSchema(input);
+
+  // Adopt the live casing of an existing type / parent (jarvis
+  // `resolve_graph_label` / `resolve_canonical_node_type`).
+  const existingType = await resolver.resolveType(plan.type);
+  const parent = (await resolver.resolveType(plan.parent)) ?? null;
+  if (!parent) throw new GraphValidationError("UNKNOWN_TYPE", plan.type, `parent schema ${plan.parent} does not exist`, "parent");
+  if (isVeinType(parent)) throw new GraphValidationError("UNKNOWN_TYPE", plan.type, "Vein's own types cannot be extended (closed registry)", "parent");
+
+  const result = await bolt.write(async (tx) => {
+    if (existingType) {
+      if (isVeinType(existingType)) throw new GraphValidationError("UNKNOWN_TYPE", existingType, "Vein's own types are a closed in-code registry");
+      const live = await txRows(tx, `MATCH (s:Schema {type: $t}) WHERE s.is_deleted IS NULL OR s.is_deleted = false RETURN s.ref_id AS ref_id, keys(s) AS ks LIMIT 1`, {
+        t: existingType,
+      });
+      if (live.length) {
+        // Extend: add only attributes the schema lacks.
+        const have = new Set(live[0]!["ks"] as string[]);
+        const missing: Record<string, string> = {};
+        for (const [k, v] of Object.entries(plan.attributes)) if (!have.has(k)) missing[k] = v;
+        if (Object.keys(missing).length) await tx.run(`MATCH (s:Schema {type: $t}) SET s += $missing`, { t: existingType, missing });
+        return { created: false, ref_id: String(live[0]!["ref_id"]), type: existingType, added: Object.keys(missing).sort() };
+      }
+      // A soft-deleted schema is replaced (jarvis: delete_schema_permanently, then create).
+      await tx.run(`MATCH (s:Schema {type: $t}) DETACH DELETE s`, { t: existingType });
+    }
+    const ref_id = randomUUID();
+    await tx.run(`CREATE (s:Schema) SET s = $flat, s.ref_id = $ref_id`, { flat: { ...plan.flat, parent }, ref_id });
+    await tx.run(
+      `MATCH (child:Schema {type: $c}), (parent:Schema {type: $p})
+       MERGE (child)-[r:CHILD_OF]->(parent) ON CREATE SET r.ref_id = $r`,
+      { c: plan.type, p: parent, r: randomUUID() },
+    );
+    return { created: true, ref_id, type: plan.type, added: [] as string[] };
+  });
+
+  if (result.created) {
+    // DDL cannot run inside the write transaction. Same objects as the seeders.
+    const t = result.type;
+    await schemaStatement(bolt, `CREATE CONSTRAINT ${`unique_${t.toLowerCase()}_node_key`} IF NOT EXISTS FOR (n:\`${t}\`) REQUIRE (n.node_key, n.namespace) IS UNIQUE`);
+    await schemaStatement(bolt, `CREATE INDEX IF NOT EXISTS FOR (n:\`${t}\`) ON (n.node_key)`);
+    const d = plan.domain.toLowerCase();
+    const props = [...new Set([...searchableAttributesOf(plan.flat), "node_key"])].sort().map((p) => `n.\`${p}\``).join(", ");
+    await schemaStatement(
+      bolt,
+      `CREATE FULLTEXT INDEX \`domain_${d}_attribute_index_v2\` IF NOT EXISTS FOR (n:\`Domain_${d}\`) ON EACH [${props}]
+       OPTIONS { indexConfig: { \`fulltext.analyzer\`: 'english' } }`,
+    );
+    await schemaStatement(bolt, `CREATE VECTOR INDEX \`domain_${d}_vector_index\` IF NOT EXISTS FOR (n:\`Domain_${d}\`) ON n.text_embeddings ${VECTOR_OPTIONS}`);
+  }
+
+  resolver.invalidate();
+  const schema = await resolver.schema(result.type);
+  return {
+    created: result.created,
+    ref_id: result.ref_id,
+    type: result.type,
+    parent: schema?.parent ?? parent,
+    node_key: schema?.node_key ?? plan.node_key,
+    added: result.added,
+    attributes: schema?.attributes ?? plan.attributes,
+  };
+}

--- a/vein/src/steps/lib/graph/create-schema.ts
+++ b/vein/src/steps/lib/graph/create-schema.ts
@@ -1,0 +1,82 @@
+import { z } from "zod";
+import { defineStep, type StepContext } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+import { graphCtx, errText } from "./_shared.js";
+
+const EXAMPLE = `- id: evidence_type
+  type: graph/create-schema
+  config:
+    type: Evidence
+    parent: Thing
+    attributes:
+      description: string
+      content: "?string"
+      evidence_status: "?string"
+    node_key: description
+    title_key: description
+    description_key: content`;
+
+export default defineStep({
+  type: "graph/create-schema",
+  description:
+    "Register a NODE TYPE in the vein knowledge graph's ontology (a `:Schema` node), or add attributes to an existing one. " +
+    "graph/create-node and graph/create-triplet refuse a node whose type has no schema, or whose properties the schema " +
+    "does not declare — call this first when the type (or attribute) you need is missing from graph_get_ontology. " +
+    "`attributes` maps attribute name → type: string | boolean | int | float | complex | datetime | list, with a `?` prefix " +
+    "for OPTIONAL (e.g. '?float'); no prefix = REQUIRED on every node. `name` (string) is inherited from Thing and always " +
+    "available. `node_key` is the identity: `-`-joined attribute names (default 'name') — two nodes with the same node_key " +
+    "values in a namespace are the same node. `index` (default: the node_key attributes) lists the searchable attributes. " +
+    "If the type ALREADY EXISTS this is add-only: attributes it lacks are added, nothing existing changes, and " +
+    "parent/node_key/index are left alone (status 'Warning' with `added_attributes`). Vein's own types (VeinRun, " +
+    "VeinWorkflow, …) are a closed registry and cannot be created or extended. Edge types between node types are NOT " +
+    "schemas — create them with graph/create-triplet's create_schema_if_missing.\n\n" +
+    EXAMPLE,
+  input: z.object({
+    type: z.string().describe("The node type label to register, e.g. 'Evidence'. Letters/digits/underscore, starts with a letter."),
+    parent: z.string().optional().default("Thing").describe("Parent type in the ontology (must exist). Attributes are inherited from it. Default 'Thing'."),
+    attributes: z
+      .record(z.string(), z.string())
+      .describe("Attribute name → type string ('string', '?float', 'list', …). '?' prefix = optional. May be {} to only rely on inherited attributes."),
+    node_key: z
+      .string()
+      .optional()
+      .describe("Identity key: '-'-joined attribute names, e.g. 'name' or 'claim_text-speaker_name'. Every token must be a declared (or inherited) attribute. Default 'name'."),
+    index: z.array(z.string()).optional().describe("Searchable attributes (fulltext). Default: the node_key attributes."),
+    title_key: z.string().optional().describe("Attribute shown as a node's title in search results (default: name)."),
+    description_key: z.string().optional().describe("Attribute shown as a node's description in search results."),
+    domain: z.string().optional().describe("Domain the type belongs to (a `Domain_<domain>` label on its nodes). Default 'entity'."),
+    type_description: z.string().optional().describe("Human/LLM-facing description of what the type represents."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    try {
+      const b = await graphCtx(ctx as StepContext<VeinCapabilities>);
+      const { createNodeSchema } = await import("../../../graph/schema-crud.js");
+      const r = await createNodeSchema(b.bolt, b.schemas, {
+        type: cfg.type,
+        parent: cfg.parent,
+        attributes: cfg.attributes ?? {},
+        node_key: cfg.node_key,
+        index: cfg.index,
+        title_key: cfg.title_key,
+        description_key: cfg.description_key,
+        domain: cfg.domain,
+        type_description: cfg.type_description,
+      });
+      // No provenance marker: a Schema node is ontology, not data (not a
+      // Data_Bank node), so there is nothing for an ACCESSED edge to land on.
+      return {
+        status: r.created ? "Success" : "Warning",
+        created: r.created,
+        type: r.type,
+        ref_id: r.ref_id,
+        parent: r.parent,
+        node_key: r.node_key,
+        ...(r.created ? {} : { added_attributes: r.added, messages: [r.added.length ? `Schema already existed — added ${r.added.join(", ")}` : "Schema already existed — nothing to add"] }),
+        attributes: r.attributes,
+      };
+    } catch (e) {
+      return errText("graph/create-schema", e);
+    }
+  },
+});

--- a/vein/src/steps/lib/graph/edit-edge.ts
+++ b/vein/src/steps/lib/graph/edit-edge.ts
@@ -1,0 +1,73 @@
+import { z } from "zod";
+import { defineStep, type StepContext, withAccessedNodes } from "../../../core.js";
+import type { VeinCapabilities } from "../../../capabilities.js";
+import { graphCtx, errText } from "./_shared.js";
+
+const EXAMPLE = `- id: set_strength
+  type: graph/edit-edge
+  config:
+    source_ref_id: "{{ claim.ref_id }}"
+    edge_type: EVIDENCED_BY
+    target_ref_id: "{{ evidence.ref_id }}"
+    edge_data:
+      strength: "{{ grounded.strength }}"`;
+
+export default defineStep({
+  type: "graph/edit-edge",
+  description:
+    "Update the properties of an EXISTING edge in the vein knowledge graph (writes live to the graph). " +
+    "Edges are create-only in graph/create-triplet: writing the same source-[EDGE]->target again returns the " +
+    "existing edge unchanged ('Warning'), so this is the one way to change an edge's data afterwards. " +
+    "Locate the edge by `edge_ref_id` (from create-triplet's output) OR by the triple `source_ref_id` + `edge_type` + " +
+    "`target_ref_id`. PARTIAL update: `edge_data` properties are set/overwritten over the edge's current properties, " +
+    "`properties_to_be_deleted` removes properties; everything else is left untouched. `weight` may be set. " +
+    "The identity stamps (ref_id, edge_key, date_added_to_graph, unique_source_id) cannot be changed, and an edge " +
+    "cannot be re-pointed at other nodes — create a new edge instead.\n\n" +
+    EXAMPLE,
+  input: z.object({
+    edge_ref_id: z.string().optional().describe("ref_id of the edge (create-triplet returns it as edge_ref_id). Preferred when you have it."),
+    source_ref_id: z.string().optional().describe("With edge_type + target_ref_id: locate the edge by its endpoints instead of edge_ref_id."),
+    edge_type: z.string().optional().describe("The relationship type, e.g. 'EVIDENCED_BY' (uppercased). Required when locating by endpoints."),
+    target_ref_id: z.string().optional().describe("Target node ref_id, when locating by endpoints."),
+    edge_data: z
+      .record(z.string(), z.any())
+      .optional()
+      .describe('Properties to set/overwrite on the edge, e.g. {"strength": -0.75}. Merged over the existing properties.'),
+    properties_to_be_deleted: z.array(z.string()).optional().describe("Property names to REMOVE from the edge."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    const byRef = Boolean(cfg.edge_ref_id);
+    const byTriple = Boolean(cfg.source_ref_id || cfg.edge_type || cfg.target_ref_id);
+    if (!byRef && !byTriple) return "graph/edit-edge invalid input — pass edge_ref_id, or source_ref_id + edge_type + target_ref_id";
+    if (byRef && byTriple) return "graph/edit-edge invalid input — pass EITHER edge_ref_id OR the source_ref_id/edge_type/target_ref_id triple, not both";
+    if (byTriple && !(cfg.source_ref_id && cfg.edge_type && cfg.target_ref_id)) {
+      return "graph/edit-edge invalid input — locating by endpoints needs all of source_ref_id, edge_type and target_ref_id";
+    }
+    const hasSet = cfg.edge_data && Object.keys(cfg.edge_data).length > 0;
+    const hasDelete = cfg.properties_to_be_deleted && cfg.properties_to_be_deleted.length > 0;
+    if (!hasSet && !hasDelete) return "graph/edit-edge invalid input — pass at least one change: edge_data (properties to set) or properties_to_be_deleted";
+    try {
+      const b = await graphCtx(ctx as StepContext<VeinCapabilities>);
+      const r = await b.edges.update(
+        byRef ? { ref_id: cfg.edge_ref_id! } : { edge: cfg.edge_type!, source_ref_id: cfg.source_ref_id!, target_ref_id: cfg.target_ref_id! },
+        { set: cfg.edge_data ?? {}, remove: cfg.properties_to_be_deleted ?? [] },
+      );
+      return withAccessedNodes(
+        {
+          status: "Success",
+          edge_ref_id: r.ref_id,
+          edge_type: r.edge,
+          source_ref_id: r.source_ref_id,
+          target_ref_id: r.target_ref_id,
+          ...(hasSet ? { updated: r.updated } : {}),
+          ...(hasDelete ? { deleted: r.removed } : {}),
+        },
+        // Provenance: both endpoints (the edge itself is not a node).
+        [{ ref_id: r.source_ref_id }, { ref_id: r.target_ref_id }],
+      );
+    } catch (e) {
+      return errText("graph/edit-edge", e);
+    }
+  },
+});

--- a/vein/src/steps/lib/graph/graph-steps.test.ts
+++ b/vein/src/steps/lib/graph/graph-steps.test.ts
@@ -16,11 +16,11 @@ const cfg = testGraphConfig();
 const STEP_TYPES = [
   "graph/get-ontology", "graph/get-ontology-type", "graph/graph-search", "graph/graph-get",
   "graph/graph-get-batched", "graph/graph-neighbors", "graph/register-namespace", "graph/create-node",
-  "graph/edit-node", "graph/create-triplet", "graph/create-batch-triplet",
+  "graph/edit-node", "graph/create-triplet", "graph/create-batch-triplet", "graph/create-schema", "graph/edit-edge",
 ];
 
 describe("graph/* lib steps are discovered by the registry", () => {
-  it("all eleven twins are present, sourced from lib", async () => {
+  it("all thirteen graph steps are present, sourced from lib", async () => {
     const { registry, sources } = await buildRegistry();
     for (const t of STEP_TYPES) {
       assert.ok(registry[t], `missing ${t}`);
@@ -197,6 +197,89 @@ describe("graph/* lib steps (live Neo4j)", { skip: cfg ? false : "VEIN_TEST_NEO4
     assert.deepEqual(accessedNodesOf(out)!.map((n) => n.ref_id).sort(), [...new Set([wfRef, wfvRef, out.results[2].target_ref_id])].sort(), "endpoints of written edges");
     const steps = await run("graph/graph-search", { q: "smoke/step", type: "VeinStep", namespace: NS });
     assert.equal(steps.length, 1, "inline VeinStep created once");
+  });
+
+  it("edit-edge: by ref_id and by triple, deletes, refuses stamps / bad locators / missing edges", async () => {
+    // The ACTIVE_VERSION edge written by the batch test above.
+    let out = await run("graph/edit-edge", { source_ref_id: wfRef, edge_type: "active version", target_ref_id: wfvRef, edge_data: { strength: 0.75, note: "grounded" } });
+    assert.equal(out.status, "Success", JSON.stringify(out));
+    assert.equal(out.edge_type, "ACTIVE_VERSION");
+    assert.deepEqual(out.updated, ["strength", "note"]);
+    assert.deepEqual(accessedNodesOf(out), [{ ref_id: wfRef }, { ref_id: wfvRef }], "both endpoints");
+    const edgeRef = out.edge_ref_id;
+    out = await run("graph/edit-edge", { edge_ref_id: edgeRef, edge_data: { strength: -0.4 }, properties_to_be_deleted: ["note"] });
+    assert.deepEqual(out, { status: "Success", edge_ref_id: edgeRef, edge_type: "ACTIVE_VERSION", source_ref_id: wfRef, target_ref_id: wfvRef, updated: ["strength"], deleted: ["note"] });
+    const bolt = new Bolt(cfg!);
+    try {
+      const rows = await bolt.run(`MATCH ()-[r {ref_id: $r}]->() RETURN properties(r) AS p`, { r: edgeRef });
+      const p = rows[0]!["p"] as Record<string, unknown>;
+      assert.equal(p["strength"], -0.4);
+      assert.ok(!("note" in p));
+      assert.equal(p["edge_key"], "active_version");
+    } finally {
+      await bolt.close();
+    }
+    assert.match(await run("graph/edit-edge", { edge_ref_id: edgeRef, edge_data: { ref_id: "x" } }), /UNKNOWN_ATTRIBUTE/);
+    assert.match(await run("graph/edit-edge", { edge_ref_id: "nope", edge_data: { x: 1 } }), /NOT_FOUND/);
+    assert.match(await run("graph/edit-edge", { source_ref_id: wfvRef, edge_type: "ACTIVE_VERSION", target_ref_id: wfRef, edge_data: { x: 1 } }), /NOT_FOUND/);
+    assert.match(await run("graph/edit-edge", { edge_ref_id: edgeRef }), /invalid input/);
+    assert.match(await run("graph/edit-edge", { source_ref_id: wfRef, edge_data: { x: 1 } }), /invalid input/);
+    assert.match(await run("graph/edit-edge", { edge_ref_id: edgeRef, source_ref_id: wfRef, edge_type: "X", target_ref_id: wfvRef, edge_data: { x: 1 } }), /invalid input/);
+  });
+
+  it("create-schema: registers a type create-node can then write, extends it add-only, refuses Vein types and bad input", async () => {
+    assert.match(await run("graph/create-node", { node_type: "Evidence", namespace: NS, node_data: { description: "d" } }), /UNKNOWN_TYPE/);
+    let out = await run("graph/create-schema", {
+      type: "Evidence",
+      attributes: { description: "string", content: "?string", evidence_status: "?string" },
+      node_key: "description",
+      title_key: "description",
+      description_key: "content",
+    });
+    assert.equal(out.status, "Success", JSON.stringify(out));
+    assert.equal(out.created, true);
+    assert.deepEqual([out.type, out.parent, out.node_key], ["Evidence", "Thing", "evidence-description"]);
+    assert.equal(out.attributes.description, "?string", "core-name attribute reads optional; required via node_key");
+    assert.equal(out.attributes.content, "?string");
+    assert.equal(accessedNodesOf(out), undefined, "a Schema node is not data — no provenance marker");
+
+    const node = await run("graph/create-node", { node_type: "Evidence", namespace: NS, node_data: { description: "release notes mention vectors", evidence_status: "planned" } });
+    assert.equal(node.status, "Success", JSON.stringify(node));
+    assert.match(await run("graph/create-node", { node_type: "Evidence", namespace: NS, node_data: { description: "x", strength: 1 } }), /UNKNOWN_ATTRIBUTE/);
+
+    // Extend: add-only.
+    out = await run("graph/create-schema", { type: "evidence", attributes: { strength: "?float", description: "?string" } });
+    assert.equal(out.status, "Warning");
+    assert.equal(out.created, false);
+    assert.deepEqual(out.added_attributes, ["strength"]);
+    assert.equal(out.attributes.strength, "?float");
+    assert.equal(out.node_key, "evidence-description");
+    const edited = await run("graph/edit-node", { ref_id: node.ref_id, node_data: { strength: 0.75, evidence_status: "collected" } });
+    assert.equal(edited.status, "Success", JSON.stringify(edited));
+    const single = await run("graph/get-ontology-type", { type: "Evidence" });
+    assert.equal(single.attributes.strength, "?float");
+
+    // Edge between the new type and a Vein type is still gated by the closed Vein registry (source is Vein)…
+    assert.match(await run("graph/create-triplet", { source_ref_id: wfRef, target_ref_id: node.ref_id, edge_type: "EVIDENCED_BY", create_schema_if_missing: true }), /WRONG_TYPE/);
+    // …but between two ontology types create_schema_if_missing registers the edge schema.
+    const doc = await run("graph/create-schema", { type: "SourceDoc", attributes: { title: "string", url: "?string" }, node_key: "title" });
+    assert.equal(doc.created, true);
+    const trip = await run("graph/create-triplet", {
+      source_ref_id: node.ref_id,
+      target_type: "SourceDoc",
+      target_data: { title: "Falkor release notes", url: "https://example.test" },
+      edge_type: "HAS_SOURCE",
+      edge_data: { authority_level: "expert" },
+      create_schema_if_missing: true,
+      namespace: NS,
+    });
+    assert.equal(trip.status, "Success", JSON.stringify(trip));
+
+    assert.match(await run("graph/create-schema", { type: "VeinRun", attributes: {} }), /UNKNOWN_TYPE/);
+    assert.match(await run("graph/create-schema", { type: "Sub", parent: "VeinRun", attributes: {} }), /closed registry/);
+    assert.match(await run("graph/create-schema", { type: "Orphan", parent: "Nope", attributes: {} }), /does not exist/);
+    assert.match(await run("graph/create-schema", { type: "Bad", attributes: { score: "number" } }), /WRONG_TYPE/);
+    assert.match(await run("graph/create-schema", { type: "Bad", attributes: { a: "string" }, node_key: "b" }), /UNKNOWN_ATTRIBUTE/);
   });
 });
 


### PR DESCRIPTION
## Summary

Two vein-only `graph/*` steps (no `jarvis/*` twin) that close the gaps a workflow hits when it needs a node type the ontology lacks, or has to change an edge after writing it. Both mirror what jarvis itself does over HTTP (`POST /v2/schema`, `PATCH /v2/edges/:ref_id`).

- **`graph/create-schema`** — register a non-Vein node type in the `:Schema` meta-graph: parent must exist (default `Thing`), jarvis attribute grammar (`string | boolean | int | float | complex | datetime | list`, `?` = optional), `node_key` tokens must be declared attributes, `CHILD_OF` link, per-type `(node_key, namespace)` constraint + index, domain search indexes when absent. On an **existing** non-Vein type it is add-only (missing attributes added, nothing else touched) — which is how a workflow adds `verdict` to a jarvis-seeded `Claim`. Vein's closed registry is refused. Backed by `src/graph/schema-crud.ts`.
- **`graph/edit-edge`** — patch an existing edge's properties by `edge_ref_id` or by the `(source_ref_id, edge_type, target_ref_id)` triple (alias-rewritten, muted edges skipped, ambiguous match is an error). Edge MERGE is ON CREATE only, so this is the only way to change edge data afterwards. Identity stamps are protected; `weight` may be set. Backed by `EdgeWriter.update()`.

Context: porting the Stakwork "research claim → verdict" recipe onto vein's direct-bolt graph needed an `Evidence` type, extra `Claim` attributes, and a way to overwrite `EVIDENCED_BY.strength` after grounding. jarvis is exactly as strict about unknown types/attributes (400s), and its `create_schema_if_missing` is edge-only — these steps fill the node-schema and edge-update halves.

## Test plan

- [x] `npm test` — 622 pass
- [x] `VEIN_TEST_NEO4J_URI=bolt://localhost:7688 VEIN_TEST_NEO4J_PASSWORD=veintest npm run test:graph` — 127 pass (new: `schema-crud.test.ts` pure + live, `EdgeWriter.update` live, both steps in `graph-steps.test.ts`)
- [x] `tsc --noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)