### PR TITLE
[Jamie] Cap accumulated stdout in bash exec to prevent RangeError crash

### DIFF
--- a/mcp/src/repo/bash.ts
+++ b/mcp/src/repo/bash.ts
@@ -2,6 +2,8 @@ import { spawn } from "child_process";
 import * as fs from "fs";
 import * as path from "path";
 
+const MAX_OUTPUT_BYTES = 8 * 1024 * 1024; // 8 MB cap to stay well under V8 max string length
+
 // Execute ripgrep with args array directly
 function execRipgrepCommandDirect(
   args: string[],
@@ -28,19 +30,18 @@ function execRipgrepCommandDirect(
 
     process.stdout.on("data", (data) => {
       stdout += data.toString();
-
-      // if (stdout.length > 10000) {
-      //   process.kill("SIGKILL");
-      //   if (!resolved) {
-      //     resolved = true;
-      //     clearTimeout(timeout);
-      //     const truncated =
-      //       stdout.substring(0, 10000) +
-      //       "\n\n[... output truncated due to size limit ...]";
-      //     resolve(truncated);
-      //   }
-      //   return;
-      // }
+      if (stdout.length > MAX_OUTPUT_BYTES) {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          process.kill("SIGKILL");
+          resolve(
+            stdout.substring(0, MAX_OUTPUT_BYTES) +
+              "\n\n[... output truncated due to size limit ...]"
+          );
+        }
+        return;
+      }
     });
 
     process.stderr.on("data", (data) => {
@@ -53,14 +54,7 @@ function execRipgrepCommandDirect(
         clearTimeout(timeout);
 
         if (code === 0) {
-          // if (stdout.length > 10000) {
-          //   const truncated =
-          //     stdout.substring(0, 10000) +
-          //     "\n\n[... output truncated to 10,000 characters ...]";
-          //   resolve(truncated);
-          // } else {
           resolve(stdout);
-          // }
         } else if (code === 1) {
           resolve("No matches found");
         } else {
@@ -108,19 +102,18 @@ function execShellCommand(
 
     process.stdout.on("data", (data) => {
       stdout += data.toString();
-
-      // if (stdout.length > 10000) {
-      //   process.kill("SIGKILL");
-      //   if (!resolved) {
-      //     resolved = true;
-      //     clearTimeout(timeout);
-      //     const truncated =
-      //       stdout.substring(0, 10000) +
-      //       "\n\n[... output truncated due to size limit ...]";
-      //     resolve(truncated);
-      //   }
-      //   return;
-      // }
+      if (stdout.length > MAX_OUTPUT_BYTES) {
+        if (!resolved) {
+          resolved = true;
+          clearTimeout(timeout);
+          process.kill("SIGKILL");
+          resolve(
+            stdout.substring(0, MAX_OUTPUT_BYTES) +
+              "\n\n[... output truncated due to size limit ...]"
+          );
+        }
+        return;
+      }
     });
 
     process.stderr.on("data", (data) => {
@@ -133,11 +126,6 @@ function execShellCommand(
         clearTimeout(timeout);
 
         let output = stdout;
-        // if (output.length > 10000) {
-        //   output =
-        //     output.substring(0, 10000) +
-        //     "\n\n[... output truncated to 10,000 characters ...]";
-        // }
 
         if (code === 0) {
           resolve(output);


### PR DESCRIPTION
## Problem

`mcp/src/repo/bash.ts` accumulates child-process stdout into a single JS string with no size cap (`stdout += data.toString();`). When a command produces enough output, the string exceeds V8's maximum string length and Node throws `RangeError: Invalid string length` inside the stream `data` event. Because that throw happens outside the Promise executor, it is uncaught and crashes the whole MCP server (repo2graph), forcing a restart.

Observed in production:
```
file:///usr/src/app/build/repo/bash.js:90
stdout += data.toString();
RangeError: Invalid string length
```

## Fix

Re-enable and repair the (currently commented-out) truncation guard in both `execShellCommand` and the sibling `execRipgrepCommandDirect`, but with a **large, safe byte cap** (~8 MB) instead of the old 10,000-char cap, so normal large outputs are not truncated — only pathological output that would otherwise crash the process. When the cap is exceeded, kill the process, clear the timeout, and resolve with the truncated output plus a clear marker, rather than throwing.

The old 10,000-char cap is intentionally NOT restored — it was far too small and would truncate legitimate results. The goal is only to stay safely under V8's string-length limit.