### PR TITLE
mcp Dockerfile: fetch the tokenizers binding with npm pack, not npm install

### DIFF
--- a/mcp/Dockerfile
+++ b/mcp/Dockerfile
@@ -139,15 +139,21 @@ RUN yarn
 
 # Install linux x64 tokenizer bindings (required for fastembed in Docker)
 #
-# This is an `npm install` on top of a yarn tree, so npm re-resolves
-# package.json here and ignores yarn's `resolutions`. Without a matching npm
-# `overrides` entry it re-nests fastembed's declared onnxruntime-node 1.21.0
-# under node_modules/fastembed/node_modules, and at runtime that older
-# libonnxruntime.so.1 loads first and strut's 1.24.3 binding (same soname)
-# fails with "version VERS_1.24.3 not found". package.json carries both
-# `resolutions` (yarn) and `overrides` (npm) pinned to the same version; the
-# check below fails the build, not /lab at runtime, if a second copy sneaks in.
-RUN npm install --force --os=linux --cpu=x64 @anush008/tokenizers-linux-x64-gnu@0.0.0
+# Fetched with `npm pack` + tar rather than `npm install`: an `npm install`
+# on top of the yarn tree makes npm re-resolve all of package.json, and with
+# strut as a git dependency npm would re-clone and re-build strut its own way
+# (and did fail doing so: the `--os/--cpu` flags leak into that nested build
+# and vite gets the wrong rollup binary on arm64). `npm pack` only downloads
+# the one tarball, so node_modules stays exactly what yarn produced.
+#
+# The onnxruntime-node check below stays: yarn's `resolutions` pin it to one
+# copy (strut's binding and fastembed's must share one libonnxruntime.so, same
+# soname), and the build should fail, not /lab at runtime, if a second copy
+# ever sneaks in.
+RUN mkdir -p node_modules/@anush008/tokenizers-linux-x64-gnu && \
+    npm pack @anush008/tokenizers-linux-x64-gnu@0.0.0 --pack-destination /tmp >/dev/null && \
+    tar xzf /tmp/anush008-tokenizers-linux-x64-gnu-0.0.0.tgz --strip-components=1 -C node_modules/@anush008/tokenizers-linux-x64-gnu && \
+    rm /tmp/anush008-tokenizers-linux-x64-gnu-0.0.0.tgz
 RUN extra="$(find node_modules -mindepth 2 -type d -name onnxruntime-node -not -path 'node_modules/onnxruntime-node' -not -path 'node_modules/strut/*')"; \
     if [ -n "$extra" ]; then echo "duplicate onnxruntime-node copies (soname clash with strut):"; echo "$extra"; exit 1; fi
 


### PR DESCRIPTION
Follow-up to #1670, which merged about 18 minutes before this commit was pushed to its branch, so it never made it in. Without it the mcp image does not build.

## Problem

The Dockerfile installs the linux-x64 tokenizers binding with `npm install --force --os=linux --cpu=x64 @anush008/tokenizers-linux-x64-gnu@0.0.0` on top of the yarn tree. npm re-resolves all of `package.json` when it does that, and now that strut is a git dependency npm re-clones strut and re-runs its `prepare` its own way. That nested build fails: the `--os/--cpu` flags leak into strut's nested `web/` install, so vite gets the x64 rollup binary on an arm64 build (`Cannot find module @rollup/rollup-linux-arm64-gnu`). Even where it would succeed, it would replace yarn's strut with npm's own resolution of it.

## Fix

Fetch that one package with `npm pack` and untar it into `node_modules/@anush008/tokenizers-linux-x64-gnu`. npm never touches the tree, so `node_modules` stays exactly what yarn produced. The onnxruntime-node duplicate check stays and passes.

## Verified

Built the image (arm64) and booted it against a throwaway Neo4j with placeholder API keys:
- `GET /lab/health` → `{"ok":true,"stepCount":127}`
- `GET /lab/` → the strut UI, its bundle served from `node_modules/strut/web/dist`
- `GET /lab/workflows` → 33 seeded workflows; the graph workspace wrote to Neo4j
- no errors in the container log

Inside the image strut's install is identical to a local one (same hoisted `ai` 6.0.175 / `@ai-sdk/*` versions, five packages nested under `node_modules/strut`, one `onnxruntime-node`). strut's 709 tests pass against that tree.

Pre-existing and unrelated: the arm64 image cannot boot before or after this, because mcp's lockfile has no arm64 tokenizers binding for fastembed. Prod is amd64. The arm64 test above stubbed that module.
