### PR TITLE
strut desktop: refuse quarantined downloads, list every binary to sign

### DIFF
--- a/strut/plans/local-desktop-and-stt.md
+++ b/strut/plans/local-desktop-and-stt.md
@@ -120,7 +120,8 @@ be a real file anyway, so there is nothing to gain from bundling yet (§2.4).
   tsc + vite, stage `package.json` + `build/` + `web/dist/` + the two entry
   points, `npm install --omit=dev` in the stage, keep one
   `sherpa-onnx-<platform>` and only this platform's `onnxruntime-node`
-  binaries, list the `.node` files the host must code-sign, then (`--smoke`)
+  binaries, list the native binaries (`.node` + dylibs) the host must
+  code-sign, then (`--smoke`)
   spawn `desktop.js` from a temp dir with only `STRUT_WORKSPACE` and
   `STRUT_CACHE_DIR` set, parse the ready line for port + key, and check
   `/health`, `/steps` (a workspace step that `import "strut"`),
@@ -136,7 +137,8 @@ be a real file anyway, so there is nothing to gain from bundling yet (§2.4).
   keeps it and `graph/embeddings.ts` fails with a clear message without it)
   and sourcemaps/typings/docs stripped (~70 MB). Largest pieces left: sherpa
   34 MB, `aieo` 15 MB (its nested `ai`/`@ai-sdk`/`zod` copies — align
-  versions to dedupe), `react-dom` 7 MB. One `.node` addon to sign. The
+  versions to dedupe), `react-dom` 7 MB. Four Mach-O binaries to sign (the
+  sherpa addon and its three dylibs; all ad-hoc signed as shipped). The
   earlier ~150 MB estimate assumed an esbuild bundle, which the step loader
   rules out for now (§2.4).
 
@@ -478,7 +480,7 @@ artifact per user/company) or beside it. Lean: same artifact, two sections.
    plus the corrections UI. Proves the loop before packaging.
 5. **Phase A packaging**: strut side done (`package:desktop` + `desktop.js`
    launcher + smoke test + release tarballs); remaining is the macOS host:
-   embed Node + the staged dir, code-sign the listed addon, spawn
+   embed Node + the staged dir, code-sign the listed binaries, spawn
    `desktop.js` and stream the mic (`native-dictation-client.md`).
 6. **Kotlin host**, Windows shell override.
 7. Later: single-binary (phase B), local vector store or LadybugDB backend

--- a/strut/plans/native-dictation-client.md
+++ b/strut/plans/native-dictation-client.md
@@ -19,15 +19,23 @@ machine; the package does not include Node.
 - **Download.** The `strut-v*` GitHub release has `strut-darwin-arm64.tar.gz`
   and `strut-darwin-x64.tar.gz`. Unpack and run `./strut --open`: the web UI
   it opens has dictation built in, so you can try the recognizer before
-  writing a line of client code.
+  writing a line of client code. If the browser downloaded it, macOS
+  quarantines every extracted file and loading the unnotarized speech addon
+  would hang the process on a Gatekeeper prompt; `./strut` detects that and
+  tells you to run `xattr -dr com.apple.quarantine <dir>` once. A `curl`
+  download has no quarantine.
 - **Build.** In `strut/` of a checkout: `yarn install`, `npm --prefix web
   install`, then `npm run package:desktop -- --smoke --tar`. Same layout at
   `dist-desktop/strut/`, and the tarball beside it.
 
 The directory is `package.json`, `build/`, `web/dist/`, `node_modules/`
-(one `sherpa-onnx-<platform>` package; the script prints the single `.node`
-addon the app must code-sign), plus two entry points: `desktop.js`, which a
-host spawns, and `strut`, a shell wrapper over it.
+(one `sherpa-onnx-<platform>` package), plus two entry points: `desktop.js`,
+which a host spawns, and `strut`, a shell wrapper over it. The packaging
+script prints the native binaries the app must code-sign and notarize: the
+`sherpa-onnx.node` addon and the three dylibs beside it (`libonnxruntime`,
+`libsherpa-onnx-c-api`, `libsherpa-onnx-cxx-api`). They ship ad-hoc signed,
+which is why an unsigned download trips Gatekeeper; inside a signed,
+notarized app bundle there is no prompt.
 
 A host runs `node <dir>/desktop.js` from any cwd with **no required env**.
 The launcher defaults to the filesystem workspace (no Neo4j), binds

--- a/strut/scripts/package-desktop.mjs
+++ b/strut/scripts/package-desktop.mjs
@@ -207,11 +207,14 @@ async function report() {
     for (const e of await readdir(d, { withFileTypes: true })) {
       const p = join(d, e.name);
       if (e.isDirectory()) await walk(p);
-      else if (e.name.endsWith(".node")) addons.push(p.slice(nm.length + 1));
+      else if (/\.(node|dylib|so|dll)$/.test(e.name)) addons.push(p.slice(nm.length + 1));
     }
   };
   await walk(nm);
-  log(`native addons the host must code-sign (${addons.length}):`);
+  // The addon plus the shared libraries it links (sherpa ships libonnxruntime
+  // and its C/C++ API dylibs beside sherpa-onnx.node). All of them must be
+  // signed and notarized inside the app bundle, not just the .node.
+  log(`native binaries the host must code-sign (${addons.length}):`);
   for (const a of addons) console.log(`    ${a}`);
 }
 

--- a/strut/scripts/strut
+++ b/strut/scripts/strut
@@ -12,4 +12,16 @@ if [ "$major" -lt 20 ]; then
   echo "strut: Node $(node -v) is too old; 20 or newer required" >&2
   exit 1
 fi
+# A browser download is quarantined, and Archive Utility marks every extracted
+# file. Loading the (ad-hoc signed, unnotarized) speech addon then blocks the
+# whole process on a Gatekeeper prompt instead of failing — refuse up front.
+if [ "$(uname)" = "Darwin" ]; then
+  q=$(find "$dir/node_modules" -path '*/sherpa-onnx-darwin-*/*' -type f -xattrname com.apple.quarantine 2>/dev/null | head -1)
+  if [ -n "$q" ]; then
+    echo "strut: this download is quarantined by macOS; loading the speech addon would hang on a Gatekeeper prompt." >&2
+    echo "strut: clear it once, then rerun:" >&2
+    echo "  xattr -dr com.apple.quarantine \"$dir\"" >&2
+    exit 1
+  fi
+fi
 exec node "$dir/desktop.js" "$@"


### PR DESCRIPTION
Found while testing the release tarball the way a mac dev would receive it.

- **Gatekeeper hang.** A browser-downloaded tarball is quarantined and Archive Utility marks every extracted file. `dlopen` of the ad-hoc-signed `sherpa-onnx.node` then blocks the whole Node process on a "developer cannot be verified" prompt: the ready line prints, and every HTTP request hangs (reproduced: `/health` timed out, node process alive). The `strut` wrapper now detects `com.apple.quarantine` on the sherpa package and exits 1 with `xattr -dr com.apple.quarantine <dir>` instead. Verified: quarantined → refusal message; cleared → boots with `available: true`. A `curl` download has no quarantine; a signed, notarized app bundle has no prompt.
- **Four binaries to sign, not one.** The report only walked `.node`; `libonnxruntime.dylib`, `libsherpa-onnx-c-api.dylib`, `libsherpa-onnx-cxx-api.dylib` sit beside it, all ad-hoc signed as shipped. Now lists `.node/.dylib/.so/.dll`.
- Docs: §0 of `native-dictation-client.md` and §2.3/§5 of `local-desktop-and-stt.md` updated.

Unrelated to the above but relevant to the release: the `strut-v0.1.0` tag still points at `a57bf3e6` (before the yarn.lock fix in #1667), so both tag runs failed at install and the release has no assets. After this merges, re-point the tag to `main`:

```bash
git tag -d strut-v0.1.0 && git push origin :refs/tags/strut-v0.1.0 && git tag strut-v0.1.0 origin/main && git push origin strut-v0.1.0
```
