### PR TITLE
vein: durable resume never leaves a run stuck

### DIFF
--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -141,6 +141,7 @@ cd vein && npm run dev        # serves API + UI on :3000
 | `VEIN_CHAT_MAX_STEPS` | `30`         | Max agent tool-call iterations per chat turn |
 | `VEIN_CHAT_RUN_WAIT_MS` | `60000`    | How long the chat's `run_workflow` waits before a run auto-detaches (dispatch mode) |
 | `VEIN_CHAT_MAX_AUTO_TURNS` | `10`    | Max consecutive notification-triggered chat turns before the chat parks (runaway guard) |
+| `VEIN_AUTO_RESUME` | `1` (file-backed) | Boot-time auto-resume of runs cut off by a crash/restart (RUN_CONTROL_SPEC §5.3): the newest root run per workflow with a log but no summary, unless paused/cancelling, older than 7 days, or already resumed 5 times. `0` disables. |
 | `NEO4J_URI` / `NEO4J_HOST` | (unset) / `localhost:7687` | Graph backend connection — same names and defaults as mcp's own Neo4j client: `NEO4J_URI` wins, else `bolt://<NEO4J_HOST>`; `NEO4J_USER`/`NEO4J_PASSWORD` default `neo4j`/`testtest`; optional `NEO4J_DATABASE`. The `graph/*` lib steps read these via the secrets capability (secret store → env) and need nothing configured for a local Neo4j; `openGraphBackendFromEnv` stays opt-in (null when neither is set). |
 | `VEIN_GRAPH_NAMESPACE` | `default`   | jarvis namespace every Vein node is written into |
 | `VEIN_GRAPH_EMBEDDINGS` | (on)       | `off` disables the local MiniLM embedder (vectors stay NULL; search is fulltext-only) |

--- a/vein/RUN_CONTROL_SPEC.md
+++ b/vein/RUN_CONTROL_SPEC.md
@@ -260,9 +260,37 @@ step. Three crash-specific hardenings:
   re-execution contract doing its job; steps whose effects must not
   double need their own idempotency (none in the current lab do).
 
-Optionally, the server can offer auto-resume of summary-less runs on
-boot (off by default — a human choosing Resume on a "stale" run is the
-right v1 ergonomics).
+### 5.3 Boot-time auto-resume
+
+IMPLEMENTED (`autoResumeStaleRuns` in `createVein.ts`; on by default for
+a file-backed store, `VEIN_AUTO_RESUME=0` or `autoResume: false` to
+disable; runs a few seconds after construction). The operational goal:
+a long serial workflow must never need to be started over because the
+server restarted.
+
+**Cut off vs. cancelled is knowable.** Cancel and error always FINALIZE
+(`run.cancelled` / `run.error` + `run.json`), so a run with a log and no
+summary died with its process. Two markers close the remaining gaps:
+`run.cancelling` is appended when cancel is REQUESTED (a run that dies
+before reaching its boundary is finalized as cancelled on boot, not
+resumed), and `run.paused` with no later `run.resumed` means a human
+parked it (left alone, resume by hand).
+
+**Roots only.** `run.start` records `parentRunId` for a nested run
+(derived from the controller tree). Boot resumes only root runs: a
+parent re-executing its launching step relaunches its children (§5.1
+at-least-once), so resuming orphaned children would only duplicate work
+that reports to nobody.
+
+**Per workflow, the newest run only**, newest-first by run id. If the
+newest root run has a summary, nothing was cut off. Guards: a log that
+already ends in a terminal event just gets its missing summary written;
+a run whose last event is older than **7 days** is skipped; a run with
+**5** or more `run.resumed` markers is skipped (a step that
+deterministically kills the server must not loop forever). Every
+decision is logged as `[auto-resume] wf/run: resumed|finalized|skipped —
+reason`, and the same DAG resolution as the endpoint applies (pinned
+version by hash; refused, never forced, when no version matches).
 
 ### 5.2 Resume after failure — retry from the failed step
 

--- a/vein/RUN_CONTROL_SPEC.md
+++ b/vein/RUN_CONTROL_SPEC.md
@@ -238,9 +238,15 @@ graceful pause-then-restart merely avoids re-spending the in-flight
 step. Three crash-specific hardenings:
 
 - **Torn tail.** A process killed mid-append can leave a truncated final
-  JSONL line (step outputs are large; single-write atomicity is not
-  guaranteed). The journal reader must skip an unparseable trailing line
-  — it belongs to an incomplete unit by definition.
+  JSONL line (step outputs are large; `appendFile` writes them in several
+  chunks). The resume endpoint HEALS the log first (`store.repairLog`:
+  truncate to the last newline) so the resumed run's first append starts
+  on a fresh line instead of being glued onto the fragment — which would
+  silently drop that event and leave a merged, unparseable line behind.
+  Independently, the readers (`getRunEvents`, `tailEvents`) skip any
+  corrupt line with a warning rather than throwing: a log that cannot be
+  read is a run that is stuck for good, and a corrupt line never belongs
+  to a completed unit.
 - **Durability policy.** `appendFile` lands in the page cache; a whole-
   SYSTEM crash (not a process kill) can lose recently "written" events.
   Option: fsync on `step.end` / run-level events only (the events worth
@@ -323,10 +329,13 @@ transcript per tool call and resume mid-session — deliberately out of
 v1, it drags in provider-state questions the rungs below don't need.
 
 **Validity guards.** Resume refuses when: a live controller exists for
-the runId (it's not dead, pause it instead); the workflow's current
-content hash differs from the one recorded at `run.start` (the runner
+the runId (it's not dead, pause it instead); no stored version of the
+workflow matches the content hash recorded at `run.start` (the runner
 must record it there — replaying outputs into a DIFFERENT DAG is
-undefined; power users may override with an explicit flag); or the run
+undefined; power users may override with an explicit flag). When the
+ACTIVE version's hash differs but an older or pinned version still
+matches, resume runs against that version — a long run must not
+dead-end on "content changed" just because someone published since; or the run
 finished successfully with no `from` invalidation (§5.2 — `error` and
 `cancelled` runs ARE resumable). Registry drift (a custom step edited
 between crash and resume) is allowed but WARNED — steps re-executing

--- a/vein/src/core.ts
+++ b/vein/src/core.ts
@@ -147,7 +147,12 @@ export type RunEventType =
   /** Non-terminal markers so parked time is visible in the log (§4), and so a
    *  `run.resumed` after a terminal event reopens tails (§5.2). */
   | "run.paused"
-  | "run.resumed";
+  | "run.resumed"
+  /** Non-terminal marker: cancel was REQUESTED. The run finalizes as
+   *  `run.cancelled` at its next boundary — but if the process dies first,
+   *  this marker is what tells boot-time auto-resume (§5.3) that the run
+   *  was being cancelled, not cut off. */
+  | "run.cancelling";
 
 /** A single event in the run log. */
 export interface RunEvent {
@@ -169,6 +174,11 @@ export interface RunEvent {
    *  re-executes steps with the SAME knob values the original run used. */
   params?: Record<string, unknown>;
   paramOverrides?: Record<string, Record<string, unknown>>;
+  /** The launching run's id, recorded on `run.start` for a NESTED run (one
+   *  attached under a parent controller — RUN_CONTROL_SPEC §2.2). Absent
+   *  for a root run. Boot-time auto-resume (§5.3) resumes only roots: a
+   *  parent re-executing its launching step relaunches its children. */
+  parentRunId?: string;
   /** Graph nodes this step reported touching (the provenance convention,
    *  plans/generic-storage.md "v2") — lifted verbatim from the output's
    *  `_nodes` marker on `step.end`, exempt from any truncation. The graph

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -124,12 +124,37 @@ export interface VeinOptions<TServices = unknown> {
    *  `VEIN_CHAT_MAX_AUTO_TURNS` or 10. */
   chatMaxAutoTurns?: number;
 
+  /** Boot-time auto-resume of runs cut off by a crash/restart
+   *  (RUN_CONTROL_SPEC §5.3). Defaults to ON for a file-backed store unless
+   *  `VEIN_AUTO_RESUME=0`; pass `false` to disable, or an object to tune
+   *  the guards. Only the NEWEST root run per workflow is considered. */
+  autoResume?: boolean | AutoResumeOptions;
+
   /** Directory containing the built web UI (the `dist` folder). Defaults
    *  to vein's own bundled UI resolved relative to this module, so it
    *  works regardless of the host process's CWD. The built UI uses
    *  relative asset paths, so it can be mounted at any sub-path (e.g.
    *  `/lab`) as long as the host serves it with a trailing slash. */
   webDist?: string;
+}
+
+export interface AutoResumeOptions {
+  /** Ignore cut-off runs whose last event is older than this. Default 7 days. */
+  maxAgeMs?: number;
+  /** Give up on a run that has already been resumed this many times — a step
+   *  that deterministically kills the server must not loop forever. Default 5. */
+  maxResumes?: number;
+  /** Delay after construction before the scan runs (lets the host finish
+   *  booting). Default 3000ms; 0 runs it on the next tick. */
+  delayMs?: number;
+}
+
+/** One line of the boot-time auto-resume report. */
+export interface AutoResumeOutcome {
+  workflow: string;
+  runId: string;
+  action: "resumed" | "finalized" | "skipped";
+  reason: string;
 }
 
 /**
@@ -158,6 +183,13 @@ export interface Vein<TServices = unknown> {
   /** Re-scan the workspace for newly-published custom steps. No-op when
    *  the instance was constructed with an explicit `registry`. */
   rebuildRegistry: () => Promise<void>;
+
+  /** Resume every run cut off by the previous process (RUN_CONTROL_SPEC
+   *  §5.3): the newest root run of each workflow that has a log but no
+   *  summary, was not paused or cancelling, is younger than `maxAgeMs`,
+   *  and has fewer than `maxResumes` prior resumes. Runs automatically
+   *  after boot when `autoResume` is enabled; callable directly. */
+  autoResumeStaleRuns: (opts?: AutoResumeOptions) => Promise<AutoResumeOutcome[]>;
 
   /** Run a workflow by name (resolves through the workspace) or by Flow
    *  object. `services` is auto-injected from the instance; pass a
@@ -353,7 +385,7 @@ export async function createVein<TServices = unknown>(
   const appendControlEvent = async (
     workflow: string,
     runId: string,
-    type: "run.paused" | "run.resumed",
+    type: "run.paused" | "run.resumed" | "run.cancelling",
   ) => {
     await store.append(workflow, runId, {
       ts: new Date().toISOString(),
@@ -603,6 +635,224 @@ export async function createVein<TServices = unknown>(
     return null;
   };
 
+  type PreparedResume = {
+    ok: true;
+    name: string;
+    runId: string;
+    flow: Flow;
+    version?: string;
+    journal: Record<string, unknown>;
+    runStart: NonNullable<ReturnType<typeof readRunStart>>;
+    events: RunEvent[];
+  };
+  type ResumeRefusal = { ok: false; status: 400 | 404 | 409; error: string };
+
+  /** Everything a durable resume (§5) needs, or a refusal with the HTTP
+   *  status it maps to. Shared by the resume endpoint and boot-time
+   *  auto-resume (§5.3). Heals a torn log, recovers the run's input/params
+   *  from `run.start`, resolves the DAG the run actually executed, and
+   *  builds (optionally `from`-invalidated) the journal. */
+  const prepareDurableResume = async (
+    name: string,
+    runId: string,
+    body: { from?: string; force?: boolean },
+  ): Promise<PreparedResume | ResumeRefusal> => {
+    // Crash hardening (§5.1): a kill mid-append leaves a torn final line.
+    // Heal it BEFORE reading, or the resumed run's first append would be
+    // glued onto the fragment and the whole log would turn unreadable.
+    if (await store.repairLog?.(name, runId)) {
+      console.warn(`[run ${runId}] repaired a torn event log before resume`);
+    }
+    const events = await store.getRunEvents(name, runId);
+    const runStart = readRunStart(events);
+    if (!runStart) {
+      return { ok: false, status: 409, error: "Run log has no run.start event — cannot resume" };
+    }
+
+    let flow: Flow;
+    let version: string | undefined;
+    try {
+      flow = await workspace.getWorkflow(name);
+    } catch (err) {
+      return { ok: false, status: 404, error: err instanceof Error ? err.message : String(err) };
+    }
+
+    // Validity guard (§5): replaying outputs into a DIFFERENT DAG is
+    // undefined. When the active version's hash differs from the one
+    // recorded at run.start, resume against the version the run actually
+    // executed if it is still on record (a run of a pinned or since-
+    // superseded version must not dead-end on "content changed"); refuse
+    // only when no stored version matches, unless forced.
+    const currentHash = await workspace.getWorkflowHash(name);
+    if (runStart.workflowHash && currentHash && runStart.workflowHash !== currentHash) {
+      const pinned = await findWorkflowVersionByHash(name, runStart.workflowHash);
+      if (pinned) {
+        flow = await workspace.getWorkflowVersion(name, pinned);
+        version = pinned;
+      } else if (!body.force) {
+        return {
+          ok: false,
+          status: 409,
+          error:
+            `Workflow content changed since this run started (recorded ${runStart.workflowHash}, ` +
+            `active ${currentHash}) and no stored version matches — replaying its journal into a ` +
+            `different DAG is refused. Pass { force: true } to override.`,
+        };
+      }
+    }
+    if (!runStart.workflowHash) {
+      console.warn(
+        `[run ${runId}] no workflow hash recorded at run.start (pre-run-control log) — resuming without the DAG guard`,
+      );
+    }
+
+    let journal = buildJournal(events);
+    if (body.from) {
+      try {
+        const inv = await invalidateFrom(journal, body.from, flow, workspace);
+        journal = inv.journal;
+        for (const w of inv.warnings) console.warn(`[run ${runId}] resume from=${body.from}: ${w}`);
+      } catch (err) {
+        return { ok: false, status: 400, error: err instanceof Error ? err.message : String(err) };
+      }
+    }
+    return { ok: true, name, runId, flow, version, journal, runStart, events };
+  };
+
+  /** Relaunch a prepared durable resume under its ORIGINAL runId (§5). */
+  const launchDurableResume = (p: PreparedResume) => {
+    launchDetached(
+      p.flow,
+      {
+        input: p.runStart.input,
+        runId: p.runId,
+        params: p.runStart.params,
+        paramOverrides: p.runStart.paramOverrides,
+      },
+      { journal: p.journal, resume: true, ...(p.version ? { version: p.version } : {}) },
+    );
+  };
+
+  const isTerminalEvent = (e: RunEvent) =>
+    e.type === "run.end" || e.type === "run.error" || e.type === "run.cancelled";
+
+  /** Write the summary a dead run never got to write: its log already ends
+   *  in a terminal event (crash between the event append and `finalize`),
+   *  or it was cancelling when the process died (finalize as cancelled,
+   *  appending the `run.cancelled` the boundary would have emitted). */
+  const finalizeDeadRun = async (
+    name: string,
+    runId: string,
+    events: RunEvent[],
+    status: "success" | "error" | "cancelled",
+  ) => {
+    const last = events[events.length - 1]!;
+    const start = events.find((e) => e.type === "run.start");
+    if (status === "cancelled" && last.type !== "run.cancelled") {
+      await store.append(name, runId, { ts: new Date().toISOString(), runId, path: name, type: "run.cancelled" });
+    }
+    const startedAt = start?.ts ?? events[0]!.ts;
+    const finishedAt = last.type === "run.end" || last.type === "run.error" || last.type === "run.cancelled"
+      ? last.ts
+      : new Date().toISOString();
+    await store.finalize(name, runId, {
+      runId,
+      workflow: name,
+      startedAt,
+      finishedAt,
+      durationMs: Math.max(0, Date.parse(finishedAt) - Date.parse(startedAt)),
+      status,
+      input: start?.input,
+      ...(status === "success" ? { output: last.output } : {}),
+      ...(status === "error" && last.error ? { error: last.error } : {}),
+    });
+  };
+
+  /** Boot-time auto-resume (RUN_CONTROL_SPEC §5.3). Every run that died
+   *  with the previous process has a log and no summary. For each
+   *  workflow, look only at the NEWEST root run (children are relaunched by
+   *  their parent's re-executed step) and:
+   *    - log already terminal → just write the missing summary;
+   *    - last control marker `run.cancelling` → finalize as cancelled;
+   *    - last control marker `run.paused` → leave parked (a human chose that);
+   *    - older than `maxAgeMs`, or resumed ≥ `maxResumes` times → skip, loudly;
+   *    - otherwise → durable resume, same path as the endpoint. */
+  const autoResumeStaleRuns = async (o: AutoResumeOptions = {}): Promise<AutoResumeOutcome[]> => {
+    const maxAgeMs = o.maxAgeMs ?? 7 * 24 * 60 * 60 * 1000;
+    const maxResumes = o.maxResumes ?? 5;
+    const out: AutoResumeOutcome[] = [];
+    const report = (workflow: string, runId: string, action: AutoResumeOutcome["action"], reason: string) => {
+      out.push({ workflow, runId, action, reason });
+      console.warn(`[auto-resume] ${workflow}/${runId}: ${action} — ${reason}`);
+    };
+
+    let workflows: Array<{ name: string }>;
+    try {
+      workflows = await workspace.listWorkflows();
+    } catch (err) {
+      console.error(`[auto-resume] could not list workflows:`, err);
+      return out;
+    }
+
+    for (const { name } of workflows) {
+      let runIds: string[];
+      try {
+        runIds = await store.listRuns(name); // newest first
+      } catch {
+        continue;
+      }
+      for (const runId of runIds) {
+        if (controllers.has(`${name}/${runId}`)) break; // live in this process
+        if (await store.getRunSummary(name, runId)) break; // newest finished → nothing was cut off
+        await store.repairLog?.(name, runId);
+        const events = await store.getRunEvents(name, runId);
+        const runStart = readRunStart(events);
+        if (!runStart) break; // unreadable / empty — a human's call
+        if (runStart.parentRunId) continue; // nested: its parent relaunches it
+
+        const last = events[events.length - 1]!;
+        if (isTerminalEvent(last)) {
+          const status = last.type === "run.end" ? "success" : last.type === "run.error" ? "error" : "cancelled";
+          await finalizeDeadRun(name, runId, events, status);
+          report(name, runId, "finalized", `log already ended in ${last.type}; wrote the missing summary`);
+          break;
+        }
+        const marker = [...events].reverse().find(
+          (e) => e.type === "run.paused" || e.type === "run.resumed" || e.type === "run.cancelling",
+        );
+        if (marker?.type === "run.cancelling") {
+          await finalizeDeadRun(name, runId, events, "cancelled");
+          report(name, runId, "finalized", "was cancelling when the process died; finalized as cancelled");
+          break;
+        }
+        if (marker?.type === "run.paused") {
+          report(name, runId, "skipped", "was paused when the process died — resume it by hand");
+          break;
+        }
+        const ageMs = Date.now() - Date.parse(last.ts);
+        if (!(ageMs <= maxAgeMs)) {
+          report(name, runId, "skipped", `last event ${Math.round(ageMs / 3_600_000)}h ago exceeds the ${Math.round(maxAgeMs / 3_600_000)}h age cap`);
+          break;
+        }
+        const resumes = events.filter((e) => e.type === "run.resumed").length;
+        if (resumes >= maxResumes) {
+          report(name, runId, "skipped", `already resumed ${resumes} times (cap ${maxResumes}) — a step may be crashing the server; resume by hand`);
+          break;
+        }
+        const prepared = await prepareDurableResume(name, runId, {});
+        if (!prepared.ok) {
+          report(name, runId, "skipped", prepared.error);
+          break;
+        }
+        if (controllers.has(`${name}/${runId}`)) break;
+        launchDurableResume(prepared);
+        report(name, runId, "resumed", `replaying ${Object.keys(prepared.journal).length} journaled step(s)${prepared.version ? ` against version ${prepared.version}` : ""}`);
+        break;
+      }
+    }
+    return out;
+  };
+
   /** Resolve a control request target: its live controller (if any) and
    *  whether the run exists at all. */
   const findRun = async (name: string, runId: string) => {
@@ -623,6 +873,10 @@ export async function createVein<TServices = unknown>(
       );
     }
     controller.cancel();
+    // Marker: if the process dies before the run reaches its boundary and
+    // finalizes as `run.cancelled`, boot-time auto-resume must know this run
+    // was being cancelled, not cut off (§5.3).
+    await appendControlEvent(name, runId, "run.cancelling");
     return c.json({ ok: true, runId, state: controller.state }, 202);
   });
 
@@ -674,82 +928,16 @@ export async function createVein<TServices = unknown>(
       );
     }
 
-    // Crash hardening (§5.1): a kill mid-append leaves a torn final line.
-    // Heal it BEFORE reading, or the resumed run's first append would be
-    // glued onto the fragment and the whole log would turn unreadable.
-    if (await store.repairLog?.(name, runId)) {
-      console.warn(`[run ${runId}] repaired a torn event log before resume`);
-    }
-    const events = await store.getRunEvents(name, runId);
-    const runStart = readRunStart(events);
-    if (!runStart) {
-      return c.json({ error: "Run log has no run.start event — cannot resume" }, 409);
-    }
-
-    let flow: Flow;
-    let version: string | undefined;
-    try {
-      flow = await workspace.getWorkflow(name);
-    } catch (err) {
-      return c.json({ error: err instanceof Error ? err.message : String(err) }, 404);
-    }
-
-    // Validity guard (§5): replaying outputs into a DIFFERENT DAG is
-    // undefined. When the active version's hash differs from the one
-    // recorded at run.start, resume against the version the run actually
-    // executed if it is still on record (a run of a pinned or since-
-    // superseded version must not dead-end on "content changed"); refuse
-    // only when no stored version matches, unless forced.
-    const currentHash = await workspace.getWorkflowHash(name);
-    if (runStart.workflowHash && currentHash && runStart.workflowHash !== currentHash) {
-      const pinned = await findWorkflowVersionByHash(name, runStart.workflowHash);
-      if (pinned) {
-        flow = await workspace.getWorkflowVersion(name, pinned);
-        version = pinned;
-      } else if (!body.force) {
-        return c.json(
-          {
-            error:
-              `Workflow content changed since this run started (recorded ${runStart.workflowHash}, ` +
-              `active ${currentHash}) and no stored version matches — replaying its journal into a ` +
-              `different DAG is refused. Pass { force: true } to override.`,
-          },
-          409,
-        );
-      }
-    }
-    if (!runStart.workflowHash) {
-      console.warn(
-        `[run ${runId}] no workflow hash recorded at run.start (pre-run-control log) — resuming without the DAG guard`,
-      );
-    }
-
-    let journal = buildJournal(events);
-    if (body.from) {
-      try {
-        const inv = await invalidateFrom(journal, body.from, flow, workspace);
-        journal = inv.journal;
-        for (const w of inv.warnings) console.warn(`[run ${runId}] resume from=${body.from}: ${w}`);
-      } catch (err) {
-        return c.json({ error: err instanceof Error ? err.message : String(err) }, 400);
-      }
-    }
+    const prepared = await prepareDurableResume(name, runId, body);
+    if (!prepared.ok) return c.json({ error: prepared.error }, prepared.status);
 
     // Re-check liveness after the awaits above: two concurrent resume
     // requests must not both launch onto the same log.
     if (controllers.has(`${name}/${runId}`)) {
       return c.json({ error: "Resume already in flight for this run" }, 409);
     }
-    launchDetached(
-      flow,
-      {
-        input: runStart.input,
-        runId,
-        params: runStart.params,
-        paramOverrides: runStart.paramOverrides,
-      },
-      { journal, resume: true, ...(version ? { version } : {}) },
-    );
+    const { version, journal } = prepared;
+    launchDurableResume(prepared);
     return c.json({
       ok: true,
       runId,
@@ -1675,6 +1863,22 @@ export async function createVein<TServices = unknown>(
     return p;
   }
 
+  // Boot-time auto-resume (§5.3): on by default for a file-backed store
+  // (an in-memory store cannot hold a cut-off run), off with
+  // `VEIN_AUTO_RESUME=0` or `autoResume: false`. Deferred and unref'd so a
+  // host that constructs vein and exits (tests, CLIs) is never held open.
+  const autoResumeEnabled =
+    opts.autoResume === undefined
+      ? fileBacked && process.env["VEIN_AUTO_RESUME"] !== "0"
+      : opts.autoResume !== false;
+  if (autoResumeEnabled) {
+    const o = typeof opts.autoResume === "object" ? opts.autoResume : {};
+    const timer = setTimeout(() => {
+      void autoResumeStaleRuns(o).catch((err) => console.error(`[auto-resume] scan failed:`, err));
+    }, o.delayMs ?? 3000);
+    timer.unref?.();
+  }
+
   return {
     app,
     workspace,
@@ -1684,6 +1888,7 @@ export async function createVein<TServices = unknown>(
     services,
     getRegistry: () => registry,
     rebuildRegistry,
+    autoResumeStaleRuns,
     run,
     listen,
   };

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -312,7 +312,7 @@ export async function createVein<TServices = unknown>(
   const dataDir =
     opts.dataDir ??
     (fileBacked ? workspace.path : (process.env["VEIN_WORKSPACE"] ?? "./workspace"));
-  const store = opts.store ?? (fileBacked ? new FileRunStore(dataDir) : new MemoryRunStore());
+  const store: RunStore = opts.store ?? (fileBacked ? new FileRunStore(dataDir) : new MemoryRunStore());
   // Controllers for runs currently executing **in this process** (keyed
   // `${workflow}/${runId}`) — RUN_CONTROL_SPEC §2.2. A controller's presence
   // IS "in-flight" (superseding the old `activeRuns` set): detached execution
@@ -588,6 +588,21 @@ export async function createVein<TServices = unknown>(
   // `error`, or `cancelled` run — or, with `from`, re-runs a completed run
   // from a chosen step.
 
+  /** The stored workflow version whose content hash is `hash`, or null.
+   *  Lets a durable resume run against the exact DAG a run executed when
+   *  the active version has since moved on (§5 validity guard). */
+  const findWorkflowVersionByHash = async (name: string, hash: string): Promise<string | null> => {
+    const meta = await workspace.getWorkflowMetadata(name);
+    if (!meta) return null;
+    // Prefer the active version when it matches; then newest first so a
+    // republished identical version wins over an older twin.
+    const labels = Object.keys(meta.versions).sort((a, b) => b.localeCompare(a));
+    for (const v of [meta.active, ...labels]) {
+      if ((await workspace.getWorkflowHash(name, v)) === hash) return v;
+    }
+    return null;
+  };
+
   /** Resolve a control request target: its live controller (if any) and
    *  whether the run exists at all. */
   const findRun = async (name: string, runId: string) => {
@@ -659,6 +674,12 @@ export async function createVein<TServices = unknown>(
       );
     }
 
+    // Crash hardening (§5.1): a kill mid-append leaves a torn final line.
+    // Heal it BEFORE reading, or the resumed run's first append would be
+    // glued onto the fragment and the whole log would turn unreadable.
+    if (await store.repairLog?.(name, runId)) {
+      console.warn(`[run ${runId}] repaired a torn event log before resume`);
+    }
     const events = await store.getRunEvents(name, runId);
     const runStart = readRunStart(events);
     if (!runStart) {
@@ -666,6 +687,7 @@ export async function createVein<TServices = unknown>(
     }
 
     let flow: Flow;
+    let version: string | undefined;
     try {
       flow = await workspace.getWorkflow(name);
     } catch (err) {
@@ -673,18 +695,28 @@ export async function createVein<TServices = unknown>(
     }
 
     // Validity guard (§5): replaying outputs into a DIFFERENT DAG is
-    // undefined — refuse on a content-hash mismatch unless forced.
+    // undefined. When the active version's hash differs from the one
+    // recorded at run.start, resume against the version the run actually
+    // executed if it is still on record (a run of a pinned or since-
+    // superseded version must not dead-end on "content changed"); refuse
+    // only when no stored version matches, unless forced.
     const currentHash = await workspace.getWorkflowHash(name);
-    if (runStart.workflowHash && currentHash && runStart.workflowHash !== currentHash && !body.force) {
-      return c.json(
-        {
-          error:
-            `Workflow content changed since this run started (recorded ${runStart.workflowHash}, ` +
-            `active ${currentHash}) — replaying its journal into a different DAG is refused. ` +
-            `Pass { force: true } to override.`,
-        },
-        409,
-      );
+    if (runStart.workflowHash && currentHash && runStart.workflowHash !== currentHash) {
+      const pinned = await findWorkflowVersionByHash(name, runStart.workflowHash);
+      if (pinned) {
+        flow = await workspace.getWorkflowVersion(name, pinned);
+        version = pinned;
+      } else if (!body.force) {
+        return c.json(
+          {
+            error:
+              `Workflow content changed since this run started (recorded ${runStart.workflowHash}, ` +
+              `active ${currentHash}) and no stored version matches — replaying its journal into a ` +
+              `different DAG is refused. Pass { force: true } to override.`,
+          },
+          409,
+        );
+      }
     }
     if (!runStart.workflowHash) {
       console.warn(
@@ -716,9 +748,15 @@ export async function createVein<TServices = unknown>(
         params: runStart.params,
         paramOverrides: runStart.paramOverrides,
       },
-      { journal, resume: true },
+      { journal, resume: true, ...(version ? { version } : {}) },
     );
-    return c.json({ ok: true, runId, resumed: "journal", replaying: Object.keys(journal).length }, 202);
+    return c.json({
+      ok: true,
+      runId,
+      resumed: "journal",
+      replaying: Object.keys(journal).length,
+      ...(version ? { version } : {}),
+    }, 202);
   });
 
   // Resolve this workflow's declared `promotes` against a run's OUTPUT — the

--- a/vein/src/journal.ts
+++ b/vein/src/journal.ts
@@ -28,6 +28,8 @@ export function readRunStart(
   workflowHash?: string;
   params?: Record<string, unknown>;
   paramOverrides?: Record<string, Record<string, unknown>>;
+  /** Set for a nested run (§5.3: boot-time auto-resume resumes roots only). */
+  parentRunId?: string;
 } | null {
   const start = events.find((e) => e.type === "run.start");
   if (!start) return null;
@@ -36,6 +38,7 @@ export function readRunStart(
     workflowHash: start.workflowHash,
     params: start.params,
     paramOverrides: start.paramOverrides,
+    parentRunId: start.parentRunId,
   };
 }
 

--- a/vein/src/run-control.test.ts
+++ b/vein/src/run-control.test.ts
@@ -837,6 +837,22 @@ describe("durable resume", () => {
 
 // ── Crash hardening: torn tail + tail reopening ────────────────────────────
 
+describe("tree linkage on disk", () => {
+  it("run.start records parentRunId for a nested run, nothing for a root", async () => {
+    const store = new MemoryRunStore();
+    const wf = flow("leaf", { input: z.any(), steps: [step("a", "value", { result: 1 })] });
+    const registry = { value: valueStep } as StepRegistry;
+    const parent = new RunController("parent-run", "parent-wf");
+    const child = new RunController("child-run", "leaf", parent);
+    await runWorkflow(wf, {}, registry, { runId: "child-run", store, controller: child });
+    await runWorkflow(wf, {}, registry, { runId: "root-run", store, controller: parent });
+    const childStart = (await store.getRunEvents("leaf", "child-run")).find((e) => e.type === "run.start")!;
+    const rootStart = (await store.getRunEvents("leaf", "root-run")).find((e) => e.type === "run.start")!;
+    assert.equal(childStart.parentRunId, "parent-run");
+    assert.equal(rootStart.parentRunId, undefined);
+  });
+});
+
 describe("crash hardening", () => {
   it("getRunEvents skips an unparseable trailing line (torn tail)", async () => {
     const dir = join(tmpdir(), `vein-test-${randomUUID()}`);
@@ -978,6 +994,7 @@ describe("run control endpoints", () => {
       registry,
       serveUi: false,
       enableChat: false,
+      autoResume: false, // exercised explicitly via vein.autoResumeStaleRuns()
     });
     const store = vein.store as FileRunStore;
     const cleanup = () => rm(dir, { recursive: true, force: true });
@@ -1278,6 +1295,242 @@ describe("run control endpoints", () => {
     } finally {
       await cleanup();
     }
+  });
+
+  it("POST cancel appends a run.cancelling marker before the run finalizes", async () => {
+    const gate = createGateStep();
+    const { vein, workspace, store, cleanup } = await makeServer({ gate: gate.stepDef });
+    try {
+      await workspace.publishWorkflowByContent(
+        "markme",
+        [
+          "name: markme",
+          "steps:",
+          "  - id: a",
+          "    type: gate",
+          "    config: { name: a }",
+          "  - id: b",
+          "    type: gate",
+          "    config: { name: b }",
+        ].join("\n"),
+      );
+      const launch = await vein.app.request("/workflows/markme/run", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: {} }),
+      });
+      const { runId } = (await launch.json()) as { runId: string };
+      await gate.waitForStart("a");
+      const res = await vein.app.request(`/workflows/markme/runs/${runId}/cancel`, { method: "POST" });
+      assert.equal(res.status, 202);
+      const types = (await store.getRunEvents("markme", runId)).map((e) => e.type);
+      assert.ok(types.includes("run.cancelling"));
+      assert.ok(!types.includes("run.cancelled")); // still parked in the gate
+      gate.release("a");
+      const summary = await waitForSummary(store, "markme", runId);
+      assert.equal(summary.status, "cancelled");
+    } finally {
+      await cleanup();
+    }
+  });
+
+  describe("boot-time auto-resume", () => {
+    const WF = ["name: boot", "steps:", "  - id: one", "    type: counter", "  - id: two", "    type: flakey"].join("\n");
+
+    /** Fabricate the log a crash leaves behind: run.start (+hash), step one
+     *  done, step two started, no run.json. */
+    async function writeCutOffLog(
+      workspace: WorkspaceManager,
+      store: FileRunStore,
+      runId: string,
+      extra: { ts?: string; parentRunId?: string; markers?: RunEvent["type"][]; terminal?: RunEvent["type"] } = {},
+    ) {
+      const ts = extra.ts ?? new Date().toISOString();
+      const ev = (type: RunEvent["type"], path: string, more: Partial<RunEvent> = {}) =>
+        ({ ts, runId, path, type, ...more }) as RunEvent;
+      const workflowHash = (await workspace.getWorkflowHash("boot")) ?? undefined;
+      await store.append("boot", runId, ev("run.start", "boot", { input: {}, workflowHash, ...(extra.parentRunId ? { parentRunId: extra.parentRunId } : {}) }));
+      await store.append("boot", runId, ev("step.end", "boot/one", { stepType: "counter", output: 1 }));
+      for (const m of extra.markers ?? []) await store.append("boot", runId, ev(m, "boot"));
+      await store.append("boot", runId, ev("step.start", "boot/two", { stepType: "flakey" }));
+      if (extra.terminal) await store.append("boot", runId, ev(extra.terminal, "boot", { output: { done: true } }));
+    }
+
+    async function bootServer() {
+      const counter = createCounterStep();
+      const flakey = createFlakeyStep(0);
+      const made = await makeServer({ counter: counter.stepDef, flakey: flakey.stepDef });
+      await made.workspace.publishWorkflowByContent("boot", WF);
+      return { ...made, counter, flakey };
+    }
+
+    it("resumes the newest cut-off root run: replays `one`, re-runs `two`, finalizes", async () => {
+      const { vein, workspace, store, counter, flakey, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000");
+        const report = await vein.autoResumeStaleRuns();
+        assert.deepEqual(report.map((r) => [r.runId, r.action]), [["1000", "resumed"]]);
+        const summary = await waitForSummary(store, "boot", "1000");
+        assert.equal(summary.status, "success");
+        assert.equal(counter.calls(), 0); // replayed
+        assert.equal(flakey.attempts(), 1); // re-executed
+        const types = (await store.getRunEvents("boot", "1000")).map((e) => e.type);
+        assert.ok(types.includes("run.resumed"));
+        // Idempotent: a second scan finds the summary and does nothing.
+        assert.deepEqual(await vein.autoResumeStaleRuns(), []);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("only the newest run counts: an older cut-off run behind a finished one is left alone", async () => {
+      const { vein, workspace, store, flakey, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000");
+        // A newer, completed run.
+        const launch = await vein.app.request("/workflows/boot/run", {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ input: {} }),
+        });
+        const { runId } = (await launch.json()) as { runId: string };
+        await waitForSummary(store, "boot", runId);
+        const before = flakey.attempts();
+        assert.deepEqual(await vein.autoResumeStaleRuns(), []);
+        assert.equal(flakey.attempts(), before);
+        assert.equal(await store.getRunSummary("boot", "1000"), null);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("skips nested runs (parentRunId) — the parent relaunches them", async () => {
+      const { vein, workspace, store, flakey, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "2000", { parentRunId: "some-parent" });
+        await writeCutOffLog(workspace, store, "1000"); // older ROOT run — still resumed
+        const report = await vein.autoResumeStaleRuns();
+        assert.deepEqual(report.map((r) => [r.runId, r.action]), [["1000", "resumed"]]);
+        await waitForSummary(store, "boot", "1000");
+        assert.equal(flakey.attempts(), 1);
+        assert.equal(await store.getRunSummary("boot", "2000"), null);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("finalizes a run that was cancelling when the process died, instead of resuming it", async () => {
+      const { vein, workspace, store, flakey, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000", { markers: ["run.cancelling"] });
+        const report = await vein.autoResumeStaleRuns();
+        assert.equal(report[0]!.action, "finalized");
+        const summary = await store.getRunSummary("boot", "1000");
+        assert.equal(summary?.status, "cancelled");
+        assert.equal(flakey.attempts(), 0);
+        const types = (await store.getRunEvents("boot", "1000")).map((e) => e.type);
+        assert.equal(types[types.length - 1], "run.cancelled");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("leaves a paused run parked", async () => {
+      const { vein, workspace, store, flakey, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000", { markers: ["run.paused"] });
+        const report = await vein.autoResumeStaleRuns();
+        assert.equal(report[0]!.action, "skipped");
+        assert.match(report[0]!.reason, /paused/);
+        assert.equal(flakey.attempts(), 0);
+        assert.equal(await store.getRunSummary("boot", "1000"), null);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("a pause that was later resumed does not count as parked", async () => {
+      const { vein, workspace, store, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000", { markers: ["run.paused", "run.resumed"] });
+        const report = await vein.autoResumeStaleRuns();
+        assert.equal(report[0]!.action, "resumed");
+        await waitForSummary(store, "boot", "1000");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("writes the missing summary when the log already ended in run.end", async () => {
+      const { vein, workspace, store, flakey, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000", { terminal: "run.end" });
+        const report = await vein.autoResumeStaleRuns();
+        assert.equal(report[0]!.action, "finalized");
+        const summary = await store.getRunSummary("boot", "1000");
+        assert.equal(summary?.status, "success");
+        assert.deepEqual(summary?.output, { done: true });
+        assert.equal(flakey.attempts(), 0);
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("skips a run older than the age cap", async () => {
+      const { vein, workspace, store, flakey, cleanup } = await bootServer();
+      try {
+        const eightDaysAgo = new Date(Date.now() - 8 * 24 * 3_600_000).toISOString();
+        await writeCutOffLog(workspace, store, "1000", { ts: eightDaysAgo });
+        const report = await vein.autoResumeStaleRuns();
+        assert.equal(report[0]!.action, "skipped");
+        assert.match(report[0]!.reason, /age cap/);
+        assert.equal(flakey.attempts(), 0);
+        // A wider cap resumes it.
+        const again = await vein.autoResumeStaleRuns({ maxAgeMs: 30 * 24 * 3_600_000 });
+        assert.equal(again[0]!.action, "resumed");
+        await waitForSummary(store, "boot", "1000");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("gives up after maxResumes prior resumes (crash-loop guard)", async () => {
+      const { vein, workspace, store, flakey, cleanup } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000", {
+          markers: ["run.resumed", "run.resumed", "run.resumed", "run.resumed", "run.resumed"],
+        });
+        const report = await vein.autoResumeStaleRuns();
+        assert.equal(report[0]!.action, "skipped");
+        assert.match(report[0]!.reason, /resumed 5 times/);
+        assert.equal(flakey.attempts(), 0);
+        // Four prior resumes is still under the cap.
+        await writeCutOffLog(workspace, store, "3000", {
+          markers: ["run.resumed", "run.resumed", "run.resumed", "run.resumed"],
+        });
+        const again = await vein.autoResumeStaleRuns();
+        assert.deepEqual(again.map((r) => [r.runId, r.action]), [["3000", "resumed"]]);
+        await waitForSummary(store, "boot", "3000");
+      } finally {
+        await cleanup();
+      }
+    });
+
+    it("refuses (never forces) when no stored version matches the recorded hash", async () => {
+      const { vein, workspace, store, flakey, cleanup, dir } = await bootServer();
+      try {
+        await writeCutOffLog(workspace, store, "1000");
+        const file = join(dir, "workflows", "boot", "runs", "1000", "events.jsonl");
+        const raw = await readFile(file, "utf-8");
+        await writeFile(file, raw.replace(/"workflowHash":"[^"]+"/, '"workflowHash":"deadbeef"'), "utf-8");
+        const report = await vein.autoResumeStaleRuns();
+        assert.equal(report[0]!.action, "skipped");
+        assert.match(report[0]!.reason, /no stored version matches/);
+        assert.equal(flakey.attempts(), 0);
+      } finally {
+        await cleanup();
+      }
+    });
   });
 
   it("POST resume with `from` re-runs a completed run from a chosen step", async () => {

--- a/vein/src/run-control.test.ts
+++ b/vein/src/run-control.test.ts
@@ -867,6 +867,54 @@ describe("crash hardening", () => {
     await rm(dir, { recursive: true, force: true });
   });
 
+  it("repairLog truncates a torn tail so the next append lands on its own line", async () => {
+    const dir = join(tmpdir(), `vein-test-${randomUUID()}`);
+    const store = new FileRunStore(dir);
+    const ev = (type: RunEvent["type"], path: string, extra: Partial<RunEvent> = {}) =>
+      ({ ts: "t", runId: "r1", path, type, ...extra }) as RunEvent;
+    await store.append("wf", "r1", ev("run.start", "wf", { input: {} }));
+    await store.append("wf", "r1", ev("step.end", "wf/a", { output: 1 }));
+    const file = join(dir, "workflows", "wf", "runs", "r1", "events.jsonl");
+    // SIGKILL mid-append: a large step.end cut off with no newline.
+    await appendFile(file, '{"ts":"t","runId":"r1","path":"wf/b","type":"step.end","output":"' + "x".repeat(200_000), "utf-8");
+
+    assert.equal(await store.repairLog("wf", "r1"), true);
+    assert.equal(await store.repairLog("wf", "r1"), false); // idempotent
+
+    // What a durable resume does next: append past the crash point.
+    await store.append("wf", "r1", ev("run.resumed", "wf"));
+    await store.append("wf", "r1", ev("step.replayed", "wf/a", { output: 1 }));
+    const events = await store.getRunEvents("wf", "r1");
+    assert.deepEqual(
+      events.map((e) => e.type),
+      ["run.start", "step.end", "run.resumed", "step.replayed"],
+    );
+    const tailed: string[] = [];
+    for await (const e of store.tailEvents("wf", "r1", { intervalMs: 10, signal: AbortSignal.timeout(300) })) {
+      tailed.push(e.type);
+    }
+    assert.deepEqual(tailed, ["run.start", "step.end", "run.resumed", "step.replayed"]);
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("getRunEvents and tailEvents skip a corrupt line anywhere (a log never becomes unreadable)", async () => {
+    const dir = join(tmpdir(), `vein-test-${randomUUID()}`);
+    const store = new FileRunStore(dir);
+    const ev = (type: RunEvent["type"], path: string) => ({ ts: "t", runId: "r1", path, type }) as RunEvent;
+    await store.append("wf", "r1", ev("run.start", "wf"));
+    const file = join(dir, "workflows", "wf", "runs", "r1", "events.jsonl");
+    // A torn fragment that a later append got glued onto (the pre-repairLog failure mode).
+    await appendFile(file, '{"ts":"t","runId":"r1","path":"wf/b","type":"step.e{"ts":"t","type":"run.resumed"}\n', "utf-8");
+    await store.append("wf", "r1", ev("run.end", "wf"));
+
+    const events = await store.getRunEvents("wf", "r1");
+    assert.deepEqual(events.map((e) => e.type), ["run.start", "run.end"]);
+    const tailed: string[] = [];
+    for await (const e of store.tailEvents("wf", "r1", { intervalMs: 10 })) tailed.push(e.type);
+    assert.deepEqual(tailed, ["run.start", "run.end"]);
+    await rm(dir, { recursive: true, force: true });
+  });
+
   it("tailEvents scans past run.error when a run.resumed follows (historical reopen)", async () => {
     const dir = join(tmpdir(), `vein-test-${randomUUID()}`);
     const store = new FileRunStore(dir);
@@ -933,7 +981,23 @@ describe("run control endpoints", () => {
     });
     const store = vein.store as FileRunStore;
     const cleanup = () => rm(dir, { recursive: true, force: true });
-    return { vein, workspace, store, cleanup };
+    return { vein, workspace, store, dir, cleanup };
+  }
+
+  /** Poll a run's log until `pred` holds (a resumed run's run.json already
+   *  exists, so completion is observed on the log, not the summary). */
+  async function waitForLog(
+    store: FileRunStore,
+    wf: string,
+    runId: string,
+    pred: (events: RunEvent[]) => boolean,
+  ) {
+    const deadline = Date.now() + 3000;
+    for (;;) {
+      if (pred(await store.getRunEvents(wf, runId))) return;
+      if (Date.now() > deadline) throw new Error("waitForLog timed out");
+      await sleep(10);
+    }
   }
 
   async function waitForSummary(store: FileRunStore, wf: string, runId: string) {
@@ -1058,7 +1122,7 @@ describe("run control endpoints", () => {
   it("POST resume durably resumes a failed run (replay + retry) and enforces the hash guard", async () => {
     const counter = createCounterStep();
     const flakey = createFlakeyStep(1);
-    const { vein, workspace, store, cleanup } = await makeServer({
+    const { vein, workspace, store, dir, cleanup } = await makeServer({
       counter: counter.stepDef,
       flakey: flakey.stepDef,
     });
@@ -1111,7 +1175,11 @@ describe("run control endpoints", () => {
       });
       assert.equal(refuse.status, 400);
 
-      // Hash guard: publish a CHANGED active version → resume with `from` is refused…
+      // Hash guard: publish a CHANGED active version. The run's recorded hash
+      // still matches the stored v1, so resume runs against v1 — the run
+      // must not dead-end on "content changed" just because the active
+      // version moved on.
+      const v1 = (await workspace.getWorkflowMetadata("resumable"))!.active;
       await workspace.publishWorkflowByContent(
         "resumable",
         [
@@ -1126,12 +1194,87 @@ describe("run control endpoints", () => {
           "    config: { result: changed }",
         ].join("\n"),
       );
+      const pinned = await vein.app.request(`/workflows/resumable/runs/${runId}/resume`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ from: "resumable/two" }),
+      });
+      assert.equal(pinned.status, 202);
+      assert.equal(((await pinned.json()) as { version?: string }).version, v1);
+      await waitForLog(store, "resumable", runId, (evts) =>
+        evts.filter((e) => e.type === "run.resumed").length === 2 && evts[evts.length - 1]!.type === "run.end");
+      assert.equal(flakey.attempts(), 3);
+      const evts = await store.getRunEvents("resumable", runId);
+      // v1's DAG: no `three` step ran, and the run completed again.
+      assert.ok(!evts.some((e) => e.path === "resumable/three"));
+      assert.equal(evts[evts.length - 1]!.type, "run.end");
+
+      // No stored version matches the recorded hash → refused without force.
+      const file = join(dir, "workflows", "resumable", "runs", runId, "events.jsonl");
+      const raw = await readFile(file, "utf-8");
+      await writeFile(file, raw.replace(/"workflowHash":"[^"]+"/, '"workflowHash":"deadbeef"'), "utf-8");
       const mismatch = await vein.app.request(`/workflows/resumable/runs/${runId}/resume`, {
         method: "POST",
         headers: { "content-type": "application/json" },
         body: JSON.stringify({ from: "resumable/two" }),
       });
       assert.equal(mismatch.status, 409);
+      const forced = await vein.app.request(`/workflows/resumable/runs/${runId}/resume`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ from: "resumable/two", force: true }),
+      });
+      assert.equal(forced.status, 202);
+      await waitForLog(store, "resumable", runId, (evts) =>
+        evts.filter((e) => e.type === "run.resumed").length === 3 && evts[evts.length - 1]!.type === "run.end");
+      assert.equal(flakey.attempts(), 4);
+    } finally {
+      await cleanup();
+    }
+  });
+
+  it("POST resume heals a torn log (crash mid-append) and the resumed log stays readable", async () => {
+    const counter = createCounterStep();
+    const flakey = createFlakeyStep(1);
+    const { vein, workspace, store, dir, cleanup } = await makeServer({
+      counter: counter.stepDef,
+      flakey: flakey.stepDef,
+    });
+    try {
+      await workspace.publishWorkflowByContent(
+        "torn",
+        ["name: torn", "steps:", "  - id: one", "    type: counter", "  - id: two", "    type: flakey"].join("\n"),
+      );
+      const launch = await vein.app.request("/workflows/torn/run", {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ input: {} }),
+      });
+      const { runId } = (await launch.json()) as { runId: string };
+      assert.equal((await waitForSummary(store, "torn", runId)).status, "error");
+
+      // Make it look like the process died mid-append: no run.json, torn tail.
+      const runDir = join(dir, "workflows", "torn", "runs", runId);
+      await rm(join(runDir, "run.json"));
+      await appendFile(join(runDir, "events.jsonl"), '{"ts":"t","runId":"' + runId + '","path":"torn/two","type":"step.end","output":{"partial', "utf-8");
+
+      const resume = await vein.app.request(`/workflows/torn/runs/${runId}/resume`, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      assert.equal(resume.status, 202);
+      const summary = await waitForSummary(store, "torn", runId);
+      assert.equal(summary.status, "success");
+      assert.equal(counter.calls(), 1);
+
+      const types = (await store.getRunEvents("torn", runId)).map((e) => e.type);
+      assert.ok(types.includes("run.resumed"), `run.resumed survived: ${types.join(",")}`);
+      assert.ok(types.includes("step.replayed"));
+      assert.equal(types[types.length - 1], "run.end");
+      // No partial-JSON garbage left in the log.
+      const raw = await readFile(join(runDir, "events.jsonl"), "utf-8");
+      for (const line of raw.split("\n").filter(Boolean)) JSON.parse(line);
     } finally {
       await cleanup();
     }

--- a/vein/src/runner.ts
+++ b/vein/src/runner.ts
@@ -166,6 +166,9 @@ export async function runWorkflow<TServices = unknown>(
       path: wfName,
       input: parsedInput,
       ...(opts?.workflowHash ? { workflowHash: opts.workflowHash } : {}),
+      // Tree linkage on disk: a nested run names its parent so boot-time
+      // auto-resume can tell roots from children (§5.3).
+      ...(opts?.controller?.parent ? { parentRunId: opts.controller.parent.runId } : {}),
       // Recorded so a durable resume re-executes with the same knob values.
       ...(opts?.params ? { params: opts.params } : {}),
       ...(opts?.paramOverrides ? { paramOverrides: opts.paramOverrides } : {}),

--- a/vein/src/store.ts
+++ b/vein/src/store.ts
@@ -20,6 +20,20 @@ function reopensRun(event: RunEvent): boolean {
   return event.type === "run.resumed";
 }
 
+/** Parse one JSONL line, or `undefined` (with a warning) when it is not
+ *  valid JSON. A corrupt line — a torn tail from a crash mid-append, or a
+ *  line another append got glued onto — belongs to no completed unit, so
+ *  readers skip it rather than failing: a run's log must never become
+ *  unreadable, or the run is stuck (unresumable, untailable) for good. */
+function parseJsonlLine<T>(line: string, file: string): T | undefined {
+  try {
+    return JSON.parse(line) as T;
+  } catch {
+    console.warn(`[store] skipping corrupt line in ${file} (${line.length} bytes)`);
+    return undefined;
+  }
+}
+
 /**
  * Generic tail of an append-only JSONL file: yield every parsed line from the
  * start of the file (history), then follow appends (live) until `isTerminal`
@@ -91,7 +105,8 @@ export async function* tailJsonl<T>(
         leftover = leftover.slice(nl + 1);
         for (const line of complete.split("\n")) {
           if (!line) continue;
-          const event = JSON.parse(line) as T;
+          const event = parseJsonlLine<T>(line, file);
+          if (event === undefined) continue; // corrupt line — skip, keep tailing
           yield event;
           if (isTerminal(event)) {
             if (!opts.reopens) return;
@@ -158,6 +173,12 @@ export interface RunStore {
   tailEvents(workflow: string, runId: string, opts?: TailOpts): AsyncGenerator<RunEvent>;
   /** Start time (epoch ms) of the most recent run, or null if never run. */
   lastRunAt(workflow: string): Promise<number | null>;
+  /** Heal a log left torn by a crash mid-append (a truncated final line with
+   *  no newline) so the next append starts on a fresh line instead of being
+   *  glued onto the fragment. Called before a durable resume; returns true
+   *  when something was repaired. Optional — backends whose appends are
+   *  atomic (in-memory, a database row) have nothing to heal. */
+  repairLog?(workflow: string, runId: string): Promise<boolean>;
 }
 
 /**
@@ -373,29 +394,69 @@ export class FileRunStore implements RunStore {
     yield* tailJsonl<RunEvent>(file, isTerminal, { ...opts, reopens: reopensRun });
   }
 
-  /** Read events.jsonl for a specific run. Tolerates a TORN TAIL: a process
-   *  killed mid-append can leave a truncated final line (single-write
-   *  atomicity is not guaranteed for large outputs) — it belongs to an
-   *  incomplete unit by definition, so it is skipped, not fatal (§5.1). */
+  /** Truncate a torn tail (§5.1): a process killed mid-append — `appendFile`
+   *  writes large outputs in several chunks — leaves a partial final line
+   *  with no newline. Left alone, the resumed run's first append would be
+   *  glued onto it, silently losing that event and making the merged line
+   *  unparseable. Drop everything after the last newline; the fragment
+   *  belongs to an incomplete unit by definition. */
+  async repairLog(workflow: string, runId: string): Promise<boolean> {
+    const file = join(this.runDir(workflow, runId), "events.jsonl");
+    let fh;
+    try {
+      fh = await open(file, "r+");
+    } catch {
+      return false; // no log yet — nothing to heal
+    }
+    try {
+      const { size } = await fh.stat();
+      if (size === 0) return false;
+      const tail = Buffer.alloc(1);
+      await fh.read(tail, 0, 1, size - 1);
+      if (tail[0] === 0x0a) return false; // ends in "\n" — intact
+      // Walk back to the last newline (reading in blocks from the end).
+      const block = 64 * 1024;
+      let end = size;
+      let cut = 0;
+      while (end > 0) {
+        const start = Math.max(0, end - block);
+        const buf = Buffer.alloc(end - start);
+        await fh.read(buf, 0, buf.length, start);
+        const nl = buf.lastIndexOf(0x0a);
+        if (nl >= 0) {
+          cut = start + nl + 1;
+          break;
+        }
+        end = start;
+      }
+      await fh.truncate(cut);
+      console.warn(
+        `[store] repaired torn tail of ${workflow}/${runId}: dropped ${size - cut} bytes after the last complete event`,
+      );
+      return true;
+    } finally {
+      await fh.close();
+    }
+  }
+
+  /** Read events.jsonl for a specific run. Tolerates corrupt lines — a
+   *  torn tail from a crash mid-append (§5.1), or any line that failed to
+   *  parse — by skipping them with a warning: an unreadable log would leave
+   *  the run stuck (unresumable, unlistable), and a corrupt line never
+   *  belongs to a completed unit. */
   async getRunEvents(workflow: string, runId: string): Promise<RunEvent[]> {
+    const file = join(this.runDir(workflow, runId), "events.jsonl");
     let raw: string;
     try {
-      raw = await readFile(
-        join(this.runDir(workflow, runId), "events.jsonl"),
-        "utf-8",
-      );
+      raw = await readFile(file, "utf-8");
     } catch {
       return [];
     }
-    const lines = raw.trim().split("\n").filter(Boolean);
     const events: RunEvent[] = [];
-    for (let i = 0; i < lines.length; i++) {
-      try {
-        events.push(JSON.parse(lines[i]!) as RunEvent);
-      } catch (err) {
-        if (i === lines.length - 1) continue; // torn tail — skip
-        throw err; // corruption anywhere else is a real error
-      }
+    for (const line of raw.split("\n")) {
+      if (!line.trim()) continue;
+      const event = parseJsonlLine<RunEvent>(line, file);
+      if (event !== undefined) events.push(event);
     }
     return events;
   }


### PR DESCRIPTION
## Summary

Goal: a long serial workflow that crashes must always be resumable from its log, and after a server restart it should pick itself back up. Not thrifty replay, just never a "start over" state.

### Commit 1: never stuck
- **Torn-tail corruption (real bug, repro'd).** A kill mid-append leaves a truncated final line. The reader skipped it, but resume then appended `run.resumed` onto the fragment: that event was silently lost, and once the next event landed the merged line was no longer last, so `getRunEvents` and `tailEvents` threw. The run was unreadable, untailable, and unresumable for good. Fix: `FileRunStore.repairLog` truncates to the last newline and the resume path calls it before reading.
- **Readers never throw on a bad line.** `getRunEvents` and `tailJsonl` skip a corrupt line anywhere with a warning. Also self-heals logs already corrupted this way.
- **Version-pinned resume.** When the active version's hash differs from the one recorded at `run.start`, resume runs against the stored version whose hash matches instead of 409ing. Only an unmatched hash is refused (still overridable with `force`).

### Commit 2: boot-time auto-resume (spec §5.3)
- On boot (file-backed store; `VEIN_AUTO_RESUME=0` or `autoResume: false` disables; `vein.autoResumeStaleRuns()` callable directly) resume, per workflow, the **newest root run** with a log but no summary.
- **Cut off vs cancelled is knowable.** Cancel/error always finalize. New `run.cancelling` marker on cancel request: a run that dies before its boundary is finalized as cancelled on boot, not resumed. `run.paused` with no later `run.resumed` is left parked.
- **Roots only.** `run.start` records `parentRunId` (derived from the controller tree). Children are relaunched by the parent's re-executed step.
- **Guards.** 7-day age cap; give up after 5 prior resumes (crash-loop guard); a log that already ends terminal just gets its missing summary; DAG resolved by hash, never forced. Every decision logged as `[auto-resume] wf/run: resumed|finalized|skipped — reason`.
- Endpoint and boot scan share one `prepareDurableResume`.

## Test plan
- [x] Store: repairLog truncates and is idempotent; readers skip a glued/corrupt line.
- [x] Endpoint: resume of a torn, summary-less log succeeds and leaves a clean log; changed active version resumes against v1; tampered hash 409s; `force` overrides; cancel appends `run.cancelling`.
- [x] Runner: nested runs record `parentRunId`, roots don't.
- [x] Auto-resume: resumes newest cut-off root; ignores an older cut-off run behind a finished one; skips children; finalizes cancelling as cancelled; leaves paused parked; pause-then-resume not parked; writes missing summary for a terminal log; age cap (and override); 5-resume cap (4 still resumes); unmatched hash skipped.
- [x] `npm test` in vein: 639 pass, 0 fail. mcp lab typechecks against the rebuilt vein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)