### PR TITLE
vein chat: unstick stale-live chats, make chats run concurrently

### DIFF
--- a/vein/src/ai/notifier.ts
+++ b/vein/src/ai/notifier.ts
@@ -85,6 +85,10 @@ export interface ChatNotifier {
   turnEnded(chatId: string): Promise<void>;
   /** Deliver one notification: queue if a turn is live, else wake now. */
   deliver(chatId: string, text: string): Promise<void>;
+  /** Is a turn for this chat running in THIS process? The authoritative
+   *  liveness check — `meta.status === "live"` on disk can be stale after a
+   *  crash/restart (see `createVein`'s `reconcileStaleChat`). */
+  isLive(chatId: string): boolean;
 }
 
 export function createChatNotifier(opts: {
@@ -140,6 +144,10 @@ export function createChatNotifier(opts: {
   }
 
   return {
+    isLive(chatId) {
+      return live.has(chatId);
+    },
+
     turnStarted(chatId) {
       live.add(chatId);
     },

--- a/vein/src/chat-endpoints.test.ts
+++ b/vein/src/chat-endpoints.test.ts
@@ -128,6 +128,28 @@ describe("chat endpoints", () => {
     assert.ok(text.includes("event: done"), text);
   });
 
+  it("POST /chat is a 409 while that chat has a turn in progress", async () => {
+    const vein = await makeVein();
+    const post = (body: object) =>
+      vein.app.request("/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+    const first = await post({ message: "start" });
+    assert.equal(first.status, 202);
+    const { chatId } = (await first.json()) as { chatId: string };
+
+    // The turn launched by the first POST is live in-process (it will fail
+    // shortly for lack of an API key, but liveness is claimed synchronously).
+    const second = await post({ chatId, message: "again" });
+    assert.equal(second.status, 409);
+
+    // A different chat is unaffected — chats run concurrently.
+    const other = await post({ message: "elsewhere" });
+    assert.equal(other.status, 202);
+  });
+
   it("a chat left live by a dead process is reconciled to error on read", async () => {
     // Simulate a crash mid-turn: meta says live, events.jsonl has no
     // terminal for the turn, and nothing is running in this process.

--- a/vein/src/chat-endpoints.test.ts
+++ b/vein/src/chat-endpoints.test.ts
@@ -128,6 +128,35 @@ describe("chat endpoints", () => {
     assert.ok(text.includes("event: done"), text);
   });
 
+  it("a chat left live by a dead process is reconciled to error on read", async () => {
+    // Simulate a crash mid-turn: meta says live, events.jsonl has no
+    // terminal for the turn, and nothing is running in this process.
+    const vein = await makeVein();
+    await chatStore.createChat({ id: "c1" });
+    await chatStore.setMeta("c1", { status: "live", currentTurn: 0 });
+    await chatStore.appendEvent("c1", {
+      ts: new Date().toISOString(),
+      chatId: "c1",
+      turn: 0,
+      type: "text-delta",
+      delta: "partial",
+    });
+
+    const get = await vein.app.request("/chat/c1");
+    const { meta } = (await get.json()) as { meta: { status: string } };
+    assert.equal(meta.status, "error");
+
+    // The tail now terminates (would hang forever without the synthesized
+    // chat.error) and reports the reconciled status.
+    const res = await vein.app.request("/chat/c1/stream?turn=0");
+    const text = await res.text();
+    assert.ok(text.includes("chat.error"), text);
+    assert.ok(text.includes('"status":"error"'), text);
+
+    const list = (await (await vein.app.request("/chats")).json()) as { status: string }[];
+    assert.equal(list[0]!.status, "error");
+  });
+
   it("GET /chat/:id/stream for a not-yet-started turn sends done immediately", async () => {
     const vein = await makeVein();
     await chatStore.createChat({ id: "c1" }); // currentTurn -1

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -1460,6 +1460,14 @@ export async function createVein<TServices = unknown>(
       if (chatId && !meta) {
         return c.json({ error: `Chat "${chatId}" not found` }, 404);
       }
+      if (meta) {
+        // One turn per chat at a time — two agents appending to the same
+        // transcript would interleave. (Different chats run concurrently.)
+        if (notifier.isLive(meta.id)) {
+          return c.json({ error: `Chat "${meta.id}" has a turn in progress` }, 409);
+        }
+        meta = await reconcileStaleChat(meta);
+      }
       if (!chatId) {
         chatId = generateChatId();
         meta = await chatStore.createChat({

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -11,7 +11,7 @@ import { z } from "zod";
 import type { Flow, StepRegistry, RunEvent, RunResult } from "./core.js";
 import type { RunStore } from "./store.js";
 import { FileRunStore, MemoryRunStore, generateRunId, summarizeFromEvents } from "./store.js";
-import type { ChatStore, ChatEvent } from "./chat-store.js";
+import type { ChatStore, ChatEvent, ChatMeta } from "./chat-store.js";
 import {
   FileChatStore,
   MemoryChatStore,
@@ -1422,6 +1422,32 @@ export async function createVein<TServices = unknown>(
       })();
     }
 
+    /**
+     * A turn that was live when this process died never wrote its
+     * `chat.end`/`chat.error` — `meta.status` stays `"live"` on disk and any
+     * tail of that turn waits forever (which is what pins the UI: the client
+     * treats a live chat as loading until its stream ends). Liveness is only
+     * knowable in-process (`notifier.isLive`), so reconcile lazily on every
+     * read: no running turn → emit the missing terminal and mark the chat
+     * `"error"`. Returns the (possibly patched) meta.
+     */
+    async function reconcileStaleChat(meta: ChatMeta): Promise<ChatMeta> {
+      if (meta.status !== "live" || meta.currentTurn < 0 || notifier.isLive(meta.id)) {
+        return meta;
+      }
+      console.warn(
+        `[chat ${meta.id}] turn ${meta.currentTurn} marked live but no turn is running — interrupted by a restart; marking error.`,
+      );
+      await chatStore.appendEvent(meta.id, {
+        ts: new Date().toISOString(),
+        chatId: meta.id,
+        turn: meta.currentTurn,
+        type: "chat.error",
+        error: { message: "Turn interrupted: the server restarted mid-turn." },
+      });
+      return (await chatStore.setMeta(meta.id, { status: "error" })) ?? meta;
+    }
+
     // Send a message: append it, launch the turn detached, return ids (202).
     app.post("/chat", async (c) => {
       const body = await c.req.json<{ chatId?: string; message?: string; title?: string }>();
@@ -1461,15 +1487,17 @@ export async function createVein<TServices = unknown>(
 
     // List chat sessions (newest first).
     app.get("/chats", async (c) => {
-      return c.json(await chatStore.listChats());
+      const list = await chatStore.listChats();
+      return c.json(await Promise.all(list.map(reconcileStaleChat)));
     });
 
     // Reattach to a chat turn's event stream (live or completed) — SSE tail.
     // Defaults to the latest turn; pass ?turn=N to follow a specific one.
     app.get("/chat/:chatId/stream", async (c) => {
       const chatId = c.req.param("chatId");
-      const meta = await chatStore.getMeta(chatId);
-      if (!meta) return c.json({ error: `Chat "${chatId}" not found` }, 404);
+      const stored = await chatStore.getMeta(chatId);
+      if (!stored) return c.json({ error: `Chat "${chatId}" not found` }, 404);
+      const meta = await reconcileStaleChat(stored);
 
       const turnParam = c.req.query("turn");
       const turn = turnParam != null ? Number(turnParam) : meta.currentTurn;
@@ -1500,8 +1528,9 @@ export async function createVein<TServices = unknown>(
     // Full chat transcript + meta (for reload / reattach).
     app.get("/chat/:chatId", async (c) => {
       const chatId = c.req.param("chatId");
-      const meta = await chatStore.getMeta(chatId);
+      let meta = await chatStore.getMeta(chatId);
       if (!meta) return c.json({ error: `Chat "${chatId}" not found` }, 404);
+      meta = await reconcileStaleChat(meta);
       const messages = await chatStore.loadMessages(chatId);
       return c.json({ meta, messages });
     });

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -450,7 +450,10 @@ export async function sendChat(
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ message, ...(chatId ? { chatId } : {}) }),
   });
-  if (!res.ok) throw new Error(`chat: ${res.status} ${res.statusText}`);
+  if (!res.ok) {
+    // 409 = the chat already has a turn in progress (reattach instead).
+    throw Object.assign(new Error(`chat: ${res.status} ${res.statusText}`), { status: res.status });
+  }
   return (await res.json()) as { chatId: string; turn: number };
 }
 
@@ -470,8 +473,17 @@ export async function streamChat(
   chatId: string,
   turn: number,
   callbacks: ChatCallbacks,
+  signal?: AbortSignal,
 ): Promise<void> {
-  const res = await fetch(`${BASE}/chat/${chatId}/stream?turn=${turn}`);
+  // Aborting detaches this client from the turn — the turn itself keeps
+  // running server-side. Resolves silently (no onFinish) when aborted.
+  let res: Response;
+  try {
+    res = await fetch(`${BASE}/chat/${chatId}/stream?turn=${turn}`, { signal });
+  } catch (err) {
+    if (signal?.aborted) return;
+    throw err;
+  }
   const reader = res.body?.getReader();
   if (!reader) throw new Error("No response body");
 
@@ -483,7 +495,14 @@ export async function streamChat(
   let eventType = "message";
 
   while (true) {
-    const { done, value } = await reader.read();
+    let chunk: ReadableStreamReadResult<Uint8Array>;
+    try {
+      chunk = await reader.read();
+    } catch (err) {
+      if (signal?.aborted) return;
+      throw err;
+    }
+    const { done, value } = chunk;
     if (done) break;
     buf += decoder.decode(value, { stream: true });
     const lines = buf.split("\n");
@@ -509,6 +528,7 @@ export async function streamChat(
     }
   }
 
+  if (signal?.aborted) return;
   callbacks.onFinish(status);
 }
 

--- a/vein/web/src/components/ChatFlyout.tsx
+++ b/vein/web/src/components/ChatFlyout.tsx
@@ -169,6 +169,16 @@ export function ChatFlyout(props: {
   // Highest turn this client has rendered/streamed — the poll below compares
   // against it to notice server-initiated turns (run notifications).
   const seenTurn = useRef(-1);
+  // The stream this client is attached to (at most one). Switching chats or
+  // starting a new one aborts it — the turn keeps running server-side and
+  // `loadChat` reattaches when you come back. Several chats can be live at
+  // once; `loading` only means "the chat I'm LOOKING AT has a live turn".
+  const streamRef = useRef<AbortController | null>(null);
+  const detach = useCallback(() => {
+    streamRef.current?.abort();
+    streamRef.current = null;
+  }, []);
+  useEffect(() => detach, [detach]);
 
   useEffect(() => { inputRef.current?.focus(); }, []);
 
@@ -195,7 +205,7 @@ export function ChatFlyout(props: {
 
   // Build the incremental stream callbacks. Each `step.finish` starts a fresh
   // bubble; tool calls/results also drive the canvas (workflow created/ran).
-  const streamCallbacks = useCallback((): api.ChatCallbacks => {
+  const streamCallbacks = useCallback((signal: AbortSignal): api.ChatCallbacks => {
     let textBuf = "";
     let toolBuf: api.ToolCallInfo[] = [];
     // A trailing text/tool entry may only be replaced in place by the step
@@ -205,6 +215,7 @@ export function ChatFlyout(props: {
     let stepHasToolEntry = false;
     return {
       onTextDelta: (delta) => {
+        if (signal.aborted) return;
         textBuf += delta;
         const content = textBuf;
         const replace = stepHasTextEntry;
@@ -220,6 +231,7 @@ export function ChatFlyout(props: {
         });
       },
       onToolCall: (tc) => {
+        if (signal.aborted) return;
         toolBuf.push(tc);
         if (tc.name === "create_workflow" && tc.input?.name) {
           props.onWorkflowCreated(tc.input.name);
@@ -238,6 +250,7 @@ export function ChatFlyout(props: {
         });
       },
       onToolResult: (tr) => {
+        if (signal.aborted) return;
         if (tr.name === "run_workflow" && tr.input?.name && tr.output?.runId) {
           props.onWorkflowRan(tr.input.name, tr.output.runId);
         }
@@ -249,15 +262,32 @@ export function ChatFlyout(props: {
         stepHasToolEntry = false;
       },
       onFinish: () => {
+        if (signal.aborted) return;
         setLoading(false);
       },
     };
   }, [props.onWorkflowCreated, props.onWorkflowRan]);
 
+  /** Attach to a turn's stream (replacing any current attachment) and
+   *  follow it to its end. */
+  const attach = useCallback(async (id: string, turn: number) => {
+    detach();
+    const ac = new AbortController();
+    streamRef.current = ac;
+    setLoading(true);
+    try {
+      await api.streamChat(id, turn, streamCallbacks(ac.signal), ac.signal);
+    } finally {
+      if (streamRef.current === ac) streamRef.current = null;
+    }
+  }, [detach, streamCallbacks]);
+
   // Load a chat's transcript and — if a turn is still live server-side (we may
   // have closed the tab) — reattach to its stream. Shared by mount-restore and
   // clicking an entry in the history list.
   const loadChat = useCallback(async (id: string) => {
+    detach();
+    setLoading(false);
     setShowHistory(false);
     setExpanded({});
     setChatId(id);
@@ -267,8 +297,7 @@ export function ChatFlyout(props: {
       setEntries(transcriptToEntries(messages));
       seenTurn.current = meta.currentTurn;
       if (meta.status === "live" && meta.currentTurn >= 0) {
-        setLoading(true);
-        await api.streamChat(id, meta.currentTurn, streamCallbacks());
+        await attach(id, meta.currentTurn);
       }
     } catch {
       // Stale id (e.g. workspace wiped) — drop it and start fresh.
@@ -276,7 +305,7 @@ export function ChatFlyout(props: {
       setChatId(null);
       setEntries([]);
     }
-  }, [streamCallbacks]);
+  }, [detach, attach]);
 
   // On mount: restore the persisted chat (if any).
   useEffect(() => {
@@ -298,8 +327,7 @@ export function ChatFlyout(props: {
           seenTurn.current = meta.currentTurn;
           setEntries(transcriptToEntries(messages));
           if (meta.status === "live") {
-            setLoading(true);
-            await api.streamChat(chatId, meta.currentTurn, streamCallbacks());
+            await attach(chatId, meta.currentTurn);
           }
         }
       } catch {
@@ -307,16 +335,20 @@ export function ChatFlyout(props: {
       }
     }, TURN_POLL_MS);
     return () => clearInterval(t);
-  }, [chatId, loading, showHistory, streamCallbacks]);
+  }, [chatId, loading, showHistory, attach]);
 
+  // Always available — a live turn in the current chat keeps running
+  // detached; it's just no longer the one on screen.
   const newChat = useCallback(() => {
+    detach();
+    setLoading(false);
     storage.remove(CHAT_ID_KEY);
     setChatId(null);
     setEntries([]);
     setExpanded({});
     setShowHistory(false);
     seenTurn.current = -1;
-  }, []);
+  }, [detach]);
 
   // Toggle the history list, fetching the latest sessions when opening.
   const toggleHistory = useCallback(async () => {
@@ -347,12 +379,19 @@ export function ChatFlyout(props: {
         storage.save(CHAT_ID_KEY, id);
       }
       seenTurn.current = turn;
-      await api.streamChat(id, turn, streamCallbacks());
-    } catch {
+      await attach(id, turn);
+    } catch (err) {
+      if ((err as { status?: number }).status === 409 && chatId) {
+        // The chat is still working on an earlier message (we were
+        // detached, e.g. after switching away) — reattach, keep the draft.
+        setInput(text);
+        await loadChat(chatId);
+        return;
+      }
       setEntries((prev) => [...prev, { kind: "text", content: "Error connecting to AI." }]);
       setLoading(false);
     }
-  }, [input, loading, chatId, streamCallbacks]);
+  }, [input, loading, chatId, attach, loadChat]);
 
   const handleKeyDown = (e: KeyboardEvent) => {
     if (e.key === "Enter" && !e.shiftKey) {
@@ -388,7 +427,7 @@ export function ChatFlyout(props: {
           >
             <HistoryIcon />
           </button>
-          <button class="btn" onClick={newChat} disabled={loading}>New chat</button>
+          <button class="btn" onClick={newChat}>New chat</button>
           <button class="flyout-close" onClick={props.onClose} aria-label="Close"><CloseIcon /></button>
         </div>
       </div>
@@ -404,6 +443,9 @@ export function ChatFlyout(props: {
                 class={`chat-history-item${ch.id === chatId ? " is-current" : ""}`}
                 onClick={() => loadChat(ch.id)}
               >
+                {ch.status === "live" && (
+                  <span class="chat-history-live" title="Working" aria-label="Working" />
+                )}
                 <span class="chat-history-title">{ch.title || "Untitled chat"}</span>
                 <span class="chat-history-time">{relativeTime(ch.updatedAt)}</span>
               </button>

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -1296,6 +1296,19 @@ body.is-resizing-flyout * {
   font-size: 11px;
   flex-shrink: 0;
 }
+.chat-history-live {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: var(--ok);
+  flex-shrink: 0;
+  align-self: center;
+  animation: chat-live-pulse 1.4s ease-in-out infinite;
+}
+@keyframes chat-live-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.35; }
+}
 
 .chat-msg {
   max-width: 92%;


### PR DESCRIPTION
## Why
Killing the vein server mid-chat-turn leaves that chat's `meta.status` as `"live"` on disk with no `chat.end`/`chat.error` in `events.jsonl`. On reload the web UI restores the persisted chat, sees it live, opens the SSE tail, and waits for a terminal that never comes. `loading` stays true forever, so **New chat**, **Send**, and the textarea are all disabled with no error anywhere.

## Server
- `notifier.isLive(chatId)`: expose the in-process liveness set (the only authoritative signal; disk status can be stale).
- `reconcileStaleChat`: on every chat read (`GET /chat/:id`, `GET /chat/:id/stream`, `GET /chats`), a chat marked live with no running turn gets a synthesized `chat.error` for its current turn and is marked `"error"`. Tails terminate, the client's stream finishes, the UI unlocks.
- `POST /chat` on a chat with an in-process turn is a **409**: one turn per chat at a time (two agents appending to one transcript would interleave). Different chats run concurrently.

## Client
- One `AbortController` per attached stream. **New chat** and switching in history abort the current tail; the turn keeps running server-side and `loadChat` reattaches on return. Stream is also aborted on unmount.
- `loading` now means only "the chat on screen has a live turn". New chat is never disabled.
- History list shows a pulsing dot on live chats.
- A 409 from send (chat still busy after switching away) reattaches and keeps the draft in the input.

## Tests
- Crashed-mid-turn chat is reconciled to `error` by all three reads and its stream ends.
- 409 on a second message to a live chat; a different chat still gets 202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)