### PR TITLE
lab: build smoke registries from materializeCustomSteps()

### DIFF
--- a/mcp/src/lab/harvey/smoke.ts
+++ b/mcp/src/lab/harvey/smoke.ts
@@ -181,7 +181,7 @@ async function main() {
     const wsDir = join(base, "ws");
     const workspace = new WorkspaceManager(wsDir);
     await seedHarveySteps(workspace);
-    const { registry } = await buildRegistry(workspace.path);
+    const { registry } = await buildRegistry(await workspace.materializeCustomSteps());
     assert.ok(registry["harvey/get-task"] && registry["harvey/evaluate"]);
 
     const ctx = {

--- a/mcp/src/lab/jarvis/smoke.ts
+++ b/mcp/src/lab/jarvis/smoke.ts
@@ -57,7 +57,7 @@ async function main() {
   try {
     const workspace = new WorkspaceManager(dir);
     await seedJarvisSteps(workspace);
-    const { registry } = await buildRegistry(workspace.path);
+    const { registry } = await buildRegistry(await workspace.materializeCustomSteps());
     const expected = [
       "jarvis/get-ontology", "jarvis/get-ontology-type", "jarvis/graph-search",
       "jarvis/graph-get", "jarvis/graph-get-batched", "jarvis/graph-neighbors",

--- a/mcp/src/lab/sheets/smoke.ts
+++ b/mcp/src/lab/sheets/smoke.ts
@@ -79,7 +79,7 @@ async function main() {
   try {
     const workspace = new WorkspaceManager(dir);
     await seedSheetsSteps(workspace);
-    const { registry } = await buildRegistry(workspace.path);
+    const { registry } = await buildRegistry(await workspace.materializeCustomSteps());
     const expected = [
       "sheets/create-spreadsheet", "sheets/update-values", "sheets/batch-update-values",
       "sheets/get-values", "sheets/add-sheet", "sheets/import-spreadsheet",


### PR DESCRIPTION
## Summary
- The harvey, sheets and jarvis lab smoke scripts still built the vein step registry from `workspace.path`. Since the graph-backend workspace change, `buildRegistry` expects the directory returned by `workspace.materializeCustomSteps()`, so these scripts no longer discovered any custom steps.
- Applies the same one-line fix already made to `deliver-smoke.ts` in #1648.

## Verification
Ran each from `mcp/` after `yarn refresh-vein`:
- `npx tsx src/lab/harvey/smoke.ts` → ALL HARVEY SMOKE CHECKS PASSED
- `npx tsx src/lab/sheets/smoke.ts` → ALL SHEETS SMOKE CHECKS PASSED
- `npx tsx src/lab/jarvis/smoke.ts` → ALL JARVIS SMOKE CHECKS PASSED