### PR TITLE
strut: migrate pre-rename Vein* graph data to Strut* at boot

### DIFF
--- a/strut/src/createStrut.test.ts
+++ b/strut/src/createStrut.test.ts
@@ -569,6 +569,24 @@ describe("createStrut", () => {
     assert.ok(def.input instanceof ourZ.ZodObject, "the step's zod is this process's zod (one module instance)");
   });
 
+  it("custom steps published before the rename can still `import \"vein\"`", async () => {
+    // Pre-#1664 step versions live in the graph verbatim (their content hash
+    // is their identity), so the resolve hook keeps the old bare specifier.
+    const ws = new WorkspaceManager(tempDir);
+    await ws.publishStep(
+      "legacy-hook-step",
+      `import { z, defineStep } from "vein";
+       export default defineStep({
+         type: "legacy-hook-step",
+         input: z.object({}),
+         output: z.string(),
+         async run() { return "still here"; },
+       });`,
+    );
+    const strut = await createStrut({ workspace: ws, store: new MemoryRunStore(), serveUi: false, enableChat: false, stt: false });
+    assert.ok("legacy-hook-step" in strut.getRegistry(), "step importing the old package name loads");
+  });
+
   it("a non-file WorkspaceStore gets in-memory store defaults and still loads custom steps", async () => {
     const ws = pathlessWorkspace(new WorkspaceManager(tempDir));
     // Import-free step source (the temp dir sits outside the project tree,

--- a/strut/src/graph/backend.ts
+++ b/strut/src/graph/backend.ts
@@ -3,8 +3,9 @@
  * the reader, and (optionally) the local embedder — opened once per
  * config and cached, with the boot-time obligations run on open:
  *
- *   1. `seedStrutDomain` — schema meta-graph, constraints, indexes (§4);
- *   2. `backfillEmbeddings` — heal any NULL vectors left by a crash (§2).
+ *   1. `migrateVeinToStrut` — one-shot rename of pre-#1664 `Vein*` names;
+ *   2. `seedStrutDomain` — schema meta-graph, constraints, indexes (§4);
+ *   3. `backfillEmbeddings` — heal any NULL vectors left by a crash (§2).
  *
  * Consumers (the `graph/*` lab steps, a future `Neo4jWorkspaceStore` and
  * run projector) call `openGraphBackend(cfg)` and share the instance.
@@ -17,6 +18,7 @@ import { seedJarvisOntology, type OntologySeedReport } from "./ontology-seed.js"
 import { SchemaResolver } from "./schema-resolver.js";
 import { seedStrutDomain, type SeedReport } from "./schema-seed.js";
 import { GraphReader } from "./search.js";
+import { migrateVeinToStrut, type VeinMigrationReport } from "./vein-migration.js";
 
 export interface GraphBackendOptions {
   /** `false` disables embeddings entirely (vectors stay NULL, search is
@@ -43,6 +45,7 @@ export interface GraphBackend {
   readonly embedder: Embedder | undefined;
   /** What the boot-time seed did (undefined when skipped). */
   readonly seed: SeedReport | undefined;
+  readonly veinMigration: VeinMigrationReport | undefined;
   readonly ontologySeed: OntologySeedReport | undefined;
   readonly backfill: BackfillReport | undefined;
   close(): Promise<void>;
@@ -104,9 +107,18 @@ async function open(cfg: GraphConfig, opts: GraphBackendOptions): Promise<GraphB
     const embedder: Embedder | undefined =
       opts.embeddings === false ? undefined : typeof opts.embeddings === "object" ? opts.embeddings : await MiniLMEmbedder.load();
     let seed: SeedReport | undefined;
+    let veinMigration: VeinMigrationReport | undefined;
     let ontologySeed: OntologySeedReport | undefined;
     let backfill: BackfillReport | undefined;
     if (!opts.skipBoot) {
+      // Legacy names first, so the seed below extends the renamed Schema
+      // nodes instead of creating twins beside them.
+      veinMigration = await migrateVeinToStrut(bolt);
+      if (veinMigration.status === "migrated") {
+        console.warn(`[graph] renamed legacy Vein* graph data to Strut*: ${JSON.stringify(veinMigration)}`);
+      } else if (veinMigration.strays > 0) {
+        console.warn(`[graph] ${veinMigration.strays} Domain_vein node(s) carry no Vein type label and were left alone`);
+      }
       // Ontology first so a standalone DB gets jarvis's own Thing (with its
       // ref_id) before the Strut domain hangs off it.
       if (opts.seedOntology) ontologySeed = await seedJarvisOntology(bolt);
@@ -123,6 +135,7 @@ async function open(cfg: GraphConfig, opts: GraphBackendOptions): Promise<GraphB
       schemas,
       embedder,
       seed,
+      veinMigration,
       ontologySeed,
       backfill,
       async close() {

--- a/strut/src/graph/vein-migration.test.ts
+++ b/strut/src/graph/vein-migration.test.ts
@@ -1,0 +1,252 @@
+import { describe, it, before, after, beforeEach } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Bolt } from "./bolt.js";
+import { openGraphBackend, type GraphBackend } from "./backend.js";
+import { seedStrutDomain, STRUT_MIGRATION_ID, DOMAIN_VECTOR_INDEX, DOMAIN_FULLTEXT_INDEX_V2 } from "./schema-seed.js";
+import { STRUT_SCHEMAS, STRUT_DOMAIN_LABEL, searchableAttributes, vectorIndexedPairs, vectorIndexName, embeddingColumn } from "./strut-schemas.js";
+import { graphSnapshot, testGraphConfig, wipeGraph, type GraphSnapshot } from "./test-util.js";
+import { Neo4jWorkspaceStore } from "./workspace-store.js";
+import {
+  LEGACY_DOMAIN,
+  LEGACY_DOMAIN_LABEL,
+  VEIN_MIGRATION_ID,
+  VeinMigrationCollision,
+  legacyTypes,
+  migrateVeinToStrut,
+} from "./vein-migration.js";
+
+const cfg = testGraphConfig();
+
+describe("vein-migration (pure)", () => {
+  it("derives the nine renames from the library", () => {
+    const types = legacyTypes();
+    assert.equal(types.length, STRUT_SCHEMAS.length);
+    for (const t of types) {
+      assert.ok(t.type.startsWith("Strut") && t.legacy.startsWith("Vein"), `${t.type} / ${t.legacy}`);
+      assert.equal(t.legacy.slice(4), t.type.slice(5));
+      assert.ok(t.nodeKeySpec.startsWith(t.keyPrefix), `${t.nodeKeySpec} starts with ${t.keyPrefix}`);
+    }
+    const run = types.find((t) => t.type === "StrutRun")!;
+    assert.deepEqual(run, {
+      type: "StrutRun",
+      legacy: "VeinRun",
+      nodeKeySpec: "strutrun-run_id",
+      keyPrefix: "strutrun-",
+      legacyKeyPrefix: "veinrun-",
+    });
+  });
+});
+
+// ── live ────────────────────────────────────────────────────────────────────
+
+const VECTOR_OPTIONS =
+  "OPTIONS { indexConfig: { `vector.dimensions`: 384, `vector.similarity_function`: 'cosine' } }";
+
+/** Drop every constraint, then every index, that mentions one of `labels`. */
+async function dropSchemaObjectsOn(bolt: Bolt, labels: string[]): Promise<void> {
+  const list = labels.map((l) => `'${l}'`).join(", ");
+  const cs = await bolt.run(
+    `SHOW CONSTRAINTS YIELD name, labelsOrTypes WHERE any(l IN labelsOrTypes WHERE l IN [${list}]) RETURN name`,
+  );
+  for (const c of cs) await bolt.run(`DROP CONSTRAINT \`${c["name"]}\` IF EXISTS`);
+  const is = await bolt.run(
+    `SHOW INDEXES YIELD name, type, labelsOrTypes
+     WHERE type <> 'LOOKUP' AND any(l IN labelsOrTypes WHERE l IN [${list}]) RETURN name`,
+  );
+  for (const i of is) await bolt.run(`DROP INDEX \`${i["name"]}\` IF EXISTS`);
+}
+
+/**
+ * Turn a seeded + populated Strut database back into exactly what the
+ * pre-rename code wrote: labels, node_keys, Schema nodes, constraint and
+ * index names, ledger row. The rename (#1664) was purely mechanical, so the
+ * inverse is too — which is what makes the round-trip assertion exact.
+ */
+async function demigrate(bolt: Bolt): Promise<void> {
+  const types = legacyTypes();
+  for (const t of types) {
+    await bolt.run(
+      `MATCH (n:\`${t.type}\`)
+       SET n:\`${t.legacy}\`:\`${LEGACY_DOMAIN_LABEL}\`
+       SET n.node_key = $old + substring(n.node_key, size($new))
+       REMOVE n:\`${t.type}\`:\`${STRUT_DOMAIN_LABEL}\``,
+      { old: t.legacyKeyPrefix, new: t.keyPrefix },
+    );
+    await bolt.run(
+      `MATCH (s:Schema {type: $type}) SET s.type = $legacy, s.domain = $domain, s.node_key = $spec`,
+      { type: t.type, legacy: t.legacy, domain: LEGACY_DOMAIN, spec: t.legacyKeyPrefix + t.nodeKeySpec.slice(t.keyPrefix.length) },
+    );
+  }
+  await dropSchemaObjectsOn(bolt, [...types.map((t) => t.type), STRUT_DOMAIN_LABEL]);
+  for (const t of types) {
+    await bolt.run(
+      `CREATE CONSTRAINT unique_${t.legacy.toLowerCase()}_node_key IF NOT EXISTS
+       FOR (n:\`${t.legacy}\`) REQUIRE (n.node_key, n.namespace) IS UNIQUE`,
+    );
+    await bolt.run(`CREATE INDEX IF NOT EXISTS FOR (n:\`${t.legacy}\`) ON (n.node_key)`);
+  }
+  const legacyDomainVector = DOMAIN_VECTOR_INDEX.replace("strut", "vein");
+  const legacyDomainFulltext = DOMAIN_FULLTEXT_INDEX_V2.replace("strut", "vein");
+  await bolt.run(
+    `CREATE VECTOR INDEX \`${legacyDomainVector}\` IF NOT EXISTS FOR (n:\`${LEGACY_DOMAIN_LABEL}\`) ON n.text_embeddings ${VECTOR_OPTIONS}`,
+  );
+  for (const { type, prop } of vectorIndexedPairs()) {
+    const legacy = types.find((t) => t.type === type)!.legacy;
+    await bolt.run(
+      `CREATE VECTOR INDEX \`${vectorIndexName(type, prop).replace(/^strut/, "vein")}\` IF NOT EXISTS
+       FOR (n:\`${legacy}\`) ON n.${embeddingColumn(prop)} ${VECTOR_OPTIONS}`,
+    );
+  }
+  const props = [...searchableAttributes(), "node_key"].map((p) => `n.\`${p}\``).join(", ");
+  await bolt.run(
+    `CREATE FULLTEXT INDEX \`${legacyDomainFulltext}\` IF NOT EXISTS
+     FOR (n:\`${LEGACY_DOMAIN_LABEL}\`) ON EACH [${props}]
+     OPTIONS { indexConfig: { \`fulltext.analyzer\`: 'english' } }`,
+  );
+  await bolt.run(`MATCH (m:Migration {migration_id: $id}) DELETE m`, { id: STRUT_MIGRATION_ID });
+  await bolt.run(`CREATE (:Migration {migration_id: 'vein_domain_seed_v1', executed_at: timestamp()})`);
+}
+
+/** Snapshot minus what legitimately differs across a round trip: the
+ *  ledger rows, and Neo4j's auto-generated names for unnamed objects. */
+function normalize(s: GraphSnapshot) {
+  const anon = (name: unknown) => (typeof name === "string" && /^(index|constraint)_[0-9a-f]+$/.test(name) ? "<auto>" : name);
+  const byJson = (a: unknown, b: unknown) => (JSON.stringify(a) < JSON.stringify(b) ? -1 : 1);
+  return {
+    nodes: s.nodes.filter((n) => !n.labels.includes("Migration")),
+    rels: s.rels,
+    constraints: (s.constraints as Array<Record<string, unknown>>).map((c) => ({ ...c, name: anon(c["name"]) })).sort(byJson),
+    indexes: (s.indexes as Array<Record<string, unknown>>).map((i) => ({ ...i, name: anon(i["name"]) })).sort(byJson),
+  };
+}
+
+const LEGACY_STEP = `import { z, defineStep } from "vein";
+export default defineStep({ type: "legacy/step", input: z.object({}), output: z.any(), async run() { return 1; } });
+`;
+
+describe("migrateVeinToStrut (live Neo4j)", { skip: cfg ? false : "STRUT_TEST_NEO4J_URI not set" }, () => {
+  let backend: GraphBackend;
+  let scratch: string;
+  const bolt = () => backend.bolt;
+  const countLegacy = async () => {
+    const [r] = await bolt().run(
+      `OPTIONAL MATCH (n:\`${LEGACY_DOMAIN_LABEL}\`) WITH count(n) AS nodes
+       OPTIONAL MATCH (s:Schema) WHERE s.type STARTS WITH 'Vein' RETURN nodes, count(s) AS schemas`,
+    );
+    return { nodes: Number(r!["nodes"]), schemas: Number(r!["schemas"]) };
+  };
+  const countStrut = async () =>
+    Number((await bolt().run(`MATCH (n:\`${STRUT_DOMAIN_LABEL}\`) RETURN count(n) AS c`))[0]!["c"]);
+
+  before(async () => {
+    backend = await openGraphBackend(cfg!, { embeddings: false, skipBoot: true });
+    scratch = await mkdtemp(join(tmpdir(), "strut-vein-mig-"));
+  });
+  after(async () => {
+    await backend?.close();
+    await rm(scratch, { recursive: true, force: true });
+  });
+  beforeEach(async () => {
+    await wipeGraph(bolt());
+  });
+
+  it("round-trips a pre-rename database exactly, and the store sees the same workflows and steps", async () => {
+    await seedStrutDomain(bolt());
+    const ws = new Neo4jWorkspaceStore(backend, { materializeDir: join(scratch, "steps") });
+    await ws.publishWorkflow("wf", "v1", { steps: [{ id: "a", type: "log", config: { message: "x" } }] }, "first");
+    await ws.publishStep("legacy/step", LEGACY_STEP, "old");
+    const before = {
+      workflows: await ws.listWorkflows(),
+      steps: await ws.listSteps(),
+      versions: await ws.listStepVersions("legacy/step"),
+      hash: await ws.getWorkflowHash("wf"),
+    };
+    const golden = normalize(await graphSnapshot(bolt()));
+
+    await demigrate(bolt());
+    assert.deepEqual(await countLegacy(), { nodes: 4, schemas: 9 });
+    assert.equal(await countStrut(), 0);
+    assert.deepEqual((await ws.listWorkflows()), [], "sanity: the renamed store cannot see legacy rows");
+
+    const r = await migrateVeinToStrut(bolt());
+    assert.equal(r.status, "migrated");
+    assert.deepEqual(r.schemasRenamed.sort(), STRUT_SCHEMAS.map((s) => s.type).sort());
+    assert.deepEqual(r.schemasDropped, []);
+    assert.deepEqual(r.relabeled, { StrutWorkflow: 1, StrutWorkflowVersion: 1, StrutStep: 1, StrutStepVersion: 1 });
+    assert.equal(r.droppedConstraints.length, 9);
+    // 9 node_key range indexes + domain vector + domain fulltext + 4 per-stem vector.
+    assert.equal(r.droppedIndexes.length, 15);
+    assert.ok(r.droppedIndexes.includes("domain_vein_vector_index"));
+    assert.ok(r.droppedIndexes.includes("veinstep_input_vector_index"));
+    assert.equal(r.strays, 0);
+    assert.deepEqual(await countLegacy(), { nodes: 0, schemas: 0 });
+
+    const seed = await seedStrutDomain(bolt());
+    assert.deepEqual(seed.createdSchemas, [], "renamed Schema nodes are found, not recreated");
+    assert.deepEqual(seed.reconciled, {}, "renamed Schema nodes lack nothing");
+    assert.deepEqual(normalize(await graphSnapshot(bolt())), golden);
+
+    const fresh = new Neo4jWorkspaceStore(backend, { materializeDir: join(scratch, "steps2") });
+    assert.deepEqual(await fresh.listWorkflows(), before.workflows);
+    assert.deepEqual(await fresh.listSteps(), before.steps);
+    assert.deepEqual(await fresh.listStepVersions("legacy/step"), before.versions);
+    assert.equal(await fresh.getWorkflowHash("wf"), before.hash);
+    assert.equal((await fresh.getStepSource("legacy/step"))?.code, LEGACY_STEP, "source bytes untouched");
+
+    const ledger = await bolt().run(`MATCH (m:Migration) RETURN m.migration_id AS id ORDER BY id`);
+    assert.deepEqual(ledger.map((x) => x["id"]), [STRUT_MIGRATION_ID, VEIN_MIGRATION_ID, "vein_domain_seed_v1"].sort());
+
+    const snap = await graphSnapshot(bolt());
+    assert.equal((await migrateVeinToStrut(bolt())).status, "already_done");
+    assert.deepEqual(await graphSnapshot(bolt()), snap, "second run is a no-op");
+  });
+
+  it("refuses to run over a node_key collision and changes nothing", async () => {
+    await seedStrutDomain(bolt());
+    const ws = new Neo4jWorkspaceStore(backend, { materializeDir: join(scratch, "steps") });
+    await ws.publishStep("s", LEGACY_STEP.replace("legacy/step", "s"));
+    await bolt().run(
+      `CREATE (:VeinStep:Node:Data_Bank:\`${LEGACY_DOMAIN_LABEL}\`
+        {node_key: 'veinstep-s', namespace: $ns, ref_id: 'legacy-ref', step_type: 's'})`,
+      { ns: cfg!.namespace },
+    );
+    const snap = await graphSnapshot(bolt());
+    await assert.rejects(migrateVeinToStrut(bolt()), (e: unknown) => {
+      assert.ok(e instanceof VeinMigrationCollision);
+      assert.deepEqual(e.collisions, [{ legacy: "veinstep-s", key: "strutstep-s", labels: e.collisions[0]!.labels }]);
+      assert.ok(e.collisions[0]!.labels.includes("StrutStep"));
+      assert.match(e.message, /veinstep-s → strutstep-s/);
+      return true;
+    });
+    assert.deepEqual(await graphSnapshot(bolt()), snap);
+    assert.equal(Number((await bolt().run(`MATCH (m:Migration {migration_id: $id}) RETURN count(m) AS c`, { id: VEIN_MIGRATION_ID }))[0]!["c"]), 0);
+  });
+
+  it("drops a legacy Schema node whose Strut twin already exists", async () => {
+    await seedStrutDomain(bolt());
+    const [twin] = await bolt().run(`MATCH (s:Schema {type: 'StrutRun'}) RETURN s.ref_id AS ref_id`);
+    await bolt().run(
+      `MATCH (t:Schema {type: 'Thing'})
+       CREATE (s:Schema {type: 'VeinRun', domain: 'Vein', parent: 'Thing', node_key: 'veinrun-run_id', ref_id: 'legacy-schema'})
+       CREATE (s)-[:CHILD_OF {ref_id: 'legacy-edge'}]->(t)`,
+    );
+    const r = await migrateVeinToStrut(bolt());
+    assert.equal(r.status, "migrated");
+    assert.deepEqual(r.schemasDropped, ["StrutRun"]);
+    assert.deepEqual(r.schemasRenamed, []);
+    const rows = await bolt().run(`MATCH (s:Schema) WHERE toLower(s.type) = 'strutrun' RETURN s.ref_id AS ref_id`);
+    assert.deepEqual(rows.map((x) => x["ref_id"]), [twin!["ref_id"]]);
+    assert.deepEqual(await countLegacy(), { nodes: 0, schemas: 0 });
+  });
+
+  it("boot path: a fresh database is a no-op that stamps the ledger, and the seed still runs after it", async () => {
+    await backend.close();
+    backend = await openGraphBackend(cfg!, { embeddings: false });
+    assert.equal(backend.veinMigration?.status, "nothing_to_do");
+    assert.equal(backend.seed?.mode, "standalone");
+    assert.equal((await migrateVeinToStrut(bolt())).status, "already_done");
+  });
+});

--- a/strut/src/graph/vein-migration.ts
+++ b/strut/src/graph/vein-migration.ts
@@ -1,0 +1,213 @@
+/**
+ * One-shot rename of the pre-rename graph domain: `Vein*` → `Strut*`.
+ *
+ * Before the package was renamed (stakgraph #1664) strut wrote its nodes
+ * under `VeinWorkflow`, `VeinStep`, … with `Domain_vein` and node_keys like
+ * `veinstep-<type>`. Nothing about those rows changed except the names, so
+ * this pass rewrites the names in place and leaves everything else —
+ * `ref_id`s, edges, `content_hash`es, embeddings, `Data_Bank` — untouched:
+ *
+ *   1. guard: refuse (throw) if any rewritten `(node_key, namespace)` is
+ *      already held by another node — a database that was booted on the
+ *      renamed code and re-published into needs a human, not a merge policy;
+ *   2. `:Schema` meta-nodes: `type`, `domain`, `node_key` spec renamed in
+ *      place (edge-schema relationships hang off the same nodes). A legacy
+ *      Schema whose Strut twin already exists (the seed ran on the renamed
+ *      code before this migration existed) is dropped instead — two Schema
+ *      nodes for one type would break jarvis;
+ *   3. data nodes, per type, in batches: add the `Strut*` + `Domain_strut`
+ *      labels, rewrite the node_key prefix, remove the legacy labels;
+ *   4. drop every constraint and index on a legacy label — the seed that
+ *      runs next recreates them under the new names (jarvis rebuilds its
+ *      own `domain_<x>_attribute_index` from `Schema.domain` by itself);
+ *   5. stamp the `Migration` ledger so this never scans again.
+ *
+ * Runs at boot before `seedStrutDomain` (backend.ts). Idempotent at every
+ * step, so a crash mid-way is repaired by the next boot. Step sources that
+ * `import "vein"` are deliberately NOT rewritten (the content hash is the
+ * version's identity); strut-resolve-hook.ts keeps `"vein"` as an alias.
+ */
+import { Bolt } from "./bolt.js";
+import { schemaStatement } from "./schema-seed.js";
+import { STRUT_DOMAIN, STRUT_DOMAIN_LABEL, STRUT_SCHEMAS } from "./strut-schemas.js";
+
+export const VEIN_MIGRATION_ID = "strut_rename_vein_v1";
+export const LEGACY_DOMAIN = "Vein";
+export const LEGACY_DOMAIN_LABEL = "Domain_vein";
+const NEW_PREFIX = "Strut";
+const LEGACY_PREFIX = "Vein";
+const BATCH = 1000;
+
+export interface LegacyType {
+  /** Current label, e.g. `StrutRun`. */
+  type: string;
+  /** Pre-rename label, e.g. `VeinRun`. */
+  legacy: string;
+  /** node_key spec from the library, e.g. `strutrun-run_id`. */
+  nodeKeySpec: string;
+  /** node_key value prefixes: `strutrun-` / `veinrun-`. */
+  keyPrefix: string;
+  legacyKeyPrefix: string;
+}
+
+/** The nine renames, derived from the live library so they cannot drift. */
+export function legacyTypes(): LegacyType[] {
+  return STRUT_SCHEMAS.map((s) => {
+    if (!s.type.startsWith(NEW_PREFIX)) throw new Error(`legacyTypes: ${s.type} is not a ${NEW_PREFIX}* type`);
+    const legacy = LEGACY_PREFIX + s.type.slice(NEW_PREFIX.length);
+    return {
+      type: s.type,
+      legacy,
+      nodeKeySpec: s.node_key,
+      keyPrefix: `${s.type.toLowerCase()}-`,
+      legacyKeyPrefix: `${legacy.toLowerCase()}-`,
+    };
+  });
+}
+
+export interface VeinMigrationReport {
+  /** `already_done` = ledger row present, nothing scanned; `nothing_to_do` =
+   *  scanned, found no legacy names, ledger stamped. */
+  status: "migrated" | "already_done" | "nothing_to_do";
+  /** Legacy Schema nodes renamed in place (new type names). */
+  schemasRenamed: string[];
+  /** Legacy Schema nodes dropped because a Strut twin already existed. */
+  schemasDropped: string[];
+  /** Data nodes relabeled, per new type. */
+  relabeled: Record<string, number>;
+  droppedConstraints: string[];
+  droppedIndexes: string[];
+  /** `Domain_vein` nodes left alone because they carry no legacy type label. */
+  strays: number;
+}
+
+export class VeinMigrationCollision extends Error {
+  constructor(readonly collisions: Array<{ legacy: string; key: string; labels: string[] }>) {
+    const sample = collisions
+      .slice(0, 5)
+      .map((c) => `${c.legacy} → ${c.key} (held by ${c.labels.join(":")})`)
+      .join("; ");
+    super(
+      `migrateVeinToStrut: ${collisions.length} node_key collision(s) — a Strut node already holds a key a legacy ` +
+        `node would be renamed to; resolve by hand before booting: ${sample}`,
+    );
+    this.name = "VeinMigrationCollision";
+  }
+}
+
+export async function migrateVeinToStrut(bolt: Bolt): Promise<VeinMigrationReport> {
+  const report: VeinMigrationReport = {
+    status: "nothing_to_do",
+    schemasRenamed: [],
+    schemasDropped: [],
+    relabeled: {},
+    droppedConstraints: [],
+    droppedIndexes: [],
+    strays: 0,
+  };
+  const ledger = await bolt.run(`MATCH (m:Migration {migration_id: $id}) RETURN count(m) AS c`, { id: VEIN_MIGRATION_ID });
+  if (Number(ledger[0]?.["c"] ?? 0) > 0) {
+    report.status = "already_done";
+    return report;
+  }
+
+  const types = legacyTypes();
+  const legacyLabels = [...types.map((t) => t.legacy), LEGACY_DOMAIN_LABEL];
+
+  // 1. Collision guard — read-only, before anything is touched.
+  const collisions: VeinMigrationCollision["collisions"] = [];
+  for (const t of types) {
+    const rows = await bolt.run(
+      `MATCH (v:\`${t.legacy}\`) WHERE v.node_key STARTS WITH $old
+       WITH v, $new + substring(v.node_key, size($old)) AS k
+       MATCH (s:Node {node_key: k, namespace: v.namespace})
+       RETURN v.node_key AS legacy, k AS key, labels(s) AS labels LIMIT 25`,
+      { old: t.legacyKeyPrefix, new: t.keyPrefix },
+    );
+    for (const r of rows) collisions.push({ legacy: r["legacy"] as string, key: r["key"] as string, labels: r["labels"] as string[] });
+  }
+  if (collisions.length > 0) throw new VeinMigrationCollision(collisions);
+
+  let touched = false;
+
+  // 2. Schema meta-nodes.
+  for (const t of types) {
+    const twin = await bolt.run(`MATCH (s:Schema) WHERE toLower(s.type) = toLower($t) RETURN count(s) AS c`, { t: t.type });
+    const hasTwin = Number(twin[0]?.["c"] ?? 0) > 0;
+    const rows = hasTwin
+      ? await bolt.run(`MATCH (s:Schema {type: $legacy}) DETACH DELETE s RETURN count(s) AS c`, { legacy: t.legacy })
+      : await bolt.run(
+          `MATCH (s:Schema {type: $legacy})
+           SET s.type = $type, s.domain = $domain, s.node_key = $spec
+           RETURN count(s) AS c`,
+          { legacy: t.legacy, type: t.type, domain: STRUT_DOMAIN, spec: t.nodeKeySpec },
+        );
+    if (Number(rows[0]?.["c"] ?? 0) > 0) {
+      touched = true;
+      (hasTwin ? report.schemasDropped : report.schemasRenamed).push(t.type);
+    }
+  }
+
+  // 3. Data nodes, batched by label so a large run/tool-call history does
+  //    not become one giant transaction.
+  for (const t of types) {
+    let total = 0;
+    for (;;) {
+      const rows = await bolt.run(
+        `MATCH (v:\`${t.legacy}\`) WITH v LIMIT ${BATCH}
+         SET v:\`${t.type}\`:\`${STRUT_DOMAIN_LABEL}\`
+         SET v.node_key = CASE WHEN v.node_key STARTS WITH $old
+                               THEN $new + substring(v.node_key, size($old))
+                               ELSE v.node_key END
+         REMOVE v:\`${t.legacy}\`:\`${LEGACY_DOMAIN_LABEL}\`
+         RETURN count(v) AS c`,
+        { old: t.legacyKeyPrefix, new: t.keyPrefix },
+      );
+      const c = Number(rows[0]?.["c"] ?? 0);
+      total += c;
+      if (c < BATCH) break;
+    }
+    if (total > 0) {
+      touched = true;
+      report.relabeled[t.type] = total;
+    }
+  }
+  const strays = await bolt.run(`MATCH (n:\`${LEGACY_DOMAIN_LABEL}\`) RETURN count(n) AS c`);
+  report.strays = Number(strays[0]?.["c"] ?? 0);
+
+  // 4. Schema objects on legacy labels. Constraints first: dropping one
+  //    drops its backing index, so the index listing must come after.
+  const labelList = legacyLabels.map((l) => `'${l}'`).join(", ");
+  const constraints = await bolt.run(
+    `SHOW CONSTRAINTS YIELD name, labelsOrTypes
+     WHERE any(l IN labelsOrTypes WHERE l IN [${labelList}])
+     RETURN name ORDER BY name`,
+  );
+  for (const r of constraints) {
+    await bolt.run(`DROP CONSTRAINT \`${r["name"]}\` IF EXISTS`);
+    report.droppedConstraints.push(r["name"] as string);
+  }
+  const indexes = await bolt.run(
+    `SHOW INDEXES YIELD name, type, labelsOrTypes
+     WHERE type <> 'LOOKUP' AND any(l IN labelsOrTypes WHERE l IN [${labelList}])
+     RETURN name ORDER BY name`,
+  );
+  for (const r of indexes) {
+    await bolt.run(`DROP INDEX \`${r["name"]}\` IF EXISTS`);
+    report.droppedIndexes.push(r["name"] as string);
+  }
+  if (constraints.length + indexes.length > 0) touched = true;
+
+  // 5. Ledger.
+  await schemaStatement(
+    bolt,
+    `CREATE CONSTRAINT migration_id_unique IF NOT EXISTS
+     FOR (m:Migration) REQUIRE m.migration_id IS UNIQUE`,
+  );
+  await bolt.run(`MERGE (m:Migration {migration_id: $id}) ON CREATE SET m.executed_at = timestamp()`, {
+    id: VEIN_MIGRATION_ID,
+  });
+
+  report.status = touched ? "migrated" : "nothing_to_do";
+  return report;
+}

--- a/strut/src/index.ts
+++ b/strut/src/index.ts
@@ -247,6 +247,7 @@ export {
   type AttrType,
 } from "./graph/strut-schemas.js";
 export { seedStrutDomain, type SeedReport } from "./graph/schema-seed.js";
+export { migrateVeinToStrut, VeinMigrationCollision, type VeinMigrationReport } from "./graph/vein-migration.js";
 export {
   NodeWriter,
   GraphValidationError,

--- a/strut/src/strut-resolve-hook.ts
+++ b/strut/src/strut-resolve-hook.ts
@@ -17,8 +17,14 @@
  * Node's hooks thread; keep it dependency-free. Everything that isn't exactly
  * `"strut"` falls through to the next resolver (tsx in dev, Node's default in
  * prod), so subpaths and every other package behave as before.
+ *
+ * `"vein"` is the pre-rename package name (#1664) and resolves the same way:
+ * step versions published before the rename live in the graph verbatim —
+ * their content hash is their identity — and still `import "vein"`.
  */
 let entry = "";
+
+const SELF_SPECIFIERS = new Set(["strut", "vein"]);
 
 export function initialize(data: { entry: string }): void {
   entry = data.entry;
@@ -29,6 +35,6 @@ type ResolveResult = { url: string; format?: string | null; shortCircuit?: boole
 type NextResolve = (specifier: string, context: ResolveContext) => Promise<ResolveResult>;
 
 export async function resolve(specifier: string, context: ResolveContext, next: NextResolve): Promise<ResolveResult> {
-  if (specifier === "strut" && entry) return { url: entry, shortCircuit: true };
+  if (entry && SELF_SPECIFIERS.has(specifier)) return { url: entry, shortCircuit: true };
   return next(specifier, context);
 }


### PR DESCRIPTION
Stacked on #1664. Merge that first; this one then retargets to `main`.

## Why

#1664 renamed the package but a database written before it (swarm38: 97 steps, 107 step versions, 46 workflows, 106 workflow versions, all in namespace `default`) still carries `Vein*` labels, `Domain_vein`, and `veinstep-…` node keys. The renamed store cannot see any of it.

## What

`migrateVeinToStrut` (`strut/src/graph/vein-migration.ts`) runs at graph-backend boot before `seedStrutDomain`, guarded by a `Migration {migration_id: "strut_rename_vein_v1"}` ledger row. It renames in place and leaves `ref_id`s, edges, `content_hash`es, embeddings, and `Data_Bank` untouched:

1. **Collision guard** — throws `VeinMigrationCollision` (boot fails loudly) if a rewritten `(node_key, namespace)` is already held by another node. A DB that was booted on the renamed code and re-published into needs a human, not a merge policy.
2. **Schema meta-nodes** — `type`, `domain`, `node_key` spec renamed in place, ref_ids kept. A legacy Schema whose Strut twin already exists (seed ran on renamed code before this landed) is dropped instead, so jarvis never sees two Schema nodes for one type.
3. **Data nodes** — per type, batched: add `Strut*` + `Domain_strut`, rewrite the `node_key` prefix, remove the legacy labels.
4. **Constraints and indexes** on legacy labels dropped (9 uniqueness constraints, 9 unnamed `node_key` range indexes looked up by label, `domain_vein_*`, 4 per-stem vector indexes). The seed that runs next recreates them. Jarvis rebuilds its own `domain_<x>_attribute_index` from `Schema.domain` by itself.
5. **Ledger** stamped. Idempotent at every step; a crash mid-way is repaired by the next boot.

**Step sources are not rewritten.** All 107 step versions on swarm38 `import "vein"`, and `content_hash` is a version's identity, so rewriting would orphan every `active_version` pointer. Instead `strut-resolve-hook.ts` accepts `"vein"` as an alias of `"strut"`. This is the one back-compat shim worth keeping.

Jarvis needs no change: `jarvis-backend` has zero references to the Vein names, and it derives domain labels from `Schema.domain`.

## Tests

- `vein-migration.test.ts` (live, in `test:graph`): seeds and publishes under Strut, mechanically de-migrates the DB to the exact pre-rename shape (labels, keys, Schema nodes, constraint/index names, ledger), migrates back, and asserts a normalized whole-graph snapshot **round-trips exactly**. Also: second run is a no-op, collision refuses and changes nothing, twin-Schema drop, fresh-DB boot path.
- `createStrut.test.ts`: a step that `import`s `"vein"` still loads.
- `npm test` 693/693, `npm run test:graph` 146/146 against a throwaway `neo4j:5`.

## Rollout on swarm38

Deploy this build and boot. Expected log line: `[graph] renamed legacy Vein* graph data to Strut*: {...relabeled: {StrutWorkflow: 46, StrutWorkflowVersion: 106, StrutStep: 97, StrutStepVersion: 107}...}`. Verify with:

```cypher
MATCH (n:Domain_vein) RETURN count(n)          // 0
MATCH (n:Domain_strut) RETURN count(n)         // 356
MATCH (m:Migration) WHERE m.migration_id CONTAINS 'strut' RETURN m.migration_id
```
