### PR TITLE
vein: desktop embedding — client doc, `import "vein"` hook, package:desktop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,5 @@ vein/build
 vein/node_modules
 vein/web/dist
 vein/web/node_modules
+# vein desktop packaging output (scripts/package-desktop.mjs)
+vein/dist-desktop

--- a/vein/package.json
+++ b/vein/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "build": "tsc",
     "build:web": "npm --prefix web run build",
+    "package:desktop": "node scripts/package-desktop.mjs",
     "dev": "npm run build:web && tsx --env-file=.env src/server.ts",
     "start": "node build/server.js",
     "test": "tsx --test src/expr.test.ts src/core.test.ts src/runner.test.ts src/run-control.test.ts src/control-flow.test.ts src/store.test.ts src/workspace.test.ts src/storage-conformance.test.ts src/integration.test.ts src/services.test.ts src/cassette.test.ts src/run-step.test.ts src/createVein.test.ts src/authoring.test.ts src/ai-integration.test.ts src/chat-store.test.ts src/chat-endpoints.test.ts src/steps/registry.test.ts src/steps/core/agent.test.ts src/steps/core/pack.test.ts src/auth.test.ts src/secret-store.test.ts src/artifacts.test.ts src/slack.test.ts src/gdrive.test.ts src/html-extract.test.ts src/shell.test.ts src/validate.test.ts src/model-dir.test.ts src/audio/hotwords.test.ts src/audio/stt.test.ts src/audio/ws.test.ts",

--- a/vein/plans/local-desktop-and-stt.md
+++ b/vein/plans/local-desktop-and-stt.md
@@ -76,12 +76,13 @@ the API key is obtained.
    step files ship as real files. It breaks any single-file build. Fix when we
    go single-file: a build-time generated step manifest (static imports) with
    `readdir` only for custom steps.
-3. **Custom steps are materialized to disk and `import "vein"`**
-   (`graph/workspace-store.ts` `materializeCustomSteps`, and the fs workspace's
-   `steps/custom`). Node resolves `vein` by walking up from the file. The app
-   must ensure a resolvable `node_modules/vein` exists above the materialize
-   dir — simplest is to make the data dir live under the app's bundle tree, or
-   write a one-line shim package that re-exports from the running server.
+3. ~~**Custom steps are materialized to disk and `import "vein"`.**~~ Done:
+   a module resolve hook (`src/vein-resolve-hook.ts`, registered by the
+   step registry) maps the bare specifier to the running vein's own entry,
+   so the workspace can live anywhere (Application Support on desktop) and
+   steps get the same module instance the server runs. A one-line
+   `package.json` (`"type": "module"`) is written beside the custom steps so
+   tsx in dev treats them as ESM out of tree, as Node already does.
 4. **`web/dist` is resolved relative to the module** (`createVein.ts` ~L450).
    Add a `VEIN_WEB_DIST` override so the host can pass an absolute path.
 5. **Bind address.** `serve({ fetch, port })` binds all interfaces. Add

--- a/vein/plans/local-desktop-and-stt.md
+++ b/vein/plans/local-desktop-and-stt.md
@@ -115,7 +115,20 @@ vein/
   with zero code change. `import.meta.url` inside the bundle must resolve to
   the bundle's own dir; esbuild's `--inject` of an `import.meta.url` shim or
   `__dirname` replacement handles this.
-- Size estimate: ~150 MB before models. Acceptable.
+- **Built by `npm run package:desktop -- --smoke`** (`scripts/package-desktop.mjs`):
+  tsc + vite, stage `package.json` + `build/` + `web/dist/`, `npm install
+  --omit=dev` in the stage, keep one `sherpa-onnx-<platform>` and only this
+  platform's `onnxruntime-node` binaries, list the `.node` files the host
+  must code-sign, then (`--smoke`) boot the copy from a temp dir with the
+  §2.5 env and a workspace outside the tree holding a step that
+  `import "vein"`, and check `/health`, `/steps`, `/audio/models`
+  (`available: true`) and the UI. `--platform` cross-stages.
+- Measured (darwin-arm64, 2026-09-07): **376 MB** before the Node binary and
+  models. Largest pieces: `onnxruntime-web` 134 MB (MiniLM's WASM backend,
+  a transformers dep; its many wasm variants are the next pruning target),
+  `onnxruntime-node` 36 MB after pruning, sherpa 34 MB, `aieo` 32 MB. The
+  earlier ~150 MB estimate assumed an esbuild bundle, which the step loader
+  rules out for now (§2.4).
 
 ### 2.4 Packaging: phase B (single binary, later)
 
@@ -449,8 +462,9 @@ artifact per user/company) or beside it. Lean: same artifact, two sections.
    alias (the last one lands with step 1).
 4. **First dream cycle**: a sessions → llm → `PUT /audio/hotwords` workflow
    plus the corrections UI. Proves the loop before packaging.
-5. **Phase A packaging**: esbuild bundle, Node binary, native dir, a macOS
-   host proof-of-concept that spawns vein and streams the mic.
+5. **Phase A packaging**: vein side done (`package:desktop` + smoke test);
+   remaining is the macOS host: embed Node + the staged dir, code-sign the
+   listed addons, spawn vein and stream the mic.
 6. **Kotlin host**, Windows shell override.
 7. Later: single-binary (phase B), local vector store or LadybugDB backend
    (§3, §3.1), batch `audio/transcribe` step, offline-mobile bindings.

--- a/vein/plans/local-desktop-and-stt.md
+++ b/vein/plans/local-desktop-and-stt.md
@@ -123,10 +123,14 @@ vein/
   §2.5 env and a workspace outside the tree holding a step that
   `import "vein"`, and check `/health`, `/steps`, `/audio/models`
   (`available: true`) and the UI. `--platform` cross-stages.
-- Measured (darwin-arm64, 2026-09-07): **376 MB** before the Node binary and
-  models. Largest pieces: `onnxruntime-web` 134 MB (MiniLM's WASM backend,
-  a transformers dep; its many wasm variants are the next pruning target),
-  `onnxruntime-node` 36 MB after pruning, sherpa 34 MB, `aieo` 32 MB. The
+- Measured (darwin-arm64, 2026-09-07): **99 MB** before the Node binary and
+  models, with the defaults: the embeddings stack uninstalled
+  (`@huggingface/transformers` + `onnxruntime-web`/`-node` + `sharp`,
+  ~200 MB — MiniLM only serves graph search, which needs Neo4j; `--embeddings`
+  keeps it and `graph/embeddings.ts` fails with a clear message without it)
+  and sourcemaps/typings/docs stripped (~70 MB). Largest pieces left: sherpa
+  34 MB, `aieo` 15 MB (its nested `ai`/`@ai-sdk`/`zod` copies — align
+  versions to dedupe), `react-dom` 7 MB. One `.node` addon to sign. The
   earlier ~150 MB estimate assumed an esbuild bundle, which the step loader
   rules out for now (§2.4).
 

--- a/vein/plans/local-desktop-and-stt.md
+++ b/vein/plans/local-desktop-and-stt.md
@@ -391,6 +391,8 @@ the route, never at boot; server images pre-bake.
 
 ### 4.6 Client responsibilities (Swift / Kotlin)
 
+Full client contract, with a Swift sketch: `native-dictation-client.md`.
+
 - Capture the microphone natively (AVAudioEngine / AudioRecord), 16 kHz
   mono PCM16LE. Do **not** use `getUserMedia` inside the webview.
 - Live: open `/audio/stream`, send ~100 ms frames, render partials, replace

--- a/vein/plans/native-dictation-client.md
+++ b/vein/plans/native-dictation-client.md
@@ -1,0 +1,328 @@
+# Native dictation client (macOS / iOS / Kotlin) → vein `/audio/stream`
+
+Scope: a native app that captures the microphone itself and streams audio to
+a running vein for speech-to-text. Nothing here involves vein's web UI; the
+app owns capture, the UI for the transcript, and what it does with the text.
+The server side is complete on `main`. This is the contract to build against.
+
+Source of truth for the protocol: `vein/src/audio/ws.ts` (socket),
+`vein/src/audio/stt.ts` (`SttStreamOptions`, events), `vein/src/audio/routes.ts`
+(HTTP). Design background: `local-desktop-and-stt.md` §4.
+
+---
+
+## 1. The moving parts
+
+| Piece | Where | Notes |
+|---|---|---|
+| Recognizer | inside vein (sherpa-onnx, CPU) | Models download once into `VEIN_MODEL_DIR` / `<VEIN_CACHE_DIR>/vein/models` |
+| Audio capture | the app | AVAudioEngine / AudioRecord, any sample rate, mono |
+| Transport | one WebSocket per dictation | `GET /audio/stream`, JSON control frames + binary PCM |
+| Push-to-talk alternative | one HTTP request | `POST /audio/transcribe` with a WAV body |
+| Model install | HTTP, once | `GET /audio/models`, `POST /audio/models/:id/download` (SSE progress) |
+| Learning loop | HTTP | sessions, corrections, named hotword lists |
+
+Base URL is whatever the app spawned or was configured with, e.g.
+`http://127.0.0.1:<port>` for a local child process (the port comes from vein's
+`{"event":"ready","port":N}` stdout line) or `https://host/lab` behind mcp.
+Every `/audio/*` route and the socket sit under that base.
+
+## 2. Auth
+
+If vein runs with `VEIN_API_KEY` set (a desktop host should generate one per
+launch), every `/audio/*` request and the socket upgrade must carry it:
+
+- HTTP and WebSocket: `Authorization: Bearer <VEIN_API_KEY>` — a
+  `URLSessionWebSocketTask` / OkHttp socket can set request headers, so use the
+  header; `?key=<VEIN_API_KEY>` on the socket URL is the fallback for clients
+  that can't.
+- Behind mcp's `/lab` mount the credential is mcp's instead: HTTP Basic
+  `admin:<API_TOKEN>` or `x-api-token: <API_TOKEN>`, on both HTTP and the
+  upgrade.
+
+Wrong or missing credential: HTTP `401`, and the upgrade is refused with `401`
+before the WebSocket handshake completes.
+
+## 3. Install models (once, before first use)
+
+`GET /audio/models` →
+
+```json
+{
+  "available": true,
+  "modelDir": "/Users/me/.cache/vein/models",
+  "models": [
+    { "id": "zipformer-en-kroko", "bytes": 57000000, "chunkMs": 1280, "hotwords": true,
+      "cased": true, "installed": true, "default": "model", "description": "…" },
+    { "id": "nemo-fast-conformer-en-80ms", "bytes": 103000000, "chunkMs": 80, "hotwords": false,
+      "cased": false, "installed": false, "default": "partialModel", "description": "…" },
+    …
+  ]
+}
+```
+
+`available: false` means the sherpa addon didn't load in that vein; every
+audio call will answer `501 { "error": "stt not available" }`.
+
+Install the pair marked `default` (`model` = finals, `partialModel` = fast
+partials; ~160 MB total):
+
+`POST /audio/models/<id>/download` → `text/event-stream`:
+
+```
+event: progress
+data: {"phase":"download","received":1048576,"total":57123456}
+…
+event: progress
+data: {"phase":"extract"}
+event: progress
+data: {"phase":"done"}
+```
+
+or `event: error` / `data: {"error":"…"}`. Idempotent; re-running on an
+installed model returns `done` immediately. If you skip this, the first
+stream triggers the download and its `ready` arrives only after it finishes,
+which can be a minute on a slow link — pre-install at app setup.
+
+## 4. Streaming dictation — the socket
+
+Open `ws(s)://<base>/audio/stream` with the auth header, then:
+
+### 4.1 Client → server
+
+1. One text frame, the start message. Everything except `type` is optional:
+
+   ```json
+   {
+     "type": "start",
+     "sampleRate": 48000,
+     "model": "zipformer-en-kroko",
+     "partialModel": "nemo-fast-conformer-en-80ms",
+     "hotwords": ["Sphinx", "sphinx", "Stakwork :2"],
+     "hotwordsScore": 2,
+     "session": "2026-09-07T17:12:41Z-dictation",
+     "endpoint": { "rule1": 2.4, "rule2": 1.0, "rule3": 20 }
+   }
+   ```
+
+   | Field | Default | Meaning |
+   |---|---|---|
+   | `sampleRate` | 16000 | Rate of the PCM you will send. Declare your capture rate; vein resamples. **It must not change for the life of the stream** (see §5). |
+   | `model` | `VEIN_STT_MODEL` / catalog default (`zipformer-en-kroko`) | Finals model. Hotword-capable Zipformer by default. |
+   | `partialModel` | `VEIN_STT_PARTIAL_MODEL` / catalog default (`nemo-fast-conformer-en-80ms`) | Fast greedy model that produces partials. `null` = single recognizer: finals model does both, partials every ~1.3 s. |
+   | `hotwords` | none | Either a stored list name (string) or inline phrases. A phrase may carry its own boost as ` :score`; objects `{ "phrase": "…", "score": 2 }` also work. |
+   | `hotwordsScore` | 2 | Boost for phrases without their own score. 1.5–3 is the useful range; 5 over-biases. |
+   | `session` | none | Log every final under `<dataDir>/audio/sessions/<id>.jsonl` for the learning loop (§7). |
+   | `endpoint` | `{2.4, 1.0, 20}` | Seconds: `rule1` trailing silence with no speech yet, `rule2` trailing silence after speech, `rule3` max utterance length. Each triggers a `final`. |
+
+2. Binary frames: raw **PCM16 little-endian, mono**, at `sampleRate`. No
+   header, no framing. Around 100 ms per frame (4800 samples = 9600 bytes at
+   48 kHz) is the sweet spot; any size works. Frames sent before `ready` are
+   buffered and fed once the recognizer is up.
+
+3. One text frame `{"type":"end"}` when the user stops. Vein pads ~2 s of
+   silence so the last words decode, emits the trailing `final`, waits for
+   the session log to land, then closes with code `1000`.
+
+Closing the socket without `end` discards whatever hadn't reached a `final`.
+
+### 4.2 Server → client (all text frames, JSON)
+
+| Message | When |
+|---|---|
+| `{"type":"ready","model":"…","partialModel":"…"\|null,"hotwords":"<list name>"\|"inline"\|null}` | Recognizers are built. ~1 s cold, a few ms when cached. Start rendering. |
+| `{"type":"partial","text":"…"}` | On every change to the in-progress text. Replace, don't append: `text` is the whole current utterance. Lowercase, unpunctuated when it comes from the NeMo partials model. |
+| `{"type":"final","index":0,"text":"…","words":[{"text":"Ask","start":0.32},…]}` | An utterance closed (endpoint rule) or the stream ended. `text` supersedes the partials shown for it; the next partial starts a new utterance. Cased and punctuated from the finals model. `index` counts finals within the stream (continues across a resumed `session`); `start` is seconds from stream start. |
+| `{"type":"error","error":"…"}` | Then close `1011`. Bad start message, unknown model or list, or a decode failure. |
+
+Two things the app should do with these:
+
+- **Render**: committed text = all `final.text` so far, joined with a space;
+  live text = the latest `partial.text` after it. A punctuation-only final
+  (`"."`) can arrive on `end`; attach it to the previous word.
+- **Timing** on an M-series Mac with the default pair: partials trail the
+  audio by 50–100 ms; a final lands ~300 ms after `end`; CPU ≈ 10 ms per
+  100 ms of audio. Send frames at capture pace, not faster.
+
+## 5. Audio contract (the parts that bite)
+
+- **Mono PCM16LE only.** AVAudioEngine's input tap gives Float32, often
+  deinterleaved stereo. Take channel 0, scale by 32768, clamp, write Int16
+  little-endian. Compressed formats are not accepted.
+- **Declare your real rate and never change it.** sherpa `exit(-1)`s the whole
+  vein process on a mid-stream rate change. Vein rejects a rate change before
+  it reaches the addon, but only if the client declares the rate it actually
+  sends: if the input device changes (AirPods connect, mic switches) and the
+  rate changes, **end the stream and start a new one**.
+- **Do not resample in the app.** 48 kHz in is fine; vein resamples to the
+  engine's 16 kHz. Resampling yourself only adds a place to get it wrong.
+- **Frame cadence.** ~100 ms frames. Bigger frames raise partial latency; much
+  smaller ones just add socket overhead.
+- **Echo cancellation / noise suppression** are the app's job if wanted
+  (`AVAudioSession` voice-processing mode on iOS, `kAUVoiceIOProperty` /
+  `setVoiceProcessingEnabled` on macOS). Vein does nothing to the audio.
+
+## 6. Push-to-talk: `POST /audio/transcribe`
+
+For a hold-to-talk button or a voice memo, skip the socket: buffer the
+capture, wrap it as a WAV (any rate, 8/16/24-bit PCM, mono), and
+
+```
+POST /audio/transcribe?model=zipformer-en-kroko&hotwords=<list>&session=<id>
+Content-Type: audio/wav
+<wav bytes>
+```
+
+→ `{ "text": "…", "segments": [{ "text", "words" }], "model", "hotwords", "durationMs" }`.
+Single recognizer (no `partialModel`); same casing and punctuation as a
+`final`. Bodies under 44 bytes are rejected as not-a-WAV.
+
+## 7. The learning loop (sessions, corrections, hotword lists)
+
+Only if the app wants recognition to improve for its user. All optional.
+
+- **Sessions.** Pass `session` on `start` (or `transcribe`). Finals are
+  appended to `<dataDir>/audio/sessions/<id>.jsonl`. Read back with
+  `GET /audio/sessions` (list) and `GET /audio/sessions/<id>` →
+  `{ "id", "entries": [ { "type":"final", "t", "index", "text", "words", "model", "hotwords" }, { "type":"correction", "t", "index", "text" } ] }`.
+- **Corrections.** When the user edits a final's text, send
+  `POST /audio/sessions/<id>/corrections` with `{ "index": <final.index>, "text": "<edited>" }`.
+  This is the highest-signal data the dream cycle gets; the app should send
+  it whenever it lets the user edit.
+- **Hotword lists.** `PUT /audio/hotwords/<name>` with a `text/plain` body,
+  one phrase per line, optional ` :score`, or JSON `{ "phrases": [...] }`.
+  `GET /audio/hotwords` lists names; `GET /audio/hotwords/<name>` returns the
+  text; `DELETE` removes it. A stream names one with `"hotwords": "<name>"`.
+  The app can seed a list from the user's contacts, projects, or vocabulary;
+  a scheduled vein workflow can maintain it from sessions and corrections.
+
+Hotword rules worth knowing: only the finals model honors them (the partials
+model is greedy), the boost only helps a spelling the model could already
+emit (it won't turn "stack work" into "Stakwork"; that's a post-correction
+glossary), and casing must match what the model would emit, so list proper
+nouns both ways.
+
+## 8. Errors and lifecycle
+
+| Situation | What you see | Do |
+|---|---|---|
+| vein not up yet | connection refused | wait for the `ready` stdout line / `GET /health` |
+| sherpa addon missing on that vein | `501 {"error":"stt not available"}`; socket `error` then close `1011` | tell the user; it's an install problem |
+| bad credential | HTTP `401`; upgrade refused | fix the key |
+| unknown model / list | socket `error` (`unknown stt model "x"` / `unknown hotwords list "x"`), close `1011` | check `GET /audio/models`, `GET /audio/hotwords` |
+| audio before `start` | socket `error`, close `1011` | send the start frame first |
+| network drop mid-stream | socket closes without a trailing `final` | reconnect and start a new stream (same `session` is fine; `index` continues) |
+| app killed | nothing; vein reaps the stream on close | — |
+
+vein handles `SIGTERM` cleanly; a host that kills the child on quit loses
+only the un-`end`ed utterance.
+
+## 9. Swift sketch (macOS, AVAudioEngine → URLSessionWebSocketTask)
+
+Not production code; the shape of it. Two things are intentional: the tap
+runs at the input node's native format and the declared `sampleRate` is read
+from that same format, so the two can't disagree.
+
+```swift
+import AVFoundation
+import Foundation
+
+final class VeinDictation {
+    private let engine = AVAudioEngine()
+    private var task: URLSessionWebSocketTask?
+    var onPartial: ((String) -> Void)?
+    var onFinal: ((String, Int) -> Void)?
+    var onError: ((String) -> Void)?
+
+    func start(base: URL, apiKey: String, session: String) throws {
+        let input = engine.inputNode
+        let fmt = input.inputFormat(forBus: 0)          // e.g. 48 kHz, Float32, 1–2 ch
+        let rate = Int(fmt.sampleRate)
+
+        var req = URLRequest(url: base.appendingPathComponent("audio/stream")
+            .withScheme(base.scheme == "https" ? "wss" : "ws"))
+        req.setValue("Bearer \(apiKey)", forHTTPHeaderField: "Authorization")
+        let t = URLSession.shared.webSocketTask(with: req)
+        task = t
+        t.resume()
+        receiveLoop(t)
+
+        let startMsg: [String: Any] = [
+            "type": "start", "sampleRate": rate, "session": session,
+            // "hotwords": ["Sphinx", "sphinx"], "partialModel": NSNull() for single-recognizer
+        ]
+        let data = try JSONSerialization.data(withJSONObject: startMsg)
+        t.send(.string(String(decoding: data, as: UTF8.self))) { _ in }
+
+        // ~100 ms per buffer at the native rate; bufferSize is advisory.
+        input.installTap(onBus: 0, bufferSize: AVAudioFrameCount(fmt.sampleRate / 10), format: fmt) { [weak self] buf, _ in
+            guard let ch0 = buf.floatChannelData?[0] else { return }
+            let n = Int(buf.frameLength)
+            var pcm = Data(count: n * 2)
+            pcm.withUnsafeMutableBytes { raw in
+                let out = raw.bindMemory(to: Int16.self)
+                for i in 0..<n {
+                    let v = max(-1, min(1, ch0[i]))
+                    out[i] = Int16(v * 32767).littleEndian
+                }
+            }
+            self?.task?.send(.data(pcm)) { _ in }
+        }
+        engine.prepare()
+        try engine.start()
+    }
+
+    func stop() {
+        engine.inputNode.removeTap(onBus: 0)
+        engine.stop()
+        task?.send(.string(#"{"type":"end"}"#)) { _ in }   // vein sends the trailing final, then closes 1000
+    }
+
+    private func receiveLoop(_ t: URLSessionWebSocketTask) {
+        t.receive { [weak self] result in
+            guard let self else { return }
+            switch result {
+            case .failure(let e):
+                self.onError?(e.localizedDescription)           // includes close without `end`
+                return
+            case .success(.string(let s)):
+                if let d = s.data(using: .utf8),
+                   let m = try? JSONSerialization.jsonObject(with: d) as? [String: Any],
+                   let type = m["type"] as? String {
+                    switch type {
+                    case "partial": self.onPartial?(m["text"] as? String ?? "")
+                    case "final":   self.onFinal?(m["text"] as? String ?? "", m["index"] as? Int ?? 0)
+                    case "error":   self.onError?(m["error"] as? String ?? "error")
+                    default: break                                   // "ready"
+                    }
+                }
+            default: break
+            }
+            self.receiveLoop(t)
+        }
+    }
+}
+
+private extension URL {
+    func withScheme(_ s: String) -> URL {
+        var c = URLComponents(url: self, resolvingAgainstBaseURL: false)!
+        c.scheme = s
+        return c.url!
+    }
+}
+```
+
+Kotlin (OkHttp `WebSocket` + `AudioRecord` at `ENCODING_PCM_16BIT`, mono) is
+the same shape and needs no float conversion: `AudioRecord` already yields
+PCM16LE.
+
+## 10. Checklist before shipping a client
+
+- [ ] Auth header on both HTTP and the upgrade; handle `401`.
+- [ ] `GET /audio/models` at setup; install the `default` pair with progress UI; surface `available: false`.
+- [ ] `sampleRate` in `start` is read from the actual capture format; a device change ends the stream and starts a new one.
+- [ ] Mono PCM16LE, ~100 ms frames, sent at capture pace.
+- [ ] `end` on stop; wait for the trailing `final` and close `1000` before discarding state.
+- [ ] Render partial as replace-in-place, final as commit; glue a punctuation-only final to the previous word.
+- [ ] Pass a `session`; send corrections when the user edits.
+- [ ] `error` frame → show it; reconnect on transport loss with a new stream.

--- a/vein/scripts/package-desktop.mjs
+++ b/vein/scripts/package-desktop.mjs
@@ -1,0 +1,244 @@
+#!/usr/bin/env node
+/**
+ * Stage a self-contained vein directory for embedding in a native desktop
+ * app (plans/local-desktop-and-stt.md §2.3, "phase A").
+ *
+ *   npm run package:desktop -- [--platform darwin-arm64] [--out dist-desktop] [--smoke] [--skip-build]
+ *
+ * Output: <out>/vein/ containing package.json, build/ (server + steps as
+ * loose files — the registry scans them), web/dist/, and a production-only
+ * node_modules/ with exactly one sherpa-onnx platform package and only this
+ * platform's onnxruntime-node binaries. The host adds an official Node
+ * binary beside it and runs `node build/server.js` with the env in §2.5.
+ *
+ * --smoke boots the staged copy from a temp directory (so nothing can leak
+ * in from this checkout), with a workspace outside the package tree that
+ * holds a custom step importing "vein", and checks /health, /audio/models
+ * (`available: true` = the sherpa addon loaded) and that the step registered.
+ *
+ * Not a single-file build on purpose: the step loader scans directories and
+ * the sherpa addon must be a real file beside the binary either way (§2.4).
+ */
+import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const args = process.argv.slice(2);
+const flag = (name, dflt) => {
+  const i = args.indexOf(`--${name}`);
+  return i >= 0 ? (args[i + 1] && !args[i + 1].startsWith("--") ? args[i + 1] : true) : dflt;
+};
+const platform = String(flag("platform", `${process.platform === "win32" ? "win" : process.platform}-${process.arch}`));
+const out = resolve(ROOT, String(flag("out", "dist-desktop")));
+const smoke = flag("smoke", false) === true;
+const skipBuild = flag("skip-build", false) === true;
+const stage = join(out, "vein");
+
+const SHERPA_PLATFORMS = ["darwin-arm64", "darwin-x64", "linux-x64", "linux-arm64", "win-x64", "win-ia32"];
+if (!SHERPA_PLATFORMS.includes(platform)) {
+  console.error(`unknown platform ${platform}; one of ${SHERPA_PLATFORMS.join(", ")}`);
+  process.exit(2);
+}
+// onnxruntime-node lays its binaries out as bin/napi-v6/<os>/<arch>.
+const [ortOs, ortArch] = platform.replace(/^win-/, "win32-").split("-");
+
+const log = (m) => console.log(`[package-desktop] ${m}`);
+const run = (cmd, cmdArgs, cwd = ROOT) => {
+  const r = spawnSync(cmd, cmdArgs, { cwd, stdio: "inherit", env: process.env });
+  if (r.status !== 0) throw new Error(`${cmd} ${cmdArgs.join(" ")} failed (${r.status})`);
+};
+const sizeOf = async (p) => {
+  const s = await stat(p);
+  if (!s.isDirectory()) return s.size;
+  let n = 0;
+  for (const e of await readdir(p)) n += await sizeOf(join(p, e));
+  return n;
+};
+const mb = (n) => `${Math.round(n / 1e6)} MB`;
+
+async function build() {
+  if (skipBuild) return log("skipping build (--skip-build)");
+  log("building server (tsc) and web UI (vite)");
+  run("npm", ["run", "build"]);
+  run("npm", ["run", "build:web"]);
+}
+
+async function stageFiles() {
+  await rm(stage, { recursive: true, force: true });
+  await mkdir(stage, { recursive: true });
+  const pkg = JSON.parse(await readFile(join(ROOT, "package.json"), "utf-8"));
+  // The host runs `node build/server.js`; drop the dev surface from the manifest.
+  delete pkg.devDependencies;
+  delete pkg.scripts;
+  pkg.private = true;
+  await writeFile(join(stage, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
+  await cp(join(ROOT, "build"), join(stage, "build"), { recursive: true });
+  await cp(join(ROOT, "web", "dist"), join(stage, "web", "dist"), { recursive: true });
+  log(`staged build/ + web/dist/ → ${stage}`);
+}
+
+async function installDeps() {
+  log("installing production dependencies (npm install --omit=dev)");
+  // optionalDependencies (sherpa-onnx-node + its platform packages) come along;
+  // the other platforms are removed below.
+  run("npm", ["install", "--omit=dev", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts"], stage);
+  const nm = join(stage, "node_modules");
+
+  // One sherpa platform package.
+  for (const p of SHERPA_PLATFORMS) {
+    if (p === platform) continue;
+    await rm(join(nm, `sherpa-onnx-${p}`), { recursive: true, force: true });
+  }
+  const keep = join(nm, `sherpa-onnx-${platform}`);
+  try {
+    await stat(keep);
+  } catch {
+    log(`sherpa-onnx-${platform} isn't installed on this machine's npm view; fetching it explicitly`);
+    const ver = JSON.parse(await readFile(join(nm, "sherpa-onnx-node", "package.json"), "utf-8")).version;
+    run("npm", ["install", "--no-save", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts", "--force", `sherpa-onnx-${platform}@${ver}`], stage);
+  }
+
+  // Only this platform's onnxruntime binaries (the package ships all of them).
+  const ortBin = join(nm, "onnxruntime-node", "bin", "napi-v6");
+  try {
+    for (const os of await readdir(ortBin)) {
+      if (os !== ortOs) {
+        await rm(join(ortBin, os), { recursive: true, force: true });
+        continue;
+      }
+      for (const arch of await readdir(join(ortBin, os))) {
+        if (arch !== ortArch) await rm(join(ortBin, os, arch), { recursive: true, force: true });
+      }
+    }
+  } catch {
+    /* onnxruntime-node absent — nothing to prune */
+  }
+  await rm(join(nm, ".package-lock.json"), { force: true });
+}
+
+async function report() {
+  const nm = join(stage, "node_modules");
+  const total = await sizeOf(stage);
+  const rows = [];
+  for (const e of await readdir(nm)) {
+    if (e.startsWith(".")) continue;
+    if (e.startsWith("@")) {
+      for (const s of await readdir(join(nm, e))) rows.push([`${e}/${s}`, await sizeOf(join(nm, e, s))]);
+    } else rows.push([e, await sizeOf(join(nm, e))]);
+  }
+  rows.sort((a, b) => b[1] - a[1]);
+  log(`staged ${stage}: ${mb(total)} total, ${rows.length} packages; largest:`);
+  for (const [name, size] of rows.slice(0, 8)) console.log(`    ${mb(size).padStart(7)}  ${name}`);
+  const addons = [];
+  const walk = async (d) => {
+    for (const e of await readdir(d, { withFileTypes: true })) {
+      const p = join(d, e.name);
+      if (e.isDirectory()) await walk(p);
+      else if (e.name.endsWith(".node")) addons.push(p.slice(nm.length + 1));
+    }
+  };
+  await walk(nm);
+  log(`native addons the host must code-sign (${addons.length}):`);
+  for (const a of addons) console.log(`    ${a}`);
+}
+
+const freePort = () =>
+  new Promise((res, rej) => {
+    const s = createServer();
+    s.listen(0, "127.0.0.1", () => {
+      const { port } = s.address();
+      s.close(() => res(port));
+    });
+    s.on("error", rej);
+  });
+
+async function smokeTest() {
+  // Run from a temp copy so resolution can't fall back into this checkout.
+  const tmp = await mkdtemp(join(tmpdir(), "vein-desktop-"));
+  const app = join(tmp, "vein");
+  const workspace = join(tmp, "Application Support", "workspace");
+  const cache = join(tmp, "cache");
+  log(`smoke: copying stage → ${app}`);
+  await cp(stage, app, { recursive: true });
+  await mkdir(join(workspace, "steps", "custom"), { recursive: true });
+  await writeFile(
+    join(workspace, "steps", "custom", "smoke-step.ts"),
+    `import { z, defineStep } from "vein";
+export default defineStep({
+  type: "smoke-step",
+  input: z.object({ name: z.string() }),
+  output: z.string(),
+  async run({ input }) { return "hi " + input.name; },
+});
+`,
+  );
+  const port = await freePort();
+  const key = "smoke-key";
+  const env = {
+    ...process.env,
+    VEIN_HOST: "127.0.0.1",
+    VEIN_PORT: String(port),
+    VEIN_WORKSPACE: workspace,
+    VEIN_WORKSPACE_BACKEND: "fs",
+    VEIN_API_KEY: key,
+    VEIN_CACHE_DIR: cache,
+  };
+  log(`smoke: node build/server.js on 127.0.0.1:${port} (workspace + cache under ${tmp})`);
+  const child = spawn(process.execPath, ["build/server.js"], { cwd: app, env, stdio: ["ignore", "pipe", "pipe"] });
+  let output = "";
+  child.stdout.on("data", (d) => (output += d));
+  child.stderr.on("data", (d) => (output += d));
+  const base = `http://127.0.0.1:${port}`;
+  const headers = { authorization: `Bearer ${key}` };
+  const deadline = Date.now() + 30_000;
+  let up = false;
+  while (Date.now() < deadline && !up) {
+    if (child.exitCode !== null) break;
+    try {
+      up = (await fetch(`${base}/health`)).ok;
+    } catch {
+      await new Promise((r) => setTimeout(r, 250));
+    }
+  }
+  const failures = [];
+  try {
+    if (!up) throw new Error(`server did not come up:\n${output}`);
+    const health = await (await fetch(`${base}/health`)).json();
+    if (!health.ok) failures.push("health not ok");
+    if (health.dataDir !== workspace) failures.push(`dataDir ${health.dataDir} != ${workspace}`);
+
+    const steps = await (await fetch(`${base}/steps`)).text();
+    if (!steps.includes("smoke-step")) failures.push('custom step importing "vein" from an out-of-tree workspace did not register');
+
+    const unauth = await fetch(`${base}/audio/models`);
+    if (unauth.status !== 401) failures.push(`/audio/models without key: ${unauth.status}, expected 401`);
+    const models = await (await fetch(`${base}/audio/models`, { headers })).json();
+    if (!models.available) failures.push("sherpa addon did not load in the staged copy (available: false)");
+    if (!models.modelDir.startsWith(cache)) failures.push(`modelDir ${models.modelDir} not under VEIN_CACHE_DIR`);
+
+    const ui = await fetch(`${base}/`);
+    if (!ui.ok || !(await ui.text()).includes("<div id=\"app\"")) failures.push("web UI index did not serve");
+  } catch (e) {
+    failures.push(String(e));
+  } finally {
+    child.kill("SIGTERM");
+  }
+  if (/Warning: failed to load step/.test(output)) failures.push(`step load warning:\n${output}`);
+  await rm(tmp, { recursive: true, force: true });
+  if (failures.length) {
+    console.error(`[package-desktop] SMOKE FAILED\n - ${failures.join("\n - ")}`);
+    process.exit(1);
+  }
+  log("smoke: OK — boots from an unrelated path, addon loads, out-of-tree custom step resolves, UI serves");
+}
+
+await build();
+await stageFiles();
+await installDeps();
+await report();
+if (smoke) await smokeTest();
+log(`done. Host contract: plans/local-desktop-and-stt.md §2.5; run \`node build/server.js\` inside ${stage}`);

--- a/vein/scripts/package-desktop.mjs
+++ b/vein/scripts/package-desktop.mjs
@@ -3,13 +3,20 @@
  * Stage a self-contained vein directory for embedding in a native desktop
  * app (plans/local-desktop-and-stt.md §2.3, "phase A").
  *
- *   npm run package:desktop -- [--platform darwin-arm64] [--out dist-desktop] [--smoke] [--skip-build]
+ *   npm run package:desktop -- [--platform darwin-arm64] [--out dist-desktop] [--smoke] [--skip-build] [--embeddings]
  *
  * Output: <out>/vein/ containing package.json, build/ (server + steps as
  * loose files — the registry scans them), web/dist/, and a production-only
  * node_modules/ with exactly one sherpa-onnx platform package and only this
  * platform's onnxruntime-node binaries. The host adds an official Node
  * binary beside it and runs `node build/server.js` with the env in §2.5.
+ *
+ * Two size cuts, both on by default:
+ *   - the embeddings stack (@huggingface/transformers + onnxruntime-web/-node
+ *     + sharp, ~200 MB) is uninstalled — MiniLM only serves graph search,
+ *     which needs a Neo4j the desktop build doesn't ship; `--embeddings`
+ *     keeps it, and graph/embeddings.ts fails with a clear message without it;
+ *   - sourcemaps, typings, and docs are stripped from node_modules (~100 MB).
  *
  * --smoke boots the staged copy from a temp directory (so nothing can leak
  * in from this checkout), with a workspace outside the package tree that
@@ -36,6 +43,7 @@ const platform = String(flag("platform", `${process.platform === "win32" ? "win"
 const out = resolve(ROOT, String(flag("out", "dist-desktop")));
 const smoke = flag("smoke", false) === true;
 const skipBuild = flag("skip-build", false) === true;
+const embeddings = flag("embeddings", false) === true;
 const stage = join(out, "vein");
 
 const SHERPA_PLATFORMS = ["darwin-arm64", "darwin-x64", "linux-x64", "linux-arm64", "win-x64", "win-ia32"];
@@ -117,7 +125,47 @@ async function installDeps() {
   } catch {
     /* onnxruntime-node absent — nothing to prune */
   }
+  if (!embeddings) {
+    // npm removes the package and everything only it depended on, and drops
+    // it from the staged package.json so the manifest matches the build.
+    log("removing the embeddings stack (@huggingface/transformers and its deps); --embeddings keeps it");
+    run("npm", ["uninstall", "--omit=dev", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts", "@huggingface/transformers"], stage);
+  }
   await rm(join(nm, ".package-lock.json"), { force: true });
+  await strip(nm);
+}
+
+// Sourcemaps, typings, and docs are dead weight in a shipped app. Licenses
+// stay. Only node_modules is touched (vein's own build/ keeps its .d.ts).
+const STRIP_EXT = [".map", ".d.ts", ".d.mts", ".d.cts", ".md", ".markdown"];
+const STRIP_NAMES = new Set(["CHANGELOG", "CHANGES", "HISTORY", ".github", ".vscode", ".idea"]);
+async function strip(dir) {
+  let files = 0;
+  let bytes = 0;
+  const walk = async (d) => {
+    for (const e of await readdir(d, { withFileTypes: true })) {
+      const p = join(d, e.name);
+      const base = e.name.replace(/\.(md|txt|markdown)$/i, "");
+      if (STRIP_NAMES.has(base) || STRIP_NAMES.has(e.name)) {
+        bytes += await sizeOf(p);
+        files++;
+        await rm(p, { recursive: true, force: true });
+        continue;
+      }
+      if (e.isDirectory()) {
+        await walk(p);
+        continue;
+      }
+      if (/^licen[cs]e/i.test(e.name)) continue;
+      if (STRIP_EXT.some((x) => e.name.endsWith(x))) {
+        bytes += (await stat(p)).size;
+        files++;
+        await rm(p, { force: true });
+      }
+    }
+  };
+  await walk(dir);
+  log(`stripped ${files} sourcemap/typing/doc files (${mb(bytes)}) from node_modules`);
 }
 
 async function report() {

--- a/vein/src/createVein.test.ts
+++ b/vein/src/createVein.test.ts
@@ -547,6 +547,28 @@ describe("createVein", () => {
     assert.equal(missing.status, 404);
   });
 
+  it("custom steps can `import \"vein\"` from a workspace outside the package tree", async () => {
+    // tempDir is under the OS tmpdir — no `vein` package is reachable by
+    // walking up from it. The resolve hook (vein-resolver.ts) maps the bare
+    // specifier to this running vein, so the step gets the same defineStep/z.
+    const ws = new WorkspaceManager(tempDir);
+    await ws.publishStep(
+      "hook-step",
+      `import { z, defineStep } from "vein";
+       export default defineStep({
+         type: "hook-step",
+         input: z.object({ name: z.string() }),
+         output: z.string(),
+         async run({ input }) { return "hi " + input.name; },
+       });`,
+    );
+    const vein = await createVein({ workspace: ws, store: new MemoryRunStore(), serveUi: false, enableChat: false, stt: false });
+    assert.ok("hook-step" in vein.getRegistry(), "step importing vein loads from an out-of-tree workspace");
+    const { z: ourZ } = await import("zod");
+    const def = vein.getRegistry()["hook-step"]!;
+    assert.ok(def.input instanceof ourZ.ZodObject, "the step's zod is this process's zod (one module instance)");
+  });
+
   it("a non-file WorkspaceStore gets in-memory store defaults and still loads custom steps", async () => {
     const ws = pathlessWorkspace(new WorkspaceManager(tempDir));
     // Import-free step source (the temp dir sits outside the project tree,

--- a/vein/src/graph/embeddings.ts
+++ b/vein/src/graph/embeddings.ts
@@ -51,7 +51,21 @@ export class MiniLMEmbedder implements Embedder {
 
   /** Load (downloading on first use) and self-check the output dimension. */
   static async load(opts: MiniLMOptions = {}): Promise<MiniLMEmbedder> {
-    const tf: Transformers = await import("@huggingface/transformers");
+    let tf: Transformers;
+    try {
+      tf = await import("@huggingface/transformers");
+    } catch (e) {
+      // The desktop package (scripts/package-desktop.mjs) omits the
+      // embeddings stack: MiniLM only serves graph search, which needs a
+      // Neo4j the desktop build doesn't ship. Say so instead of ENOENT.
+      if ((e as { code?: string }).code === "ERR_MODULE_NOT_FOUND") {
+        throw new Error(
+          "embeddings are not available in this vein build (@huggingface/transformers is not installed); " +
+            "graph search needs a server build or `package:desktop --embeddings`",
+        );
+      }
+      throw e;
+    }
     tf.env.cacheDir = opts.cacheDir ?? modelDirFromEnv();
     tf.env.allowLocalModels = false;
     const model = opts.model ?? EMBEDDING_MODEL;

--- a/vein/src/graph/workspace-store.ts
+++ b/vein/src/graph/workspace-store.ts
@@ -22,6 +22,7 @@
  * Deletion is soft (`is_deleted = true`) — nothing is ever DETACH DELETEd.
  */
 import { mkdir, readdir, readFile, rm, writeFile } from "node:fs/promises";
+import { ensureEsmScope } from "../workspace.js";
 import { createHash } from "node:crypto";
 import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -664,6 +665,7 @@ export class Neo4jWorkspaceStore implements WorkspaceStore {
   async materializeCustomSteps(): Promise<string> {
     const dir = this.materializeDir;
     await mkdir(dir, { recursive: true });
+    await ensureEsmScope(dir);
     const wanted = new Map<string, string>();
     for (const { step, active } of await this.stepsWithActive()) {
       if (active) wanted.set(join(dir, `${step.step_type}.ts`), active.source);

--- a/vein/src/steps/registry.ts
+++ b/vein/src/steps/registry.ts
@@ -1,6 +1,7 @@
 import { readdir, readFile, stat } from "node:fs/promises";
 import { dirname, join, relative } from "node:path";
 import { fileURLToPath, pathToFileURL } from "node:url";
+import { registerVeinResolver } from "../vein-resolver.js";
 import type { AnyStepDef, StepRegistry } from "../core.js";
 
 /** Where a registered step type came from. */
@@ -217,6 +218,8 @@ export async function stepLoadError(filePath: string): Promise<string | null> {
  * report which tier each step came from without guessing from the name.
  */
 export async function buildRegistry(customDir?: string): Promise<RegistryBundle> {
+  // Custom steps `import "vein"`; make that resolve to this vein wherever the workspace lives.
+  registerVeinResolver();
   const registry: StepRegistry = { ...CORE_STEPS };
   const sources: StepSources = {};
 

--- a/vein/src/vein-resolve-hook.ts
+++ b/vein/src/vein-resolve-hook.ts
@@ -1,0 +1,34 @@
+/**
+ * Module customization hook (node:module `register`): resolve the bare
+ * specifier `"vein"` to the *running* vein's own entry module.
+ *
+ * Why: custom steps are user files under the workspace
+ * (`<workspace>/steps/custom/<name>.ts`) that `import { defineStep } from
+ * "vein"`. Node resolves a bare specifier by walking up from the importing
+ * file, so that only works when the workspace happens to sit inside a
+ * directory tree that can see a `vein` package (the dev checkout via package
+ * self-reference, mcp via its vendored copy). A desktop install keeps the
+ * workspace in Application Support, nowhere near the bundle, and a server can
+ * point VEIN_WORKSPACE anywhere. This hook removes the dependence on
+ * placement and guarantees the step gets the same module instance the server
+ * runs, not a second copy.
+ *
+ * Registered once by `registerVeinResolver()` (vein-resolver.ts). Runs on
+ * Node's hooks thread; keep it dependency-free. Everything that isn't exactly
+ * `"vein"` falls through to the next resolver (tsx in dev, Node's default in
+ * prod), so subpaths and every other package behave as before.
+ */
+let entry = "";
+
+export function initialize(data: { entry: string }): void {
+  entry = data.entry;
+}
+
+type ResolveContext = { parentURL?: string; conditions: string[]; importAttributes: Record<string, string> };
+type ResolveResult = { url: string; format?: string | null; shortCircuit?: boolean };
+type NextResolve = (specifier: string, context: ResolveContext) => Promise<ResolveResult>;
+
+export async function resolve(specifier: string, context: ResolveContext, next: NextResolve): Promise<ResolveResult> {
+  if (specifier === "vein" && entry) return { url: entry, shortCircuit: true };
+  return next(specifier, context);
+}

--- a/vein/src/vein-resolver.ts
+++ b/vein/src/vein-resolver.ts
@@ -1,0 +1,19 @@
+/**
+ * Make `import "vein"` resolve to this running vein from anywhere — see
+ * vein-resolve-hook.ts for why. Idempotent; called before the registry's
+ * first dynamic import. Works under `node build/…` (entry = build/index.js)
+ * and under tsx in dev (entry = src/index.ts, transpiled by tsx's own hook
+ * further down the chain).
+ */
+import { register } from "node:module";
+
+let registered = false;
+
+export function registerVeinResolver(): void {
+  if (registered) return;
+  registered = true;
+  const ts = import.meta.url.endsWith(".ts");
+  const entry = new URL(ts ? "./index.ts" : "./index.js", import.meta.url).href;
+  const hook = new URL(ts ? "./vein-resolve-hook.ts" : "./vein-resolve-hook.js", import.meta.url).href;
+  register(hook, { parentURL: import.meta.url, data: { entry } });
+}

--- a/vein/src/workspace.ts
+++ b/vein/src/workspace.ts
@@ -845,7 +845,9 @@ export class FileWorkspaceStore implements WorkspaceStore {
   /** Publishing already writes each active custom step to
    *  `<root>/steps/custom/<name>.ts`, so the store IS the materialization. */
   async materializeCustomSteps(): Promise<string> {
-    return this.customStepsDir();
+    const dir = this.customStepsDir();
+    await ensureEsmScope(dir);
+    return dir;
   }
 
   private customStepsDir(): string {
@@ -991,5 +993,23 @@ async function pruneEmptyDirs(startDir: string, stopDir: string): Promise<void> 
       return; // not empty, or doesn't exist
     }
     dir = dirname(dir);
+  }
+}
+
+/**
+ * Custom step files are ESM (`import { defineStep } from "vein"`). Node and
+ * tsx decide a `.ts` file's format from the nearest package.json, and a
+ * workspace outside the vein package tree has none — tsx then falls back to
+ * CommonJS and `require("vein")` bypasses the ESM resolve hook that makes
+ * the bare specifier work (vein-resolve-hook.ts). A one-line package.json
+ * beside the steps pins the format wherever the workspace lives.
+ */
+export async function ensureEsmScope(dir: string): Promise<void> {
+  await mkdir(dir, { recursive: true });
+  const pkg = join(dir, "package.json");
+  try {
+    await stat(pkg);
+  } catch {
+    await writeFile(pkg, JSON.stringify({ type: "module" }, null, 2) + "\n", "utf-8");
   }
 }


### PR DESCRIPTION
Client contract for a native app (Swift / Kotlin) that captures the microphone itself and streams to vein's `/audio/stream`: auth, model install, the socket protocol and events, the audio contract (PCM16LE mono, declared rate never changes), push-to-talk via `/audio/transcribe`, sessions/corrections/hotword lists, errors, a Swift AVAudioEngine + URLSessionWebSocketTask sketch, and a shipping checklist. Nothing about the vein web UI. Docs only.

## Also: `import "vein"` from any workspace location (plan §2.2 item 3)

Custom steps under the workspace `import { defineStep } from "vein"`. That resolved only by accident of placement (dev self-reference, mcp's vendored copy); a desktop workspace in Application Support would fail. Now `buildRegistry()` registers a `node:module` resolve hook (`src/vein-resolve-hook.ts`) mapping exactly `"vein"` to the running vein's entry — no symlinks, no source rewriting, and steps get the same module instance the server runs. `materializeCustomSteps()` also drops a `{"type":"module"}` package.json beside the steps so tsx treats out-of-tree `.ts` as ESM (plain Node already does).

Verified: new test publishes a step importing `vein` into a workspace under the OS tmpdir and asserts it loads and shares this process's zod; also booted `node build/server.js` against such a workspace and saw the step in `/steps`. Full suite green.

## Also: `npm run package:desktop -- --smoke` (plan §2.3, phase A)

`scripts/package-desktop.mjs` produces `dist-desktop/vein/`: `package.json` + `build/` + `web/dist/` + production-only `node_modules` with one `sherpa-onnx-<platform>` and only this platform's `onnxruntime-node` binaries; prints the `.node` addons to code-sign. `--smoke` copies the stage to a temp dir and boots it with the §2.5 env (127.0.0.1, key, workspace + cache outside the tree) plus an out-of-tree custom step importing `vein`, then checks `/health`, `/steps`, `/audio/models` (`available: true`) and the UI. Passes on darwin-arm64: **99 MB** before Node + models (embeddings stack dropped by default — `--embeddings` keeps it, and `MiniLMEmbedder.load()` says so clearly without it; sourcemaps/typings/docs stripped; one `.node` addon to sign). `--platform` cross-stages.