### PR TITLE
vein: desktop host prerequisites (port 0, VEIN_HOST, ready line, ?key= handoff)

### DIFF
--- a/vein/AGENTS.md
+++ b/vein/AGENTS.md
@@ -148,7 +148,9 @@ cd vein && npm run dev        # serves API + UI on :3000
 | Variable            | Default        | Description                          |
 | ------------------- | -------------- | ------------------------------------ |
 | `VEIN_WORKSPACE`    | `./workspace`  | Persistent volume for workflows/runs |
-| `VEIN_PORT`         | `3000`         | HTTP server port                     |
+| `VEIN_PORT`         | `3000`         | HTTP server port. `0` lets the OS pick; `listen()` resolves to the bound port and prints `{"event":"ready","port":N,"host":…}` on stdout for a host process to parse. |
+| `VEIN_HOST`         | (all interfaces) | Bind address. A desktop host passes `127.0.0.1` to keep a local vein off the LAN. |
+| `VEIN_WEB_DIST`     | `<module>/../web/dist` | Where the built UI is served from, for packagers that relocate it. |
 | `VEIN_API_KEY`      | (unset)        | Deployment-scoped shared secret. See "Auth" below. |
 | `VEIN_SECRET_KEY`   | (unset)        | Encryption key for the secret store (AES-256-GCM). Unset → a default dev key + one-time warning (obfuscated, not secure). See "Secrets". |
 | `VEIN_LLM_PROVIDER` | (inferred from model, else `anthropic`) | Default LLM provider for agent/llm steps (anthropic\|openai\|google\|openrouter\|xai, via aieo) |
@@ -178,6 +180,11 @@ container in the compose (vein and any service that registers steps).
   `GET /steps` and workflow execution are always public.
 - **Set (production):** the gated endpoints require
   `Authorization: Bearer <VEIN_API_KEY>`. Anything else returns `401`.
+  The web UI attaches the key to every request once it has one: a host
+  that spawns vein hands it over as `?key=` on the first page load (stored
+  in `sessionStorage`, stripped from the URL), or a user pastes it under
+  Settings → Connection (`localStorage`). The dictation WebSocket sends it
+  as `?key=`, since browsers can't set headers on an upgrade.
 
 The same secret authenticates **both directions** within a deployment:
 

--- a/vein/plans/local-desktop-and-stt.md
+++ b/vein/plans/local-desktop-and-stt.md
@@ -82,10 +82,10 @@ the API key is obtained.
    must ensure a resolvable `node_modules/vein` exists above the materialize
    dir — simplest is to make the data dir live under the app's bundle tree, or
    write a one-line shim package that re-exports from the running server.
-4. **`web/dist` is resolved relative to the module** (`createVein.ts` ~L450).
-   Add a `VEIN_WEB_DIST` override so the host can pass an absolute path.
-5. **Bind address.** `serve({ fetch, port })` binds all interfaces. Add
-   `VEIN_HOST` (default unchanged for servers; desktop passes `127.0.0.1`).
+4. ~~**`web/dist` is resolved relative to the module.**~~ Done: `VEIN_WEB_DIST`
+   (or the `webDist` option) overrides it.
+5. ~~**Bind address.**~~ Done: `VEIN_HOST` (default unchanged for servers;
+   desktop passes `127.0.0.1`), and `VEIN_PORT=0` resolves to the bound port.
 6. **Shell steps spawn `bash`** (`shell.ts`). macOS/Linux fine; Windows needs
    either Git-Bash detection or a `VEIN_SHELL` override. Not blocking for a
    macOS-first release.
@@ -141,12 +141,13 @@ Host spawns `node server.cjs` with env:
 
 Protocol:
 
-- vein prints one JSON line on stdout when ready:
-  `{"event":"ready","port":51234}`. Today `listen()` logs a human string; add
-  the structured line (keep the human one).
-- Host loads the webview at `http://127.0.0.1:<port>/` and injects the API key
-  (e.g. via a `?key=` on first load that the UI stores in `sessionStorage`,
-  or a host-set cookie). Decide once; `?key=` is simplest.
+- vein prints one JSON line on stdout when ready (done):
+  `{"event":"ready","port":51234,"host":"127.0.0.1"}`, after the human lines.
+  `listen()` also rejects on a bind failure instead of crashing.
+- Host loads the webview at `http://127.0.0.1:<port>/?key=<VEIN_API_KEY>`
+  (done): the UI stores the key in `sessionStorage`, strips it from the URL,
+  and sends it as a bearer on every request and as `?key=` on the dictation
+  socket. Settings → Connection also accepts a pasted key (`localStorage`).
 - Host kills the child on quit. vein already handles `SIGTERM` via the run
   store's durable resume, so a hard kill is recoverable.
 - Health: `GET /health` (add if missing) so the host can detect a crashed
@@ -441,9 +442,9 @@ artifact per user/company) or beside it. Lean: same artifact, two sections.
    server with no desktop work at all.
 2. **Model bake-off**: measure the NeMo / Nemotron streaming variants for
    partial latency and accuracy on the same clips; pick the default.
-3. **Server prerequisites for desktop**: `VEIN_HOST`, `VEIN_WEB_DIST`,
-   structured `ready` line, `?key=` handoff in the UI, `VEIN_MODEL_DIR`
-   alias (the last one lands with step 1).
+3. ~~**Server prerequisites for desktop**~~: done — `VEIN_HOST`,
+   `VEIN_WEB_DIST`, `VEIN_PORT=0`, structured `ready` line, `vein.close()`,
+   `?key=` handoff in the UI, `VEIN_MODEL_DIR` / `VEIN_CACHE_DIR` fallback.
 4. **First dream cycle**: a sessions → llm → `PUT /audio/hotwords` workflow
    plus the corrections UI. Proves the loop before packaging.
 5. **Phase A packaging**: esbuild bundle, Node binary, native dir, a macOS

--- a/vein/src/createVein.test.ts
+++ b/vein/src/createVein.test.ts
@@ -677,3 +677,64 @@ describe("createVein", () => {
     assert.deepEqual(await pRes.json(), []);
   });
 });
+
+describe("listen()", () => {
+  let tempDir: string;
+  beforeEach(async () => {
+    tempDir = join(tmpdir(), `vein-listen-${randomUUID()}`);
+    await mkdir(tempDir, { recursive: true });
+  });
+  afterEach(async () => {
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  it("binds an OS-picked port on 0, honors the host, and prints a ready line", async () => {
+    const vein = await createVein({
+      workspace: new WorkspaceManager(tempDir),
+      store: new MemoryRunStore(),
+      serveUi: false,
+      enableChat: false,
+      stt: false,
+    });
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...a: unknown[]) => lines.push(a.map(String).join(" "));
+    let port: number;
+    try {
+      port = await vein.listen(0, "127.0.0.1");
+    } finally {
+      console.log = orig;
+    }
+    try {
+      assert.ok(port > 0, `expected a real port, got ${port}`);
+      const ready = lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).find((j) => j?.event === "ready");
+      assert.deepEqual(ready, { event: "ready", port, host: "127.0.0.1" });
+      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      assert.equal(res.status, 200);
+      assert.equal(((await res.json()) as { ok: boolean }).ok, true);
+    } finally {
+      await vein.close();
+    }
+    await assert.rejects(fetch(`http://127.0.0.1:${port}/health`), "server should be closed");
+  });
+
+  it("rejects when the port is taken instead of crashing the process", async () => {
+    const mk = () =>
+      createVein({
+        workspace: new WorkspaceManager(tempDir),
+        store: new MemoryRunStore(),
+        serveUi: false,
+        enableChat: false,
+        stt: false,
+      });
+    const a = await mk();
+    const port = await a.listen(0, "127.0.0.1");
+    const b = await mk();
+    try {
+      await assert.rejects(b.listen(port, "127.0.0.1"), /EADDRINUSE/);
+    } finally {
+      await a.close();
+      await b.close();
+    }
+  });
+});

--- a/vein/src/createVein.ts
+++ b/vein/src/createVein.ts
@@ -223,9 +223,18 @@ export interface Vein<TServices = unknown> {
    *  vein.stt)` to get the dictation socket; `listen()` does it. */
   stt: SttService | null;
 
-  /** Boot the Hono server with `@hono/node-server`. Resolves to the
-   *  bound port. Convenience wrapper — feel free to mount `app` yourself. */
-  listen: (port?: number) => Promise<number>;
+  /** Boot the Hono server with `@hono/node-server`. Resolves once the
+   *  socket is listening, to the *bound* port — so `listen(0)` (or
+   *  `VEIN_PORT=0`) lets the OS pick one, which a desktop host that spawns
+   *  vein as a child process relies on. `host` (or `VEIN_HOST`) sets the
+   *  bind address; unset binds every interface, `127.0.0.1` keeps a local
+   *  vein off the LAN. Prints one JSON line on stdout when ready,
+   *  `{"event":"ready","port":N,"host":"…"}`, for hosts to parse.
+   *  Convenience wrapper — feel free to mount `app` yourself. */
+  listen: (port?: number, host?: string) => Promise<number>;
+
+  /** Stop the server started by `listen()` (no-op otherwise). */
+  close: () => Promise<void>;
 }
 
 export interface VeinRunOptions<TServices = unknown> {
@@ -467,6 +476,7 @@ export async function createVein<TServices = unknown>(
     opts.chatMaxAutoTurns ?? Number(process.env["VEIN_CHAT_MAX_AUTO_TURNS"] ?? 10);
   const webDist =
     opts.webDist ??
+    process.env["VEIN_WEB_DIST"] ??
     resolve(dirname(fileURLToPath(import.meta.url)), "../web/dist");
   const registryWasInjected = opts.registry !== undefined;
 
@@ -1914,20 +1924,51 @@ export async function createVein<TServices = unknown>(
 
   // ── Listener ─────────────────────────────────────────────────────────────
 
-  async function listen(port?: number): Promise<number> {
+  let httpServer: import("node:http").Server | null = null;
+
+  async function listen(port?: number, host?: string): Promise<number> {
     warnIfUnconfigured();
-    const p = port ?? parseInt(process.env["VEIN_PORT"] ?? "3000", 10);
+    const requested = port ?? parseInt(process.env["VEIN_PORT"] ?? "3000", 10);
+    const hostname = host ?? process.env["VEIN_HOST"] ?? undefined;
     console.log(
       fileBacked
         ? `vein workspace: ${dataDir}`
         : `vein workspace: ${workspace.constructor.name} (data dir: ${dataDir})`,
     );
     console.log(`vein steps: ${Object.keys(registry).length} registered`);
-    console.log(`vein server: http://localhost:${p}`);
-    const server = serve({ fetch: app.fetch, port: p });
+    const server = serve({ fetch: app.fetch, port: requested, ...(hostname ? { hostname } : {}) }) as unknown as import("node:http").Server;
+    httpServer = server;
     // The dictation socket upgrades on the Node server, not inside Hono.
-    if (stt) attachAudioWebSocket(server as unknown as import("node:http").Server, stt);
-    return p;
+    if (stt) attachAudioWebSocket(server, stt);
+    // Resolve on the *bound* port (requested may be 0) — and surface a bind
+    // failure (EADDRINUSE etc.) as a rejection instead of an unhandled error.
+    const bound = await new Promise<number>((resolvePort, reject) => {
+      const onError = (e: Error) => reject(e);
+      server.once("error", onError);
+      const done = () => {
+        server.off("error", onError);
+        const addr = server.address();
+        resolvePort(addr && typeof addr === "object" ? addr.port : requested);
+      };
+      if (server.listening) done();
+      else server.once("listening", done);
+    });
+    console.log(`vein server: http://${hostname ?? "localhost"}:${bound}`);
+    // Structured ready line for a host that spawned us (desktop app): one
+    // JSON object on its own stdout line, after the human ones.
+    console.log(JSON.stringify({ event: "ready", port: bound, host: hostname ?? "0.0.0.0" }));
+    return bound;
+  }
+
+  async function close(): Promise<void> {
+    const s = httpServer;
+    if (!s) return;
+    httpServer = null;
+    if (!s.listening) return; // bind failed or already closed
+    await new Promise<void>((resolveClose, reject) => {
+      s.close((e) => (e ? reject(e) : resolveClose()));
+      s.closeAllConnections?.();
+    });
   }
 
   // Boot-time auto-resume (§5.3): on by default for a file-backed store
@@ -1959,6 +2000,7 @@ export async function createVein<TServices = unknown>(
     run,
     stt,
     listen,
+    close,
   };
 }
 

--- a/vein/src/server.ts
+++ b/vein/src/server.ts
@@ -66,9 +66,9 @@ export async function getApp() {
  * await vein.listen(port);
  * ```
  */
-export async function startServer(port?: number): Promise<void> {
+export async function startServer(port?: number, host?: string): Promise<void> {
   const vein = await getDefault();
-  await vein.listen(port);
+  await vein.listen(port, host);
 }
 
 // Run directly when invoked as a script.

--- a/vein/web/src/api.ts
+++ b/vein/web/src/api.ts
@@ -16,10 +16,73 @@ function deriveBase(): string {
 
 const BASE = deriveBase();
 
+// ── API key ────────────────────────────────────────────────────────────────
+// When the server sets VEIN_API_KEY, gated routes need `Authorization:
+// Bearer`. A host that spawns vein (desktop app) hands the per-launch key to
+// the UI as `?key=` on first load; we stash it in sessionStorage and strip
+// it from the URL. A user can also paste one in Settings (localStorage),
+// for a server deployment. sessionStorage (this launch) wins.
+const KEY_STORAGE = "vein/apiKey";
+
+function captureKeyFromUrl(): void {
+  try {
+    const url = new URL(location.href);
+    const key = url.searchParams.get("key");
+    if (!key) return;
+    sessionStorage.setItem(KEY_STORAGE, key);
+    url.searchParams.delete("key");
+    history.replaceState(history.state, "", url.pathname + url.search + url.hash);
+  } catch {
+    // no storage / no history API — the key just isn't remembered
+  }
+}
+captureKeyFromUrl();
+
+export function getApiKey(): string {
+  try {
+    return sessionStorage.getItem(KEY_STORAGE) || localStorage.getItem(KEY_STORAGE) || "";
+  } catch {
+    return "";
+  }
+}
+
+/** Save a user-entered key (Settings). Empty clears it. */
+export function setApiKey(key: string): void {
+  try {
+    if (key) localStorage.setItem(KEY_STORAGE, key);
+    else {
+      localStorage.removeItem(KEY_STORAGE);
+      sessionStorage.removeItem(KEY_STORAGE);
+    }
+  } catch {}
+}
+
+/** Where the active key came from, for the Settings hint. */
+export function apiKeySource(): "url" | "settings" | null {
+  try {
+    if (sessionStorage.getItem(KEY_STORAGE)) return "url";
+    if (localStorage.getItem(KEY_STORAGE)) return "settings";
+  } catch {}
+  return null;
+}
+
+function authHeaders(): Record<string, string> {
+  const key = getApiKey();
+  return key ? { Authorization: `Bearer ${key}` } : {};
+}
+
+/** `fetch` against the API base with the key attached. Every call goes
+ *  through here so a gated deployment works without per-call plumbing. */
+export function apiFetch(path: string, init: RequestInit = {}): Promise<Response> {
+  const headers = new Headers(init.headers ?? {});
+  for (const [k, v] of Object.entries(authHeaders())) if (!headers.has(k)) headers.set(k, v);
+  return fetch(`${BASE}${path}`, { ...init, headers });
+}
+
 export async function fetchJSON<T>(path: string, opts?: RequestInit): Promise<T> {
-  const res = await fetch(`${BASE}${path}`, {
-    headers: { "Content-Type": "application/json" },
+  const res = await apiFetch(path, {
     ...opts,
+    headers: { "Content-Type": "application/json", ...(opts?.headers as Record<string, string> | undefined) },
   });
   if (!res.ok) {
     let msg = `${res.status} ${res.statusText}`;
@@ -68,7 +131,7 @@ export async function downloadSttModel(
   id: string,
   onProgress: (p: SttDownloadProgress) => void,
 ): Promise<void> {
-  const res = await fetch(`${BASE}/audio/models/${encodeURIComponent(id)}/download`, { method: "POST" });
+  const res = await apiFetch(`/audio/models/${encodeURIComponent(id)}/download`, { method: "POST" });
   if (!res.ok || !res.body) throw new Error(`download ${id}: ${res.status} ${res.statusText}`);
   const reader = res.body.getReader();
   const dec = new TextDecoder();
@@ -91,10 +154,14 @@ export async function downloadSttModel(
   }
 }
 
-/** WebSocket URL for `/audio/stream` on the same origin + mount path. */
+/** WebSocket URL for `/audio/stream` on the same origin + mount path. A
+ *  browser WebSocket can't set headers, so the key rides as `?key=`. */
 export function sttStreamUrl(): string {
   const proto = location.protocol === "https:" ? "wss:" : "ws:";
-  return `${proto}//${location.host}${BASE}/audio/stream`;
+  const url = new URL(`${proto}//${location.host}${BASE}/audio/stream`);
+  const key = getApiKey();
+  if (key) url.searchParams.set("key", key);
+  return url.toString();
 }
 
 // ── Workflows ──────────────────────────────────────────────────────────────
@@ -121,7 +188,7 @@ export const getWorkflowMeta = (name: string) =>
   fetchJSON<WorkflowMeta>(`/workflows/${name}`);
 
 export const getWorkflowCode = async (name: string, version: string) => {
-  const res = await fetch(`${BASE}/workflows/${name}/${version}`);
+  const res = await apiFetch(`/workflows/${name}/${version}`);
   return res.text();
 };
 
@@ -201,7 +268,7 @@ export const publishWorkflowYaml = (
   });
 
 export const getWorkflowYaml = async (name: string, version: string) => {
-  const res = await fetch(`${BASE}/workflows/${name}/${version}`);
+  const res = await apiFetch(`/workflows/${name}/${version}`);
   return res.text();
 };
 
@@ -234,7 +301,7 @@ export async function launchWorkflow(
   input: unknown,
   params?: Record<string, unknown>,
 ): Promise<{ runId: string }> {
-  const res = await fetch(`${BASE}/workflows/${name}/run`, {
+  const res = await apiFetch(`/workflows/${name}/run`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -258,7 +325,7 @@ export async function streamRun(
 ): Promise<any> {
   let res: Response;
   try {
-    res = await fetch(`${BASE}/workflows/${name}/runs/${runId}/stream`, { signal });
+    res = await apiFetch(`/workflows/${name}/runs/${runId}/stream`, { signal });
   } catch (e) {
     if ((e as Error)?.name === "AbortError") return null;
     throw e;
@@ -516,7 +583,7 @@ export async function sendChat(
   message: string,
   chatId?: string,
 ): Promise<{ chatId: string; turn: number }> {
-  const res = await fetch(`${BASE}/chat`, {
+  const res = await apiFetch(`/chat`, {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify({ message, ...(chatId ? { chatId } : {}) }),
@@ -550,7 +617,7 @@ export async function streamChat(
   // running server-side. Resolves silently (no onFinish) when aborted.
   let res: Response;
   try {
-    res = await fetch(`${BASE}/chat/${chatId}/stream?turn=${turn}`, { signal });
+    res = await apiFetch(`/chat/${chatId}/stream?turn=${turn}`, { signal });
   } catch (err) {
     if (signal?.aborted) return;
     throw err;

--- a/vein/web/src/components/SettingsDialog.tsx
+++ b/vein/web/src/components/SettingsDialog.tsx
@@ -23,6 +23,16 @@ export function SettingsDialog(props: {
   const [busy, setBusy] = useState<string | null>(null); // model id being downloaded
   const [progress, setProgress] = useState("");
   const [hotwords, setHotwords] = useState(settings.hotwords);
+  const [apiKey, setApiKeyState] = useState(api.getApiKey());
+  const keySource = api.apiKeySource();
+
+  const saveApiKey = (value: string) => {
+    const v = value.trim();
+    if (v === api.getApiKey()) return;
+    api.setApiKey(v);
+    setApiKeyState(v);
+    refresh();
+  };
 
   const refresh = async () => {
     try {
@@ -94,6 +104,24 @@ export function SettingsDialog(props: {
     >
       <div class="dialog settings-dialog">
         <div class="dialog-title">Settings</div>
+
+        <div class="settings-section-title">Connection</div>
+        <div class="dialog-hint">
+          Only needed when the server sets <code>VEIN_API_KEY</code>. Sent as a bearer
+          token on every request (and as <code>?key=</code> on the dictation socket).
+          {keySource === "url" && " This session's key came from the launch URL."}
+        </div>
+        <div class="dialog-field">
+          <label>API key</label>
+          <input
+            type="password"
+            value={apiKey}
+            placeholder="VEIN_API_KEY (blank in dev)"
+            autocomplete="off"
+            onInput={(e) => setApiKeyState((e.target as HTMLInputElement).value)}
+            onBlur={(e) => saveApiKey((e.target as HTMLInputElement).value)}
+          />
+        </div>
 
         <div class="settings-section-title">Dictation</div>
         <div class="dialog-hint">


### PR DESCRIPTION
## What

The four gaps between `main` and the host↔vein contract in `vein/plans/local-desktop-and-stt.md` §2.5, so a native desktop app can spawn vein as a child process and talk to it from a webview.

- **`VEIN_PORT=0`** — `listen()` now resolves once the socket is bound, to the real port. `listen(port?, host?)`; rejects on bind failure (EADDRINUSE) instead of crashing.
- **`VEIN_HOST`** — bind address (desktop passes `127.0.0.1`). Default unchanged: all interfaces.
- **Ready line** — after the human log lines, one JSON object on stdout: `{"event":"ready","port":51234,"host":"127.0.0.1"}`. Plus `vein.close()`.
- **`?key=` handoff** — the UI stores a `?key=` from the first page load in `sessionStorage`, strips it from the URL, attaches it as `Authorization: Bearer` on every API call (all fetches now go through `apiFetch`), and as `?key=` on the dictation socket. Settings → Connection also accepts a pasted key (`localStorage`) for server deployments where `VEIN_API_KEY` is set — the previously-open "auth later" item.
- `VEIN_WEB_DIST` override for packagers (§2.2 item 4).

Host contract now: spawn `node build/server.js` with `VEIN_HOST=127.0.0.1 VEIN_PORT=0 VEIN_WORKSPACE=… VEIN_WORKSPACE_BACKEND=fs VEIN_API_KEY=<random> VEIN_CACHE_DIR=…`, read the `ready` line, load `http://127.0.0.1:<port>/?key=<VEIN_API_KEY>` in the webview.

## Verified

- Unit: two new `listen()` tests (port 0 + host + ready line + `/health` + `close()`; EADDRINUSE rejects). Full suite green.
- Manual: booted with `VEIN_PORT=0 VEIN_HOST=127.0.0.1 VEIN_API_KEY=…`, got the ready line on an OS-picked port, `/audio/models` 401 without the key and 200 with it, loaded the UI via `?key=` (URL stripped, key in sessionStorage), and dictated into the chat over the keyed WebSocket.

## Docs

`AGENTS.md` env table + Auth section; plan §2.2 / §2.5 / §5 updated.