### PR TITLE
lab: wfbench — roster ids match Hive's, default namespace, explicit model rule

### DIFF
--- a/mcp/src/lab/AGENTS.md
+++ b/mcp/src/lab/AGENTS.md
@@ -614,10 +614,13 @@ workflow (design + step map: `plans/wfbench-harness.md`). One task in
 (`{ task_slug, task_title?, instructions, criteria, workflow_input_json?,
 rerun_expected_output?, webhook_url? }` — Hive's payload shape), one callback
 out. `wfbench-run`: graph roster (EvalSet → EvalRequirement×N, EvalTrigger,
-HAS_BASELINE_TRIGGER on the EvalSet's first trigger else HAS_TRIGGER — 58313's
-ids, written with vein's `graph/*` steps under `input.namespace ||
-params.namespace`; Hive passes the partition its own roster upsert used so
-the writes merge onto its nodes) ‖ the
+HAS_BASELINE_TRIGGER on the EvalSet's first trigger else HAS_TRIGGER — written
+with vein's `graph/*` steps under `input.namespace || params.namespace`,
+default `default`. EvalSet id = the task slug VERBATIM and EvalRequirement id
+= `<slug>::<criterion_id>` — Hive's `eval-nodes.ts` ids, because Hive upserts
+this roster itself before dispatch and its rubrics reader looks it up by
+those; ours merge onto its nodes by node_key. Trigger/output/criterion ids
+follow 58313/58312: `<slug>-<runId>`, `<slug>-<runId>-<criterion_id>`) ‖ the
 author (core `agent` + `agentTools: ["meta/*"]`, editor tool only — 54419's
 twin) builds `wfbench-<slug>` → resolve the version it actually shipped
 (`vpin || vactive`, `published` vs `vbefore` — the gaia-evolve-gen guard) →

--- a/mcp/src/lab/plans/wfbench-harness.md
+++ b/mcp/src/lab/plans/wfbench-harness.md
@@ -32,7 +32,7 @@ Not a "chat assistant as a step". Reasons:
 | 58313 (stakwork) | vein |
 | --- | --- |
 | `set_var` | workflow `input` + `params` |
-| EvalSet / EvalRequirement / EvalTrigger roster (55741, 58114, 55740, `hop_check_trigger_exists`, `guard_first_run`) | `graph/create-node` (EvalSet), `foreach` → `graph/create-node` (EvalRequirement), `graph/graph-neighbors` + `if` → `graph/create-triplet` with `HAS_BASELINE_TRIGGER` or `HAS_TRIGGER` |
+| EvalSet / EvalRequirement / EvalTrigger roster (55741, 58114, 55740, `hop_check_trigger_exists`, `guard_first_run`) | `graph/create-node` (EvalSet), `graph/create-batch-triplet` (EvalRequirements), `graph/graph-neighbors` + `wfbench/trigger-edge` → `graph/create-triplet` with `HAS_BASELINE_TRIGGER` or `HAS_TRIGGER`. Ids: EvalSet = task slug verbatim, EvalRequirement = `<slug>::<criterion_id>` — Hive's `eval-nodes.ts` convention (Hive upserts the roster before dispatch and reads it back by those ids), not harvey's `<slug>-<id>` |
 | `run_workflow_editor` (54419) | `agent` + `agentTools: ["meta/*"]`, `toolFilter: [str_replace_based_edit_tool]`, schema `{ workflow, version, summary, changes, missingSecrets }` |
 | `extract_artifacts.py`, JSONPath for workflowId/version | schema output; never trust the echo — `meta/get-workflow` pin fallback (`vpin.version || vactive.version`) + the `published` gate vs `vbefore` (copy from `gaia-evolve-gen`) |
 | 58414 WhileLoop ×15 + `api_fallback_fetch` | gone. `meta/publish-workflow` is synchronous; `meta/get-workflow { name, version }` returns the YAML |

--- a/mcp/src/lab/wfbench/smoke.ts
+++ b/mcp/src/lab/wfbench/smoke.ts
@@ -98,7 +98,8 @@ async function main() {
 
     // ── 3. normalize-task ────────────────────────────────────────────────
     let task: any = await run("wfbench/normalize-task", {
-      task_slug: "Fetch PR Titles!",
+      task_slug: " wfbench/fetch-pr-titles ",
+      task_title: "Fetch PR Titles!",
       instructions: "Given owner/repo, list the titles of open PRs.",
       criteria: JSON.stringify([
         { id: "c1", title: "Uses input keys", match_criteria: "reads owner and repo" },
@@ -108,18 +109,20 @@ async function main() {
       workflow_input_json: '{"owner":"stakwork","repo":"hive"}',
       rerun_expected_output: '{"titles":["a"]}',
     });
-    assert.equal(task.task_slug, "fetch-pr-titles");
+    assert.equal(task.task_slug, "wfbench/fetch-pr-titles"); // verbatim (trimmed) — Hive's EvalSet id
+    assert.equal(task.task_key, "wfbench-fetch-pr-titles"); // slugified — the candidate workflow name
     assert.equal(task.task_title, "Fetch PR Titles!");
     assert.deepEqual(task.criteria.map((c: any) => c.id), ["c1", "c1-2", "c3"]);
     assert.deepEqual(task.criteria[2].deliverables, ["out.json"]);
     assert.deepEqual(task.workflow_input_keys, ["owner", "repo"]);
     assert.deepEqual(task.rerun_expected_output, { titles: ["a"] });
     await assert.rejects(() => run("wfbench/normalize-task", { task_slug: "x", instructions: "y", criteria: "[]" }), /non-empty/);
+    await assert.rejects(() => run("wfbench/normalize-task", { task_slug: "   ", instructions: "y", criteria: [{ id: "a" }] }), /blank/);
     await assert.rejects(
       () => run("wfbench/normalize-task", { task_slug: "x", instructions: "y", criteria: [{ id: "a" }], workflow_input_json: "[1]" }),
       /JSON object/,
     );
-    console.log("✔ normalize-task (slug / criteria ids / JSON strings / hard fails)");
+    console.log("✔ normalize-task (verbatim slug + key / criteria ids / JSON strings / hard fails)");
 
     // ── 4. build-roster (58313 ids, ontology-declared attrs only) ────────
     const roster: any = await run(
@@ -128,29 +131,29 @@ async function main() {
       ctx,
     );
     assert.equal(roster.run_id, "run42");
-    assert.deepEqual(roster.evalset, { node_type: "EvalSet", node_data: { id: "fetch-pr-titles", name: "Fetch PR Titles!" } });
+    assert.deepEqual(roster.evalset, { node_type: "EvalSet", node_data: { id: "wfbench/fetch-pr-titles", name: "Fetch PR Titles!" } });
     assertDeclared("EvalSet", roster.evalset.node_data);
     assert.equal(roster.requirement_triplets.length, 3);
-    assert.deepEqual(roster.requirement_ids, ["fetch-pr-titles-c1", "fetch-pr-titles-c1-2", "fetch-pr-titles-c3"]);
+    assert.deepEqual(roster.requirement_ids, ["wfbench/fetch-pr-titles::c1", "wfbench/fetch-pr-titles::c1-2", "wfbench/fetch-pr-titles::c3"]);
     for (const [i, t] of roster.requirement_triplets.entries()) {
       assert.equal(t.edge_type, "HAS_REQUIREMENT");
-      assert.deepEqual(t.source_data, { id: "fetch-pr-titles" });
+      assert.deepEqual(t.source_data, { id: "wfbench/fetch-pr-titles" });
       assert.equal(t.edge_data.order, i);
       assertDeclared("EvalRequirement", t.target_data);
       assert.ok(edgeAllowed("EvalSet", "HAS_REQUIREMENT", "EvalRequirement"));
     }
     assert.equal(roster.requirement_triplets[0].target_data.description, "reads owner and repo");
-    assert.equal(roster.trigger_id, "fetch-pr-titles-run42");
+    assert.equal(roster.trigger_id, "wfbench/fetch-pr-titles-run42");
     assert.equal(roster.trigger.node_type, "EvalTrigger");
     const trig = roster.trigger.node_data;
-    assert.equal(trig.id, "fetch-pr-titles-run42");
+    assert.equal(trig.id, "wfbench/fetch-pr-titles-run42");
     assert.equal(trig.project_id, "run42");
     assert.equal(trig.workflow_id, "wfbench-run");
     assert.equal(trig.workflow_version_id, "v3");
     assert.equal(trig.workflow_input, task.instructions);
     assertDeclared("EvalTrigger", trig);
     assert.ok(edgeAllowed("EvalSet", "HAS_TRIGGER", "EvalTrigger") && edgeAllowed("EvalSet", "HAS_BASELINE_TRIGGER", "EvalTrigger"));
-    console.log("✔ build-roster (EvalSet / EvalRequirement×3 / EvalTrigger — 58313 ids, declared attrs)");
+    console.log("✔ build-roster (EvalSet / EvalRequirement×3 / EvalTrigger — Hive roster ids, declared attrs)");
 
     // ── 5. trigger-edge (guard_first_run) ────────────────────────────────
     let e: any = await run("wfbench/trigger-edge", { neighbors: [], trigger_ref_id: "t1" });
@@ -241,14 +244,14 @@ async function main() {
     assert.deepEqual([scores.n_passed, scores.n_total, scores.all_pass], [2, 3, false]);
     const chain: any = await run("wfbench/build-eval-output", { task_slug: task.task_slug, scores, trigger_ref_id: "trig-ref", judge_model: "claude-sonnet-5" }, ctx);
     assert.equal(chain.scored, true);
-    assert.equal(chain.output_id, "fetch-pr-titles-run42");
-    assert.equal(chain.trigger_id, "fetch-pr-titles-run42");
+    assert.equal(chain.output_id, "wfbench/fetch-pr-titles-run42");
+    assert.equal(chain.trigger_id, "wfbench/fetch-pr-titles-run42");
     // 1 spine + 2 per criterion
     assert.equal(chain.triplets.length, 1 + 2 * 3);
     const spine = chain.triplets[0];
     assert.deepEqual([spine.source_ref_id, spine.target_type, spine.edge_type], ["trig-ref", "EvalTriggerOutput", "HAS_OUTPUT"]);
     assert.deepEqual(spine.target_data, {
-      id: "fetch-pr-titles-run42", result: "fail", verdict: "fail", score: 2, max_score: 3, n_passed: 2, n_total: 3, judge_model: "claude-sonnet-5",
+      id: "wfbench/fetch-pr-titles-run42", result: "fail", verdict: "fail", score: 2, max_score: 3, n_passed: 2, n_total: 3, judge_model: "claude-sonnet-5",
     });
     assertDeclared("EvalTriggerOutput", spine.target_data);
     assert.ok(edgeAllowed("EvalTrigger", "HAS_OUTPUT", "EvalTriggerOutput"));
@@ -258,9 +261,9 @@ async function main() {
     assert.deepEqual([fromOutput.source_type, fromOutput.edge_type, fromOutput.target_type], ["EvalTriggerOutput", "HAS_CRITERION_RESULT", "CriterionResult"]);
     assert.deepEqual(fromOutput.source_data, spine.target_data); // identical object → batch dedupe hits
     assert.deepEqual([fromReq.source_type, fromReq.edge_type, fromReq.target_type], ["EvalRequirement", "HAS_CRITERION_RESULT", "CriterionResult"]);
-    assert.deepEqual(fromReq.source_data, { id: "fetch-pr-titles-c1" });
+    assert.deepEqual(fromReq.source_data, { id: "wfbench/fetch-pr-titles::c1" });
     assert.deepEqual(fromReq.target_data, fromOutput.target_data);
-    assert.deepEqual(fromOutput.target_data, { id: "fetch-pr-titles-run42-c1", criterion_id: "c1", title: "Uses input keys", verdict: "pass", reasoning: "ok" });
+    assert.deepEqual(fromOutput.target_data, { id: "wfbench/fetch-pr-titles-run42-c1", criterion_id: "c1", title: "Uses input keys", verdict: "pass", reasoning: "ok" });
     assertDeclared("CriterionResult", fromOutput.target_data);
     assert.ok(edgeAllowed("EvalTriggerOutput", "HAS_CRITERION_RESULT", "CriterionResult") && edgeAllowed("EvalRequirement", "HAS_CRITERION_RESULT", "CriterionResult"));
     assert.equal(chain.triplets[3].target_data.verdict, "fail");
@@ -279,9 +282,9 @@ async function main() {
     console.log("✔ build-eval-output (EvalTriggerOutput + CriterionResult×3, 58312 ids, declared attrs, slots→refs)");
 
     // ── 11. webhook-body (resolve_webhook_payload) ───────────────────────
-    const base = { task_slug: "fetch-pr-titles", task_title: "Fetch PR Titles!", judge_model: "claude-sonnet-5" };
+    const base = { task_slug: "wfbench/fetch-pr-titles", task_title: "Fetch PR Titles!", judge_model: "claude-sonnet-5" };
     let body: any = await run("wfbench/webhook-body", { ...base, keys: { keys_match: false, error_type: "input_keys_mismatch", error: "m" }, cls: { launch_ok: false } });
-    assert.deepEqual(body, { task_slug: "fetch-pr-titles", task_title: "Fetch PR Titles!", harness_error: true, error_type: "input_keys_mismatch", error: "m" });
+    assert.deepEqual(body, { task_slug: "wfbench/fetch-pr-titles", task_title: "Fetch PR Titles!", harness_error: true, error_type: "input_keys_mismatch", error: "m" });
     body = await run("wfbench/webhook-body", { ...base, keys: { keys_match: true }, cls: { launch_ok: false, error_type: "launch_refused", error: "r" } });
     assert.deepEqual([body.harness_error, body.error_type, body.n_passed], [true, "launch_refused", undefined]);
     body = await run("wfbench/webhook-body", { ...base, keys: { keys_match: true }, cls: { launch_ok: true }, mats: { n_materials: 0 } });

--- a/mcp/src/lab/wfbench/steps/build-eval-output.ts
+++ b/mcp/src/lab/wfbench/steps/build-eval-output.ts
@@ -7,7 +7,7 @@ import { z, defineStep, type StepContext } from "vein";
  *
  *   EvalTrigger(<slug>-<runId>) -HAS_OUTPUT-> EvalTriggerOutput(<slug>-<runId>)
  *   EvalTriggerOutput -HAS_CRITERION_RESULT-> CriterionResult (one per criterion)
- *   EvalRequirement(<slug>-<criterion_id>) -HAS_CRITERION_RESULT-> CriterionResult
+ *   EvalRequirement(<slug>::<criterion_id>) -HAS_CRITERION_RESULT-> CriterionResult
  *
  * EvalTriggerOutput carries 58312's fields: result, verdict, score,
  * max_score, n_passed, n_total, judge_model (its `name` is not declared on
@@ -78,7 +78,7 @@ export default defineStep({
       });
       triplets.push({
         source_type: "EvalRequirement",
-        source_data: { id: `${slug}-${cid}` },
+        source_data: { id: `${slug}::${cid}` },
         target_type: "CriterionResult",
         target_data: critData,
         edge_type: "HAS_CRITERION_RESULT",

--- a/mcp/src/lab/wfbench/steps/build-roster.ts
+++ b/mcp/src/lab/wfbench/steps/build-roster.ts
@@ -5,10 +5,15 @@ import { z, defineStep, type StepContext } from "vein";
  * write-ready payloads — the writes themselves are graph/create-node and
  * graph/create-batch-triplet. Node ids follow 58313 exactly:
  *
- *   EvalSet         id = task_slug                        (55741)
- *   EvalRequirement id = <task_slug>-<criterion_id>       (58114, one per criterion,
+ *   EvalSet         id = task_slug (verbatim)             (55741)
+ *   EvalRequirement id = <task_slug>::<criterion_id>      (one per criterion,
  *                                                          EvalSet -HAS_REQUIREMENT-> it)
  *   EvalTrigger     id = <task_slug>-<project_id>         (55741; project_id = this runId)
+ *
+ * The EvalSet and EvalRequirement ids are Hive's (eval-nodes.ts): Hive upserts
+ * this roster itself before dispatch and its rubrics reader looks the EvalSet
+ * up by the exact slug and the requirements by "<slug>::<id>", so our writes
+ * MERGE onto Hive's nodes by node_key instead of creating a second roster.
  *
  * Properties are limited to what the jarvis ontology declares for each
  * type (vein's graph backend rejects undeclared attributes): 58313's
@@ -20,7 +25,7 @@ import { z, defineStep, type StepContext } from "vein";
 export default defineStep({
   type: "wfbench/build-roster",
   description:
-    "Build the eval roster payloads for one run with 58313's id conventions: EvalSet { id: task_slug }, EvalRequirement { id: <slug>-<criterion_id> } triplets (HAS_REQUIREMENT, edge order), EvalTrigger { id: <slug>-<runId>, workflow_id, workflow_version_id, workflow_input, project_id }. Output: { run_id, evalset_id, trigger_id, evalset: { node_type, node_data }, requirement_triplets, requirement_ids, trigger: { node_type, node_data } }.",
+    "Build the eval roster payloads for one run: EvalSet { id: task_slug (verbatim) }, EvalRequirement { id: <slug>::<criterion_id> } (Hive's eval-nodes ids, so the writes merge onto Hive's roster) triplets (HAS_REQUIREMENT, edge order), EvalTrigger { id: <slug>-<runId>, workflow_id, workflow_version_id, workflow_input, project_id }. Output: { run_id, evalset_id, trigger_id, evalset: { node_type, node_data }, requirement_triplets, requirement_ids, trigger: { node_type, node_data } }.",
   input: z.object({
     task_slug: z.string().min(1),
     task_title: z.string(),
@@ -40,7 +45,7 @@ export default defineStep({
       source_data: { id: slug },
       target_type: "EvalRequirement",
       target_data: {
-        id: `${slug}-${c.id}`,
+        id: `${slug}::${c.id}`,
         name: String(c.title ?? ""),
         description: String(c.match_criteria ?? ""),
         deliverables: Array.isArray(c.deliverables) ? c.deliverables : [],

--- a/mcp/src/lab/wfbench/steps/normalize-task.ts
+++ b/mcp/src/lab/wfbench/steps/normalize-task.ts
@@ -7,7 +7,14 @@ import { z, defineStep } from "vein";
  * before any agent budget is spent, exactly where 58313's set_var would
  * have choked.
  *
- * Output: { task_slug, task_title, instructions, criteria, n_criteria,
+ * task_slug is kept VERBATIM: it is the EvalSet id, and Hive's roster upsert
+ * + rubrics reader (eval-nodes.ts / fetchTaskRubricRoster) key the EvalSet on
+ * the exact corpus slug, e.g. "wfbench/generate-capital-city" — slugifying it
+ * would create a second roster Hive never finds. task_key is the slugified
+ * form, used only where a name must be filesystem/URL safe (the candidate
+ * workflow name).
+ *
+ * Output: { task_slug, task_key, task_title, instructions, criteria, n_criteria,
  *           workflow_input, workflow_input_keys, rerun_expected_output }
  *   criteria: [{ id, title, match_criteria, deliverables }] (rubric order kept)
  */
@@ -32,9 +39,9 @@ const parseMaybeJson = (v: unknown): unknown => {
 export default defineStep({
   type: "wfbench/normalize-task",
   description:
-    "Normalize a benchmark task (task_slug, task_title, instructions, criteria as array or JSON string, workflow_input_json as object or JSON string, rerun_expected_output) into the harness shape. Throws on empty/invalid criteria or a non-object workflow input. Output: { task_slug, task_title, instructions, criteria: [{ id, title, match_criteria, deliverables }], n_criteria, workflow_input, workflow_input_keys, rerun_expected_output }.",
+    "Normalize a benchmark task (task_slug, task_title, instructions, criteria as array or JSON string, workflow_input_json as object or JSON string, rerun_expected_output) into the harness shape. task_slug is kept verbatim (the EvalSet id Hive looks up); task_key is its slugified form for workflow names. Throws on empty/invalid criteria or a non-object workflow input. Output: { task_slug, task_key, task_title, instructions, criteria: [{ id, title, match_criteria, deliverables }], n_criteria, workflow_input, workflow_input_keys, rerun_expected_output }.",
   input: z.object({
-    task_slug: z.string().min(1).describe("Task id — slugified; becomes the EvalSet id."),
+    task_slug: z.string().min(1).describe("Task id, kept verbatim — it is the EvalSet id (Hive: the corpus slug, e.g. 'wfbench/generate-capital-city')."),
     task_title: z.string().optional().describe("Human title (defaults to the slug)."),
     instructions: z.string().min(1).describe("The one-line (or longer) English task the author builds a workflow from."),
     criteria: z.any().describe("Rubric: JSON array (or JSON string) of { id, title, match_criteria, deliverables? }."),
@@ -46,8 +53,10 @@ export default defineStep({
   }),
   output: z.any(),
   async run(cfg) {
-    const task_slug = slugify(cfg.task_slug);
-    if (!task_slug) throw new Error(`wfbench/normalize-task: task_slug "${cfg.task_slug}" slugifies to nothing`);
+    const task_slug = cfg.task_slug.trim();
+    if (!task_slug) throw new Error("wfbench/normalize-task: task_slug is blank");
+    const task_key = slugify(task_slug);
+    if (!task_key) throw new Error(`wfbench/normalize-task: task_slug "${cfg.task_slug}" slugifies to nothing`);
     const task_title = (cfg.task_title ?? "").trim() || cfg.task_slug;
 
     const rawCriteria = parseMaybeJson(cfg.criteria);
@@ -76,6 +85,7 @@ export default defineStep({
 
     return {
       task_slug,
+      task_key,
       task_title,
       instructions: cfg.instructions,
       criteria,

--- a/mcp/src/lab/wfbench/workflows/wfbench-run.yaml
+++ b/mcp/src/lab/wfbench/workflows/wfbench-run.yaml
@@ -4,7 +4,9 @@ name: wfbench-run
 # / 57425 / 58312). One task in, one Hive callback out:
 #
 #   roster (graph)  EvalSet → EvalRequirement×N, EvalTrigger, HAS_TRIGGER |
-#                   HAS_BASELINE_TRIGGER — 58313's ids, on graph/* steps
+#                   HAS_BASELINE_TRIGGER — on graph/* steps; EvalSet/EvalRequirement
+#                   ids are Hive's (slug verbatim, <slug>::<criterion_id>) so the
+#                   writes merge onto the roster Hive upserts before dispatch
 #   author          the meta/* authoring agent (54419's twin) builds a NEW
 #                   workflow named wfbench-<slug> from the instructions
 #   resolve         pin the version it actually shipped (never its echo)
@@ -136,7 +138,7 @@ steps:
     type: meta/get-workflow
     depends: task
     config:
-      name: "wfbench-{{ task.task_slug }}"
+      name: "wfbench-{{ task.task_key }}"
 
   - id: author
     type: agent
@@ -156,7 +158,7 @@ steps:
         {{ task.instructions }}
 
         Build a NEW vein workflow that does exactly this, and publish it under
-        the EXACT name "wfbench-{{ task.task_slug }}" (meta/publish-workflow;
+        the EXACT name "wfbench-{{ task.task_key }}" (meta/publish-workflow;
         republishing the same name creates a new version — iterate that way).
 
         INPUT CONTRACT: the harness will launch your workflow ONCE with this
@@ -214,13 +216,13 @@ steps:
     type: meta/get-workflow
     depends: author
     config:
-      name: "wfbench-{{ task.task_slug }}"
+      name: "wfbench-{{ task.task_key }}"
 
   - id: vpin
     type: meta/get-workflow
     depends: author
     config:
-      name: "wfbench-{{ task.task_slug }}"
+      name: "wfbench-{{ task.task_key }}"
       version: "{{ author.object.version }}"
 
   - id: cand
@@ -228,7 +230,7 @@ steps:
     depends: [vpin, vactive, vbefore]
     config:
       author: "{{ author }}"
-      candidate: "wfbench-{{ task.task_slug }}"
+      candidate: "wfbench-{{ task.task_key }}"
       vbefore: "{{ vbefore }}"
       vpin: "{{ vpin }}"
       vactive: "{{ vactive }}"
@@ -441,8 +443,10 @@ steps:
 
 params:
   # Graph partition every roster/record write lands in (registered on each
-  # run) unless the run's input.namespace overrides it.
-  namespace: wfbench
+  # run) unless the run's input.namespace overrides it. "default" is the
+  # jarvis/vein default partition — where Hive's own roster upsert lands, so
+  # the EvalSet/EvalRequirement writes merge onto Hive's nodes.
+  namespace: default
   authorModel: claude-sonnet-5
   # An author that reads step docs, drafts, publishes, smoke-tests and fixes
   # burns calls fast; the publish-early rule below protects the budget.
@@ -496,6 +500,9 @@ params:
     HARD CONTRACT (the harness runs it as-is):
     - publish under the EXACT workflow name you were given; the version you
       return must be a real version string from meta/publish-workflow.
+    - every `llm` or `agent` step sets `model` EXPLICITLY (e.g.
+      model: claude-sonnet-5). Never rely on the engine default: graders
+      look for a model identifier in the workflow and fail its absence.
     - the workflow's output is its LAST step's output — make that the
       task's deliverable (structured, not prose).
     - secrets: reference NAMES from meta/list-secrets only (steps read them


### PR DESCRIPTION
Follow-up from the first strut run through Hive (hive#5268 on the hive swarm): it completed and Hive received the callback with per-criterion verdicts, but the history row said "No rubric roster — score not comparable", and its one FAIL was the model-identifier criterion.

## Roster parity with Hive
Hive upserts the EvalSet + EvalRequirement roster itself before dispatch and its rubrics reader looks it up by **the corpus slug verbatim** (`wfbench/generate-capital-city`) and requirement ids **`<slug>::C-00N`** (`src/lib/workflow-benchmarks/eval-nodes.ts`). The harness slugified the slug and used `<slug>-<id>`, under its own `wfbench` partition — a second roster Hive never reads.

- `wfbench/normalize-task`: `task_slug` kept verbatim (trimmed) = the EvalSet id; new `task_key` (slugified) is used only for the candidate workflow name `wfbench-<task_key>`.
- `wfbench/build-roster` / `wfbench/build-eval-output`: EvalRequirement ids are `<slug>::<criterion_id>`. Trigger/output/criterion ids unchanged.
- `params.namespace` defaults to `default` — the jarvis/vein default partition, where Hive's upsert lands — so the writes merge onto Hive's nodes by node_key. `input.namespace` still overrides.

## Author rule
`authorSystem` hard contract: every `llm`/`agent` step sets `model` explicitly.

## Verification
`npx tsc --noEmit` clean; `npx tsx src/lab/wfbench/smoke.ts` green.

(Two further commits were briefly pushed to this branch after merge by mistake; they are re-landed as their own PR.)