### PR TITLE
lab: seeders retire steps they no longer ship

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -15,6 +15,11 @@ workflows/steps inside it — **not** separate servers. Adding an experiment
 
 - `createLabVein.ts` — the single instance: registry (vein core+lib + all
   experiment steps), merged `services` bag, seeded workflow templates.
+  **Seeding is additive**: dropping a step from a seeder's `SEED_STEPS` does
+  NOT remove it from existing workspaces (graph-backed ones persist, and
+  the author agent keeps discovering it). When you remove or rename a
+  seeded step, add the old type to that seeder's `RETIRED_STEPS` list —
+  `retireSteps` (`seed-opts.ts`) soft-deletes it at boot.
 - `mount.ts` — bridges the vein (Hono) app into Express under `/lab`
   (API + run-streaming SSE). Registered before `express.json()` to keep
   raw request streams. Lazy-initialized so mcp boot isn't coupled to

--- a/mcp/src/lab/gaia/seed.ts
+++ b/mcp/src/lab/gaia/seed.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
-import { SEED_OPTS } from "../seed-opts.js";
+import { SEED_OPTS, retireSteps } from "../seed-opts.js";
 
 /**
  * GAIA LAB steps + workflows — the harness that scored 5/5 on the first
@@ -39,6 +39,9 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   { file: "summarize-batch.ts", type: "gaia/summarize-batch" },
   { file: "digest-results.ts", type: "gaia/digest-results" },
 ];
+
+// Types this seeder USED to publish (seeding is additive — see retireSteps).
+const RETIRED_STEPS = ["gaia/pack-result"]; // → vein core `pack`
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 
@@ -102,4 +105,5 @@ export async function seedGaiaSteps(workspace: WorkspaceStore): Promise<void> {
       );
     }
   }
+  await retireSteps(workspace, RETIRED_STEPS, "gaia");
 }

--- a/mcp/src/lab/harvey/seed.ts
+++ b/mcp/src/lab/harvey/seed.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
-import { SEED_OPTS } from "../seed-opts.js";
+import { SEED_OPTS, retireSteps } from "../seed-opts.js";
 
 /**
  * Harvey LAB verification steps — THIN plumbing only. The actual grader is
@@ -43,6 +43,15 @@ const SEED_STEPS: Array<{ file: string; type: string }> = [
   // production prompts' harvey_generate_docx/_xlsx calls work verbatim.
   { file: "generate-docx.ts", type: "harvey/generate-docx" },
   { file: "generate-xlsx.ts", type: "harvey/generate-xlsx" },
+];
+
+// Types this seeder USED to publish. Seeding is additive, so without this a
+// dropped step lingers in every existing workspace (see retireSteps).
+const RETIRED_STEPS = [
+  "harvey/pack-result", // → vein core `pack`
+  "harvey/aggregate-scores", // → eval/aggregate-scores
+  "harvey/build-eval-chain", // → eval/build-eval-chain
+  "harvey/criterion-refs", // → eval/criterion-refs
 ];
 
 const HERE = dirname(fileURLToPath(import.meta.url));
@@ -141,4 +150,5 @@ export async function seedHarveySteps(workspace: WorkspaceStore): Promise<void> 
       );
     }
   }
+  await retireSteps(workspace, RETIRED_STEPS, "harvey");
 }

--- a/mcp/src/lab/seed-opts.ts
+++ b/mcp/src/lab/seed-opts.ts
@@ -1,4 +1,4 @@
-import type { PublishByContentOptions } from "vein";
+import type { PublishByContentOptions, WorkspaceStore } from "vein";
 
 /**
  * How every lab seeder reconciles its committed templates into the workspace
@@ -11,3 +11,24 @@ import type { PublishByContentOptions } from "vein";
  * still the only way to propagate it to other instances.
  */
 export const SEED_OPTS: PublishByContentOptions = { reactivateKnown: false };
+
+/**
+ * Retire steps a seeder no longer ships. Seeding is ADDITIVE — a step dropped
+ * from a `SEED_STEPS` list stays live in every existing workspace (the graph
+ * workspace is persistent, and the file one keeps its materialized file), so
+ * an author agent keeps discovering and using it. Each seeder keeps a
+ * `RETIRED_STEPS` list of the types it used to publish and calls this at the
+ * end of its step seeding; `deleteStep` is a soft delete on the graph store
+ * (restorable by a later publish under the same name) and an unlink on the
+ * file store. Missing types are a silent no-op, so a fresh workspace pays
+ * nothing.
+ */
+export async function retireSteps(workspace: WorkspaceStore, types: readonly string[], tag: string): Promise<void> {
+  for (const type of types) {
+    try {
+      if (await workspace.deleteStep(type)) console.log(`[${tag}] retired step: ${type}`);
+    } catch (err) {
+      console.warn(`[${tag}] could not retire step "${type}":`, err instanceof Error ? err.message : err);
+    }
+  }
+}

--- a/mcp/src/lab/wfbench/seed.ts
+++ b/mcp/src/lab/wfbench/seed.ts
@@ -2,7 +2,7 @@ import { readFile } from "node:fs/promises";
 import { fileURLToPath } from "node:url";
 import { dirname, join } from "node:path";
 import type { WorkspaceStore } from "vein";
-import { SEED_OPTS } from "../seed-opts.js";
+import { SEED_OPTS, retireSteps } from "../seed-opts.js";
 
 /**
  * wfbench — the Workflow Editor Agent Benchmark harness (the vein port of
@@ -53,6 +53,9 @@ const SEED_WORKFLOWS: Array<{ name: string; description: string }> = [
   },
 ];
 
+// Types this seeder USED to publish (seeding is additive — see retireSteps).
+const RETIRED_STEPS = ["wfbench/pack-result"]; // → vein core `pack`
+
 const HERE = dirname(fileURLToPath(import.meta.url));
 
 export async function seedWfbenchSteps(workspace: WorkspaceStore): Promise<void> {
@@ -66,6 +69,7 @@ export async function seedWfbenchSteps(workspace: WorkspaceStore): Promise<void>
       console.warn(`[wfbench] could not seed step "${type}":`, err instanceof Error ? err.message : err);
     }
   }
+  await retireSteps(workspace, RETIRED_STEPS, "wfbench");
 }
 
 export async function seedWfbenchWorkflows(workspace: WorkspaceStore): Promise<void> {

--- a/mcp/src/lab/wfbench/smoke.ts
+++ b/mcp/src/lab/wfbench/smoke.ts
@@ -35,6 +35,14 @@ async function main() {
   try {
     // ── 1. seed + discover ───────────────────────────────────────────────
     const workspace = new WorkspaceManager(dir);
+    // A step this seeder USED to ship, left over from an earlier deploy —
+    // reseeding must retire it (seeding is additive otherwise).
+    await workspace.publishStep(
+      "wfbench/pack-result",
+      'import { z, defineStep } from "vein";\nexport default defineStep({ type: "wfbench/pack-result", input: z.any(), output: z.any(), async run(cfg) { return cfg; } });\n',
+      undefined,
+      "old-deploy",
+    );
     await seedEvalSteps(workspace);
     await seedArtifactSteps(workspace);
     await seedWfbenchSteps(workspace);
@@ -66,7 +74,9 @@ async function main() {
       "agent",
     ];
     for (const t of expectedSteps) assert.ok(registry[t], `registry missing ${t}`);
-    console.log(`✔ seeded + discovered ${expectedSteps.length} steps`);
+    assert.equal(registry["wfbench/pack-result"], undefined, "retired step must not be discoverable after reseeding");
+    assert.ok(registry["pack"], "core pack step");
+    console.log(`✔ seeded + discovered ${expectedSteps.length} steps; stale wfbench/pack-result retired`);
 
     // ── 2. static validation (what meta/validate-workflow runs) ──────────
     const vein = await createVein({ workspace, serveUi: false });


### PR DESCRIPTION
Seeding is additive: dropping a step from a seeder's `SEED_STEPS` never removed it from an existing workspace, and the lab's workspace is graph-backed and persistent. That's how the wfbench author kept picking `gaia/pack-result` two runs after #1651 deleted it from the repo — the type was still discoverable and still loaded.

- `retireSteps(workspace, types, tag)` in `seed-opts.ts`: `workspace.deleteStep` per type (soft delete on the graph store, unlink on the file store), logs only when something was actually retired, silent on a fresh workspace.
- `RETIRED_STEPS` lists: harvey (`pack-result`, `aggregate-scores`, `build-eval-chain`, `criterion-refs` — the four moved in #1648/#1651), gaia and wfbench (`pack-result`). Each seeder calls it after seeding its steps.
- wfbench smoke publishes a stale `wfbench/pack-result` first and asserts reseeding retires it.
- AGENTS.md: the rule, next to the seeding model.

Verified: mcp `tsc` clean; smokes green (wfbench, harvey deliver, gaia, gaia evolve, harvey evolve — the last one runs against the real local graph workspace and retired the three stale harvey types there).