### PR TITLE
vein: meta/validate-workflow; lab: promote eval scoring steps to eval/*

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -458,12 +458,13 @@ completed ingestions, and skip re-merging requirements.
   all-pass ⇒ `EvalSet.recursion=false`), and `harvey-judge-criterion` /
   `harvey-dispute-criterion` (per-criterion agent-in-schema-mode subflows —
   they exist because foreach bodies get no onError; a judge crash scores as
-  an honest FAIL via `harvey/aggregate-scores`' zip, never a pass).
+  an honest FAIL via `eval/aggregate-scores`' zip, never a pass).
 - Steps: `harvey/normalize-documents`, `harvey/ingest-state`,
   `harvey/drafter-plan`, `harvey/validate-deliverables`,
-  `harvey/filter-contested`, `harvey/aggregate-scores`,
-  `harvey/merge-disputes`, `harvey/build-eval-chain`,
-  `harvey/criterion-refs` (pure/plumbing), `harvey/generate-docx` +
+  `harvey/filter-contested`, `harvey/merge-disputes` (pure/plumbing;
+  the generic scoring trio `eval/aggregate-scores`, `eval/build-eval-chain`,
+  `eval/criterion-refs` is shared with other rubric harnesses — see
+  `eval/`), `harvey/generate-docx` +
   `harvey/generate-xlsx` (pandoc / openpyxl deliverable generators,
   granted as agent tools so the production prompts' generate calls work),
   `harvey/graph-sub-agent` — the PINNED read-only graph research sub-agent
@@ -654,6 +655,14 @@ Domain-agnostic eval substrate, shared by every experiment. See
   tasks (byte-identical wrong answer ×≥3 = bias — immune to redundancy and
   prompt nudges; distinct wrong answers = variance). Verdict channel only —
   gold never enters. Smoke: `npx tsx src/lab/eval/matrix-smoke.ts`.
+- `eval/aggregate-scores`, `eval/build-eval-chain`, `eval/criterion-refs` —
+  rubric-judged SCORING plumbing (promoted from `harvey/*`, exercised by
+  `harvey/deliver-smoke.ts`): zip a rubric with per-criterion judge verdicts
+  (same order; null/error = honest FAIL; length mismatch refuses) into
+  scores_json; build the idempotent EvalSet→EvalTrigger→EvalTriggerOutput→
+  CriterionResult(+EvalRequirement) batch-triplet payload for
+  `graph/create-batch-triplet` (`workflow` names the scored workflow);
+  recover the persisted CriterionResult ref_ids from the batch results.
 
 **Naming rule:** `eval/*` = generic. The eval *workflows* that wire these with
 a rubric/task/dataset belong to the experiment and are named `<experiment>-…`.

--- a/mcp/src/lab/eval/seed.ts
+++ b/mcp/src/lab/eval/seed.ts
@@ -24,6 +24,11 @@ import { SEED_OPTS } from "../seed-opts.js";
  *     bands (floor/movable/ceiling), the empirical noise floor from
  *     same-version re-runs, and bias-vs-variance tags for never-correct
  *     tasks (plans/evolve-scoreboard-and-task-matrix.md, Phase 1).
+ *   - `eval/aggregate-scores`, `eval/build-eval-chain`, `eval/criterion-refs`
+ *     — rubric-judged scoring plumbing (promoted from harvey/*): zip judge
+ *     verdicts into scores_json, build the EvalSet→EvalTrigger→
+ *     EvalTriggerOutput→CriterionResult batch-triplet payload, recover the
+ *     persisted CriterionResult ref_ids. Used by harvey-score and wfbench.
  */
 
 const SEED_STEPS: Array<{ file: string; type: string }> = [
@@ -32,6 +37,9 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "optimize.ts", type: "eval/optimize" },
   { file: "evolve-loop.ts", type: "eval/evolve-loop" },
   { file: "matrix.ts", type: "eval/matrix" },
+  { file: "aggregate-scores.ts", type: "eval/aggregate-scores" },
+  { file: "build-eval-chain.ts", type: "eval/build-eval-chain" },
+  { file: "criterion-refs.ts", type: "eval/criterion-refs" },
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));

--- a/mcp/src/lab/eval/steps/aggregate-scores.ts
+++ b/mcp/src/lab/eval/steps/aggregate-scores.ts
@@ -2,8 +2,9 @@ import { z, defineStep } from "vein";
 
 /**
  * Fold the per-criterion judge verdicts into the run's scores object (the
- * format_results / scores_json equivalent, shaped like the harvey-labs
- * harness: score = number of passes, all-pass gating).
+ * format_results / scores_json equivalent, shaped like the harvey-labs /
+ * stakwork rubric harnesses: score = number of passes, all-pass gating).
+ * Domain-agnostic: any rubric-judged eval (harvey-score, wfbench) uses it.
  *
  * `results` is the judge foreach's output array, IN THE SAME ORDER as
  * `rubric` (vein's foreach preserves input order), so criterion identity
@@ -13,7 +14,7 @@ import { z, defineStep } from "vein";
  * counts as an honest FAIL with the error recorded, never as a pass.
  */
 export default defineStep({
-  type: "harvey/aggregate-scores",
+  type: "eval/aggregate-scores",
   description:
     "Zip rubric criteria with their judge verdicts (same order) into scores_json: { score, max_score, " +
     "n_passed, n_total, pass_rate, all_pass, judge_model, criteria_results, failed, judgeCost }. " +
@@ -30,7 +31,7 @@ export default defineStep({
       // A length mismatch means the zip is unsafe — misattributed verdicts
       // are worse than a loud failure.
       throw new Error(
-        `harvey/aggregate-scores: ${cfg.results.length} results for ${cfg.rubric.length} criteria — refusing to zip`,
+        `eval/aggregate-scores: ${cfg.results.length} results for ${cfg.rubric.length} criteria — refusing to zip`,
       );
     }
     const criteria_results = cfg.rubric.map((c, i) => {

--- a/mcp/src/lab/eval/steps/build-eval-chain.ts
+++ b/mcp/src/lab/eval/steps/build-eval-chain.ts
@@ -9,6 +9,8 @@ import { z, defineStep, type StepContext } from "vein";
  *     -HAS_CRITERION_RESULT-> CriterionResult (one per judged criterion)
  *   EvalRequirement -HAS_TRIGGER-> EvalTrigger (one per judged criterion)
  *
+ * Domain-agnostic (harvey-score, wfbench): the domain passes its EvalSet id
+ * and the workflow name recorded as the trigger's agent.
  * Pure payload construction — the write itself is graph/create-batch-triplet
  * (its inline-node dedupe collapses the repeated EvalTriggerOutput side).
  * Ids are derived from ctx.runId, so a retried write MERGES instead of
@@ -17,21 +19,21 @@ import { z, defineStep, type StepContext } from "vein";
  * criteria_results are passed.
  */
 export default defineStep({
-  type: "harvey/build-eval-chain",
+  type: "eval/build-eval-chain",
   description:
     "Construct the create-batch-triplet payload persisting a scored attempt: EvalSet→EvalTrigger→" +
     "EvalTriggerOutput→CriterionResult(+EvalRequirement links), ids derived from the runId (idempotent " +
     "rewrites). Output: { triplets, trigger_id, output_id }.",
   input: z.object({
     evalsetId: z.string().describe("EvalSet id (the task namespace slug)."),
-    task: z.string().describe("The harvey task id (recorded as the trigger's workflow_input)."),
-    scores: z.any().describe("harvey/aggregate-scores output (criteria_results may carry dispute annotations)."),
+    task: z.string().describe("The task id (recorded as the trigger's workflow_input)."),
+    scores: z.any().describe("eval/aggregate-scores output (criteria_results may carry dispute annotations)."),
     criteria_results: z
       .array(z.any())
       .optional()
-      .describe("Override for scores.criteria_results — pass harvey/merge-disputes' ANNOTATED list."),
+      .describe("Override for scores.criteria_results — e.g. harvey/merge-disputes' ANNOTATED list."),
     judge_model: z.string().optional(),
-    workflow: z.string().default("harvey-deliver").describe("Recorded as EvalTrigger.workflow_id/agent."),
+    workflow: z.string().describe("The scored workflow's name — recorded as EvalTrigger.workflow_id/agent."),
   }),
   output: z.any(),
   async run(cfg, ctx) {
@@ -64,7 +66,7 @@ export default defineStep({
     };
 
     // Position of each criterion's HAS_CRITERION_RESULT triplet in the array
-    // below — harvey/criterion-refs zips these with the batch write's results
+    // below — eval/criterion-refs zips these with the batch write's results
     // to recover the created CriterionResult ref_ids.
     const criterionSlots: Array<{ criterion_id: string; index: number }> = [];
     const triplets: Array<Record<string, any>> = [

--- a/mcp/src/lab/eval/steps/criterion-refs.ts
+++ b/mcp/src/lab/eval/steps/criterion-refs.ts
@@ -1,7 +1,7 @@
 import { z, defineStep } from "vein";
 
 /**
- * Zip harvey/build-eval-chain's criterion slots with graph/create-batch-
+ * Zip eval/build-eval-chain's criterion slots with graph/create-batch-
  * triplet's per-triplet results to recover each persisted CriterionResult
  * node's ref_id: slots name the triplet-array INDEX of each criterion's
  * HAS_CRITERION_RESULT write, and the batch step returns results in input
@@ -14,13 +14,13 @@ import { z, defineStep } from "vein";
  * then simply run without graph anchoring, never blocking scoring.
  */
 export default defineStep({
-  type: "harvey/criterion-refs",
+  type: "eval/criterion-refs",
   description:
     "Recover persisted CriterionResult ref_ids: zip build-eval-chain's criterionSlots with " +
     "create-batch-triplet's results. Fail-soft ([] on any shape surprise). Output: " +
     "[{ criterion_id, ref_id }].",
   input: z.object({
-    slots: z.any().optional().describe("harvey/build-eval-chain's criterionSlots: [{ criterion_id, index }]."),
+    slots: z.any().optional().describe("eval/build-eval-chain's criterionSlots: [{ criterion_id, index }]."),
     record: z.any().optional().describe("graph/create-batch-triplet's output ({ results: [...] })."),
   }),
   output: z.any(),

--- a/mcp/src/lab/harvey/deliver-smoke.ts
+++ b/mcp/src/lab/harvey/deliver-smoke.ts
@@ -16,15 +16,17 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { join } from "node:path";
 import { WorkspaceManager, buildRegistry, type StepContext } from "vein";
 import { seedHarveySteps, seedHarveyWorkflows } from "./seed.js";
+import { seedEvalSteps } from "../eval/seed.js";
 
 async function main() {
   const dir = mkdtempSync(join(process.cwd(), ".harvey-deliver-smoke-"));
   try {
     // ── 1. seed + discover ───────────────────────────────────────────────
     const workspace = new WorkspaceManager(dir);
+    await seedEvalSteps(workspace);
     await seedHarveySteps(workspace);
     await seedHarveyWorkflows(workspace);
-    const { registry } = await buildRegistry(workspace.path);
+    const { registry } = await buildRegistry(await workspace.materializeCustomSteps());
 
     const expectedSteps = [
       "harvey/normalize-documents",
@@ -33,10 +35,10 @@ async function main() {
       "harvey/drafter-plan",
       "harvey/validate-deliverables",
       "harvey/filter-contested",
-      "harvey/aggregate-scores",
+      "eval/aggregate-scores",
       "harvey/merge-disputes",
-      "harvey/build-eval-chain",
-      "harvey/criterion-refs",
+      "eval/build-eval-chain",
+      "eval/criterion-refs",
       "harvey/generate-docx",
       "harvey/generate-xlsx",
       // graph/* are vein LIB steps — discovered from the engine, not seeded.
@@ -176,7 +178,7 @@ async function main() {
     console.log("✔ filter-contested (drop + fail-open)");
 
     // ── 7. aggregate-scores (zip; null = honest fail) ────────────────────
-    out = await run("harvey/aggregate-scores", {
+    out = await run("eval/aggregate-scores", {
       rubric,
       results: [
         { object: { verdict: "pass", reasoning: "ok" }, cost: 0.1 },
@@ -196,7 +198,7 @@ async function main() {
     assert.equal(out.failed[0].match_criteria, "...");
     assert.equal(out.judgeCost, 0.1);
     await assert.rejects(
-      () => run("harvey/aggregate-scores", { rubric, results: [null] }),
+      () => run("eval/aggregate-scores", { rubric, results: [null] }),
       /refusing to zip/,
     );
     console.log("✔ aggregate-scores (zip / honest fail / length guard)");
@@ -245,7 +247,7 @@ async function main() {
     console.log("✔ merge-disputes (left-join + refs + fail-soft + contested)");
 
     // ── 8b. criterion-refs (slot × batch-result zip, fail-soft) ──────────
-    let refs: any = await run("harvey/criterion-refs", {
+    let refs: any = await run("eval/criterion-refs", {
       slots: [
         { criterion_id: "c1", index: 2 },
         { criterion_id: "c2", index: 4 },
@@ -261,17 +263,18 @@ async function main() {
       },
     });
     assert.deepEqual(refs, [{ criterion_id: "c1", ref_id: "cr1" }]); // errored slot dropped
-    refs = await run("harvey/criterion-refs", { slots: "garbage", record: { error: "record failed" } });
+    refs = await run("eval/criterion-refs", { slots: "garbage", record: { error: "record failed" } });
     assert.deepEqual(refs, []);
     console.log("✔ criterion-refs (zip + fail-soft)");
 
     // ── 9. build-eval-chain (ontology shape) ─────────────────────────────
     const ctx = { runId: "run42" } as StepContext;
     const chain: any = await run(
-      "harvey/build-eval-chain",
+      "eval/build-eval-chain",
       {
         evalsetId: "slug",
         task: "a/b",
+        workflow: "harvey-deliver",
         scores: out,
         criteria_results: [
           { id: "c1", criterion_id: "c1", title: "A", verdict: "pass", reasoning: "ok" },

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -31,17 +31,16 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "digest-results.ts", type: "harvey/digest-results" },
   // harvey-deliver pipeline steps (standalone production-style pipeline —
   // rubric as input; NOT part of the benchmark harness): intake, drafting
-  // plan, scoring plumbing, and the pinned read-only graph sub-agent.
+  // plan, scoring plumbing, and the pinned read-only graph sub-agent. The
+  // generic scoring steps (aggregate-scores, build-eval-chain,
+  // criterion-refs) live in eval/* now — seeded by eval/seed.ts.
   { file: "normalize-documents.ts", type: "harvey/normalize-documents" },
   { file: "graph-sub-agent.ts", type: "harvey/graph-sub-agent" },
   { file: "ingest-state.ts", type: "harvey/ingest-state" },
   { file: "drafter-plan.ts", type: "harvey/drafter-plan" },
   { file: "validate-deliverables.ts", type: "harvey/validate-deliverables" },
   { file: "filter-contested.ts", type: "harvey/filter-contested" },
-  { file: "aggregate-scores.ts", type: "harvey/aggregate-scores" },
   { file: "merge-disputes.ts", type: "harvey/merge-disputes" },
-  { file: "build-eval-chain.ts", type: "harvey/build-eval-chain" },
-  { file: "criterion-refs.ts", type: "harvey/criterion-refs" },
   // deliverable generation (pandoc / openpyxl) — grantable agent tools so the
   // production prompts' harvey_generate_docx/_xlsx calls work verbatim.
   { file: "generate-docx.ts", type: "harvey/generate-docx" },

--- a/mcp/src/lab/harvey/steps/merge-disputes.ts
+++ b/mcp/src/lab/harvey/steps/merge-disputes.ts
@@ -33,7 +33,7 @@ export default defineStep({
     "annotates nothing. Output: { criteria_results, annotations, flagged_count, contested_count, " +
     "contested_requirements }.",
   input: z.object({
-    criteria_results: z.array(z.any()).describe("Full criteria_results from harvey/aggregate-scores."),
+    criteria_results: z.array(z.any()).describe("Full criteria_results from eval/aggregate-scores."),
     failed: z.array(z.any()).default([]).describe("The failed subset, in the order disputes ran."),
     disputes: z
       .any()
@@ -42,7 +42,7 @@ export default defineStep({
     criterionRefs: z
       .any()
       .optional()
-      .describe("[{ criterion_id, ref_id }] for the persisted CriterionResult nodes (harvey/criterion-refs output)."),
+      .describe("[{ criterion_id, ref_id }] for the persisted CriterionResult nodes (eval/criterion-refs output)."),
     requirements: z
       .any()
       .optional()

--- a/mcp/src/lab/harvey/workflows/harvey-judge-criterion.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-judge-criterion.yaml
@@ -5,7 +5,7 @@ name: harvey-judge-criterion
 # verdict. Run per criterion by harvey-score's foreach (this subflow exists
 # because foreach bodies get no onError of their own — the fall-soft lives on
 # the agent step here: a judge crash returns { error } and is scored as an
-# honest FAIL by harvey/aggregate-scores, never a pass).
+# honest FAIL by eval/aggregate-scores, never a pass).
 #
 # The judge is the core agent step in SCHEMA mode with bash-only tools: it
 # reads the deliverables itself (pandoc for .docx — mirrors the harness's

--- a/mcp/src/lab/harvey/workflows/harvey-score.yaml
+++ b/mcp/src/lab/harvey/workflows/harvey-score.yaml
@@ -86,7 +86,7 @@ steps:
             taskDescription: "{{ input.task_description }}"
 
   - id: scores
-    type: harvey/aggregate-scores
+    type: eval/aggregate-scores
     depends: judged
     config:
       rubric: "{{ scorable.rubric }}"
@@ -95,7 +95,7 @@ steps:
       dropped: "{{ scorable.dropped }}"
 
   - id: chain
-    type: harvey/build-eval-chain
+    type: eval/build-eval-chain
     depends: scores
     config:
       evalsetId: "{{ input.evalset_id }}"
@@ -121,7 +121,7 @@ steps:
   # record write failed) — the dispute agents anchor Cause triplets to them
   # and the annotation write-back targets them.
   - id: critrefs
-    type: harvey/criterion-refs
+    type: eval/criterion-refs
     depends: record
     config:
       slots: "{{ chain.criterionSlots }}"

--- a/mcp/src/lab/plans/wfbench-harness.md
+++ b/mcp/src/lab/plans/wfbench-harness.md
@@ -1,0 +1,134 @@
+# wfbench — the Workflow Editor benchmark harness as a vein workflow
+
+Port of stakwork workflow 58313 ("Workflow Editor Agent Benchmark — Task
+Runner", v189235) plus its nested workflows, rebuilt on the lab's existing
+produce → run → judge → record substrate. Second purpose: use the same
+harness to PORT stakwork workflows onto vein one task at a time, with a
+rubric that checks the port is faithful.
+
+## Decision: the author is an `agent` step with `agentTools: ["meta/*"]`
+
+Not a "chat assistant as a step". Reasons:
+
+- The chat builder (`vein/src/ai/tools.ts`) and `meta/*` are the SAME
+  authoring capability (`services.authoring`). `meta/*` is its in-run form.
+  This is exactly how `gaia-evolve-gen` / `harvey-evolve-gen` already author
+  candidates, and it is what EVOLVE_SPEC §5.3.2 prescribes.
+- The chat is a detached background job with its own store, dispatch
+  notifications and auto-turn caps. Wrapping it as a step means polling a
+  chat and parsing prose; the agent step gives schema-mode structured
+  output, `cost`/`steps`, per-tool-call events on the canvas, retry/onError
+  and run-control tree linkage for free.
+- Stakwork 54419 "Workflow Editor JSON" is itself just a wrapper around an
+  agent loop (54517). The vein twin of "54419 as a black box returning
+  artifact pointers" is `agent` + `meta/*` returning `{ workflow, version }`.
+- Chat-only tools the author does NOT need: `bash` (forbidden next to
+  `meta/*`), `graph_query`, run control, `set_active_version`. The one
+  worth adding is `validate_workflow` → new `meta/validate-workflow` step
+  (thin wrapper over the same `validate(yaml, name)`).
+
+## Step map (58313 → vein)
+
+| 58313 (stakwork) | vein |
+| --- | --- |
+| `set_var` | workflow `input` + `params` |
+| EvalSet / EvalRequirement / EvalTrigger roster (55741, 58114, 55740, `hop_check_trigger_exists`, `guard_first_run`) | `graph/create-node` (EvalSet), `foreach` → `graph/create-node` (EvalRequirement), `graph/graph-neighbors` + `if` → `graph/create-triplet` with `HAS_BASELINE_TRIGGER` or `HAS_TRIGGER` |
+| `run_workflow_editor` (54419) | `agent` + `agentTools: ["meta/*"]`, `toolFilter: [str_replace_based_edit_tool]`, schema `{ workflow, version, summary, changes, missingSecrets }` |
+| `extract_artifacts.py`, JSONPath for workflowId/version | schema output; never trust the echo — `meta/get-workflow` pin fallback (`vpin.version || vactive.version`) + the `published` gate vs `vbefore` (copy from `gaia-evolve-gen`) |
+| 58414 WhileLoop ×15 + `api_fallback_fetch` | gone. `meta/publish-workflow` is synchronous; `meta/get-workflow { name, version }` returns the YAML |
+| `wfbench_check_input_keys.py` | pure step `wfbench/check-input-keys` (declared `input` keys of the produced YAML vs the task's `workflow_input_json`) |
+| 57425 Run Trigger + webhook wait | `meta/run-workflow { name, version, input }` — awaits, own runId, refuses non-`ai` workflows |
+| `wfbench_classify_run_result.py` | pure step `wfbench/classify-run` over `run.status` / `run.output` / `run.runId` |
+| `wfbench_build_produced_materials.py` | pure step `wfbench/build-materials` (produced YAML + agent-authored custom steps via `meta/get-step`, run output via `meta/get-run`, expected output, launch payload) |
+| `guard_materials_present` | `if n_materials > 0`, else harness error `no_materials_produced` |
+| skill `harvey_lab_score_rubric` (all criteria, one call) | `foreach` criteria → subflow `wfbench-judge-criterion` (clone of `harvey-judge-criterion`: agent schema mode, materials in prompt / artifacts dir, NO tools) → `eval/aggregate-scores`. Judge crash = `{ error }` = honest FAIL |
+| `guard_judge_ran`, `guard_valid_score` | `if` on aggregate output, else `judge_failed` |
+| 58312 record (EvalTriggerOutput + CriterionResult + edges) | `eval/build-eval-chain` → `graph/create-batch-triplet` (idempotent on runId) |
+| `resolve_webhook_payload` (4-way) + `post_result` | one `wfbench/pack-result` depending on every branch (`||` chain) → `if webhookUrl` → `http POST`. Output == what was posted (fixes the 58313 `set_output` divergence) |
+
+Webhook body: byte-compatible with what Hive parses today
+(`RunnerScoreSchema`): success `{ task_slug, task_title, n_passed, n_total,
+all_pass, pass_rate, judge_model, criteria_results }`, failure
+`{ harness_error: true, error_type }` with no score fields.
+
+## Files
+
+```
+mcp/src/lab/wfbench/
+  seed.ts                          # seedWfbenchSteps / seedWfbenchWorkflows (SEED_OPTS)
+  steps/
+    check-input-keys.ts            # pure
+    classify-run.ts                # pure
+    build-materials.ts             # pure (reads meta/* outputs passed in)
+    pack-result.ts                 # pure passthrough (like harvey/pack-result)
+    stakwork-fetch.ts              # GET jobs.stakwork.com workflow body + one project's
+                                   #   input/output; STAK_CUSTOMER_TOKEN via ctx.services.secrets
+  workflows/
+    wfbench-run.yaml               # the 58313 twin (input below)
+    wfbench-judge-criterion.yaml   # per-criterion judge subflow
+    wfbench-port-task.yaml         # stakwork workflow id → task object (+ derived rubric)
+    wfbench-batch.yaml             # foreach tasks → wfbench-run
+```
+
+`wfbench-run` input: `{ task_slug, task_title, instructions, criteria,
+workflow_input_json, rerun_expected_output?, webhookUrl?, namespace?,
+baseline_workflow? }`. Params: `authorSystem`, `authorModel`,
+`authorMaxSteps`, `judgeSystem`, `judgeModel`, `judgeMaxSteps`.
+
+Registered in `createLabVein.ts` next to gaia. Needs the graph (mcp's
+Neo4j), `ANTHROPIC_API_KEY`, and `STAK_CUSTOMER_TOKEN` in the secret store
+for the port path.
+
+## Grant discipline
+
+- author: `meta/*` + editor tool only. Never bash, never `graph/*`, never
+  `wfbench/*`.
+- judge: no tools (materials are pre-resolved into the prompt). Cheap and
+  non-gameable.
+- produced workflow: runs via `meta/run-workflow` so it is necessarily
+  publisher `ai`; the seeded harness surface can never be graded as a
+  candidate.
+
+## The port use case
+
+Each stakwork workflow becomes ONE task for `wfbench-run`:
+
+- `instructions` = the stakwork body JSON (`data.workflow` from
+  `wfbench/stakwork-fetch`) + "port this to vein" + a translation
+  cheat-sheet in `params.authorSystem`:
+  SetVar → `input`/`params`; JSONBuilder / JSONPathParser / IfElseValue →
+  `{{ }}` templates; Request → `http`; IfElseCondition → `if` + `when`;
+  WhileLoop → `loop`; ForEachCondition → `foreach`; WorkflowRunner →
+  `subflow`; Script → `meta/create-step`; Skill/LLM → `agent` / `llm`;
+  `[#(step).output.x]` → `{{ step.x }}`; `%%SECRET%%` → secret NAMES from
+  `meta/list-secrets` (the harvey seeder already did this mapping by hand
+  for the deliver pipeline — same rules, now given to the agent).
+- `workflow_input_json` + `rerun_expected_output` = one completed stakwork
+  project's real input and output for that workflow (fetched, not
+  invented). Faithfulness is then judged against a real run, not prose.
+- `criteria` = derived once per workflow by `wfbench-port-task` (an agent
+  in schema mode reading the stakwork body: same input keys, every step
+  with a side effect present, same output shape, secrets by name, no
+  hardcoded values) and kept as EvalRequirements after a human glance.
+  Nothing in the produce path ever sees them.
+
+`baseline_workflow` (Hive's v2 edit-existing case): `meta/publish-workflow`
+refuses to overwrite a workflow the agent surface did not author, so the
+harness first republishes the baseline YAML under `<name>-candidate` (now
+publisher `ai`) and points the author at that. Cheap to support from day
+one; 58313 v1 skipped it.
+
+## Small vein/lab changes needed
+
+1. DONE — `meta/validate-workflow` step (wraps the chat's `validate`).
+2. DONE — `harvey/build-eval-chain`, `harvey/aggregate-scores`,
+   `harvey/criterion-refs` promoted to `eval/*` (no aliases: harvey-score
+   and the smoke were re-pointed in the same change; `workflow` is now a
+   required input of build-eval-chain).
+
+## Not ported on purpose
+
+- 58414's polling loop and the `api_fallback_fetch` (no async publish).
+- 57425's webhook wait (`meta/run-workflow` awaits).
+- 54419's `set_metadata` gap on the `workflow_id="new"` path.
+- The graph "Page" blurb calling it a timing page.

--- a/vein/EVOLVE_SPEC.md
+++ b/vein/EVOLVE_SPEC.md
@@ -254,6 +254,7 @@ in-workflow author on iteration one:
 | `meta/create-step`, `meta/edit-step` | `workspace.publishStep` | `create_step` refuses existing names — without edit, every iteration pollutes the registry (`my-fetcher-2`, `-3`, …) |
 | `meta/run-step` | `runSingleStep` + cassettes | the inner loop: test ONE step, offline via record/replay, without paying for a full candidate run |
 | `meta/list-workflows`, `meta/get-workflow` | workflow discovery | read current source before editing |
+| `meta/validate-workflow` | `validateWorkflowYaml` (the chat's `validate_workflow`) | static check before publishing — a typo never becomes a version |
 | `meta/publish-workflow` | create/edit as an explicit upsert | the candidate artifact |
 | `meta/run-workflow` | `runWorkflow` | test the candidate end to end |
 | `meta/list-runs`, `meta/get-run` | run-store reads | debug a failed candidate — **provenance-scoped, see §6** |

--- a/vein/src/authoring.test.ts
+++ b/vein/src/authoring.test.ts
@@ -65,6 +65,7 @@ describe("authoring capability (the meta surface)", () => {
       "meta/run-step",
       "meta/list-workflows",
       "meta/get-workflow",
+      "meta/validate-workflow",
       "meta/publish-workflow",
       "meta/run-workflow",
       "meta/list-runs",
@@ -247,6 +248,40 @@ describe("authoring capability (the meta surface)", () => {
     const listed = (await authoring.listWorkflows()) as any;
     const entry = listed.workflows.find((w: any) => w.name === "cand-inrun");
     assert.equal(entry.publisher, "ai");
+  });
+
+  it("validateWorkflow is the static check behind meta/validate-workflow — no publish", async () => {
+    const bad = await authoring.validateWorkflow(
+      "name: cand-invalid\nsteps:\n  - id: a\n    type: no/such-step\n    config: {}\n",
+    );
+    assert.equal(bad.ok, false);
+    assert.ok(bad.errors.some((e) => /no\/such-step/.test(e.message)), JSON.stringify(bad.errors));
+
+    // A YAML without `name:` passes when the publish name is supplied.
+    const good = await authoring.validateWorkflow(
+      "steps:\n  - id: say\n    type: log\n    config:\n      message: hi\n",
+      "cand-valid",
+    );
+    assert.equal(good.ok, true, JSON.stringify(good.errors));
+    assert.equal(good.summary.steps, 1);
+
+    // Nothing was published either way.
+    const listed = (await authoring.listWorkflows()) as any;
+    assert.ok(!listed.workflows.some((w: any) => w.name === "cand-valid" || w.name === "cand-invalid"));
+
+    // ...and the step form reaches it inside a run.
+    const result = await vein.run({
+      name: "meta-validate-test",
+      input: z.any(),
+      steps: [
+        { id: "check", type: "meta/validate-workflow", config: {
+          name: "cand-valid",
+          yaml: "steps:\n  - id: say\n    type: log\n    config:\n      message: hi\n",
+        } },
+      ],
+    });
+    assert.equal(result.status, "success", JSON.stringify(result.error));
+    assert.equal((result.output as any).ok, true);
   });
 
   it("listSecrets returns names only", async () => {

--- a/vein/src/authoring.ts
+++ b/vein/src/authoring.ts
@@ -10,6 +10,7 @@ import type { CassetteMode } from "./cassette.js";
 import type { SecretInfo } from "./secret-store.js";
 import { lsSteps, searchSteps, readStepSource } from "./ai/stepHelpers.js";
 import { zodToFields } from "./ai/schemaHelpers.js";
+import { validateWorkflowYaml, type ValidationResult } from "./validate.js";
 
 /**
  * The AUTHORING core — the workspace's author/test/inspect operations, shared
@@ -354,6 +355,9 @@ export interface AuthoringCapability {
   runStep(type: string, args?: RunStepArgs): Promise<RunStepResult | { error: string }>;
   listWorkflows(): Promise<unknown>;
   getWorkflow(name: string, version?: string): Promise<unknown>;
+  /** Static check of workflow YAML WITHOUT publishing — the chat builder's
+   *  `validate_workflow`, for in-run authors (`meta/validate-workflow`). */
+  validateWorkflow(yaml: string, name?: string): Promise<ValidationResult>;
   publishWorkflow(
     name: string,
     yaml: string,
@@ -521,6 +525,15 @@ export function buildAuthoringCapability(deps: AuthoringDeps): AuthoringCapabili
         publisher: entry.publisher,
         yaml,
       };
+    },
+
+    async validateWorkflow(yaml, name) {
+      const workflows = await workspace.listWorkflows().catch(() => []);
+      return validateWorkflowYaml(yaml, {
+        registry: await deps.getRegistry(),
+        workflows: workflows.map((w) => ({ name: w.name, versions: w.versions })),
+        name,
+      });
     },
 
     async publishWorkflow(name, yaml, description, category) {

--- a/vein/src/steps/lib/meta/validate-workflow.ts
+++ b/vein/src/steps/lib/meta/validate-workflow.ts
@@ -1,0 +1,20 @@
+import { z } from "zod";
+import { defineStep } from "../../../core.js";
+import { requireAuthoring } from "./_shared.js";
+
+export default defineStep({
+  type: "meta/validate-workflow",
+  description:
+    "Statically check workflow YAML WITHOUT publishing — call before meta/publish-workflow so a typo never becomes a published version. Errors (would fail or hang at run time): YAML/unquoted-template problems, missing/duplicate step ids, unknown step types, `depends` on unknown ids, dependency cycles, template references to unknown roots, config fields that fail a step's schema (template-valued fields are skipped), subflows naming a workflow/version that doesn't exist. Warnings: unknown config fields, `when` without an `if` gate, references to steps that aren't upstream dependencies. Returns { ok, errors: [{ path, message }], warnings: [...], summary }.",
+  input: z.object({
+    yaml: z.string().describe("Full workflow YAML to check"),
+    name: z
+      .string()
+      .optional()
+      .describe("The name you will publish under (lets a YAML without `name:` pass, as publishing stamps it in)."),
+  }),
+  output: z.any(),
+  async run(cfg, ctx) {
+    return requireAuthoring(ctx.services).validateWorkflow(cfg.yaml, cfg.name);
+  },
+});


### PR DESCRIPTION
Groundwork for the wfbench harness (the vein port of stakwork 58313, design in `mcp/src/lab/plans/wfbench-harness.md`).

## vein
- `AuthoringCapability.validateWorkflow(yaml, name?)` — the chat builder's `validate_workflow`, reachable in-run.
- New lib step `meta/validate-workflow` wrapping it, so an authoring agent can static-check YAML before `meta/publish-workflow`. Test covers unknown step type, name-less YAML with a publish name, no-publish side effect, and the step form inside a run.
- EVOLVE_SPEC meta-step table row.

## lab
- `harvey/aggregate-scores`, `harvey/build-eval-chain`, `harvey/criterion-refs` → `eval/*` (they carry no harvey config; `build-eval-chain.workflow` is now required instead of defaulting to `harvey-deliver`). `harvey-score`, `merge-disputes`, both seeders, AGENTS.md and the deliver smoke re-pointed. No aliases kept: nothing else referenced the old names.
- `deliver-smoke.ts` now builds the registry from `materializeCustomSteps()`; passing the workspace root had been failing at the first registry assertion since the graph-backend change. `harvey/smoke.ts`, `sheets/smoke.ts`, `jarvis/smoke.ts` have the same one-liner bug and are left for a follow-up.

## Verification
- vein: `tsc` clean, `npm test` 664/664.
- mcp: `tsc --noEmit` clean after `yarn refresh-vein`; `npx tsx src/lab/harvey/deliver-smoke.ts` all checks pass.