### PR TITLE
[Jamie] Add circuit-breaker to describe_nodes so a capped/failing key aborts instead of looping forever

### DIFF
--- a/mcp/src/repo/descriptions.ts
+++ b/mcp/src/repo/descriptions.ts
@@ -144,6 +144,7 @@ export const describe_nodes_agent = async (req: Request, res: Response) => {
     const providerOptions = getProviderOptions(llm.provider, undefined, llm.modelName);
 
     // Loop until cost limit reached or no more nodes
+    let fatalError: Error | null = null;
     while (true) {
       if (totalCost >= cost_limit) {
         console.log(
@@ -231,6 +232,20 @@ ${content.slice(0, 2000)}`;
               });
             } catch (e) {
               console.error(`[describe_nodes] Error on node ${name}:`, e);
+              const err = e as Error;
+              const msg = `${err?.message ?? ""} ${((err as any)?.cause as Error)?.message ?? ""}`.toLowerCase();
+              const isFatal = [
+                "key limit exceeded",
+                "quota",
+                "insufficient",
+                "401",
+                "invalid api key",
+                "invalid_api_key",
+                "unauthorized",
+              ].some((needle) => msg.includes(needle));
+              if (isFatal && !fatalError) {
+                fatalError = err;
+              }
             }
           }),
       );
@@ -239,6 +254,19 @@ ${content.slice(0, 2000)}`;
       for (const r of results) {
         totalCost += r.cost;
         totalUsage = addUsage(totalUsage, r.usage);
+      }
+
+      if (fatalError) {
+        console.error(
+          `[describe_nodes] Fatal error detected (${fatalError.message}). Aborting run.`,
+        );
+        break;
+      }
+      if (nodes.length > 0 && results.length === 0) {
+        console.error(
+          "[describe_nodes] Entire batch failed with no successful descriptions. Aborting to avoid an infinite loop.",
+        );
+        break;
       }
 
       // Bulk write to Neo4j


### PR DESCRIPTION
## Problem

In `mcp/src/repo/descriptions.ts`, `describe_nodes_agent` runs an infinite `while(true)` batch loop. Each per-node error is caught, logged as `[describe_nodes] Error on node X`, and swallowed so the loop continues.

The loop only exits when `totalCost >= cost_limit` or no un-described nodes remain. `totalCost` is only incremented from successful nodes, and `bulk_update_descriptions` only runs when `results.length > 0`. So when every node in a batch fails for a systemic reason — e.g. an OpenRouter `Key limit exceeded` — `totalCost` stays `0`, no node is marked described, the same batch is re-fetched, and the loop spins forever at `concurrency` parallel calls. This floods the `repo2graph` container with thousands of identical error lines per second.

## Fix

Add a circuit-breaker: detect fatal non-retryable key/auth errors and abort the run; and if an entire batch produces zero successful results, break out of the loop instead of re-fetching the same failing batch.