### PR TITLE
vein: reseed leaves UI/API edits active (reactivateKnown: false)

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -526,9 +526,11 @@ are thin plumbing over `ctx.services.gaia.*`.
   produce variant) and `gaia-batch` ({ level, limit }: one
   score call for the whole batch). This is the harness that went 1/5 → 5/5
   on the level-1 batch (EVOLVE_SPEC §1), promoted from the workspace where
-  the assistant authored it. Seeding is content-hash reconciled — the
-  committed copy is authoritative at boot, so a workspace-side evolution
-  survives restarts only once it's ported back here. The from-scratch
+  the assistant authored it. Seeding is content-hash reconciled (`SEED_OPTS`,
+  `seed-opts.ts`) — a CHANGED committed copy wins at boot, an unchanged one
+  leaves a workspace-side edit active, so a workspace-side evolution
+  survives restarts but propagates to other instances only once it's ported
+  back here. The from-scratch
   authoring recipe is kept in `notes/GAIA.md` as an authoring eval; it is no
   longer the path to a working harness.
 

--- a/mcp/src/lab/artifacts/seed.ts
+++ b/mcp/src/lab/artifacts/seed.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /** Generic artifact plumbing steps (NOT an experiment). Today just
  *  `artifacts/dir` — see steps/dir.ts. */
@@ -16,7 +17,7 @@ export async function seedArtifactSteps(workspace: WorkspaceStore): Promise<void
   for (const { file, type } of SEED_STEPS) {
     try {
       const code = await readFile(join(dir, file), "utf-8");
-      const { version, changed } = await workspace.publishStep(type, code, undefined, "artifacts-seed");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "artifacts-seed", SEED_OPTS);
       if (changed) console.log(`[artifacts] seeded step: ${type} @ ${version}`);
     } catch (err) {
       console.warn(`[artifacts] could not seed step "${type}":`, err instanceof Error ? err.message : err);

--- a/mcp/src/lab/concepts/seed.ts
+++ b/mcp/src/lab/concepts/seed.ts
@@ -2,19 +2,21 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /**
  * Workflow + step templates shipped with the concepts experiment. They are
  * the canonical, committed source of truth in this repo; on boot they're
  * reconciled into the workspace by **content hash**:
  *
- *   - unchanged template  → same version id → no-op (no churn)
+ *   - unchanged template  → same version id → no-op (no churn); an edit made
+ *                            in the UI/API meanwhile stays active
  *   - edited template      → new version id  → published + activated, while
  *                            prior versions are retained for rollback
  *
  * This is what makes "edit here, commit, redeploy/reseed → propagates to
  * every vein instance" work, without clobbering local experiment history.
- * (See vein `publishWorkflowByContent` / `publishStep`.)
+ * (See vein `publishWorkflowByContent` / `publishStep` + `SEED_OPTS`.)
  */
 
 const SEED_WORKFLOWS = [
@@ -71,6 +73,8 @@ export async function seedConceptWorkflows(
         yaml,
         undefined,
         "concepts",
+        undefined,
+        SEED_OPTS,
       );
       if (changed) console.log(`[concepts] seeded workflow: ${name} @ ${version}`);
     } catch (err) {
@@ -100,6 +104,7 @@ export async function seedConceptSteps(
         code,
         undefined,
         "concepts-seed",
+        SEED_OPTS,
       );
       if (changed) console.log(`[concepts] seeded step: ${type} @ ${version}`);
     } catch (err) {

--- a/mcp/src/lab/createLabVein.ts
+++ b/mcp/src/lab/createLabVein.ts
@@ -140,8 +140,9 @@ export async function createLabVein(
   // Seed each experiment's workflow + step templates into the workspace
   // BEFORE building the vein, so the registry's discovery picks up the
   // seeded steps. Steps are self-contained custom steps (not injected
-  // in-code) — content-hash reconciled, editable + versioned via the vein
-  // API/UI. No `registry` is passed, so createVein discovers core + lib +
+  // in-code) — content-hash reconciled (see seed-opts.ts: a changed template
+  // wins, an unchanged one leaves UI/API edits active), editable + versioned
+  // via the vein API/UI. No `registry` is passed, so createVein discovers core + lib +
   // these custom steps via `workspace.materializeCustomSteps()` (and step
   // publishing is enabled).
   //

--- a/mcp/src/lab/eval/seed.ts
+++ b/mcp/src/lab/eval/seed.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /**
  * GENERIC, domain-agnostic eval primitives (STEPS only), seeded into the vein
@@ -40,7 +41,7 @@ export async function seedEvalSteps(workspace: WorkspaceStore): Promise<void> {
   for (const { file, type } of SEED_STEPS) {
     try {
       const code = await readFile(join(dir, file), "utf-8");
-      const { version, changed } = await workspace.publishStep(type, code, undefined, "eval-seed");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "eval-seed", SEED_OPTS);
       if (changed) console.log(`[eval] seeded step: ${type} @ ${version}`);
     } catch (err) {
       console.warn(

--- a/mcp/src/lab/gaia/seed.ts
+++ b/mcp/src/lab/gaia/seed.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /**
  * GAIA LAB steps + workflows — the harness that scored 5/5 on the first
@@ -79,7 +80,7 @@ export async function seedGaiaWorkflows(workspace: WorkspaceStore): Promise<void
   for (const { name, description } of SEED_WORKFLOWS) {
     try {
       const yaml = await readFile(join(dir, `${name}.yaml`), "utf-8");
-      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, description, "gaia");
+      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, description, "gaia", undefined, SEED_OPTS);
       if (changed) console.log(`[gaia] seeded workflow: ${name} @ ${version}`);
     } catch (err) {
       console.warn(`[gaia] could not seed workflow "${name}":`, err instanceof Error ? err.message : err);
@@ -92,7 +93,7 @@ export async function seedGaiaSteps(workspace: WorkspaceStore): Promise<void> {
   for (const { file, type } of SEED_STEPS) {
     try {
       const code = await readFile(join(dir, file), "utf-8");
-      const { version, changed } = await workspace.publishStep(type, code, undefined, "gaia-seed");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "gaia-seed", SEED_OPTS);
       if (changed) console.log(`[gaia] seeded step: ${type} @ ${version}`);
     } catch (err) {
       console.warn(

--- a/mcp/src/lab/gitsee/seed.ts
+++ b/mcp/src/lab/gitsee/seed.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /**
  * Workflow + step templates for the `gitsee` experiment (self-contained port of
@@ -71,7 +72,7 @@ export async function seedGitseeWorkflows(workspace: WorkspaceStore): Promise<vo
   for (const name of SEED_WORKFLOWS) {
     try {
       const yaml = await readFile(join(dir, `${name}.yaml`), "utf-8");
-      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, undefined, "gitsee");
+      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, undefined, "gitsee", undefined, SEED_OPTS);
       if (changed) console.log(`[gitsee] seeded workflow: ${name} @ ${version}`);
     } catch (err) {
       console.warn(
@@ -87,7 +88,7 @@ export async function seedGitseeSteps(workspace: WorkspaceStore): Promise<void> 
   for (const { file, type } of SEED_STEPS) {
     try {
       const code = await readFile(join(dir, file), "utf-8");
-      const { version, changed } = await workspace.publishStep(type, code, undefined, "gitsee-seed");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "gitsee-seed", SEED_OPTS);
       if (changed) console.log(`[gitsee] seeded step: ${type} @ ${version}`);
     } catch (err) {
       console.warn(

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /**
  * Harvey LAB verification steps — THIN plumbing only. The actual grader is
@@ -121,7 +122,7 @@ export async function seedHarveyWorkflows(workspace: WorkspaceStore): Promise<vo
   for (const name of SEED_WORKFLOWS) {
     try {
       const yaml = await expandIncludes(await readFile(join(dir, `${name}.yaml`), "utf-8"));
-      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, "harvey-seed", "harvey");
+      const { version, changed } = await workspace.publishWorkflowByContent(name, yaml, "harvey-seed", "harvey", undefined, SEED_OPTS);
       if (changed) console.log(`[harvey] seeded workflow: ${name} @ ${version}`);
     } catch (err) {
       console.warn(`[harvey] could not seed workflow "${name}":`, err instanceof Error ? err.message : err);
@@ -134,7 +135,7 @@ export async function seedHarveySteps(workspace: WorkspaceStore): Promise<void> 
   for (const { file, type } of SEED_STEPS) {
     try {
       const code = await readFile(join(dir, file), "utf-8");
-      const { version, changed } = await workspace.publishStep(type, code, undefined, "harvey-seed");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "harvey-seed", SEED_OPTS);
       if (changed) console.log(`[harvey] seeded step: ${type} @ ${version}`);
     } catch (err) {
       console.warn(

--- a/mcp/src/lab/jarvis/seed.ts
+++ b/mcp/src/lab/jarvis/seed.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /**
  * Jarvis knowledge-graph steps, seeded into the vein workspace. Each is a
@@ -43,7 +44,7 @@ export async function seedJarvisSteps(workspace: WorkspaceStore): Promise<void> 
   for (const { file, type } of SEED_STEPS) {
     try {
       const code = await readFile(join(dir, file), "utf-8");
-      const { version, changed } = await workspace.publishStep(type, code, undefined, "jarvis-seed");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "jarvis-seed", SEED_OPTS);
       if (changed) console.log(`[jarvis] seeded step: ${type} @ ${version}`);
     } catch (err) {
       console.warn(

--- a/mcp/src/lab/seed-opts.ts
+++ b/mcp/src/lab/seed-opts.ts
@@ -1,0 +1,13 @@
+import type { PublishByContentOptions } from "vein";
+
+/**
+ * How every lab seeder reconciles its committed templates into the workspace
+ * at boot. Content-hash keyed: a template whose hash the workspace has never
+ * seen publishes the next version and activates it (a real code change wins);
+ * a template whose hash is already a known version is a NO-OP even when that
+ * version isn't active — so an edit made through the vein UI/API (or by the
+ * authoring agent) stays active across restarts until the committed template
+ * itself changes. Porting the winner back into the committed template is
+ * still the only way to propagate it to other instances.
+ */
+export const SEED_OPTS: PublishByContentOptions = { reactivateKnown: false };

--- a/mcp/src/lab/sheets/seed.ts
+++ b/mcp/src/lab/sheets/seed.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
+import { SEED_OPTS } from "../seed-opts.js";
 
 /**
  * Google Sheets steps, seeded into the vein workspace. Each is a
@@ -35,7 +36,7 @@ export async function seedSheetsSteps(workspace: WorkspaceStore): Promise<void> 
   for (const { file, type } of SEED_STEPS) {
     try {
       const code = await readFile(join(dir, file), "utf-8");
-      const { version, changed } = await workspace.publishStep(type, code, undefined, "sheets-seed");
+      const { version, changed } = await workspace.publishStep(type, code, undefined, "sheets-seed", SEED_OPTS);
       if (changed) console.log(`[sheets] seeded step: ${type} @ ${version}`);
     } catch (err) {
       console.warn(

--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -410,8 +410,9 @@ services bag can override it, same as `http`/`secrets`).
 - **Custom steps are versioned** (like workflows). `publishStep`
   is keyed by content hash (`src/version.ts`) but labeled with
   sequential `vN` ids: identical content re-activates the existing
-  version (no-op if already active), changed content publishes the
-  next `vN`. The active version's source is materialized at
+  version (no-op if already active; `{ reactivateKnown: false }` — what
+  seeders pass — skips the re-activation so UI/API edits survive a
+  reseed), changed content publishes the next `vN`. The active version's source is materialized at
   `steps/custom/<name>.ts` (what the registry loads); every version
   is archived under `steps/_history/<name>/<vid>.ts` for rollback.
   Endpoints: `GET /steps/:type/versions`, `GET /steps/:type/version/:version`,

--- a/vein/SPEC.md
+++ b/vein/SPEC.md
@@ -682,7 +682,7 @@ Subflows use their own `params` defaults; the parent's per-run override does not
 Custom steps are versioned, the same way workflows are. `publishStep` is keyed by a content **hash** (internal dedup) but labeled with friendly, sequential `vN` ids:
 
 - Identical content that's already active → no-op.
-- Identical content of an older version → re-activates it (no new version).
+- Identical content of an older version → re-activates it (no new version). Pass `{ reactivateKnown: false }` to make this a no-op instead — the boot-time seeder's setting, so a workspace edit made through the UI/API stays active until the committed template itself changes.
 - Changed content → publishes the next `vN` and activates it; prior versions are retained for rollback.
 
 The **active** version's source is materialized at `steps/custom/<name>.ts` (what the registry loads). Every version (including the active one) is archived under `steps/_history/<name>/<vid>.ts`.

--- a/vein/src/graph/workspace-store.ts
+++ b/vein/src/graph/workspace-store.ts
@@ -32,6 +32,7 @@ import {
   flowFromYaml,
   renderWorkflowYaml,
   validateStepName,
+  type PublishByContentOptions,
   type StepListEntry,
   type StepVersionsResult,
   type WorkflowListEntry,
@@ -404,6 +405,7 @@ export class Neo4jWorkspaceStore implements WorkspaceStore {
     description?: string,
     category?: string,
     publisher?: string,
+    opts?: PublishByContentOptions,
   ): Promise<{ version: string; changed: boolean }> {
     const hash = contentHash(yamlStr);
     const w = await this.workflowRow(name);
@@ -413,7 +415,9 @@ export class Neo4jWorkspaceStore implements WorkspaceStore {
       }
       const match = (await this.versionRows(name)).find((v) => v.content_hash === hash);
       if (match) {
-        if (w.active_version === hash) return { version: match.version_label, changed: false };
+        if (w.active_version === hash || opts?.reactivateKnown === false) {
+          return { version: match.version_label, changed: false };
+        }
         await this.setActiveVersion(name, match.version_label);
         return { version: match.version_label, changed: true };
       }
@@ -539,6 +543,7 @@ export class Neo4jWorkspaceStore implements WorkspaceStore {
     code: string,
     description?: string,
     publisher?: string,
+    opts?: PublishByContentOptions,
   ): Promise<{ version: string; changed: boolean }> {
     validateStepName(name);
     const hash = contentHash(code);
@@ -551,7 +556,7 @@ export class Neo4jWorkspaceStore implements WorkspaceStore {
       if (match) {
         let changed = false;
         const desired: Record<string, unknown> = {};
-        if (existing.active_version !== hash) {
+        if (existing.active_version !== hash && opts?.reactivateKnown !== false) {
           desired["active_version"] = hash;
           desired["description"] = match.description;
           changed = true;

--- a/vein/src/index.ts
+++ b/vein/src/index.ts
@@ -109,6 +109,7 @@ export {
   type StepVersionInfo,
   type StepListEntry,
   type StepVersionsResult,
+  type PublishByContentOptions,
 } from "./workspace.js";
 
 // Content-hash versioning (internal dedup) + sequential version labels

--- a/vein/src/test-util/workspace-conformance.ts
+++ b/vein/src/test-util/workspace-conformance.ts
@@ -92,11 +92,64 @@ export function workspaceConformance(impl: WorkspaceImpl): void {
       assert.equal((await ws.getWorkflow("wf")).params?.["greeting"], "newer");
     });
 
+    it("reactivateKnown: false keeps a workspace edit active across a reseed", async () => {
+      await ws.publishWorkflow("wf", "v1", { steps, params: { greeting: "old" } });
+      const seed = await ws.getWorkflowSource("wf", "v1");
+      const edit = await ws.publishWorkflowByContent("wf", seed.replace("old", "new")); // UI edit → v2
+      // Reseeding the UNCHANGED template must not demote the edit …
+      const reseed = await ws.publishWorkflowByContent("wf", seed, undefined, "cat", "seed", {
+        reactivateKnown: false,
+      });
+      assert.equal(reseed.changed, false);
+      assert.equal(reseed.version, "v1");
+      const meta = await ws.getWorkflowMetadata("wf");
+      assert.equal(meta?.active, edit.version);
+      assert.equal(meta?.category, "cat", "category is still reconciled on the no-op path");
+      // … but a CHANGED template (never-seen hash) still publishes + activates.
+      const updated = await ws.publishWorkflowByContent(
+        "wf",
+        seed.replace("old", "newer"),
+        undefined,
+        undefined,
+        undefined,
+        { reactivateKnown: false },
+      );
+      assert.equal(updated.changed, true);
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, updated.version);
+      // Default (author) behavior is unchanged: known content re-activates.
+      const back = await ws.publishWorkflowByContent("wf", seed);
+      assert.equal(back.changed, true);
+      assert.equal((await ws.getWorkflowMetadata("wf"))?.active, "v1");
+    });
+
     it("createWorkflow allocates a fresh name/version and returns it", async () => {
       const a = await ws.createWorkflow("made", { steps });
       const b = await ws.createWorkflow("made", { steps });
       assert.equal(a.name, "made");
       assert.notEqual(b.name, a.name, "a second create under the same name is renamed, not clobbered");
+    });
+
+    it("publishStep reactivateKnown: false keeps a workspace edit active across a reseed", async () => {
+      const v1 = await ws.publishStep("kept", STEP_SRC("kept", "one"), "one", "seed");
+      const edit = await ws.publishStep("kept", STEP_SRC("kept", "two"), "two"); // UI edit → v2
+      const reseed = await ws.publishStep("kept", STEP_SRC("kept", "one"), "one", "seed", {
+        reactivateKnown: false,
+      });
+      assert.equal(reseed.changed, false);
+      assert.equal(reseed.version, v1.version);
+      assert.equal((await ws.listStepVersions("kept")).active, edit.version);
+      assert.ok(
+        (await ws.getStepSource("kept"))?.code.includes("two"),
+        "the materialized (loadable) source is still the edit",
+      );
+      const updated = await ws.publishStep("kept", STEP_SRC("kept", "three"), "three", "seed", {
+        reactivateKnown: false,
+      });
+      assert.equal(updated.changed, true);
+      assert.equal((await ws.listStepVersions("kept")).active, updated.version);
+      const back = await ws.publishStep("kept", STEP_SRC("kept", "one"));
+      assert.equal(back.changed, true);
+      assert.equal((await ws.listStepVersions("kept")).active, v1.version);
     });
 
     it("step publish → list → versions → source → active switching → delete", async () => {

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -172,6 +172,18 @@ export interface StepDirMetadata {
   steps: Record<string, StepInfo>;
 }
 
+/** Options for the content-hash publishers (`publishWorkflowByContent`,
+ *  `publishStep`). */
+export interface PublishByContentOptions {
+  /** What to do when the content matches an OLDER, non-active version.
+   *  `true` (default) re-points active at it — "this exact content should be
+   *  live" (the author's intent). `false` leaves the active pointer alone —
+   *  the boot-time seeder's setting, so an edit made through the UI/API
+   *  survives every reseed until the committed template itself changes (a
+   *  never-seen hash still publishes the next `vN` and activates it). */
+  reactivateKnown?: boolean;
+}
+
 export interface StepVersionsResult {
   active: string;
   versions: string[];
@@ -248,6 +260,7 @@ export interface WorkspaceStore extends SubflowResolver {
     description?: string,
     category?: string,
     publisher?: string,
+    opts?: PublishByContentOptions,
   ): Promise<{ version: string; changed: boolean }>;
   setWorkflowCategory(name: string, category: string | null): Promise<void>;
   setActiveVersion(name: string, version: string): Promise<void>;
@@ -264,6 +277,7 @@ export interface WorkspaceStore extends SubflowResolver {
     code: string,
     description?: string,
     publisher?: string,
+    opts?: PublishByContentOptions,
   ): Promise<{ version: string; changed: boolean }>;
   listStepVersions(name: string): Promise<StepVersionsResult>;
   getStepVersionSource(name: string, version: string): Promise<string>;
@@ -528,6 +542,8 @@ export class FileWorkspaceStore implements WorkspaceStore {
    * active at it (no new version); changed content publishes the next `vN` and
    * activates it, retaining prior versions. This is the content-hash seeder's
    * primitive. Returns the version id and whether anything changed.
+   * `opts.reactivateKnown: false` turns the "re-points active" case into a
+   * no-op (see `PublishByContentOptions`).
    */
   async publishWorkflowByContent(
     name: string,
@@ -535,6 +551,7 @@ export class FileWorkspaceStore implements WorkspaceStore {
     description?: string,
     category?: string,
     publisher?: string,
+    opts?: PublishByContentOptions,
   ): Promise<{ version: string; changed: boolean }> {
     const hash = contentHash(yamlStr);
     const meta = await this.readWorkflowMetadata(name);
@@ -551,7 +568,9 @@ export class FileWorkspaceStore implements WorkspaceStore {
       );
       if (match) {
         const [vid] = match;
-        if (meta.active === vid) return { version: vid, changed: false };
+        if (meta.active === vid || opts?.reactivateKnown === false) {
+          return { version: vid, changed: false };
+        }
         await this.setActiveVersion(name, vid);
         return { version: vid, changed: true };
       }
@@ -626,6 +645,7 @@ export class FileWorkspaceStore implements WorkspaceStore {
     code: string,
     description?: string,
     publisher?: string,
+    opts?: PublishByContentOptions,
   ): Promise<{ version: string; changed: boolean }> {
     validateStepName(name);
 
@@ -636,7 +656,8 @@ export class FileWorkspaceStore implements WorkspaceStore {
     const meta = (await this.readStepMetadata(customDir)) ?? { steps: {} };
     const existing = meta.steps[name];
 
-    // Content already known → no-op (if active) or re-activate that version.
+    // Content already known → no-op (if active) or re-activate that version
+    // (unless the caller opted out of re-activation).
     if (existing) {
       const match = Object.entries(existing.versions).find(
         ([, info]) => info.hash === hash,
@@ -644,7 +665,7 @@ export class FileWorkspaceStore implements WorkspaceStore {
       if (match) {
         const [vid] = match;
         let changed = false;
-        if (existing.active !== vid) {
+        if (existing.active !== vid && opts?.reactivateKnown !== false) {
           const archived = await readFile(this.stepVersionPath(name, vid), "utf-8");
           await mkdir(dirname(filePath), { recursive: true });
           await writeFile(filePath, archived, "utf-8");


### PR DESCRIPTION
## What

`publishWorkflowByContent` / `publishStep` take an optional `{ reactivateKnown }` (default `true`, unchanged behavior). With `false`, content whose hash matches a known-but-inactive version is a **no-op** instead of re-pointing `active` at it. A never-seen hash still publishes the next `vN` and activates it.

Every lab seeder now passes `SEED_OPTS = { reactivateKnown: false }` (`mcp/src/lab/seed-opts.ts`).

## Why

Before: a workflow or step edited in the vein UI (or by the authoring agent) was demoted on the next mcp boot, because the seeder saw "known hash, not active" and flipped active back to the committed version.

After: the edit stays active until the committed template actually changes. A changed template still wins (the edit stays archived, not lost). Porting the winner back into the committed YAML/TS is still the only way to propagate it to other instances.

Trade-off accepted: a git revert of a template to earlier content is a no-op at boot (that hash is already known). Re-activate via the UI / `PUT /workflows/:name/active` in that case.

## Tests

- `vein`: 630 unit tests pass (new conformance cases run over the file store).
- `vein` live Neo4j (`workspace-store.test.ts` against the throwaway :7688 container): 16/16 pass, including the new cases.
- `mcp`: `tsc --noEmit` clean against the rebuilt vein.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
