### PR TITLE
ci: skip onnxruntime-node CUDA download in e2e workflows

### DIFF
--- a/.github/workflows/e2e-standalone.yml
+++ b/.github/workflows/e2e-standalone.yml
@@ -86,6 +86,10 @@ jobs:
 
       - name: Prepare Node Server
         working-directory: ./mcp
+        # No GPU on runners: skip the CUDA EP download that onnxruntime-node
+        # otherwise fetches from nuget.org (twice, once for the nested strut install).
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
         run: yarn install
 
       - name: Install dependencies in src/aieo

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -81,6 +81,10 @@ jobs:
 
       - name: Prepare Node Server
         working-directory: ./mcp
+        # No GPU on runners: skip the CUDA EP download that onnxruntime-node
+        # otherwise fetches from nuget.org (twice, once for the nested strut install).
+        env:
+          ONNXRUNTIME_NODE_INSTALL: skip
         run: yarn install
 
       - name: Install dependencies in src/aieo


### PR DESCRIPTION
Sets `ONNXRUNTIME_NODE_INSTALL=skip` on the `yarn install` step in `e2e-test.yml` and `e2e-standalone.yml`.

- Runners have no GPU, so the CUDA execution-provider binaries are never used.
- Since strut became a git dependency, the nested install runs onnxruntime-node's postinstall twice, each one fetching from nuget.org.
- onnxruntime-node 1.24.3's install script exits early on `skip`; CPU binaries ship in the package itself.

Cuts install time and removes the nuget.org dependency from CI.