### PR TITLE
lab: wfbench — validation as judge evidence, namespace as run input

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -615,7 +615,9 @@ workflow (design + step map: `plans/wfbench-harness.md`). One task in
 rerun_expected_output?, webhook_url? }` — Hive's payload shape), one callback
 out. `wfbench-run`: graph roster (EvalSet → EvalRequirement×N, EvalTrigger,
 HAS_BASELINE_TRIGGER on the EvalSet's first trigger else HAS_TRIGGER — 58313's
-ids, written with vein's `graph/*` steps under `params.namespace`) ‖ the
+ids, written with vein's `graph/*` steps under `input.namespace ||
+params.namespace`; Hive passes the partition its own roster upsert used so
+the writes merge onto its nodes) ‖ the
 author (core `agent` + `agentTools: ["meta/*"]`, editor tool only — 54419's
 twin) builds `wfbench-<slug>` → resolve the version it actually shipped
 (`vpin || vactive`, `published` vs `vbefore` — the gaia-evolve-gen guard) →
@@ -623,9 +625,10 @@ input-key gate (`wfbench/check-input-keys`: the `input.<key>` references in
 the produced YAML vs the launch payload; a mismatch or empty body is a harness
 error, never launched) → rerun via `meta/run-workflow` (57425's twin; own runId
 = 58313's project_id) → `wfbench/classify-run` (a runtime-FAILED rerun is still
-judged; no runId is a harness error) → `wfbench/build-materials` (workflow YAML
-+ custom step sources + launch payload + run output + expected output, inlined
-as one markdown block) → per-criterion judge (`wfbench-judge-criterion`: agent
+judged; no runId is a harness error) → `meta/validate-workflow` on the produced YAML
+(judge EVIDENCE for structural criteria, never a gate) → `wfbench/build-materials`
+(workflow YAML + custom step sources + validation result + launch payload + run
+output + expected output, inlined as one markdown block) → per-criterion judge (`wfbench-judge-criterion`: agent
 schema mode, nothing to read — a crash packs `{ error }` = honest FAIL) →
 `eval/aggregate-scores` → record `EvalTrigger -HAS_OUTPUT-> EvalTriggerOutput
 -HAS_CRITERION_RESULT-> CriterionResult <-HAS_CRITERION_RESULT- EvalRequirement`

--- a/mcp/src/lab/plans/wfbench-harness.md
+++ b/mcp/src/lab/plans/wfbench-harness.md
@@ -39,7 +39,7 @@ Not a "chat assistant as a step". Reasons:
 | `wfbench_check_input_keys.py` | pure step `wfbench/check-input-keys` (declared `input` keys of the produced YAML vs the task's `workflow_input_json`) |
 | 57425 Run Trigger + webhook wait | `meta/run-workflow { name, version, input }` — awaits, own runId, refuses non-`ai` workflows |
 | `wfbench_classify_run_result.py` | pure step `wfbench/classify-run` over `run.status` / `run.output` / `run.runId` |
-| `wfbench_build_produced_materials.py` | pure step `wfbench/build-materials` (produced YAML + agent-authored custom steps via `meta/get-step`, run output via `meta/get-run`, expected output, launch payload) |
+| `wfbench_build_produced_materials.py` | pure step `wfbench/build-materials` (produced YAML + agent-authored custom steps via `meta/get-step`, the engine's static validation via `meta/validate-workflow`, run output, expected output, launch payload) |
 | `guard_materials_present` | `if n_materials > 0`, else harness error `no_materials_produced` |
 | skill `harvey_lab_score_rubric` (all criteria, one call) | `foreach` criteria → subflow `wfbench-judge-criterion` (clone of `harvey-judge-criterion`: agent schema mode, materials in prompt / artifacts dir, NO tools) → `eval/aggregate-scores`. Judge crash = `{ error }` = honest FAIL |
 | `guard_judge_ran`, `guard_valid_score` | `if` on aggregate output, else `judge_failed` |

--- a/mcp/src/lab/wfbench/seed.ts
+++ b/mcp/src/lab/wfbench/seed.ts
@@ -49,7 +49,7 @@ const SEED_WORKFLOWS: Array<{ name: string; description: string }> = [
   {
     name: "wfbench-run",
     description:
-      "Workflow Editor Agent Benchmark — Task Runner (stakwork 58313's twin): graph roster (EvalSet/EvalRequirement/EvalTrigger) -> meta/* author builds wfbench-<slug> -> input-key gate -> rerun via meta/run-workflow -> per-criterion judge -> record EvalTriggerOutput/CriterionResult -> POST the Hive callback. Input: { task_slug, task_title?, instructions, criteria, workflow_input_json?, rerun_expected_output?, webhook_url? }.",
+      "Workflow Editor Agent Benchmark — Task Runner (stakwork 58313's twin): graph roster (EvalSet/EvalRequirement/EvalTrigger) -> meta/* author builds wfbench-<slug> -> input-key gate -> rerun via meta/run-workflow -> per-criterion judge -> record EvalTriggerOutput/CriterionResult -> POST the Hive callback. Input: { task_slug, task_title?, instructions, criteria, workflow_input_json?, rerun_expected_output?, webhook_url?, namespace? }.",
   },
 ];
 

--- a/mcp/src/lab/wfbench/smoke.ts
+++ b/mcp/src/lab/wfbench/smoke.ts
@@ -71,6 +71,7 @@ async function main() {
       "meta/get-workflow",
       "meta/run-workflow",
       "meta/get-step",
+      "meta/validate-workflow",
       "agent",
     ];
     for (const t of expectedSteps) assert.ok(registry[t], `registry missing ${t}`);
@@ -210,11 +211,14 @@ async function main() {
     let mats: any = await run("wfbench/build-materials", {
       workflow: "wfbench-fetch-pr-titles", version: "v2", workflow_yaml: yaml,
       custom_steps: [{ type: "cand/x", code: "export default 1" }, { type: "cand/y", error: "not found" }],
+      validation: { ok: false, errors: [{ path: "steps[1].type", message: "unknown step type" }], warnings: [], summary: { steps: 2 } },
       run_output: { titles: ["a"] }, execution_status: "completed", project_id: "child1",
       rerun_expected_output: { titles: ["a"] }, launch_payload: { owner: "o" }, instructions: "do it",
     });
     assert.equal(mats.n_materials, 2);
-    assert.deepEqual(mats.materials.map((m: any) => m.type), ["WORKFLOW", "STEP", "LAUNCH_PAYLOAD", "RUN_OUTPUT", "EXPECTED_OUTPUT"]);
+    assert.deepEqual(mats.materials.map((m: any) => m.type), ["WORKFLOW", "STEP", "VALIDATION", "LAUNCH_PAYLOAD", "RUN_OUTPUT", "EXPECTED_OUTPUT"]);
+    assert.match(mats.materials_text, /### VALIDATION: static validation: INVALID \(1 error\(s\), 0 warning\(s\)\)/);
+    assert.match(mats.materials_text, /unknown step type/);
     assert.equal(mats.warnings.length, 1);
     assert.match(mats.materials_text, /### WORKFLOW: wfbench-fetch-pr-titles@v2\n\n```yaml/);
     assert.match(mats.materials_text, /### STEP: cand\/x/);
@@ -222,7 +226,7 @@ async function main() {
     mats = await run("wfbench/build-materials", { workflow: "w", workflow_yaml: "", instructions: "do it" });
     assert.equal(mats.n_materials, 0);
     assert.deepEqual(mats.materials.map((m: any) => m.type), ["LAUNCH_PAYLOAD", "RUN_OUTPUT"]);
-    console.log("✔ build-materials (produced vs context / warnings / none)");
+    console.log("✔ build-materials (produced vs context / validation evidence / warnings / none)");
 
     // ── 10. judge zip → build-eval-output (58312 / 58115 chain) ──────────
     const scores: any = await run("eval/aggregate-scores", {

--- a/mcp/src/lab/wfbench/steps/build-materials.ts
+++ b/mcp/src/lab/wfbench/steps/build-materials.ts
@@ -6,8 +6,9 @@ import { z, defineStep } from "vein";
  * zero means the judge has nothing to grade and the harness reports
  * no_materials_produced instead of a fake 0/N): the workflow body and every
  * custom step the author wrote. CONTEXT materials (always attached): the
- * launch payload, the rerun's output + status, and the expected output when
- * the task carries one. `materials_text` is the single markdown block the
+ * engine's static validation of the workflow (ok / errors / warnings — the
+ * evidence for "structurally valid" criteria), the launch payload, the
+ * rerun's output + status, and the expected output when the task carries one. `materials_text` is the single markdown block the
  * judge reads — the judge needs no tools.
  */
 const clip = (s: string, max: number) => (s.length > max ? `${s.slice(0, max)}\n…[truncated ${s.length - max} chars]` : s);
@@ -22,12 +23,13 @@ const json = (v: unknown) => {
 export default defineStep({
   type: "wfbench/build-materials",
   description:
-    "Assemble judge materials from the produced workflow YAML, its custom step sources (meta/get-step outputs), the rerun output/status, the launch payload and the expected output. Output: { n_materials (produced only), materials: [{ type, name, content }], materials_text, task_desc, warnings }.",
+    "Assemble judge materials from the produced workflow YAML, its custom step sources (meta/get-step outputs), the engine's static validation (meta/validate-workflow output), the rerun output/status, the launch payload and the expected output. Output: { n_materials (produced only), materials: [{ type, name, content }], materials_text, task_desc, warnings }.",
   input: z.object({
     workflow: z.string().describe("Produced workflow name."),
     version: z.any().optional(),
     workflow_yaml: z.string().describe("Produced workflow YAML ('' when nothing was published)."),
     custom_steps: z.array(z.any()).optional().describe("meta/get-step outputs for the steps the author created."),
+    validation: z.any().optional().describe("meta/validate-workflow output for the produced YAML ({ ok, errors, warnings, summary })."),
     run_output: z.any().optional(),
     execution_status: z.string().optional(),
     project_id: z.any().optional(),
@@ -62,6 +64,16 @@ export default defineStep({
       produced.push({ type: "STEP", name, content: clip(src, cfg.maxChars) });
     }
 
+    if (cfg.validation && typeof cfg.validation === "object") {
+      const v = cfg.validation as Record<string, any>;
+      const nErr = Array.isArray(v.errors) ? v.errors.length : 0;
+      const nWarn = Array.isArray(v.warnings) ? v.warnings.length : 0;
+      context.push({
+        type: "VALIDATION",
+        name: `static validation: ${v.ok === true ? "ok" : "INVALID"} (${nErr} error(s), ${nWarn} warning(s))`,
+        content: json({ ok: v.ok, errors: v.errors ?? [], warnings: v.warnings ?? [], summary: v.summary ?? null }),
+      });
+    }
     context.push({ type: "LAUNCH_PAYLOAD", name: "workflow_input", content: json(cfg.launch_payload ?? {}) });
     context.push({
       type: "RUN_OUTPUT",

--- a/mcp/src/lab/wfbench/workflows/wfbench-judge-criterion.yaml
+++ b/mcp/src/lab/wfbench/workflows/wfbench-judge-criterion.yaml
@@ -38,9 +38,9 @@ steps:
         ## Task the workflow author was given
         {{ input.task_desc }}
 
-        ## Materials (the produced workflow, its custom steps, the launch
-        ## payload, the rerun's output and status, and the expected output
-        ## when the task has one)
+        ## Materials (the produced workflow, its custom steps, the engine's
+        ## static validation of it, the launch payload, the rerun's output and
+        ## status, and the expected output when the task has one)
         {{ input.materials_text }}
 
         ## Criterion

--- a/mcp/src/lab/wfbench/workflows/wfbench-run.yaml
+++ b/mcp/src/lab/wfbench/workflows/wfbench-run.yaml
@@ -22,7 +22,11 @@ name: wfbench-run
 # publisher "ai" — the seeded harness surface can never be graded.
 #
 # Input: { task_slug, task_title?, instructions, criteria, workflow_input_json?,
-#          rerun_expected_output?, webhook_url? }
+#          rerun_expected_output?, webhook_url?, namespace? }
+#   namespace: graph partition for every roster/record write (default
+#   params.namespace). Hive passes the partition its own roster upsert used,
+#   so vein's EvalSet/EvalRequirement writes MERGE onto Hive's nodes by id
+#   instead of creating a second roster.
 #   criteria: [{ id, title, match_criteria, deliverables? }] (or a JSON string)
 #   workflow_input_json: the payload the produced workflow is launched with
 # Output: the callback body + diagnostics (see the `result` step).
@@ -62,7 +66,7 @@ steps:
     type: graph/register-namespace
     depends: roster
     config:
-      namespace: "{{ params.namespace }}"
+      namespace: "{{ input.namespace || params.namespace }}"
 
   - id: evalset
     type: graph/create-node
@@ -70,7 +74,7 @@ steps:
     config:
       node_type: EvalSet
       node_data: "{{ roster.evalset.node_data }}"
-      namespace: "{{ params.namespace }}"
+      namespace: "{{ input.namespace || params.namespace }}"
 
   # One EvalRequirement per criterion (58114), EvalSet -HAS_REQUIREMENT-> it.
   # Inline EvalSet source merges onto the node above (same node_key).
@@ -79,7 +83,7 @@ steps:
     depends: evalset
     config:
       triplets: "{{ roster.requirement_triplets }}"
-      namespace: "{{ params.namespace }}"
+      namespace: "{{ input.namespace || params.namespace }}"
 
   # After the requirements (58313's order) so every roster write is upstream
   # of the record + result steps.
@@ -89,7 +93,7 @@ steps:
     config:
       node_type: EvalTrigger
       node_data: "{{ roster.trigger.node_data }}"
-      namespace: "{{ params.namespace }}"
+      namespace: "{{ input.namespace || params.namespace }}"
 
   # hop_check_trigger_exists + guard_first_run: prior triggers ⇒ HAS_TRIGGER,
   # none ⇒ HAS_BASELINE_TRIGGER.
@@ -100,7 +104,7 @@ steps:
       ref_id: "{{ evalset.ref_id }}"
       edge_type: [HAS_TRIGGER, HAS_BASELINE_TRIGGER]
       node_type: [EvalTrigger]
-      namespace: "{{ params.namespace }}"
+      namespace: "{{ input.namespace || params.namespace }}"
 
   - id: edge
     type: wfbench/trigger-edge
@@ -116,7 +120,7 @@ steps:
       source_ref_id: "{{ evalset.ref_id }}"
       target_ref_id: "{{ trig.ref_id }}"
       edge_type: "{{ edge.edge_type }}"
-      namespace: "{{ params.namespace }}"
+      namespace: "{{ input.namespace || params.namespace }}"
 
   # ── author (54419's twin) ─────────────────────────────────────────────
   - id: dir
@@ -229,6 +233,16 @@ steps:
       vpin: "{{ vpin }}"
       vactive: "{{ vactive }}"
 
+  # Static validation of the produced YAML (the same check the author had via
+  # meta/validate-workflow) — judge EVIDENCE for "structurally valid", not a
+  # gate: a candidate that validates poorly is still launched and judged.
+  - id: valid
+    type: meta/validate-workflow
+    depends: cand
+    config:
+      yaml: "{{ cand.yaml }}"
+      name: "{{ cand.workflow }}"
+
   # Sources of the custom steps the author says it created — judge materials.
   - id: stepsrc
     type: foreach
@@ -280,12 +294,13 @@ steps:
   # ── judge (harvey_lab_score_rubric's twin) ────────────────────────────
   - id: mats
     type: wfbench/build-materials
-    depends: [cls, stepsrc]
+    depends: [cls, stepsrc, valid]
     config:
       workflow: "{{ cand.workflow }}"
       version: "{{ cand.version }}"
       workflow_yaml: "{{ cand.yaml }}"
       custom_steps: "{{ stepsrc }}"
+      validation: "{{ valid }}"
       run_output: "{{ cls.run_output }}"
       execution_status: "{{ cls.execution_status }}"
       project_id: "{{ cls.project_id }}"
@@ -357,7 +372,7 @@ steps:
     when: true
     config:
       triplets: "{{ chain.triplets }}"
-      namespace: "{{ params.namespace }}"
+      namespace: "{{ input.namespace || params.namespace }}"
 
   - id: critrefs
     type: eval/criterion-refs
@@ -425,7 +440,8 @@ steps:
         criterion_refs: "{{ critrefs }}"
 
 params:
-  # Graph partition every roster/record write lands in (registered on each run).
+  # Graph partition every roster/record write lands in (registered on each
+  # run) unless the run's input.namespace overrides it.
   namespace: wfbench
   authorModel: claude-sonnet-5
   # An author that reads step docs, drafts, publishes, smoke-tests and fixes


### PR DESCRIPTION
Two small pieces toward the Hive "run in vein" toggle.

- **Validation as evidence.** `wfbench-run` now runs `meta/validate-workflow` on the produced YAML and `wfbench/build-materials` inlines the result as a `VALIDATION` material (`ok`, `errors`, `warnings`, `summary`). Structural criteria ("workflow is structurally valid") get judged on the engine's own check plus the rerun status instead of on the judge's reading of the YAML. Not a gate: a candidate that validates poorly is still launched and judged.
- **Namespace as input.** `input.namespace || params.namespace` on every roster/record write. Hive already upserts the EvalSet/EvalRequirement roster through jarvis before dispatch; passing that partition lets vein's writes merge onto the same nodes by id rather than creating a second roster under `wfbench`.

Verification: mcp `tsc` clean; `npx tsx src/lab/wfbench/smoke.ts` green (both workflows static-validate, build-materials asserts the VALIDATION section).