### PR TITLE
vein: raise agent bash output cap to 200k, cap stderr

### DIFF
--- a/vein/src/shell.test.ts
+++ b/vein/src/shell.test.ts
@@ -78,6 +78,13 @@ describe("shell helpers", () => {
     await assert.rejects(() => runShell("ls /definitely/not/a/path", dir), /Command failed/);
   });
 
+  it("caps oversized stderr on failure", async () => {
+    await assert.rejects(
+      () => runShell("yes x | head -c 200000 1>&2; exit 2", dir, 10_000, 100),
+      (e: Error) => e.message.length < 400 && /truncated/.test(e.message),
+    );
+  });
+
   it("runCmd passes args without shell interpolation", async () => {
     const out = await runCmd("echo", ["$HOME && rm -rf /"], dir);
     assert.equal(out.trim(), "$HOME && rm -rf /");

--- a/vein/src/shell.ts
+++ b/vein/src/shell.ts
@@ -71,12 +71,17 @@ export function capture(
         finish(() => resolve(cap(stdout)));
       }
     });
-    child.stderr?.on("data", (d) => (stderr += d.toString()));
+    // stderr is capped the same way stdout is: a failing build can emit
+    // megabytes, and an uncapped string here both risks V8's max string
+    // length and dumps the whole thing into a tool result the model reads.
+    child.stderr?.on("data", (d) => {
+      if (stderr.length <= maxBytes) stderr += d.toString();
+    });
     child.on("close", (code) =>
       finish(() => {
         if (code === 0) resolve(cap(stdout));
         else if (code === 1 && !stderr) resolve(cap(stdout) || "No matches found");
-        else reject(new Error(`Command failed (${code}): ${stderr || stdout || "Unknown error"}`));
+        else reject(new Error(`Command failed (${code}): ${cap(stderr || stdout || "Unknown error")}`));
       }),
     );
     child.on("error", (err) => finish(() => reject(err)));

--- a/vein/src/steps/core/agent.ts
+++ b/vein/src/steps/core/agent.ts
@@ -173,6 +173,15 @@ async function getRepoMap(cwd: string): Promise<string> {
 /** Max chars returned for a file summary before truncation. */
 const FILE_SUMMARY_MAX_CHARS = 12000;
 
+/** Max chars returned by `bash` before truncation. Matched to
+ *  FILE_VIEW_MAX_CHARS: `cat`-ing a file through bash and `view`-ing it are the
+ *  same retrieval, so they get the same budget — the agent legitimately needs
+ *  large output (a lockfile, a full test log, a big JSON response). This is a
+ *  context-budget cap, not a crash guard: the agent loop keeps every tool result
+ *  in the message history for the whole run, so it stays well under the model's
+ *  context window rather than going to a V8-string-limit-sized ceiling. */
+const BASH_MAX_CHARS = 200_000;
+
 /** Is an executable named `bin` on PATH? Unix-style — the agent's tools already
  *  assume a unix env (git/rg/bash). Used to skip a tool whose CLI isn't present
  *  (e.g. `file_summary` when `stakgraph` isn't installed). */
@@ -821,7 +830,7 @@ export default defineStep({
             // 10-minute timeout so the agent can run real installs/builds (not just
             // quick inspection). Note: a non-terminating process (a dev server)
             // still blocks until killed at this timeout.
-            return await runShell(command, cfg.cwd, 600_000, 10000, secretEnv);
+            return await runShell(command, cfg.cwd, 600_000, BASH_MAX_CHARS, secretEnv);
           } catch (e) {
             return `Command execution failed: ${e}`;
           }


### PR DESCRIPTION
Follow-up to #1645, which capped stdout in `mcp/src/repo/bash.ts`. Vein already had caps everywhere (`vein/src/shell.ts`'s shared `capture()` requires a `maxBytes`), so it was never exposed to that `RangeError` on stdout — but two things were wrong.

## 1. The agent bash cap was too small

The agent step's `bash` truncated at 10,000 chars (~2.5k tokens). That's far too little for legitimate retrieval — a lockfile, a full test log, a large JSON response — and it was inconsistent with the agent's own file-read path: the editor tool's `view` allows `FILE_VIEW_MAX_CHARS = 200_000`, so `cat foo.json` truncated where `view foo.json` did not. Same retrieval, same budget now (`BASH_MAX_CHARS = 200_000`).

Deliberately **not** raised to a crash-guard-sized ceiling like #1645's 8 MB: the agent loop keeps every tool result in the message history for the whole run with no compaction, so bash output is a context-budget question, not just a "stay under V8's string limit" question.

## 2. stderr was uncapped

`capture()` accumulated stderr with no cap at all:

```ts
child.stderr?.on("data", (d) => (stderr += d.toString()));
```

Same bug class #1645 fixed for stdout, and reachable — the agent's `bash` allows 10-minute installs and builds, and a noisy build writes plenty to stderr. Below the string limit it was still a problem: the uncapped stderr went into the rejection message, which `agent.ts` turns into `Command execution failed: ${e}` and hands straight to the model. Now capped on accumulation and in the error string.

(`mcp/src/repo/bash.ts` has the same uncapped stderr on both of its exec paths — not touched here.)

## Test

`shell.test.ts` gains a case asserting an oversized stderr is truncated in the rejection. `npm test` slice run: shell.test.ts 15/15, agent.test.ts 66/66, tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)