### PR TITLE
gateway: add xAI as the fourth provider; price provider-namespaced models

### DIFF
--- a/gateway/Makefile
+++ b/gateway/Makefile
@@ -7,8 +7,8 @@ OUTPUT      = $(OUTPUT_DIR)/$(PLUGIN_NAME).so
 
 # Bifrost upstream version this plugin is built against. Must match the
 # bifrost-http binary it gets loaded into — Go plugins are strict.
-BIFROST_VERSION ?= transports/v1.5.2
-GO_VERSION      ?= 1.26.2
+BIFROST_VERSION ?= transports/v1.6.2
+GO_VERSION      ?= 1.26.4
 
 # Docker image we build (dynamic bifrost-http + this plugin).
 IMAGE ?= stakgraph-gateway:dev

--- a/gateway/data/config.json
+++ b/gateway/data/config.json
@@ -42,11 +42,11 @@
         }
       ]
     },
-    "gemini": {
+    "xai": {
       "keys": [
         {
-          "name": "gemini-key-1",
-          "value": "env.GOOGLE_API_KEY",
+          "name": "xai-key-1",
+          "value": "env.XAI_API_KEY",
           "models": ["*"],
           "weight": 1.0
         }

--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -81,7 +81,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
-      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
     depends_on:
       redis:
         condition: service_healthy

--- a/gateway/internal/adminapi/ui/src/pages/canvasTheme.ts
+++ b/gateway/internal/adminapi/ui/src/pages/canvasTheme.ts
@@ -309,6 +309,17 @@ const OPENROUTER_PATHS: IconPathData = [
   },
 ];
 
+// xAI has no simple-icons glyph, so this is a geometric stand-in
+// rather than the trademark: the two strokes of an "X" in a 24-unit
+// box, the right-hand stroke pulled apart into a long diagonal plus
+// a short cap the way the wordmark reads. Stroked (not filled) so it
+// renders at the same visual weight as the OpenRouter curves.
+const XAI_PATHS: IconPathData = [
+  { d: "M4 4L20 20", mode: "stroke", strokeWidth: 3 },
+  { d: "M20 4L11.5 12.5", mode: "stroke", strokeWidth: 3 },
+  { d: "M4 20L8.5 15.5", mode: "stroke", strokeWidth: 3 },
+];
+
 // Person + bot glyphs in a 24-unit source box. The `l 0.001 0` segments
 // are degenerate dots — at stroke-linecap='round' they render as filled
 // discs of diameter = stroke-width.
@@ -341,6 +352,7 @@ const PROVIDER_ICON_META: Record<
   openai: { mode: "fill", viewBox: 24 },
   gemini: { mode: "fill", viewBox: 24 },
   openrouter: { mode: "fill", viewBox: 512 },
+  xai: { mode: "stroke", viewBox: 24 },
 };
 
 // ---------------------------------------------------------------------------
@@ -358,6 +370,7 @@ const PROVIDER_ICON_META: Record<
 //   - OpenAI:    mint, used across their docs + simple-icons
 //   - Gemini:    simple-icons "Google Gemini" (#8E75B2)
 //   - OpenRouter: openrouter.ai brand
+//   - xAI:       monochrome wordmark; a light neutral reads on midnight
 export const PROVIDER_DISPLAY: Record<
   string,
   { label: string; icon: string; color: string }
@@ -366,6 +379,7 @@ export const PROVIDER_DISPLAY: Record<
   openai: { label: "OpenAI", icon: "openai", color: "#10A37F" },
   gemini: { label: "Gemini", icon: "gemini", color: "#8E75B2" },
   openrouter: { label: "OpenRouter", icon: "openrouter", color: "#6467F2" },
+  xai: { label: "xAI", icon: "xai", color: "#D4D4D8" },
 };
 
 export function providerIcon(name: string): string {
@@ -386,6 +400,7 @@ export const canvasTheme: CanvasTheme = resolveTheme(
       openai: OPENAI_PATHS,
       gemini: GEMINI_PATHS,
       openrouter: OPENROUTER_PATHS,
+      xai: XAI_PATHS,
     },
     categories: {
       // ─── agent ───────────────────────────────────────────────────

--- a/gateway/internal/auth/pricing.go
+++ b/gateway/internal/auth/pricing.go
@@ -1,8 +1,6 @@
 package auth
 
 import (
-	"strings"
-
 	"github.com/stakwork/stakgraph/gateway/internal/pricing"
 )
 
@@ -20,36 +18,36 @@ import (
 //     bifrost prices logs.db rows from, so enforcement dollars and
 //     reported dollars agree.
 //
-// Model matching: exact key first, then the name with any
-// "provider/" prefix stripped, so "anthropic/claude-sonnet-5" and
-// "claude-sonnet-5" resolve to the same entry whichever form the
-// caller holds.
-func PriceCall(model string, promptTokens, completionTokens int) (float64, bool) {
-	if model == "" {
+// Model matching follows pricing.Keys: the bare name, then
+// "<provider>/<model>", then the name with any "provider/" prefix
+// stripped — so "claude-sonnet-5", "anthropic/claude-sonnet-5", and
+// ("xai", "grok-4") → "xai/grok-4" all resolve against either source
+// whichever form the caller holds. provider is the Bifrost provider
+// id that served the call; "" is allowed and skips the second form.
+func PriceCall(provider, model string, promptTokens, completionTokens int) (float64, bool) {
+	keys := pricing.Keys(provider, model)
+	if len(keys) == 0 {
 		return 0, false
 	}
 	const mtok = 1_000_000
-	if entry, ok := configPrice(model); ok {
+	if entry, ok := configPrice(keys); ok {
 		return float64(promptTokens)*entry.InputPerMTok/mtok +
 			float64(completionTokens)*entry.OutputPerMTok/mtok, true
 	}
-	if p, ok := pricing.Lookup(model); ok {
+	if p, ok := pricing.Lookup(provider, model); ok {
 		return float64(promptTokens)*p.InputPerMTok/mtok +
 			float64(completionTokens)*p.OutputPerMTok/mtok, true
 	}
 	return 0, false
 }
 
-func configPrice(model string) (ModelPrice, bool) {
+func configPrice(keys []string) (ModelPrice, bool) {
 	table := GetConfig().ModelPricing
 	if len(table) == 0 {
 		return ModelPrice{}, false
 	}
-	if entry, ok := table[model]; ok {
-		return entry, true
-	}
-	if i := strings.LastIndexByte(model, '/'); i >= 0 {
-		if entry, ok := table[model[i+1:]]; ok {
+	for _, k := range keys {
+		if entry, ok := table[k]; ok {
 			return entry, true
 		}
 	}

--- a/gateway/internal/auth/pricing_test.go
+++ b/gateway/internal/auth/pricing_test.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"math"
 	"testing"
 
 	"github.com/stakwork/stakgraph/gateway/internal/pricing"
@@ -13,25 +14,25 @@ func TestPriceCall(t *testing.T) {
 	t.Cleanup(func() { SetConfigForTest(Config{}) })
 
 	// 1000 in + 500 out = 0.0008 + 0.002 = 0.0028.
-	got, ok := PriceCall("claude-3-5-haiku-latest", 1000, 500)
+	got, ok := PriceCall("anthropic", "claude-3-5-haiku-latest", 1000, 500)
 	if !ok || got != 0.0028 {
 		t.Fatalf("PriceCall = (%v, %v), want (0.0028, true)", got, ok)
 	}
 
 	// Provider-prefixed form resolves to the same entry.
-	got, ok = PriceCall("anthropic/claude-3-5-haiku-latest", 1000, 500)
+	got, ok = PriceCall("anthropic", "anthropic/claude-3-5-haiku-latest", 1000, 500)
 	if !ok || got != 0.0028 {
 		t.Fatalf("prefixed PriceCall = (%v, %v), want (0.0028, true)", got, ok)
 	}
 
 	// Unpriced model: (0, false), caller logs.
-	if _, ok := PriceCall("gpt-4o", 10, 10); ok {
+	if _, ok := PriceCall("openai", "gpt-4o", 10, 10); ok {
 		t.Fatal("unpriced model must return ok=false")
 	}
 
 	// Empty table: never ok.
 	SetConfigForTest(Config{})
-	if _, ok := PriceCall("claude-3-5-haiku-latest", 10, 10); ok {
+	if _, ok := PriceCall("anthropic", "claude-3-5-haiku-latest", 10, 10); ok {
 		t.Fatal("empty pricing table must return ok=false")
 	}
 }
@@ -47,7 +48,7 @@ func TestPriceCall_CatalogFallback(t *testing.T) {
 
 	// No config entry → catalog prices it: 1000*2/1e6 + 500*10/1e6.
 	SetConfigForTest(Config{})
-	got, ok := PriceCall("claude-sonnet-5", 1000, 500)
+	got, ok := PriceCall("anthropic", "claude-sonnet-5", 1000, 500)
 	if !ok || got != 0.007 {
 		t.Fatalf("catalog PriceCall = (%v, %v), want (0.007, true)", got, ok)
 	}
@@ -56,13 +57,56 @@ func TestPriceCall_CatalogFallback(t *testing.T) {
 	SetConfigForTest(Config{ModelPricing: map[string]ModelPrice{
 		"claude-sonnet-5": {InputPerMTok: 4.0, OutputPerMTok: 20.0},
 	}})
-	got, ok = PriceCall("claude-sonnet-5", 1000, 500)
+	got, ok = PriceCall("anthropic", "claude-sonnet-5", 1000, 500)
 	if !ok || got != 0.014 {
 		t.Fatalf("config-over-catalog PriceCall = (%v, %v), want (0.014, true)", got, ok)
 	}
 
 	// Neither source knows the model → (0, false).
-	if _, ok := PriceCall("mystery-model", 10, 10); ok {
+	if _, ok := PriceCall("anthropic", "mystery-model", 10, 10); ok {
 		t.Fatal("model absent from both sources must return ok=false")
+	}
+}
+
+func TestPriceCall_ProviderNamespaced(t *testing.T) {
+	// Catalog keyed the way bifrost's datasheet keys xAI and
+	// OpenRouter rows; bifrost reports the wire model bare.
+	pricing.SetTableForTest(map[string]pricing.Price{
+		"xai/grok-4":                         {InputPerMTok: 3.0, OutputPerMTok: 15.0},
+		"openrouter/moonshotai/kimi-k2-0905": {InputPerMTok: 1.0, OutputPerMTok: 1.0},
+	})
+	t.Cleanup(func() {
+		pricing.SetTableForTest(nil)
+		SetConfigForTest(Config{})
+	})
+	SetConfigForTest(Config{})
+
+	// 1000*3/1e6 + 500*15/1e6 = 0.003 + 0.0075 (float sum, so a
+	// tolerance rather than an exact decimal).
+	got, ok := PriceCall("xai", "grok-4", 1000, 500)
+	if !ok || math.Abs(got-0.0105) > 1e-12 {
+		t.Fatalf("PriceCall(xai, grok-4) = (%v, %v), want (≈0.0105, true)", got, ok)
+	}
+	got, ok = PriceCall("openrouter", "moonshotai/kimi-k2-0905", 1000, 1000)
+	if !ok || got != 0.002 {
+		t.Fatalf("PriceCall(openrouter, …kimi) = (%v, %v), want (0.002, true)", got, ok)
+	}
+	// No provider → no namespaced candidate → the bare row is absent.
+	if _, ok := PriceCall("", "grok-4", 10, 10); ok {
+		t.Fatal("bare grok-4 without a provider must miss the namespaced catalog")
+	}
+
+	// The operator table accepts either spelling and still wins.
+	SetConfigForTest(Config{ModelPricing: map[string]ModelPrice{
+		"grok-4": {InputPerMTok: 1.0, OutputPerMTok: 1.0},
+	}})
+	if got, ok := PriceCall("xai", "grok-4", 1000, 1000); !ok || got != 0.002 {
+		t.Fatalf("bare config key over catalog = (%v, %v), want (0.002, true)", got, ok)
+	}
+	SetConfigForTest(Config{ModelPricing: map[string]ModelPrice{
+		"xai/grok-4": {InputPerMTok: 2.0, OutputPerMTok: 2.0},
+	}})
+	if got, ok := PriceCall("xai", "grok-4", 1000, 1000); !ok || got != 0.004 {
+		t.Fatalf("namespaced config key over catalog = (%v, %v), want (0.004, true)", got, ok)
 	}
 }

--- a/gateway/internal/hooks/llm_posthook.go
+++ b/gateway/internal/hooks/llm_posthook.go
@@ -96,9 +96,12 @@ func isStreamRequest(resp *schemas.BifrostResponse) bool {
 // per the phase-6 accumulator design:
 //
 //  1. Provider-computed Usage.Cost.TotalCost (only some providers).
-//  2. auth.PriceCall on the resolved model name — operator
-//     model_pricing config first, then the internal/pricing catalog
-//     (bifrost's own datasheet, refreshed daily).
+//  2. auth.PriceCall on the (provider, resolved model) pair —
+//     operator model_pricing config first, then the internal/pricing
+//     catalog (bifrost's own datasheet, refreshed daily). The
+//     provider matters: the datasheet keys some providers' rows as
+//     "<provider>/<model>" ("xai/grok-4") while Bifrost reports the
+//     wire model bare ("grok-4").
 //  3. $0, with a loud log — an unpriced model must be visible in
 //     `docker logs`, not silently guessed at.
 func resolveCost(chat *schemas.BifrostChatResponse, usage *schemas.BifrostLLMUsage, dims map[string]string) float64 {
@@ -108,22 +111,35 @@ func resolveCost(chat *schemas.BifrostChatResponse, usage *schemas.BifrostLLMUsa
 	if usage.Cost != nil && usage.Cost.TotalCost > 0 {
 		return usage.Cost.TotalCost
 	}
-	model := ""
+	model, provider := "", ""
 	if chat != nil {
 		if model = chat.ExtraFields.ResolvedModelUsed; model == "" {
 			model = chat.Model
 		}
+		provider = responseProvider(chat)
 	}
-	if cost, ok := auth.PriceCall(model, usage.PromptTokens, usage.CompletionTokens); ok {
+	if cost, ok := auth.PriceCall(provider, model, usage.PromptTokens, usage.CompletionTokens); ok {
 		return cost
 	}
 	if usage.TotalTokens > 0 {
 		pluginlog.Warnf(
-			"accounting: no price for model=%q (run_id=%s) — %d tokens accumulated as $0; add a model_pricing entry",
-			model, dims[pluginctx.DimRunID], usage.TotalTokens,
+			"accounting: no price for provider=%q model=%q (run_id=%s) — %d tokens accumulated as $0; add a model_pricing entry",
+			provider, model, dims[pluginctx.DimRunID], usage.TotalTokens,
 		)
 	}
 	return 0
+}
+
+// responseProvider returns the Bifrost provider id that actually
+// served a chat response. RoutingInfo.Provider is the current field;
+// ExtraFields.Provider is its deprecated twin, still populated by
+// core v1.6 and kept as the fallback for chunks that only carry the
+// old shape.
+func responseProvider(chat *schemas.BifrostChatResponse) string {
+	if p := chat.ExtraFields.RoutingInfo.Provider; p != "" {
+		return string(p)
+	}
+	return string(chat.ExtraFields.Provider)
 }
 
 // toolCallNames collects the tool names invoked in a non-streaming

--- a/gateway/internal/hooks/llm_posthook_test.go
+++ b/gateway/internal/hooks/llm_posthook_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/maximhq/bifrost/core/schemas"
 
 	"github.com/stakwork/stakgraph/gateway/internal/auth"
+	"github.com/stakwork/stakgraph/gateway/internal/pricing"
 )
 
 func strPtr(s string) *string { return &s }
@@ -96,5 +97,46 @@ func TestResolveCost_PrefersResolvedModel(t *testing.T) {
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 500, CompletionTokens: 500, TotalTokens: 1000}
 	if got := resolveCost(chat, usage, map[string]string{}); got != 0.001 {
 		t.Fatalf("resolved-model cost = %v, want 0.001", got)
+	}
+}
+
+// The xAI case: bifrost resolves the wire model bare ("grok-4") and
+// reports the provider on RoutingInfo; the datasheet keys the row as
+// "xai/grok-4". The hook must hand the provider to the price lookup
+// or every Grok call accumulates at $0.
+func TestResolveCost_ProviderNamespacedCatalog(t *testing.T) {
+	auth.SetConfigForTest(auth.Config{})
+	pricing.SetTableForTest(map[string]pricing.Price{
+		"xai/grok-4": {InputPerMTok: 1.0, OutputPerMTok: 1.0},
+	})
+	t.Cleanup(func() {
+		pricing.SetTableForTest(nil)
+		auth.SetConfigForTest(auth.Config{})
+	})
+
+	usage := &schemas.BifrostLLMUsage{PromptTokens: 500, CompletionTokens: 500, TotalTokens: 1000}
+
+	chat := &schemas.BifrostChatResponse{
+		Model: "grok-4",
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			ResolvedModelUsed: "grok-4",
+			RoutingInfo:       schemas.RoutingInfo{Provider: schemas.XAI, Model: "grok-4"},
+		},
+	}
+	if got := resolveCost(chat, usage, map[string]string{}); got != 0.001 {
+		t.Fatalf("RoutingInfo provider cost = %v, want 0.001", got)
+	}
+
+	// Older chunks only carry the deprecated ExtraFields.Provider.
+	chat.ExtraFields.RoutingInfo = schemas.RoutingInfo{}
+	chat.ExtraFields.Provider = schemas.XAI
+	if got := resolveCost(chat, usage, map[string]string{}); got != 0.001 {
+		t.Fatalf("deprecated provider field cost = %v, want 0.001", got)
+	}
+
+	// No provider anywhere → the namespaced row is unreachable → $0.
+	chat.ExtraFields.Provider = ""
+	if got := resolveCost(chat, usage, map[string]string{}); got != 0 {
+		t.Fatalf("provider-less cost = %v, want 0", got)
 	}
 }

--- a/gateway/internal/pricing/pricing.go
+++ b/gateway/internal/pricing/pricing.go
@@ -71,21 +71,49 @@ var (
 	retryBaseDelay = time.Second
 )
 
-// Lookup returns the catalog price for a model: exact key first,
-// then the name with any "provider/" prefix stripped (Bifrost
-// resolved names are usually bare, but callers occasionally hold the
-// prefixed form). ok=false when the catalog has no entry — the
-// caller falls through to its next price source.
-func Lookup(model string) (Price, bool) {
+// Keys returns the lookup candidates for a (provider, model) pair,
+// most specific first:
+//
+//  1. model as given — the datasheet keys most first-party rows
+//     bare ("claude-sonnet-5", "gpt-5.2"), which is also the wire
+//     model Bifrost reports in ResolvedModelUsed.
+//  2. "<provider>/<model>" — the datasheet namespaces some
+//     providers' rows under the provider id ("xai/grok-4",
+//     "openrouter/moonshotai/kimi-k2-0905") while Bifrost still
+//     reports the wire model bare ("grok-4"). Without this step
+//     every Grok and OpenRouter call priced at $0.
+//  3. the last path segment of model — callers occasionally hold a
+//     prefixed form ("anthropic/claude-sonnet-5").
+//
+// Shared by the catalog and the operator model_pricing table so the
+// two sources can't disagree on what a model name means.
+func Keys(provider, model string) []string {
+	if model == "" {
+		return nil
+	}
+	keys := []string{model}
+	if provider != "" && !strings.HasPrefix(model, provider+"/") {
+		keys = append(keys, provider+"/"+model)
+	}
+	if i := strings.LastIndexByte(model, '/'); i >= 0 && i+1 < len(model) {
+		keys = append(keys, model[i+1:])
+	}
+	return keys
+}
+
+// Lookup returns the catalog price for a model, trying each Keys
+// candidate in order. provider is the Bifrost provider id that
+// served the call ("xai", "openrouter", …); pass "" when unknown
+// and only the bare and prefix-stripped forms are tried. ok=false
+// when the catalog has no entry — the caller falls through to its
+// next price source.
+func Lookup(provider, model string) (Price, bool) {
 	m := table.Load()
-	if m == nil || model == "" {
+	if m == nil {
 		return Price{}, false
 	}
-	if p, ok := (*m)[model]; ok {
-		return p, true
-	}
-	if i := strings.LastIndexByte(model, '/'); i >= 0 {
-		if p, ok := (*m)[model[i+1:]]; ok {
+	for _, k := range Keys(provider, model) {
+		if p, ok := (*m)[k]; ok {
 			return p, true
 		}
 	}

--- a/gateway/internal/pricing/pricing_test.go
+++ b/gateway/internal/pricing/pricing_test.go
@@ -63,20 +63,65 @@ func TestParseDatasheet_RejectsGarbage(t *testing.T) {
 	}
 }
 
-func TestLookup_PrefixStrip(t *testing.T) {
-	SetTableForTest(map[string]Price{"claude-sonnet-5": {InputPerMTok: 2, OutputPerMTok: 10}})
+func TestKeys_Order(t *testing.T) {
+	cases := []struct {
+		provider, model string
+		want            []string
+	}{
+		{"anthropic", "claude-sonnet-5", []string{"claude-sonnet-5", "anthropic/claude-sonnet-5"}},
+		{"xai", "grok-4", []string{"grok-4", "xai/grok-4"}},
+		{"", "grok-4", []string{"grok-4"}},
+		// Already provider-prefixed: no double prefix, base form last.
+		{"anthropic", "anthropic/claude-sonnet-5", []string{"anthropic/claude-sonnet-5", "claude-sonnet-5"}},
+		// Nested vendor path (OpenRouter): provider form before base.
+		{"openrouter", "moonshotai/kimi-k2-0905", []string{"moonshotai/kimi-k2-0905", "openrouter/moonshotai/kimi-k2-0905", "kimi-k2-0905"}},
+		{"xai", "", nil},
+	}
+	for _, c := range cases {
+		got := Keys(c.provider, c.model)
+		if len(got) != len(c.want) {
+			t.Fatalf("Keys(%q,%q) = %v, want %v", c.provider, c.model, got, c.want)
+		}
+		for i := range got {
+			if got[i] != c.want[i] {
+				t.Fatalf("Keys(%q,%q) = %v, want %v", c.provider, c.model, got, c.want)
+			}
+		}
+	}
+}
+
+func TestLookup_ProviderNamespaced(t *testing.T) {
+	SetTableForTest(map[string]Price{
+		"claude-sonnet-5":                    {InputPerMTok: 2, OutputPerMTok: 10},
+		"xai/grok-4":                         {InputPerMTok: 3, OutputPerMTok: 15},
+		"openrouter/moonshotai/kimi-k2-0905": {InputPerMTok: 0.5, OutputPerMTok: 2},
+	})
 	t.Cleanup(func() { SetTableForTest(nil) })
 
-	if _, ok := Lookup("claude-sonnet-5"); !ok {
+	if _, ok := Lookup("anthropic", "claude-sonnet-5"); !ok {
 		t.Fatal("exact lookup failed")
 	}
-	if _, ok := Lookup("anthropic/claude-sonnet-5"); !ok {
+	if _, ok := Lookup("anthropic", "anthropic/claude-sonnet-5"); !ok {
 		t.Fatal("prefix-stripped lookup failed")
 	}
-	if _, ok := Lookup("unknown-model"); ok {
+	// The xAI regression: bifrost reports the wire model bare, the
+	// datasheet keys it under the provider.
+	if p, ok := Lookup("xai", "grok-4"); !ok || p.InputPerMTok != 3 {
+		t.Fatalf("Lookup(xai, grok-4) = (%+v, %v), want the xai/grok-4 row", p, ok)
+	}
+	if _, ok := Lookup("xai", "xai/grok-4"); !ok {
+		t.Fatal("already-prefixed model must not be double-prefixed into a miss")
+	}
+	if _, ok := Lookup("", "grok-4"); ok {
+		t.Fatal("without a provider the bare grok row must miss (there is none)")
+	}
+	if p, ok := Lookup("openrouter", "moonshotai/kimi-k2-0905"); !ok || p.OutputPerMTok != 2 {
+		t.Fatalf("Lookup(openrouter, moonshotai/kimi-k2-0905) = (%+v, %v)", p, ok)
+	}
+	if _, ok := Lookup("anthropic", "unknown-model"); ok {
 		t.Fatal("unknown model must miss")
 	}
-	if _, ok := Lookup(""); ok {
+	if _, ok := Lookup("anthropic", ""); ok {
 		t.Fatal("empty model must miss")
 	}
 }
@@ -93,7 +138,7 @@ func TestFetch_SwapsAndPersists(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "sheet.json")
 	FetchNowForTest(srv.URL, cachePath)
 
-	if p, ok := Lookup("gpt-5.2"); !ok || p.InputPerMTok != 1.75 {
+	if p, ok := Lookup("openai", "gpt-5.2"); !ok || p.InputPerMTok != 1.75 {
 		t.Fatalf("post-fetch Lookup(gpt-5.2) = (%+v, %v)", p, ok)
 	}
 	raw, err := os.ReadFile(cachePath)
@@ -116,7 +161,7 @@ func TestFetch_FailureKeepsLastGood(t *testing.T) {
 
 	FetchNowForTest(srv.URL, filepath.Join(t.TempDir(), "sheet.json"))
 
-	if _, ok := Lookup("claude-sonnet-5"); !ok {
+	if _, ok := Lookup("anthropic", "claude-sonnet-5"); !ok {
 		t.Fatal("failed fetch must keep the last-good table")
 	}
 }
@@ -133,7 +178,7 @@ func TestFetch_BadBodyKeepsLastGood(t *testing.T) {
 	cachePath := filepath.Join(t.TempDir(), "sheet.json")
 	FetchNowForTest(srv.URL, cachePath)
 
-	if _, ok := Lookup("claude-sonnet-5"); !ok {
+	if _, ok := Lookup("anthropic", "claude-sonnet-5"); !ok {
 		t.Fatal("unparseable body must keep the last-good table")
 	}
 	if _, err := os.Stat(cachePath); err == nil {

--- a/gateway/plans/llm-governance-v2.md
+++ b/gateway/plans/llm-governance-v2.md
@@ -135,7 +135,7 @@ Bifrost natively enforces:
 | Daily $ budget     | Customer (per user) | $1000/day                                              |
 | Rate limit RPM     | Customer (per user) | 1000 RPM                                               |
 | Rate limit TPM     | Customer (per user) | 5M TPM                                                 |
-| Provider allowlist | VK                  | `[anthropic, openai, openrouter, gemini]`, all `["*"]` |
+| Provider allowlist | VK                  | `[anthropic, openai, openrouter, xai]`, all `["*"]` |
 | Model allowlist    | VK                  | `["*"]` initially                                      |
 | `is_active`        | Customer (per user) | `true` by default; `false` disables account org-wide   |
 
@@ -173,7 +173,7 @@ POST /api/governance/virtual-keys
       { provider: "anthropic", allowed_models: ["*"] },
       { provider: "openai",    allowed_models: ["*"] },
       { provider: "openrouter",allowed_models: ["*"] },
-      { provider: "gemini",    allowed_models: ["*"] },
+      { provider: "xai",       allowed_models: ["*"] },
     ]
   }
 ```

--- a/gateway/plans/phases/phase-1-reconciler.md
+++ b/gateway/plans/phases/phase-1-reconciler.md
@@ -255,7 +255,7 @@ Filters available on this endpoint (lines 369-380 of governance.go):
           "budgets": [],
           "rate_limit": null
         }
-        // … openai, openrouter, gemini
+        // … openai, openrouter, xai
       ],
       "mcp_configs": [],
       "budgets": [],
@@ -306,7 +306,7 @@ Content-Type: application/json
     { "provider": "anthropic",  "allowed_models": ["*"], "key_ids": ["*"] },
     { "provider": "openai",     "allowed_models": ["*"], "key_ids": ["*"] },
     { "provider": "openrouter", "allowed_models": ["*"], "key_ids": ["*"] },
-    { "provider": "gemini",     "allowed_models": ["*"], "key_ids": ["*"] }
+    { "provider": "xai",        "allowed_models": ["*"], "key_ids": ["*"] }
   ]
 }
 ```

--- a/gateway/scripts/smoke-test.sh
+++ b/gateway/scripts/smoke-test.sh
@@ -14,7 +14,7 @@
 #   - Multiple agent names (browser / coder / chat / reviewer)
 #   - Multiple users (alice / bob / carol) and workspaces (w1 / w2)
 #   - Spread across ≥2 minute buckets via sleeps
-#   - Multiple providers (anthropic / openai / openrouter) and models
+#   - Multiple providers (anthropic / openai / openrouter / xai) and models
 #   - One streaming request
 #   - One error request (bad model name)
 #   - One request with NO dim headers (graceful absence check)
@@ -140,6 +140,9 @@ M_HAIKU="anthropic/claude-haiku-4-5-20251001"
 M_MINI="openai/gpt-4o-mini"
 M_NANO="openai/gpt-4.1-nano"
 M_KIMI="openrouter/moonshotai/kimi-k2-0905"
+# xAI retires model ids aggressively; with allowed_models ["*"] Bifrost only
+# admits ids present in api.x.ai's live /v1/models, so keep this current.
+M_GROK="xai/grok-4.3"
 
 # --- batch 1: minute N ----------------------------------------------------
 
@@ -163,6 +166,7 @@ echo "# batch 2 — minute N+1"
 call_llm chat      u_carol  w2  "$SESS_CAROL_W2" "$M_HAIKU" 'two-word greeting'
 call_llm reviewer  u_carol  w1  "$SESS_CAROL_W1" "$M_NANO"  'reply in 3 words'
 call_llm reviewer  u_carol  w1  "$SESS_CAROL_W1" "$M_KIMI"  'reply in 3 words'
+call_llm reviewer  u_carol  w1  "$SESS_CAROL_W1" "$M_GROK"  'reply in 3 words'
 
 echo
 echo "# streaming request (verify final-chunk cost lands)"

--- a/mcp/docs/gateway/README.md
+++ b/mcp/docs/gateway/README.md
@@ -7,10 +7,10 @@ Runs Bifrost locally on `http://localhost:8181` so MCP can be tested with
 ## Layout
 
 - `docker-compose.yml` — Bifrost service, host port `8181 -> container 8080`.
-- `data/config.json` — seed config: Anthropic + OpenAI + OpenRouter + Gemini
+- `data/config.json` — seed config: Anthropic + OpenAI + OpenRouter + xAI
   providers, API keys read from `env.*`, `config_store` enabled (SQLite) so the
-  Web UI works. (Bifrost calls Google's public Gemini API `gemini`; the MCP
-  client side calls the same thing `google`.)
+  Web UI works. (xAI has no dedicated Bifrost route; the MCP client sends Grok
+  through `/openai/v1` with an `xai/`-prefixed model id.)
 - `data/config.db`, `data/logs.db` — created on first boot; gitignored.
 - `.env` — symlinked to `../../.env` (the MCP `.env`) so docker-compose picks up
   `ANTHROPIC_API_KEY` etc. without copy-paste.

--- a/mcp/docs/gateway/data/config.json
+++ b/mcp/docs/gateway/data/config.json
@@ -35,11 +35,11 @@
         }
       ]
     },
-    "gemini": {
+    "xai": {
       "keys": [
         {
-          "name": "gemini-key-1",
-          "value": "env.GOOGLE_API_KEY",
+          "name": "xai-key-1",
+          "value": "env.XAI_API_KEY",
           "models": ["*"],
           "weight": 1.0
         }

--- a/mcp/docs/gateway/docker-compose.yml
+++ b/mcp/docs/gateway/docker-compose.yml
@@ -13,7 +13,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
-      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
+      XAI_API_KEY: ${XAI_API_KEY:-}
     ports:
       # Host 8181 -> container 8080. MCP server uses LLM_GATEWAY_URL=http://localhost:8181.
       - "8181:8080"


### PR DESCRIPTION
## What

Providers are now **anthropic / openai / openrouter / xai**. Gemini is dropped from `gateway/data/config.json`, `docker-compose.yml`, the plan docs' VK `provider_configs` lists, and the `mcp/docs/gateway` seed copy. xai reads `env.XAI_API_KEY`.

### Pricing fix (affects xAI and OpenRouter)

The phase-6 accumulator looked up the bare wire model only, but bifrost's datasheet keys xAI and OpenRouter rows as `<provider>/<model>` (`xai/grok-4.3`, `openrouter/moonshotai/kimi-k2-0905`). Every Grok and OpenRouter call accumulated at **$0** in Redis while `logs.db` priced it, so budget caps never counted them.

`pricing.Keys(provider, model)` now yields bare → provider-prefixed → prefix-stripped candidates, shared by the catalog and the operator `model_pricing` table. The posthook passes `RoutingInfo.Provider` (falling back to the deprecated `ExtraFields.Provider`).

### Also
- `canvasTheme.ts`: xai display entry + a geometric stand-in glyph (no simple-icons xAI mark).
- `smoke-test.sh`: xai call. Note xAI has retired `grok-4` / `grok-4-fast-*`; with `allowed_models: ["*"]` bifrost's governance only admits ids in the provider's live `/v1/models`, so the test uses `grok-4.3`.
- `Makefile`: `BIFROST_VERSION` / `GO_VERSION` now match the Dockerfile (`transports/v1.6.2`, `1.26.4`). `make docker-build` was overriding the Dockerfile default with 1.5.2.

## Verification
- `go test ./internal/... ./auth/...` green, with new regression tests for the namespaced lookup at the catalog, config-table, and posthook layers.
- UI `tsc -b` + `vite build` clean.
- Rebuilt the image and ran grok-4.3 non-streaming + streaming calls under a shadow-mode macaroon:

| run | tokens in/out | plugin cost | Redis `cost:run` |
|---|---|---|---|
| non-streaming | 197 / 4 | $0.000256 | 0.00025625 |
| streaming | 200 / 14 | $0.000285 | 0.000285 |

Both match the datasheet rate (1.25 / 2.50 per Mtok). `logs.db` shows slightly lower figures because bifrost discounts cached-read tokens; the plugin's cache-aware refinement is still the documented TODO.

## Not in this PR (other repos)
- Hive reconciler `provider_configs` needs `xai` in place of `gemini`.
- `sphinx-swarm/src/images/bifrost.rs` needs to pass `XAI_API_KEY` through.