### PR TITLE
strut: desktop launcher, release tarballs, spawn contract in the client doc

### DIFF
--- a/.github/workflows/strut-desktop.yml
+++ b/.github/workflows/strut-desktop.yml
@@ -1,0 +1,52 @@
+name: strut desktop
+
+# Stages strut for embedding in a native desktop app (strut/plans/native-dictation-client.md §0)
+# and publishes the tarballs on a `strut-v*` tag. Node is not included; the
+# tarball expects Node 20+ on the machine. darwin-arm64 is smoke-tested on the
+# runner; darwin-x64 is cross-staged (its addon can't load on an arm64 runner).
+
+on:
+  push:
+    tags:
+      - "strut-v*"
+  workflow_dispatch:
+
+jobs:
+  package:
+    runs-on: macos-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install
+        working-directory: strut
+        run: |
+          yarn install --frozen-lockfile
+          npm --prefix web install
+
+      - name: Package darwin-arm64 (smoke-tested)
+        working-directory: strut
+        run: npm run package:desktop -- --smoke --tar --out dist-desktop
+
+      - name: Package darwin-x64 (cross-staged)
+        working-directory: strut
+        run: npm run package:desktop -- --platform darwin-x64 --skip-build --tar --out dist-desktop-x64
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: strut-desktop
+          path: |
+            strut/dist-desktop/strut-darwin-arm64.tar.gz
+            strut/dist-desktop-x64/strut-darwin-x64.tar.gz
+
+      - uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/strut-v')
+        with:
+          files: |
+            strut/dist-desktop/strut-darwin-arm64.tar.gz
+            strut/dist-desktop-x64/strut-darwin-x64.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -78,4 +78,4 @@ strut/node_modules
 strut/web/dist
 strut/web/node_modules
 # strut desktop packaging output (scripts/package-desktop.mjs)
-strut/dist-desktop
+strut/dist-desktop*

--- a/strut/plans/local-desktop-and-stt.md
+++ b/strut/plans/local-desktop-and-stt.md
@@ -7,8 +7,11 @@ whether strut is that local child process or a server that a mobile app talks
 to. This doc covers both: what it takes to package strut for local use, and how
 STT lands in strut via [sherpa-onnx](https://github.com/k2-fsa/sherpa-onnx).
 
-Status: nothing below is built. Findings are from reading the tree as of
-2026-09-04.
+Status: §2 (desktop packaging + host contract) and §4 (STT) are built on
+`main`; §3 and §4.8 are not. Struck-through items are done. Findings are from
+reading the tree as of 2026-09-04, updated 2026-09-08. The client-facing
+contract, including how to obtain and spawn strut, is
+`native-dictation-client.md`.
 
 ---
 
@@ -25,8 +28,9 @@ Status: nothing below is built. Findings are from reading the tree as of
 - **Model family: Zipformer/NeMo transducers.** They are the only sherpa
   models that accept hotwords (contextual biasing), which is the mechanism
   the dream cycle drives. Whisper/Moonshine/SenseVoice are out (§4.2).
-- **Desktop ships a Node runtime + a bundled `server.cjs` + `web/dist`**, not a
-  single-file executable, for the first cut. Single-file (SEA / Bun / Deno
+- **Desktop ships strut as a staged directory** (`build/` + `node_modules/` +
+  `web/dist/` + a `desktop.js` launcher) run by a Node the host provides, not
+  a single-file executable, for the first cut. Single-file (SEA / Bun / Deno
   compile) is a later optimization once the step loader no longer scans
   directories next to the running module (§2.2).
 - **Desktop defaults to the filesystem workspace** (`STRUT_WORKSPACE_BACKEND=fs`).
@@ -100,29 +104,31 @@ Inside the app bundle (macOS `Contents/Resources/strut/`, similar on others):
 
 ```
 strut/
-  node                     # official Node binary for the platform (~110 MB)
-  server.cjs               # esbuild bundle of build/server.js + deps
-  steps/                   # build/steps/** as files (registry scans these)
+  desktop.js               # launcher: desktop defaults, then build/server.js
+  strut                    # sh wrapper over desktop.js (tarball users)
+  package.json
+  build/                   # tsc output; steps as loose files (registry scans them)
   web/dist/                # Vite output
-  native/
-    sherpa-onnx-<platform>/  # the one optionalDependency for this OS/arch
+  node_modules/            # --omit=dev; one sherpa-onnx-<platform> package
 ```
 
-- esbuild: `platform=node`, `format=cjs`, mark `sherpa-onnx-node` and any
-  `.node`-bearing package as `external`, and set `NODE_PATH` (or a small
-  resolver shim) so `require("sherpa-onnx-node")` finds `native/`.
-- Keep `steps/` as loose files so `LIB_DIR`/`CORE_DIR` scanning keeps working
-  with zero code change. `import.meta.url` inside the bundle must resolve to
-  the bundle's own dir; esbuild's `--inject` of an `import.meta.url` shim or
-  `__dirname` replacement handles this.
-- **Built by `npm run package:desktop -- --smoke`** (`scripts/package-desktop.mjs`):
-  tsc + vite, stage `package.json` + `build/` + `web/dist/`, `npm install
-  --omit=dev` in the stage, keep one `sherpa-onnx-<platform>` and only this
-  platform's `onnxruntime-node` binaries, list the `.node` files the host
-  must code-sign, then (`--smoke`) boot the copy from a temp dir with the
-  §2.5 env and a workspace outside the tree holding a step that
-  `import "strut"`, and check `/health`, `/steps`, `/audio/models`
-  (`available: true`) and the UI. `--platform` cross-stages.
+plus a Node binary the host provides (not staged; 20 or newer). No esbuild
+bundle: the step loader scans `build/steps/**`, and the sherpa addon has to
+be a real file anyway, so there is nothing to gain from bundling yet (§2.4).
+
+- **Built by `npm run package:desktop -- --smoke --tar`** (`scripts/package-desktop.mjs`):
+  tsc + vite, stage `package.json` + `build/` + `web/dist/` + the two entry
+  points, `npm install --omit=dev` in the stage, keep one
+  `sherpa-onnx-<platform>` and only this platform's `onnxruntime-node`
+  binaries, list the `.node` files the host must code-sign, then (`--smoke`)
+  spawn `desktop.js` from a temp dir with only `STRUT_WORKSPACE` and
+  `STRUT_CACHE_DIR` set, parse the ready line for port + key, and check
+  `/health`, `/steps` (a workspace step that `import "strut"`),
+  `/audio/models` (`available: true`) and the UI. `--tar` writes
+  `strut-<platform>.tar.gz`; `--platform` cross-stages.
+- **Released by `.github/workflows/strut-desktop.yml`** on a `strut-v*` tag:
+  darwin-arm64 (smoke-tested on the runner) and darwin-x64 (cross-staged)
+  tarballs as release assets.
 - Measured (darwin-arm64, 2026-09-07): **99 MB** before the Node binary and
   models, with the defaults: the embeddings stack uninstalled
   (`@huggingface/transformers` + `onnxruntime-web`/`-node` + `sharp`,
@@ -143,32 +149,36 @@ start this until phase A is in users' hands.
 
 ### 2.5 Host ↔ strut contract
 
-Host spawns `node server.cjs` with env:
+Host spawns `node <dir>/desktop.js` (done). The launcher applies these
+defaults; each is an env override, so a host can set none of them:
 
-| Var | Desktop value |
-|---|---|
-| `STRUT_HOST` | `127.0.0.1` |
-| `STRUT_PORT` | `0` (let the OS pick) |
-| `STRUT_WORKSPACE` | app-support dir, e.g. `~/Library/Application Support/<App>/strut` |
-| `STRUT_WORKSPACE_BACKEND` | `fs` |
-| `STRUT_WEB_DIST` | absolute path to bundled `web/dist` |
-| `STRUT_API_KEY` | random per launch, generated by the host |
-| `STRUT_SECRET_KEY` | stable per install, stored in the OS keychain by the host |
-| `STRUT_MODEL_DIR` | app-support `models/` (shared by MiniLM and sherpa, §4.5) |
-| `ANTHROPIC_API_KEY` etc. | from the host's settings UI |
+| Var | Launcher default | Host override |
+|---|---|---|
+| `STRUT_HOST` | `127.0.0.1` | — |
+| `STRUT_PORT` | `0` (let the OS pick) | — |
+| `STRUT_WORKSPACE` | `~/Library/Application Support/strut/workspace` (XDG / `%APPDATA%` elsewhere) | `<App>`-specific dir if wanted |
+| `STRUT_WORKSPACE_BACKEND` | `fs` | — |
+| `STRUT_WEB_DIST` | the staged `web/dist` | — |
+| `STRUT_CACHE_DIR` | `~/Library/Caches` (models at `<cache>/strut/models`, shared by MiniLM and sherpa, §4.5) | or `STRUT_MODEL_DIR` |
+| `STRUT_API_KEY` | random per launch, printed on the ready line | host-generated key |
+| `STRUT_SECRET_KEY` | unset (secrets file only obfuscated; boot warning) | stable per install, from the OS keychain |
+| `ANTHROPIC_API_KEY` etc. | unset | from the host's settings UI |
 
 Protocol:
 
 - strut prints one JSON line on stdout when ready (done):
-  `{"event":"ready","port":51234,"host":"127.0.0.1"}`, after the human lines.
-  `listen()` also rejects on a bind failure instead of crashing.
+  `{"event":"ready","port":51234,"host":"127.0.0.1","key":"…"}`, after the
+  human lines (`key` is present because the launcher sets `STRUT_READY_KEY=1`;
+  a plain `node build/server.js` omits it). The launcher also prints the UI
+  URL with `?key=` on stderr, and `--open` launches it in the browser.
+  `listen()` rejects on a bind failure instead of crashing.
 - Host loads the webview at `http://127.0.0.1:<port>/?key=<STRUT_API_KEY>`
   (done): the UI stores the key in `sessionStorage`, strips it from the URL,
   and sends it as a bearer on every request and as `?key=` on the dictation
   socket. Settings → Connection also accepts a pasted key (`localStorage`).
 - Host kills the child on quit. strut already handles `SIGTERM` via the run
   store's durable resume, so a hard kill is recoverable.
-- Health: `GET /health` (add if missing) so the host can detect a crashed
+- Health: `GET /health` (unauthenticated) so the host can detect a crashed
   child and restart it.
 
 Webview notes: WKWebView allows plain HTTP to localhost without ATS
@@ -339,9 +349,9 @@ and passes every other test.
 
 - Client: `{"type":"start","model":"<id>","sampleRate":16000,"hotwords":"<list name>"|["phrase", …],"session":"<id>"}`
   then binary PCM16LE frames, then `{"type":"end"}`.
-- Server: `{"type":"ready"}`, `{"type":"partial","text"}` on every change,
-  `{"type":"final","text","words":[{w,start}]}` on endpoint detection and on
-  `end`, `{"type":"error","error"}`.
+- Server: `{"type":"ready",model,partialModel,hotwords}`, `{"type":"partial","text"}`
+  on every change, `{"type":"final","index","text","words":[{text,start}]}` on
+  endpoint detection and on `end`, `{"type":"error","error"}`.
 - **Two recognizers per stream when `partialModel` is set**: the fast
   greedy NeMo model produces the partials, the hotword-capable Zipformer
   produces the finals and owns endpoint detection (both are reset on its
@@ -412,8 +422,9 @@ the route, never at boot; server images pre-bake.
 
 Full client contract, with a Swift sketch: `native-dictation-client.md`.
 
-- Capture the microphone natively (AVAudioEngine / AudioRecord), 16 kHz
-  mono PCM16LE. Do **not** use `getUserMedia` inside the webview.
+- Capture the microphone natively (AVAudioEngine / AudioRecord), mono
+  PCM16LE at the device's native rate — declare it in `start`, strut
+  resamples. Do **not** use `getUserMedia` inside the webview.
 - Live: open `/audio/stream`, send ~100 ms frames, render partials, replace
   with finals. Push-to-talk: buffer, wrap as WAV, `POST /audio/transcribe`.
 - Show the user's finals editable; send edits as corrections.
@@ -456,20 +467,19 @@ artifact per user/company) or beside it. Lean: same artifact, two sections.
 
 ## 5. Order of work
 
-1. **STT core** (in progress on `strut-stt`): `src/audio/` service, catalog,
-   hotwords compiler, `/audio/stream` WebSocket, `POST /audio/transcribe`,
-   `/audio/models` + download, sessions + hotword lists. Testable on a
-   server with no desktop work at all.
-2. **Model bake-off**: measure the NeMo / Nemotron streaming variants for
-   partial latency and accuracy on the same clips; pick the default.
+1. ~~**STT core**~~: done (`src/audio/` service, catalog, hotwords compiler,
+   `/audio/stream` WebSocket, `POST /audio/transcribe`, `/audio/models` +
+   download, sessions + hotword lists).
+2. ~~**Model bake-off**~~: done (§4.1); kroko finals + NeMo 80 ms partials.
 3. ~~**Server prerequisites for desktop**~~: done — `STRUT_HOST`,
    `STRUT_WEB_DIST`, `STRUT_PORT=0`, structured `ready` line, `strut.close()`,
    `?key=` handoff in the UI, `STRUT_MODEL_DIR` / `STRUT_CACHE_DIR` fallback.
 4. **First dream cycle**: a sessions → llm → `PUT /audio/hotwords` workflow
    plus the corrections UI. Proves the loop before packaging.
-5. **Phase A packaging**: strut side done (`package:desktop` + smoke test);
-   remaining is the macOS host: embed Node + the staged dir, code-sign the
-   listed addons, spawn strut and stream the mic.
+5. **Phase A packaging**: strut side done (`package:desktop` + `desktop.js`
+   launcher + smoke test + release tarballs); remaining is the macOS host:
+   embed Node + the staged dir, code-sign the listed addon, spawn
+   `desktop.js` and stream the mic (`native-dictation-client.md`).
 6. **Kotlin host**, Windows shell override.
 7. Later: single-binary (phase B), local vector store or LadybugDB backend
    (§3, §3.1), batch `audio/transcribe` step, offline-mobile bindings.

--- a/strut/plans/native-dictation-client.md
+++ b/strut/plans/native-dictation-client.md
@@ -11,6 +11,51 @@ Source of truth for the protocol: `strut/src/audio/ws.ts` (socket),
 
 ---
 
+## 0. Getting a strut to talk to
+
+Two ways to have one running locally. Both need Node 20 or newer on the
+machine; the package does not include Node.
+
+- **Download.** The `strut-v*` GitHub release has `strut-darwin-arm64.tar.gz`
+  and `strut-darwin-x64.tar.gz`. Unpack and run `./strut --open`: the web UI
+  it opens has dictation built in, so you can try the recognizer before
+  writing a line of client code.
+- **Build.** In `strut/` of a checkout: `yarn install`, `npm --prefix web
+  install`, then `npm run package:desktop -- --smoke --tar`. Same layout at
+  `dist-desktop/strut/`, and the tarball beside it.
+
+The directory is `package.json`, `build/`, `web/dist/`, `node_modules/`
+(one `sherpa-onnx-<platform>` package; the script prints the single `.node`
+addon the app must code-sign), plus two entry points: `desktop.js`, which a
+host spawns, and `strut`, a shell wrapper over it.
+
+A host runs `node <dir>/desktop.js` from any cwd with **no required env**.
+The launcher defaults to the filesystem workspace (no Neo4j), binds
+`127.0.0.1` on an OS-picked port, keeps the workspace under the platform
+app-support dir and models under the platform cache dir, and generates an
+API key per launch. It prints a few human lines, then one JSON line on
+stdout:
+
+```
+{"event":"ready","port":51234,"host":"127.0.0.1","key":"3f9a…"}
+```
+
+That line is the base URL and the credential for everything below. Every
+default is an env override:
+
+| Var | Launcher default |
+|---|---|
+| `STRUT_WORKSPACE` | `~/Library/Application Support/strut/workspace` (XDG / `%APPDATA%` elsewhere) |
+| `STRUT_CACHE_DIR` | `~/Library/Caches` — models land at `<cache>/strut/models` |
+| `STRUT_API_KEY` | random per launch; set your own to skip parsing it |
+| `STRUT_HOST` / `STRUT_PORT` | `127.0.0.1` / `0` |
+| `STRUT_WORKSPACE_BACKEND` | `fs`. The graph backend needs a Neo4j and is not for desktop. |
+| `STRUT_SECRET_KEY` | unset: the secrets file is only obfuscated, with a boot warning. A shipping host keeps a stable one in the keychain. |
+| `ANTHROPIC_API_KEY` etc. | not needed for dictation; only workflows and chat use them |
+
+The host kills the child on quit; strut handles `SIGTERM`. `GET /health` is
+unauthenticated, for liveness polling.
+
 ## 1. The moving parts
 
 | Piece | Where | Notes |
@@ -22,15 +67,16 @@ Source of truth for the protocol: `strut/src/audio/ws.ts` (socket),
 | Model install | HTTP, once | `GET /audio/models`, `POST /audio/models/:id/download` (SSE progress) |
 | Learning loop | HTTP | sessions, corrections, named hotword lists |
 
-Base URL is whatever the app spawned or was configured with, e.g.
-`http://127.0.0.1:<port>` for a local child process (the port comes from strut's
-`{"event":"ready","port":N}` stdout line) or `https://host/lab` behind mcp.
-Every `/audio/*` route and the socket sit under that base.
+Base URL is whatever the app spawned or was configured with:
+`http://127.0.0.1:<port>` for a local child process (port and key from the
+ready line, §0) or `https://host/lab` behind mcp. Every `/audio/*` route and
+the socket sit under that base.
 
 ## 2. Auth
 
-If strut runs with `STRUT_API_KEY` set (a desktop host should generate one per
-launch), every `/audio/*` request and the socket upgrade must carry it:
+If strut runs with `STRUT_API_KEY` set (the desktop launcher generates one per
+launch and puts it on the ready line, §0), every `/audio/*` request and the
+socket upgrade must carry it:
 
 - HTTP and WebSocket: `Authorization: Bearer <STRUT_API_KEY>` — a
   `URLSessionWebSocketTask` / OkHttp socket can set request headers, so use the
@@ -206,7 +252,7 @@ nouns both ways.
 
 | Situation | What you see | Do |
 |---|---|---|
-| strut not up yet | connection refused | wait for the `ready` stdout line / `GET /health` |
+| strut not up yet | connection refused | wait for the `ready` stdout line (§0) or poll `GET /health` |
 | sherpa addon missing on that strut | `501 {"error":"stt not available"}`; socket `error` then close `1011` | tell the user; it's an install problem |
 | bad credential | HTTP `401`; upgrade refused | fix the key |
 | unknown model / list | socket `error` (`unknown stt model "x"` / `unknown hotwords list "x"`), close `1011` | check `GET /audio/models`, `GET /audio/hotwords` |

--- a/strut/scripts/desktop.js
+++ b/strut/scripts/desktop.js
@@ -1,0 +1,78 @@
+#!/usr/bin/env node
+/**
+ * Desktop launcher — strut with the defaults a native host (or someone who
+ * just downloaded the tarball) wants, with no env to set
+ * (plans/local-desktop-and-stt.md §2.5). Staged beside `build/` by
+ * `package:desktop`; a host spawns `node desktop.js` and reads one stdout line:
+ *
+ *   {"event":"ready","port":51234,"host":"127.0.0.1","key":"…"}
+ *
+ * Defaults (each one an env override): filesystem workspace (no Neo4j),
+ * bind 127.0.0.1 on an OS-picked port, workspace under the platform
+ * app-support dir, models under the platform cache dir, a random API key
+ * per launch. `--open` launches the web UI in the default browser, which
+ * has dictation built in — the quickest way to try the recognizer.
+ */
+import { randomBytes } from "node:crypto";
+import { mkdir } from "node:fs/promises";
+import { homedir, platform } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawn } from "node:child_process";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const args = process.argv.slice(2);
+
+if (args.includes("--help") || args.includes("-h")) {
+  console.log(`usage: strut [--open]
+
+Runs strut locally with desktop defaults. Prints a JSON ready line on stdout
+({"event":"ready","port","host","key"}) and the UI URL on stderr.
+
+  --open   open the web UI in the default browser
+
+Env overrides (all optional): STRUT_WORKSPACE, STRUT_CACHE_DIR, STRUT_API_KEY,
+STRUT_HOST, STRUT_PORT, STRUT_WORKSPACE_BACKEND, STRUT_SECRET_KEY,
+STRUT_STT_MODEL, STRUT_STT_PARTIAL_MODEL, ANTHROPIC_API_KEY.`);
+  process.exit(0);
+}
+
+const env = process.env;
+const home = homedir();
+const os = platform();
+const dflt = (k, v) => {
+  if (env[k] === undefined || env[k] === "") env[k] = v;
+};
+const appSupport =
+  os === "darwin"
+    ? join(home, "Library", "Application Support")
+    : os === "win32"
+      ? env["APPDATA"] || join(home, "AppData", "Roaming")
+      : env["XDG_DATA_HOME"] || join(home, ".local", "share");
+const cacheRoot =
+  os === "darwin"
+    ? join(home, "Library", "Caches")
+    : os === "win32"
+      ? env["LOCALAPPDATA"] || join(home, "AppData", "Local")
+      : env["XDG_CACHE_HOME"] || join(home, ".cache");
+
+dflt("STRUT_WORKSPACE_BACKEND", "fs");
+dflt("STRUT_HOST", "127.0.0.1");
+dflt("STRUT_PORT", "0");
+dflt("STRUT_WORKSPACE", join(appSupport, "strut", "workspace"));
+dflt("STRUT_CACHE_DIR", cacheRoot); // models land at <cacheRoot>/strut/models
+dflt("STRUT_WEB_DIST", join(here, "web", "dist"));
+dflt("STRUT_API_KEY", randomBytes(24).toString("hex"));
+env["STRUT_READY_KEY"] = "1"; // put the key on the ready line for the host
+
+await mkdir(env["STRUT_WORKSPACE"], { recursive: true });
+
+const { startServer } = await import("./build/server.js");
+const port = await startServer();
+const url = `http://${env["STRUT_HOST"]}:${port}/?key=${env["STRUT_API_KEY"]}`;
+console.error(`strut ui: ${url}`);
+if (args.includes("--open")) {
+  const [cmd, cmdArgs] =
+    os === "darwin" ? ["open", [url]] : os === "win32" ? ["cmd", ["/c", "start", "", url]] : ["xdg-open", [url]];
+  spawn(cmd, cmdArgs, { stdio: "ignore", detached: true }).on("error", () => {}).unref();
+}

--- a/strut/scripts/package-desktop.mjs
+++ b/strut/scripts/package-desktop.mjs
@@ -3,13 +3,18 @@
  * Stage a self-contained strut directory for embedding in a native desktop
  * app (plans/local-desktop-and-stt.md §2.3, "phase A").
  *
- *   npm run package:desktop -- [--platform darwin-arm64] [--out dist-desktop] [--smoke] [--skip-build] [--embeddings]
+ *   npm run package:desktop -- [--platform darwin-arm64] [--out dist-desktop] [--smoke] [--tar] [--skip-build] [--embeddings]
  *
  * Output: <out>/strut/ containing package.json, build/ (server + steps as
- * loose files — the registry scans them), web/dist/, and a production-only
+ * loose files — the registry scans them), web/dist/, a production-only
  * node_modules/ with exactly one sherpa-onnx platform package and only this
- * platform's onnxruntime-node binaries. The host adds an official Node
- * binary beside it and runs `node build/server.js` with the env in §2.5.
+ * platform's onnxruntime-node binaries, and two entry points: `desktop.js`
+ * (what a host spawns: fs workspace, 127.0.0.1:0, app-support dirs, a
+ * generated API key on the ready line — every default an env override) and
+ * `strut` (shell wrapper over it for people who downloaded the tarball).
+ * Node itself is not included; the host provides one (20 or newer).
+ * `--tar` also writes <out>/strut-<platform>.tar.gz — the release asset
+ * (.github/workflows/strut-desktop.yml).
  *
  * Two size cuts, both on by default:
  *   - the embeddings stack (@huggingface/transformers + onnxruntime-web/-node
@@ -18,17 +23,17 @@
  *     keeps it, and graph/embeddings.ts fails with a clear message without it;
  *   - sourcemaps, typings, and docs are stripped from node_modules (~100 MB).
  *
- * --smoke boots the staged copy from a temp directory (so nothing can leak
- * in from this checkout), with a workspace outside the package tree that
- * holds a custom step importing "strut", and checks /health, /audio/models
- * (`available: true` = the sherpa addon loaded) and that the step registered.
+ * --smoke boots the staged copy via desktop.js from a temp directory (so
+ * nothing can leak in from this checkout) with only STRUT_WORKSPACE and
+ * STRUT_CACHE_DIR set, parses the ready line for port + key, and checks
+ * /health, /audio/models (`available: true` = the sherpa addon loaded) and
+ * that a custom step importing "strut" from that workspace registered.
  *
  * Not a single-file build on purpose: the step loader scans directories and
  * the sherpa addon must be a real file beside the binary either way (§2.4).
  */
-import { cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
+import { chmod, cp, mkdir, mkdtemp, readdir, readFile, rm, stat, writeFile } from "node:fs/promises";
 import { spawn, spawnSync } from "node:child_process";
-import { createServer } from "node:net";
 import { tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -42,6 +47,7 @@ const flag = (name, dflt) => {
 const platform = String(flag("platform", `${process.platform === "win32" ? "win" : process.platform}-${process.arch}`));
 const out = resolve(ROOT, String(flag("out", "dist-desktop")));
 const smoke = flag("smoke", false) === true;
+const tar = flag("tar", false) === true;
 const skipBuild = flag("skip-build", false) === true;
 const embeddings = flag("embeddings", false) === true;
 const stage = join(out, "strut");
@@ -55,10 +61,15 @@ if (!SHERPA_PLATFORMS.includes(platform)) {
 const [ortOs, ortArch] = platform.replace(/^win-/, "win32-").split("-");
 
 const log = (m) => console.log(`[package-desktop] ${m}`);
-const run = (cmd, cmdArgs, cwd = ROOT) => {
-  const r = spawnSync(cmd, cmdArgs, { cwd, stdio: "inherit", env: process.env });
+const run = (cmd, cmdArgs, cwd = ROOT, env = process.env) => {
+  const r = spawnSync(cmd, cmdArgs, { cwd, stdio: "inherit", env });
   if (r.status !== 0) throw new Error(`${cmd} ${cmdArgs.join(" ")} failed (${r.status})`);
 };
+// Every npm call inside the stage resolves optional platform packages for the
+// *target*, not this machine (npm ≥ 9.6.3 `os`/`cpu` config). Without this a
+// cross-stage silently ships the host's sherpa addon, and even a same-platform
+// `npm uninstall` later would reconcile the tree back to the host's.
+const npmStage = (cmdArgs) => run("npm", cmdArgs, stage, { ...process.env, npm_config_os: ortOs, npm_config_cpu: ortArch });
 const sizeOf = async (p) => {
   const s = await stat(p);
   if (!s.isDirectory()) return s.size;
@@ -86,14 +97,18 @@ async function stageFiles() {
   await writeFile(join(stage, "package.json"), JSON.stringify(pkg, null, 2) + "\n");
   await cp(join(ROOT, "build"), join(stage, "build"), { recursive: true });
   await cp(join(ROOT, "web", "dist"), join(stage, "web", "dist"), { recursive: true });
-  log(`staged build/ + web/dist/ → ${stage}`);
+  for (const f of ["desktop.js", "strut"]) {
+    await cp(join(ROOT, "scripts", f), join(stage, f));
+    await chmod(join(stage, f), 0o755);
+  }
+  log(`staged build/ + web/dist/ + desktop.js + strut → ${stage}`);
 }
 
 async function installDeps() {
   log("installing production dependencies (npm install --omit=dev)");
   // optionalDependencies (sherpa-onnx-node + its platform packages) come along;
   // the other platforms are removed below.
-  run("npm", ["install", "--omit=dev", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts"], stage);
+  npmStage(["install", "--omit=dev", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts"]);
   const nm = join(stage, "node_modules");
 
   // One sherpa platform package.
@@ -107,7 +122,7 @@ async function installDeps() {
   } catch {
     log(`sherpa-onnx-${platform} isn't installed on this machine's npm view; fetching it explicitly`);
     const ver = JSON.parse(await readFile(join(nm, "sherpa-onnx-node", "package.json"), "utf-8")).version;
-    run("npm", ["install", "--no-save", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts", "--force", `sherpa-onnx-${platform}@${ver}`], stage);
+    npmStage(["install", "--no-save", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts", "--force", `sherpa-onnx-${platform}@${ver}`]);
   }
 
   // Only this platform's onnxruntime binaries (the package ships all of them).
@@ -129,9 +144,15 @@ async function installDeps() {
     // npm removes the package and everything only it depended on, and drops
     // it from the staged package.json so the manifest matches the build.
     log("removing the embeddings stack (@huggingface/transformers and its deps); --embeddings keeps it");
-    run("npm", ["uninstall", "--omit=dev", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts", "@huggingface/transformers"], stage);
+    npmStage(["uninstall", "--omit=dev", "--no-audit", "--no-fund", "--no-package-lock", "--ignore-scripts", "@huggingface/transformers"]);
   }
   await rm(join(nm, ".package-lock.json"), { force: true });
+  // Never emit a package for the wrong platform: exactly the target's sherpa
+  // package, and only it, must be present.
+  const present = (await readdir(nm)).filter((d) => /^sherpa-onnx-(darwin|linux|win)-/.test(d));
+  if (present.length !== 1 || present[0] !== `sherpa-onnx-${platform}`) {
+    throw new Error(`expected only sherpa-onnx-${platform} in the stage, found: ${present.join(", ") || "none"} (npm ≥ 9.6.3 needed for cross-staging)`);
+  }
   await strip(nm);
 }
 
@@ -194,16 +215,6 @@ async function report() {
   for (const a of addons) console.log(`    ${a}`);
 }
 
-const freePort = () =>
-  new Promise((res, rej) => {
-    const s = createServer();
-    s.listen(0, "127.0.0.1", () => {
-      const { port } = s.address();
-      s.close(() => res(port));
-    });
-    s.on("error", rej);
-  });
-
 async function smokeTest() {
   // Run from a temp copy so resolution can't fall back into this checkout.
   const tmp = await mkdtemp(join(tmpdir(), "strut-desktop-"));
@@ -224,37 +235,38 @@ export default defineStep({
 });
 `,
   );
-  const port = await freePort();
-  const key = "smoke-key";
-  const env = {
-    ...process.env,
-    STRUT_HOST: "127.0.0.1",
-    STRUT_PORT: String(port),
-    STRUT_WORKSPACE: workspace,
-    STRUT_WORKSPACE_BACKEND: "fs",
-    STRUT_API_KEY: key,
-    STRUT_CACHE_DIR: cache,
-  };
-  log(`smoke: node build/server.js on 127.0.0.1:${port} (workspace + cache under ${tmp})`);
-  const child = spawn(process.execPath, ["build/server.js"], { cwd: app, env, stdio: ["ignore", "pipe", "pipe"] });
+  // Only the two dirs, so the launcher's own defaults (fs backend, loopback,
+  // port 0, generated key) are what gets tested. Strip any STRUT_* from the
+  // developer's shell so they can't paper over a missing default.
+  const env = Object.fromEntries(Object.entries(process.env).filter(([k]) => !k.startsWith("STRUT_")));
+  env.STRUT_WORKSPACE = workspace;
+  env.STRUT_CACHE_DIR = cache;
+  log(`smoke: node desktop.js from a foreign cwd (workspace + cache under ${tmp})`);
+  const child = spawn(process.execPath, [join(app, "desktop.js")], { cwd: tmp, env, stdio: ["ignore", "pipe", "pipe"] });
   let output = "";
-  child.stdout.on("data", (d) => (output += d));
+  let stdout = "";
+  child.stdout.on("data", (d) => ((output += d), (stdout += d)));
   child.stderr.on("data", (d) => (output += d));
-  const base = `http://127.0.0.1:${port}`;
-  const headers = { authorization: `Bearer ${key}` };
   const deadline = Date.now() + 30_000;
-  let up = false;
-  while (Date.now() < deadline && !up) {
+  let ready = null;
+  while (Date.now() < deadline && !ready) {
     if (child.exitCode !== null) break;
-    try {
-      up = (await fetch(`${base}/health`)).ok;
-    } catch {
-      await new Promise((r) => setTimeout(r, 250));
-    }
+    ready = stdout
+      .split("\n")
+      .map((l) => { try { return JSON.parse(l); } catch { return null; } })
+      .find((j) => j?.event === "ready");
+    if (!ready) await new Promise((r) => setTimeout(r, 100));
   }
   const failures = [];
   try {
-    if (!up) throw new Error(`server did not come up:\n${output}`);
+    if (!ready) throw new Error(`no ready line within 30 s:\n${output}`);
+    if (ready.host !== "127.0.0.1") failures.push(`ready.host ${ready.host}, expected 127.0.0.1`);
+    if (!(ready.port > 0)) failures.push(`ready.port ${ready.port}`);
+    if (typeof ready.key !== "string" || ready.key.length < 32) failures.push(`ready.key missing or short: ${JSON.stringify(ready.key)}`);
+    const { port, key } = ready;
+    const base = `http://127.0.0.1:${port}`;
+    const headers = { authorization: `Bearer ${key}` };
+    if (!output.includes(`strut ui: ${base}/?key=${key}`)) failures.push("launcher did not print the UI URL on stderr");
     const health = await (await fetch(`${base}/health`)).json();
     if (!health.ok) failures.push("health not ok");
     if (health.dataDir !== workspace) failures.push(`dataDir ${health.dataDir} != ${workspace}`);
@@ -281,7 +293,13 @@ export default defineStep({
     console.error(`[package-desktop] SMOKE FAILED\n - ${failures.join("\n - ")}`);
     process.exit(1);
   }
-  log("smoke: OK — boots from an unrelated path, addon loads, out-of-tree custom step resolves, UI serves");
+  log("smoke: OK — desktop.js boots with no STRUT_* env beyond the two dirs, ready line carries port + key, addon loads, out-of-tree custom step resolves, UI serves");
+}
+
+async function tarball() {
+  const name = `strut-${platform}.tar.gz`;
+  run("tar", ["-czf", join(out, name), "-C", out, "strut"]);
+  log(`wrote ${join(out, name)} (${mb((await stat(join(out, name))).size)})`);
 }
 
 await build();
@@ -289,4 +307,5 @@ await stageFiles();
 await installDeps();
 await report();
 if (smoke) await smokeTest();
-log(`done. Host contract: plans/local-desktop-and-stt.md §2.5; run \`node build/server.js\` inside ${stage}`);
+if (tar) await tarball();
+log(`done. Host contract: plans/native-dictation-client.md §0; spawn \`node ${join(stage, "desktop.js")}\` or run \`${join(stage, "strut")} --open\``);

--- a/strut/scripts/strut
+++ b/strut/scripts/strut
@@ -1,0 +1,15 @@
+#!/bin/sh
+# Runs the staged strut with desktop defaults (see desktop.js). Needs Node 20
+# or newer on PATH — the tarball does not include Node.
+set -e
+dir=$(cd "$(dirname "$0")" && pwd)
+if ! command -v node >/dev/null 2>&1; then
+  echo "strut: node not found on PATH (Node 20 or newer required): https://nodejs.org" >&2
+  exit 127
+fi
+major=$(node -p 'process.versions.node.split(".")[0]')
+if [ "$major" -lt 20 ]; then
+  echo "strut: Node $(node -v) is too old; 20 or newer required" >&2
+  exit 1
+fi
+exec node "$dir/desktop.js" "$@"

--- a/strut/src/createStrut.test.ts
+++ b/strut/src/createStrut.test.ts
@@ -758,6 +758,37 @@ describe("listen()", () => {
     await assert.rejects(fetch(`http://127.0.0.1:${port}/health`), "server should be closed");
   });
 
+  it("puts the API key on the ready line only when STRUT_READY_KEY is set", async () => {
+    const strut = await createStrut({
+      workspace: new WorkspaceManager(tempDir),
+      store: new MemoryRunStore(),
+      serveUi: false,
+      enableChat: false,
+      stt: false,
+    });
+    const lines: string[] = [];
+    const orig = console.log;
+    const prevKey = process.env["STRUT_API_KEY"];
+    const prevReady = process.env["STRUT_READY_KEY"];
+    process.env["STRUT_API_KEY"] = "launch-key";
+    process.env["STRUT_READY_KEY"] = "1";
+    console.log = (...a: unknown[]) => lines.push(a.map(String).join(" "));
+    let port: number;
+    try {
+      port = await strut.listen(0, "127.0.0.1");
+    } finally {
+      console.log = orig;
+      if (prevKey === undefined) delete process.env["STRUT_API_KEY"]; else process.env["STRUT_API_KEY"] = prevKey;
+      if (prevReady === undefined) delete process.env["STRUT_READY_KEY"]; else process.env["STRUT_READY_KEY"] = prevReady;
+    }
+    try {
+      const ready = lines.map((l) => { try { return JSON.parse(l); } catch { return null; } }).find((j) => j?.event === "ready");
+      assert.deepEqual(ready, { event: "ready", port, host: "127.0.0.1", key: "launch-key" });
+    } finally {
+      await strut.close();
+    }
+  });
+
   it("rejects when the port is taken instead of crashing the process", async () => {
     const mk = () =>
       createStrut({

--- a/strut/src/createStrut.ts
+++ b/strut/src/createStrut.ts
@@ -229,7 +229,9 @@ export interface Strut<TServices = unknown> {
    *  strut as a child process relies on. `host` (or `STRUT_HOST`) sets the
    *  bind address; unset binds every interface, `127.0.0.1` keeps a local
    *  strut off the LAN. Prints one JSON line on stdout when ready,
-   *  `{"event":"ready","port":N,"host":"…"}`, for hosts to parse.
+   *  `{"event":"ready","port":N,"host":"…"}`, for hosts to parse; with
+   *  `STRUT_READY_KEY=1` the line also carries `key` (the `STRUT_API_KEY`),
+   *  so a host that spawned strut reads port and credential from one line.
    *  Convenience wrapper — feel free to mount `app` yourself. */
   listen: (port?: number, host?: string) => Promise<number>;
 
@@ -1956,7 +1958,8 @@ export async function createStrut<TServices = unknown>(
     console.log(`strut server: http://${hostname ?? "localhost"}:${bound}`);
     // Structured ready line for a host that spawned us (desktop app): one
     // JSON object on its own stdout line, after the human ones.
-    console.log(JSON.stringify({ event: "ready", port: bound, host: hostname ?? "0.0.0.0" }));
+    const readyKey = process.env["STRUT_READY_KEY"] ? process.env["STRUT_API_KEY"] : undefined;
+    console.log(JSON.stringify({ event: "ready", port: bound, host: hostname ?? "0.0.0.0", ...(readyKey ? { key: readyKey } : {}) }));
     return bound;
   }
 

--- a/strut/src/server.ts
+++ b/strut/src/server.ts
@@ -66,9 +66,9 @@ export async function getApp() {
  * await strut.listen(port);
  * ```
  */
-export async function startServer(port?: number, host?: string): Promise<void> {
+export async function startServer(port?: number, host?: string): Promise<number> {
   const strut = await getDefault();
-  await strut.listen(port, host);
+  return strut.listen(port, host);
 }
 
 // Run directly when invoked as a script.


### PR DESCRIPTION
## What

- **`desktop.js` launcher** staged by `package:desktop`. A host spawns `node <dir>/desktop.js` with no required env: fs workspace (no Neo4j), `127.0.0.1` on an OS-picked port, workspace under the platform app-support dir, models under the platform cache dir, random API key per launch. Every default is an env override.
- **Key on the ready line.** With `STRUT_READY_KEY=1` (set by the launcher) the stdout line is `{"event":"ready","port":N,"host":"127.0.0.1","key":"…"}`, so the host reads port and credential from one line. Plain `node build/server.js` is unchanged.
- **`strut` sh wrapper** for tarball users; `./strut --open` launches the web UI, which has dictation built in.
- **Release tarballs.** `--tar` in the packaging script; `.github/workflows/strut-desktop.yml` publishes `strut-darwin-arm64.tar.gz` (smoke-tested on the runner) and `strut-darwin-x64.tar.gz` (cross-staged) on a `strut-v*` tag. Node is not included; Node 20+ on the machine.
- **Cross-stage fix.** `npm install` in the stage picked optional deps for the host, and `npm uninstall` reconciled the tree again, so a `--platform darwin-x64` stage shipped the arm64 addon. Every stage npm call now pins `npm_config_os`/`npm_config_cpu`, and the script fails if the target's sherpa package isn't the only one present.
- **Docs.** `native-dictation-client.md` §0 covers obtaining and spawning strut. `local-desktop-and-stt.md` drops the never-built esbuild/`server.cjs` layout and other stale bits (`/health` exists, `words:[{text,start}]`, native-rate capture).

## Verified locally

- `npm test`: 694/694.
- `package:desktop --smoke --tar` (darwin-arm64): smoke OK, 23 MB tarball.
- Tarball unpacked elsewhere, `./strut` under Node 20 with `env -i HOME=<tmp>`: ready line with key, `/health` ok, `/audio/models` 401 without key and `available: true` with it, workspace created under `~/Library/Application Support/strut/workspace`.
- `--platform darwin-x64 --skip-build --tar`: stage contains only `sherpa-onnx-darwin-x64` (`file` says x86_64).

The workflow itself has not run yet; first `strut-v*` tag will exercise it.
