### PR TITLE
vein chat: tool results in the flyout + 50k tool-result replay cap (env)

### DIFF
--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -140,6 +140,7 @@ cd vein && npm run dev        # serves API + UI on :3000
 | `VEIN_CHAT_MODEL`   | `claude-sonnet-5` | Anthropic model for the AI-builder chat agent |
 | `VEIN_CHAT_MAX_STEPS` | `30`         | Max agent tool-call iterations per chat turn |
 | `VEIN_CHAT_RUN_WAIT_MS` | `60000`    | How long the chat's `run_workflow` waits before a run auto-detaches (dispatch mode) |
+| `VEIN_CHAT_TOOL_RESULT_MAX_CHARS` | `50000` | Per-string cap on tool RESULTS in the history re-fed to the model on later turns (the turn that ran the tool always sees the full result; disk stays lossless). `0` disables. |
 | `VEIN_CHAT_MAX_AUTO_TURNS` | `10`    | Max consecutive notification-triggered chat turns before the chat parks (runaway guard) |
 | `NEO4J_URI` / `NEO4J_HOST` | (unset) / `localhost:7687` | Graph backend connection — same names and defaults as mcp's own Neo4j client: `NEO4J_URI` wins, else `bolt://<NEO4J_HOST>`; `NEO4J_USER`/`NEO4J_PASSWORD` default `neo4j`/`testtest`; optional `NEO4J_DATABASE`. The `graph/*` lib steps read these via the secrets capability (secret store → env) and need nothing configured for a local Neo4j; `openGraphBackendFromEnv` stays opt-in (null when neither is set). |
 | `VEIN_GRAPH_NAMESPACE` | `default`   | jarvis namespace every Vein node is written into |
@@ -598,7 +599,9 @@ services bag can override it, same as `http`/`secrets`).
   `tailJsonl` in `store.ts` (used by both `FileRunStore.tailEvents`
   and `FileChatStore`). `messages.jsonl` stays lossless on disk;
   `truncateToolMessages` trims long `role:"tool"` results only in the
-  copy re-fed to the model (token hygiene for long autonomous loops).
+  copy re-fed to the model on LATER turns (token hygiene for long
+  autonomous loops; env `VEIN_CHAT_TOOL_RESULT_MAX_CHARS`, default 50000,
+  `0` disables).
   `chatMaxSteps` (env `VEIN_CHAT_MAX_STEPS`, default 30) bounds the
   per-turn agent loop. The browser (`web/src/api.ts`: `sendChat` +
   `streamChat` + `getChat`) persists the active `chatId` in

--- a/vein/src/chat-store.test.ts
+++ b/vein/src/chat-store.test.ts
@@ -9,6 +9,8 @@ import {
   FileChatStore,
   MemoryChatStore,
   truncateToolMessages,
+  DEFAULT_TOOL_RESULT_MAX_CHARS,
+  toolResultMaxCharsFromEnv,
   isChatTerminal,
   generateChatId,
   type ChatEvent,
@@ -195,6 +197,29 @@ describe("truncateToolMessages", () => {
   it("leaves short tool content unchanged", () => {
     const msgs = [{ role: "tool", content: [{ type: "tool-result", output: "ok" }] }];
     assert.deepEqual(truncateToolMessages(msgs, 4000), msgs);
+  });
+
+  it("defaults to 50k chars and can be disabled with 0", () => {
+    const big = "x".repeat(60_000);
+    const msgs = [{ role: "tool", content: [{ type: "tool-result", output: big }] }];
+    assert.equal(DEFAULT_TOOL_RESULT_MAX_CHARS, 50_000);
+    assert.ok(((truncateToolMessages(msgs)[0]!.content as any)[0].output as string).includes("[TRUNCATED"));
+    assert.deepEqual(truncateToolMessages(msgs, 0), msgs);
+  });
+
+  it("reads the cap from VEIN_CHAT_TOOL_RESULT_MAX_CHARS", () => {
+    const prev = process.env["VEIN_CHAT_TOOL_RESULT_MAX_CHARS"];
+    try {
+      process.env["VEIN_CHAT_TOOL_RESULT_MAX_CHARS"] = "10";
+      assert.equal(toolResultMaxCharsFromEnv(), 10);
+      process.env["VEIN_CHAT_TOOL_RESULT_MAX_CHARS"] = "garbage";
+      assert.equal(toolResultMaxCharsFromEnv(), DEFAULT_TOOL_RESULT_MAX_CHARS);
+      delete process.env["VEIN_CHAT_TOOL_RESULT_MAX_CHARS"];
+      assert.equal(toolResultMaxCharsFromEnv(), DEFAULT_TOOL_RESULT_MAX_CHARS);
+    } finally {
+      if (prev === undefined) delete process.env["VEIN_CHAT_TOOL_RESULT_MAX_CHARS"];
+      else process.env["VEIN_CHAT_TOOL_RESULT_MAX_CHARS"] = prev;
+    }
   });
 });
 

--- a/vein/src/chat-store.ts
+++ b/vein/src/chat-store.ts
@@ -76,6 +76,8 @@ export interface ChatEvent {
   toolCallId?: string;
   input?: unknown;
   output?: unknown;
+  /** tool-output: the tool threw (output is the error message). */
+  isError?: boolean;
   /** chat.error */
   error?: { message: string };
 }
@@ -113,19 +115,33 @@ export interface ChatStore {
 
 // ── Tool-result truncation (token hygiene for long autonomous loops) ────────
 
+/** Default per-string cap for `truncateToolMessages`. Env
+ *  `VEIN_CHAT_TOOL_RESULT_MAX_CHARS` overrides it; `0` disables truncation. */
+export const DEFAULT_TOOL_RESULT_MAX_CHARS = 50_000;
+
+/** Resolve the tool-result cap from the environment (see above). */
+export function toolResultMaxCharsFromEnv(): number {
+  const raw = process.env["VEIN_CHAT_TOOL_RESULT_MAX_CHARS"];
+  if (raw === undefined || raw === "") return DEFAULT_TOOL_RESULT_MAX_CHARS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n >= 0 ? n : DEFAULT_TOOL_RESULT_MAX_CHARS;
+}
+
 /**
  * `messages.jsonl` stays lossless on disk (it's the transcript), but the copy
  * re-fed to the model each turn can balloon: a single `repo_overview` or eval
  * result is huge and the model already processed it. Truncate long strings
  * inside `role: "tool"` messages (tool RESULTS) before sending them back.
  * Conservative: only tool messages, only strings over `maxChars`, structure
- * preserved (we just shorten strings + add a marker). Mirrors
- * `session.ts:truncateToolResult`.
+ * preserved (we just shorten strings + add a marker). Within the turn that
+ * ran the tool the model always sees the full result — this only applies to
+ * HISTORY replayed on later turns. `maxChars` of `0` disables it.
  */
 export function truncateToolMessages(
   messages: StoredMessage[],
-  maxChars = 4000,
+  maxChars = toolResultMaxCharsFromEnv(),
 ): StoredMessage[] {
+  if (maxChars <= 0) return messages;
   const shorten = (s: string): string =>
     s.length > maxChars
       ? `${s.slice(0, maxChars)}\n\n[TRUNCATED: ${s.length} chars — full content is in the chat transcript]`

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -1393,6 +1393,15 @@ export async function createVein<TServices = unknown>(
                   output: part.output,
                 });
                 break;
+              case "tool-error":
+                await emit({
+                  type: "tool-output",
+                  toolName: part.toolName,
+                  toolCallId: part.toolCallId,
+                  output: part.error instanceof Error ? part.error.message : String(part.error),
+                  isError: true,
+                });
+                break;
               case "finish-step":
                 await emit({ type: "step.finish" });
                 break;

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -83,6 +83,8 @@ export {
   MemoryChatStore,
   generateChatId,
   truncateToolMessages,
+  DEFAULT_TOOL_RESULT_MAX_CHARS,
+  toolResultMaxCharsFromEnv,
   isChatTerminal,
 } from "./chat-store.js";
 

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -391,12 +391,16 @@ export interface ChatMessage {
 export interface ToolCallInfo {
   name: string;
   input: any;
+  toolCallId?: string;
 }
 
 export interface ToolResultInfo {
   name: string;
   input: any;
   output: any;
+  toolCallId?: string;
+  /** The tool threw; `output` is the error message. */
+  isError?: boolean;
 }
 
 export interface ChatCallbacks {
@@ -430,6 +434,8 @@ export interface ChatEvent {
   toolCallId?: string;
   input?: any;
   output?: any;
+  /** tool-output: the tool threw (output is the error message). */
+  isError?: boolean;
   error?: { message: string };
 }
 
@@ -538,10 +544,16 @@ function dispatchChatEvent(e: ChatEvent, cb: ChatCallbacks): void {
       if (e.delta) cb.onTextDelta(e.delta);
       break;
     case "tool-input":
-      cb.onToolCall({ name: e.toolName ?? "", input: e.input });
+      cb.onToolCall({ name: e.toolName ?? "", input: e.input, toolCallId: e.toolCallId });
       break;
     case "tool-output":
-      cb.onToolResult?.({ name: e.toolName ?? "", input: e.input, output: e.output });
+      cb.onToolResult?.({
+        name: e.toolName ?? "",
+        input: e.input,
+        output: e.output,
+        toolCallId: e.toolCallId,
+        isError: e.isError,
+      });
       break;
     case "step.finish":
       cb.onStepFinish();

--- a/vein/web/src/components/ChatFlyout.tsx
+++ b/vein/web/src/components/ChatFlyout.tsx
@@ -3,12 +3,16 @@ import * as api from "../api";
 import * as storage from "../storage";
 import { formatJson } from "../helpers";
 import { CloseIcon, HistoryIcon, CopyIcon, CheckIcon } from "../icons";
+import { ToolResultView } from "./ToolResultView";
 import { FlyoutResizer } from "./FlyoutResizer";
 import { Markdown } from "./Markdown";
 
 // ── Chat Flyout (AI workflow builder) ──────────────────────────────────────
 
-type ToolGroup = { name: string; calls: api.ToolCallInfo[] };
+/** A tool RESULT paired to its call. `isError` = the tool threw. */
+type ToolResult = { output: unknown; isError: boolean };
+type ToolCall = api.ToolCallInfo & { result?: ToolResult };
+type ToolGroup = { name: string; calls: ToolCall[] };
 
 type ChatEntry =
   | { kind: "user"; content: string }
@@ -40,7 +44,7 @@ const NOTIFICATION_PREFIX = "[run-notification]";
 const TURN_POLL_MS = 4000;
 
 // Coalesce consecutive same-name tool calls into groups.
-function groupCalls(calls: api.ToolCallInfo[]): ToolGroup[] {
+function groupCalls(calls: ToolCall[]): ToolGroup[] {
   const groups: ToolGroup[] = [];
   for (const tc of calls) {
     const last = groups[groups.length - 1];
@@ -53,8 +57,46 @@ function groupCalls(calls: api.ToolCallInfo[]): ToolGroup[] {
   return groups;
 }
 
+/** Attach a result to the call with the same id, searching tool entries
+ *  from the end (the call is almost always in the last one). Returns the
+ *  matched call (for callers that need its input) or null. Pure: returns a
+ *  new entries array when something changed. */
+function attachResult(
+  entries: ChatEntry[],
+  toolCallId: string | undefined,
+  result: ToolResult,
+): { entries: ChatEntry[]; call: ToolCall | null } {
+  if (!toolCallId) return { entries, call: null };
+  for (let i = entries.length - 1; i >= 0; i--) {
+    const e = entries[i]!;
+    if (e.kind !== "tool") continue;
+    for (let j = 0; j < e.groups.length; j++) {
+      const g = e.groups[j]!;
+      const k = g.calls.findIndex((c) => c.toolCallId === toolCallId);
+      if (k < 0) continue;
+      const call: ToolCall = { ...g.calls[k]!, result };
+      const groups = e.groups.slice();
+      groups[j] = { ...g, calls: g.calls.map((c, idx) => (idx === k ? call : c)) };
+      const next = entries.slice();
+      next[i] = { kind: "tool", groups };
+      return { entries: next, call };
+    }
+  }
+  return { entries, call: null };
+}
+
+/** Unwrap a stored AI SDK tool-result `output` ({ type, value }) into the
+ *  plain value + error flag the UI renders. */
+function storedOutputToResult(output: any): ToolResult {
+  if (output && typeof output === "object" && typeof output.type === "string" && "value" in output) {
+    return { output: output.value, isError: String(output.type).startsWith("error") };
+  }
+  return { output, isError: false };
+}
+
 /** Serialize the conversation as markdown — for pasting into an issue or
- *  another chat when debugging. Tool inputs are included as JSON blocks. */
+ *  another chat when debugging. Tool inputs and results are included as JSON
+ *  blocks. */
 function transcriptText(entries: ChatEntry[]): string {
   const blocks: string[] = [];
   for (const e of entries) {
@@ -68,11 +110,36 @@ function transcriptText(entries: ChatEntry[]): string {
       for (const g of e.groups) {
         for (const tc of g.calls) {
           blocks.push(`### Tool call: ${g.name}\n\`\`\`json\n${formatJson(tc.input)}\n\`\`\``);
+          if (tc.result) {
+            const label = tc.result.isError ? "Tool error" : "Tool result";
+            blocks.push(`### ${label}: ${g.name}\n\`\`\`json\n${formatJson(tc.result.output)}\n\`\`\``);
+          }
         }
       }
     }
   }
   return blocks.join("\n\n");
+}
+
+type ToolStatus = "pending" | "ok" | "error" | "unknown";
+
+const STATUS_TITLE: Record<ToolStatus, string> = {
+  pending: "Running",
+  ok: "Completed",
+  error: "Failed",
+  unknown: "No result recorded",
+};
+
+/** Roll a group's calls up to one status for the chip's dot. A call with no
+ *  result is "pending" only while this is the live tail of the chat;
+ *  otherwise the result was never recorded (e.g. the turn died). */
+function groupStatus(g: ToolGroup, live: boolean): ToolStatus {
+  let status: ToolStatus = "ok";
+  for (const c of g.calls) {
+    if (!c.result) return live ? "pending" : "unknown";
+    if (c.result.isError) status = "error";
+  }
+  return status;
 }
 
 /** Compact relative timestamp (e.g. "3m", "2h", "5d") with absolute fallback. */
@@ -103,10 +170,18 @@ function extractText(content: unknown): string {
 }
 
 /** Render stored ModelMessages (the transcript) into display entries. Tool
- *  RESULT messages (role "tool") aren't shown as bubbles — only the calls. */
+ *  RESULT messages (role "tool") aren't bubbles — each result is attached to
+ *  its call (by toolCallId) so the call's chip can disclose it. */
 function transcriptToEntries(messages: { role: string; content: unknown }[]): ChatEntry[] {
-  const entries: ChatEntry[] = [];
+  let entries: ChatEntry[] = [];
   for (const m of messages) {
+    if (m.role === "tool" && Array.isArray(m.content)) {
+      for (const part of m.content as any[]) {
+        if (part?.type !== "tool-result") continue;
+        entries = attachResult(entries, part.toolCallId, storedOutputToResult(part.output)).entries;
+      }
+      continue;
+    }
     if (m.role === "user") {
       const text = extractText(m.content);
       if (text) {
@@ -120,12 +195,12 @@ function transcriptToEntries(messages: { role: string; content: unknown }[]): Ch
       if (typeof m.content === "string") {
         if (m.content) entries.push({ kind: "text", content: m.content });
       } else if (Array.isArray(m.content)) {
-        const calls: api.ToolCallInfo[] = [];
+        const calls: ToolCall[] = [];
         for (const part of m.content as any[]) {
           if (part?.type === "text" && part.text) {
             entries.push({ kind: "text", content: part.text });
           } else if (part?.type === "tool-call") {
-            calls.push({ name: part.toolName, input: part.input });
+            calls.push({ name: part.toolName, input: part.input, toolCallId: part.toolCallId });
           }
         }
         if (calls.length) entries.push({ kind: "tool", groups: groupCalls(calls) });
@@ -207,7 +282,7 @@ export function ChatFlyout(props: {
   // bubble; tool calls/results also drive the canvas (workflow created/ran).
   const streamCallbacks = useCallback((signal: AbortSignal): api.ChatCallbacks => {
     let textBuf = "";
-    let toolBuf: api.ToolCallInfo[] = [];
+    let toolBuf: ToolCall[] = [];
     // A trailing text/tool entry may only be replaced in place by the step
     // that created it — a new step must append, not clobber the previous
     // step's entry (which may be the same kind with no bubble in between).
@@ -251,8 +326,15 @@ export function ChatFlyout(props: {
       },
       onToolResult: (tr) => {
         if (signal.aborted) return;
-        if (tr.name === "run_workflow" && tr.input?.name && tr.output?.runId) {
-          props.onWorkflowRan(tr.input.name, tr.output.runId);
+        const result: ToolResult = { output: tr.output, isError: !!tr.isError };
+        // Keep the step buffer in sync so a later same-step re-render
+        // (another tool call) doesn't drop the result again.
+        toolBuf = toolBuf.map((c) => (c.toolCallId === tr.toolCallId ? { ...c, result } : c));
+        setEntries((prev) => attachResult(prev, tr.toolCallId, result).entries);
+        // The tool-output event carries no input; recover it from the call.
+        const input = tr.input ?? toolBuf.find((c) => c.toolCallId === tr.toolCallId)?.input;
+        if (tr.name === "run_workflow" && !tr.isError && input?.name && tr.output?.runId) {
+          props.onWorkflowRan(input.name, tr.output.runId);
         }
       },
       onStepFinish: () => {
@@ -479,6 +561,7 @@ export function ChatFlyout(props: {
                   const key = `${i}:${j}`;
                   const isOpen = !!expanded[key];
                   const count = g.calls.length;
+                  const status = groupStatus(g, loading && i === entries.length - 1);
                   return (
                     <div key={j} class={`chat-tool-call${isOpen ? " is-open" : ""}`}>
                       <button
@@ -487,14 +570,28 @@ export function ChatFlyout(props: {
                         onClick={() => toggleExpanded(key)}
                         aria-expanded={isOpen}
                       >
+                        <span class={`chat-tool-dot is-${status}`} title={STATUS_TITLE[status]} />
                         <span class="chat-tool-name">{g.name}</span>
-                        {count > 1 && <span class="chat-tool-count">×{count}</span>}
+                        <span class="chat-tool-meta">
+                          {status === "error" && <span class="chat-tool-err">error</span>}
+                          {count > 1 && <span class="chat-tool-count">×{count}</span>}
+                        </span>
                       </button>
                       {isOpen && (
                         <div class="chat-tool-body">
-                          {g.calls.map((tc, k) => (
-                            <pre key={k} class="chat-tool-input">{formatJson(tc.input)}</pre>
-                          ))}
+                          {g.calls.map((tc, k) => {
+                            const rkey = `${key}:${k}:result`;
+                            return (
+                              <div key={k} class="chat-tool-item">
+                                <pre class="chat-tool-input">{formatJson(tc.input)}</pre>
+                                <ToolResultView
+                                  result={tc.result}
+                                  open={!!expanded[rkey]}
+                                  onToggle={() => toggleExpanded(rkey)}
+                                />
+                              </div>
+                            );
+                          })}
                         </div>
                       )}
                     </div>

--- a/vein/web/src/components/ToolResultView.tsx
+++ b/vein/web/src/components/ToolResultView.tsx
@@ -1,0 +1,81 @@
+import { useState } from "preact/hooks";
+import { formatJson } from "../helpers";
+import { CopyIcon, CheckIcon } from "../icons";
+
+// ── Tool result disclosure ─────────────────────────────────────────────────
+// Sits under a tool call's input inside the expanded chip. Closed by default:
+// a one-line "Result · 1.8 KB" row; click to reveal the output. Big outputs
+// show a head preview with a "show all" link (the transcript on disk is
+// lossless, so "all" really is all of it).
+
+/** Characters of a long output shown before "show all". */
+const PREVIEW_CHARS = 1500;
+
+function formatSize(chars: number): string {
+  if (chars < 1000) return `${chars} chars`;
+  if (chars < 100_000) return `${(chars / 1000).toFixed(1)} KB`;
+  return `${Math.round(chars / 1000)} KB`;
+}
+
+export function ToolResultView(props: {
+  result?: { output: unknown; isError: boolean };
+  open: boolean;
+  onToggle: () => void;
+}) {
+  const [showAll, setShowAll] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const { result, open } = props;
+  if (!result) return null;
+
+  const text = formatJson(result.output);
+  const truncated = !showAll && text.length > PREVIEW_CHARS;
+  const shown = truncated ? text.slice(0, PREVIEW_CHARS) : text;
+  const label = result.isError ? "Error" : "Result";
+
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(text);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1200);
+    } catch {
+      // Clipboard unavailable — no-op.
+    }
+  };
+
+  return (
+    <div class={`chat-tool-result${result.isError ? " is-error" : ""}`}>
+      <button
+        type="button"
+        class="chat-tool-result-head"
+        onClick={props.onToggle}
+        aria-expanded={open}
+      >
+        <span class={`chat-tool-chev${open ? " is-open" : ""}`} aria-hidden="true">▸</span>
+        <span class="chat-tool-result-label">{label}</span>
+        <span class="chat-tool-result-size">{formatSize(text.length)}</span>
+      </button>
+      {open && (
+        <div class="chat-tool-output">
+          <button
+            type="button"
+            class="chat-tool-output-copy"
+            onClick={copy}
+            title={copied ? "Copied!" : "Copy result"}
+            aria-label="Copy result"
+          >
+            {copied ? <CheckIcon size={12} /> : <CopyIcon size={12} />}
+          </button>
+          <pre class="chat-tool-output-text">{shown}</pre>
+          {truncated && (
+            <div class="chat-tool-output-bar">
+              showing {PREVIEW_CHARS.toLocaleString()} of {text.length.toLocaleString()} chars ·{" "}
+              <button type="button" class="chat-tool-link" onClick={() => setShowAll(true)}>
+                show all
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/vein/web/src/styles/components.css
+++ b/vein/web/src/styles/components.css
@@ -1412,6 +1412,15 @@ body.is-resizing-flyout * {
   gap: var(--sp-1);
   border-top: 1px solid var(--border);
 }
+.chat-tool-item {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-1);
+}
+.chat-tool-item + .chat-tool-item {
+  border-top: 1px dashed var(--border);
+  padding-top: var(--sp-1);
+}
 .chat-tool-input {
   color: var(--text-dim);
   font-family: var(--font-mono);
@@ -1422,6 +1431,122 @@ body.is-resizing-flyout * {
   max-height: 120px;
   overflow: auto;
 }
+
+/* Status dot on the chip head: pending (live tail) / ok / error / unknown. */
+.chat-tool-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--text-dim);
+}
+.chat-tool-dot.is-ok { background: var(--ok); }
+.chat-tool-dot.is-error { background: var(--danger); }
+.chat-tool-dot.is-pending {
+  background: var(--warning);
+  animation: chat-tool-pulse 1.2s ease-in-out infinite;
+}
+.chat-tool-dot.is-unknown {
+  background: transparent;
+  border: 1px solid var(--text-dim);
+}
+@keyframes chat-tool-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+.chat-tool-meta {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+}
+.chat-tool-err {
+  color: var(--danger);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.chat-tool-count { margin-left: 0; }
+
+/* Result disclosure under each call's input (see ToolResultView). */
+.chat-tool-result-head {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-1);
+  width: 100%;
+  padding: 2px 0;
+  background: transparent;
+  border: 0;
+  color: var(--text-muted);
+  font: inherit;
+  font-size: 11px;
+  text-align: left;
+  cursor: pointer;
+}
+.chat-tool-result-head:hover { color: var(--text); }
+.chat-tool-chev {
+  display: inline-block;
+  width: 10px;
+  font-size: 10px;
+  transition: transform 0.12s ease;
+}
+.chat-tool-chev.is-open { transform: rotate(90deg); }
+.chat-tool-result-label { font-weight: 600; }
+.chat-tool-result.is-error .chat-tool-result-label { color: var(--danger); }
+.chat-tool-result-size {
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.chat-tool-output {
+  position: relative;
+  border-left: 2px solid var(--border-strong);
+  background: var(--surface);
+  padding: var(--sp-2) var(--sp-3);
+  margin: 0 0 var(--sp-1) 4px;
+}
+.chat-tool-result.is-error .chat-tool-output { border-left-color: var(--danger); }
+.chat-tool-output-text {
+  color: var(--text);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  margin: 0;
+  padding-right: 18px;
+  white-space: pre-wrap;
+  word-break: break-all;
+  max-height: 320px;
+  overflow: auto;
+}
+.chat-tool-output-copy {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  display: flex;
+  padding: 3px;
+  background: transparent;
+  border: 0;
+  border-radius: var(--r-sm);
+  color: var(--text-dim);
+  cursor: pointer;
+}
+.chat-tool-output-copy:hover {
+  color: var(--text);
+  background: var(--surface-2);
+}
+.chat-tool-output-bar {
+  margin-top: var(--sp-1);
+  color: var(--text-dim);
+  font-family: var(--font-mono);
+  font-size: 10px;
+}
+.chat-tool-link {
+  background: transparent;
+  border: 0;
+  padding: 0;
+  color: var(--accent);
+  font: inherit;
+  cursor: pointer;
+}
+.chat-tool-link:hover { text-decoration: underline; }
 
 .chat-input-row {
   padding: var(--sp-3) var(--sp-4);


### PR DESCRIPTION
## What

**Chat flyout: tool results are now visible (opt-in, per call).**
- Status dot on each tool-call chip: pulsing while pending on the live tail, green on success, red on error (plus an `error` badge).
- Expanding a chip shows each call's input as before, now followed by a collapsed `Result · 1.8 KB` row. Click to reveal the output: 1,500-char head preview with "show all" for big outputs, a copy button, and a red rule for errors.
- Results are paired to calls by `toolCallId` on both paths: the live SSE stream and the stored transcript (`role:"tool"` messages were previously skipped on reload).
- The server emits `tool-error` stream parts as `tool-output` events with `isError: true`.
- Copy-transcript export now includes results.
- Fixes `onWorkflowRan` never firing from the live stream: `tool-output` events carry no `input`, so the canvas hook is now fed from the paired call.

**Tool-result replay cap: 4000 → 50000 chars, configurable.**
- `VEIN_CHAT_TOOL_RESULT_MAX_CHARS` (default `50000`, `0` disables).
- Clarified in code + AGENTS.md that this only trims tool results replayed as *history on later turns*. The turn that ran the tool always sees the full output.

## Verified
- `chat-store`, `chat-endpoints`, `createVein` test files pass (53/53); new tests for the default, `0`, and env parsing.
- Web typechecks and builds.
- Loaded a seeded transcript (grouped calls, a 19.8 KB result, an error result) in the browser: dots, badges, disclosure rows, preview/show-all, and copy all render. The live pending state was verified by reading the code only (a seeded live chat gets reconciled to `error` on read since no turn runs in-process).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
