### PR TITLE
gateway: BIFROST_PLUGIN_ENFORCE_MACAROONS env override for enforce_macaroons

### DIFF
--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -72,6 +72,15 @@ services:
       # (`bifrost:login_attempts:*`). Without it, /_plugin/login
       # returns 503 and the admin dashboard is unreachable.
       BIFROST_PLUGIN_REDIS_URL: redis://redis:6379/0
+      # Overrides the plugin's `enforce_macaroons` flag from
+      # data/config.json (baked into the image and re-seeded on every
+      # boot, so this is the only way to flip a running deployment
+      # without shipping a new image). Unset ⇒ config.json value
+      # (false: shadow mode — verify + log, never reject). true ⇒
+      # missing/invalid macaroons short-circuit with 401. Anything
+      # other than 1/true/yes/on or 0/false/no/off is logged at ERROR
+      # and ignored (boot line shows source=env-invalid).
+      BIFROST_PLUGIN_ENFORCE_MACAROONS: ${BIFROST_PLUGIN_ENFORCE_MACAROONS:-}
       # PRODUCTION=1 forces the `Secure` attribute on the session
       # cookie regardless of the request scheme. Leave unset in dev
       # so localhost HTTP can keep its cookie; flip to 1 behind a

--- a/gateway/internal/auth/config.go
+++ b/gateway/internal/auth/config.go
@@ -3,6 +3,9 @@ package auth
 import (
 	"encoding/json"
 	"sync"
+
+	"github.com/stakwork/stakgraph/gateway/internal/env"
+	"github.com/stakwork/stakgraph/gateway/internal/pluginlog"
 )
 
 // Config is the auth subset of the plugin's config block in
@@ -25,6 +28,12 @@ import (
 // Existing swarms running an old config.json will pick up the new
 // adapter in shadow mode without any operator action — that is the
 // whole point of the flag. Flip to true per-swarm as rollout proceeds.
+//
+// The env var BIFROST_PLUGIN_ENFORCE_MACAROONS (see internal/env)
+// overrides the config.json value when set, so a swarm can be flipped
+// through its environment without rebuilding the image that carries
+// config.json. EnforceMacaroonsSource records which one won so the
+// boot log can say so.
 type Config struct {
 	// EnforceMacaroons gates whether verification failures actually
 	// reject the request. When false (default, shadow mode), the
@@ -32,6 +41,15 @@ type Config struct {
 	// mismatches loudly, but lets the request continue. When true,
 	// failures short-circuit with a bifrost.Error.
 	EnforceMacaroons bool `json:"enforce_macaroons"`
+
+	// EnforceMacaroonsSource is where EnforceMacaroons came from:
+	// "env" (BIFROST_PLUGIN_ENFORCE_MACAROONS set and valid), "config"
+	// (the key is present in the plugin config block), "default"
+	// (neither — zero value, shadow mode), or "env-invalid" (the env
+	// var was set to something unparseable, an ERROR was logged, and
+	// the config/default value stands). Diagnostic only; never
+	// persisted — grep the boot line for it.
+	EnforceMacaroonsSource string `json:"-"`
 
 	// AgentBudgets is the per-agent windowed spend cap declared
 	// in plugin.yaml. Phase 6's PreLLMHook reads these to gate
@@ -75,8 +93,11 @@ type ModelPrice struct {
 // subset of fields auth cares about. Bifrost passes the raw `config`
 // JSON object verbatim, so json.Marshal+Unmarshal round-trips through
 // whatever shape it actually has.
+//
+// EnforceMacaroons is a pointer so "key absent" (source=default) and
+// "key present and false" (source=config) stay distinguishable.
 type pluginConfigEnvelope struct {
-	EnforceMacaroons bool                   `json:"enforce_macaroons"`
+	EnforceMacaroons *bool                  `json:"enforce_macaroons"`
 	AgentBudgets     map[string]AgentBudget `json:"agent_budgets"`
 	ModelPricing     map[string]ModelPrice  `json:"model_pricing"`
 }
@@ -94,7 +115,17 @@ var (
 // to flip enforce_macaroons mid-suite without restarting the package.
 //
 // Safe to call with raw == nil; in that case the zero-value Config
-// (shadow mode) is cached.
+// (shadow mode) is cached — unless the env override is set, which
+// applies on top of whatever the block held, nil included.
+//
+// Only malformed config JSON is an error. An unparseable
+// BIFROST_PLUGIN_ENFORCE_MACAROONS value is deliberately NOT fatal:
+// a plugin Init error does not stop bifrost-http, it just drops this
+// plugin — the wrapper then serves inference with no macaroon
+// verification, no claim canonicalization, and /_plugin/* down,
+// which is strictly worse than shadow mode. So the typo is logged at
+// ERROR, the boot line says source=env-invalid, and the config.json
+// value stands.
 func Init(raw any) error {
 	parsed, err := parseConfig(raw)
 	if err != nil {
@@ -125,22 +156,36 @@ func SetConfigForTest(c Config) {
 }
 
 func parseConfig(raw any) (Config, error) {
-	if raw == nil {
-		return Config{}, nil
+	cfg := Config{EnforceMacaroonsSource: "default"}
+	if raw != nil {
+		// Round-trip through JSON so we accept whatever map shape
+		// Bifrost decoded the block into. No reflection on field names.
+		buf, err := json.Marshal(raw)
+		if err != nil {
+			return Config{}, err
+		}
+		var envelope pluginConfigEnvelope
+		if err := json.Unmarshal(buf, &envelope); err != nil {
+			return Config{}, err
+		}
+		cfg.AgentBudgets = envelope.AgentBudgets
+		cfg.ModelPricing = envelope.ModelPricing
+		if envelope.EnforceMacaroons != nil {
+			cfg.EnforceMacaroons = *envelope.EnforceMacaroons
+			cfg.EnforceMacaroonsSource = "config"
+		}
 	}
-	// Round-trip through JSON so we accept whatever map shape
-	// Bifrost decoded the block into. No reflection on field names.
-	buf, err := json.Marshal(raw)
-	if err != nil {
-		return Config{}, err
+	// Env override wins over the config block. A value we can't
+	// parse keeps the plugin alive on the config value (see Init for
+	// why fatal would be worse) but must be impossible to miss: an
+	// ERROR line here and "source=env-invalid" on the boot line.
+	if v, set, err := env.EnforceMacaroonsValue(); err != nil {
+		pluginlog.Errf("auth: %v — ignoring the override; enforce_macaroons=%t from %s stands",
+			err, cfg.EnforceMacaroons, cfg.EnforceMacaroonsSource)
+		cfg.EnforceMacaroonsSource = "env-invalid"
+	} else if set {
+		cfg.EnforceMacaroons = v
+		cfg.EnforceMacaroonsSource = "env"
 	}
-	var env pluginConfigEnvelope
-	if err := json.Unmarshal(buf, &env); err != nil {
-		return Config{}, err
-	}
-	return Config{
-		EnforceMacaroons: env.EnforceMacaroons,
-		AgentBudgets:     env.AgentBudgets,
-		ModelPricing:     env.ModelPricing,
-	}, nil
+	return cfg, nil
 }

--- a/gateway/internal/auth/config_test.go
+++ b/gateway/internal/auth/config_test.go
@@ -2,6 +2,8 @@ package auth
 
 import (
 	"testing"
+
+	"github.com/stakwork/stakgraph/gateway/internal/env"
 )
 
 func TestInit_NilConfig_DefaultsToShadow(t *testing.T) {
@@ -59,5 +61,103 @@ func TestGetConfig_BeforeInit_ReturnsZero(t *testing.T) {
 	SetConfigForTest(Config{}) // simulate "never initialized"
 	if got := GetConfig(); got.EnforceMacaroons {
 		t.Fatalf("pre-Init should be shadow mode, got %+v", got)
+	}
+}
+
+// --- BIFROST_PLUGIN_ENFORCE_MACAROONS override ---------------------------
+
+func TestInit_Source_ConfigVsDefault(t *testing.T) {
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+	t.Setenv(env.EnforceMacaroons, "")
+
+	if err := Init(map[string]any{"log_level": "info"}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if got := GetConfig(); got.EnforceMacaroons || got.EnforceMacaroonsSource != "default" {
+		t.Fatalf("absent key: got enforce=%v source=%q, want false/default", got.EnforceMacaroons, got.EnforceMacaroonsSource)
+	}
+
+	if err := Init(map[string]any{"enforce_macaroons": false}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if got := GetConfig(); got.EnforceMacaroons || got.EnforceMacaroonsSource != "config" {
+		t.Fatalf("explicit false: got enforce=%v source=%q, want false/config", got.EnforceMacaroons, got.EnforceMacaroonsSource)
+	}
+}
+
+func TestInit_EnvOverride_TrueOverConfigFalse(t *testing.T) {
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+	t.Setenv(env.EnforceMacaroons, "true")
+
+	if err := Init(map[string]any{"enforce_macaroons": false}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if got := GetConfig(); !got.EnforceMacaroons || got.EnforceMacaroonsSource != "env" {
+		t.Fatalf("got enforce=%v source=%q, want true/env", got.EnforceMacaroons, got.EnforceMacaroonsSource)
+	}
+}
+
+func TestInit_EnvOverride_FalseOverConfigTrue(t *testing.T) {
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+	t.Setenv(env.EnforceMacaroons, "0")
+
+	if err := Init(map[string]any{"enforce_macaroons": true}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	if got := GetConfig(); got.EnforceMacaroons || got.EnforceMacaroonsSource != "env" {
+		t.Fatalf("got enforce=%v source=%q, want false/env", got.EnforceMacaroons, got.EnforceMacaroonsSource)
+	}
+}
+
+func TestInit_EnvOverride_AppliesToNilConfig(t *testing.T) {
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+	t.Setenv(env.EnforceMacaroons, "yes")
+
+	if err := Init(nil); err != nil {
+		t.Fatalf("Init(nil): %v", err)
+	}
+	if got := GetConfig(); !got.EnforceMacaroons || got.EnforceMacaroonsSource != "env" {
+		t.Fatalf("nil config + env: got enforce=%v source=%q, want true/env", got.EnforceMacaroons, got.EnforceMacaroonsSource)
+	}
+}
+
+func TestInit_EnvOverride_PreservesOtherFields(t *testing.T) {
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+	t.Setenv(env.EnforceMacaroons, "true")
+
+	raw := map[string]any{
+		"enforce_macaroons": false,
+		"agent_budgets":     map[string]any{"coder": map[string]any{"cap_usd": 5, "window": "1d"}},
+		"model_pricing":     map[string]any{"m": map[string]any{"input_per_mtok": 1, "output_per_mtok": 2}},
+	}
+	if err := Init(raw); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	got := GetConfig()
+	if !got.EnforceMacaroons || got.AgentBudgets["coder"].CapUSD != 5 || got.ModelPricing["m"].OutputPerMTok != 2 {
+		t.Fatalf("override must not drop sibling fields: %+v", got)
+	}
+}
+
+// An unparseable override must NOT fail Init: a plugin that fails to
+// load leaves bifrost-http serving with no verification at all, which
+// is worse than either mode. It falls back to the config value and
+// flags itself via the source.
+func TestInit_EnvOverride_GarbageFallsBackToConfig(t *testing.T) {
+	t.Cleanup(func() { SetConfigForTest(Config{}) })
+	t.Setenv(env.EnforceMacaroons, "ture")
+
+	if err := Init(map[string]any{"enforce_macaroons": true}); err != nil {
+		t.Fatalf("Init must not fail on a bad override: %v", err)
+	}
+	if got := GetConfig(); !got.EnforceMacaroons || got.EnforceMacaroonsSource != "env-invalid" {
+		t.Fatalf("config true + garbage env: got enforce=%v source=%q, want true/env-invalid", got.EnforceMacaroons, got.EnforceMacaroonsSource)
+	}
+
+	if err := Init(nil); err != nil {
+		t.Fatalf("Init(nil) must not fail on a bad override: %v", err)
+	}
+	if got := GetConfig(); got.EnforceMacaroons || got.EnforceMacaroonsSource != "env-invalid" {
+		t.Fatalf("nil config + garbage env: got enforce=%v source=%q, want false/env-invalid", got.EnforceMacaroons, got.EnforceMacaroonsSource)
 	}
 }

--- a/gateway/internal/auth/doc.go
+++ b/gateway/internal/auth/doc.go
@@ -46,7 +46,12 @@
 //
 // With enforce_macaroons=true the failure path becomes 401/402 with
 // a stable AdapterError.Code. Operators flip the flag per-swarm once
-// the shadow-mode logs show no false positives. See
+// the shadow-mode logs show no false positives — either in the
+// config.json plugin block or, without rebuilding the image, via the
+// BIFROST_PLUGIN_ENFORCE_MACAROONS env var (which wins when set; an
+// unparseable value is logged at ERROR and ignored, because a plugin
+// that fails Init leaves bifrost-http serving with no verification at
+// all — see Init). See
 // gateway/plans/phases/phase-4-macaroon-shape.md ("Verifier
 // algorithm → Bifrost-plugin adapter").
 //

--- a/gateway/internal/env/env.go
+++ b/gateway/internal/env/env.go
@@ -14,6 +14,7 @@
 package env
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
@@ -73,6 +74,18 @@ const (
 	// registry. Defaults to /app/data/trust.json so it sits next to
 	// logs.db on the same data volume.
 	TrustPath = "BIFROST_PLUGIN_TRUST_PATH"
+
+	// EnforceMacaroons overrides the plugin config block's
+	// `enforce_macaroons` flag (gateway/data/config.json). config.json
+	// is baked into the image and re-seeded on every boot, so without
+	// this there is no way to flip a single swarm from shadow to
+	// enforce mode short of shipping a new image. Truthy: 1/true/yes/on;
+	// falsy: 0/false/no/off (case-insensitive). Unset or empty ⇒ the
+	// config.json value stands. Any other value is logged at ERROR and
+	// ignored (config.json value stands; boot line reports
+	// source=env-invalid) — see internal/auth.Init for why that beats
+	// failing the plugin.
+	EnforceMacaroons = "BIFROST_PLUGIN_ENFORCE_MACAROONS"
 
 	// RedisURL is the connection string for the macaroon-enforcement
 	// Redis. In sphinx-swarm this points at the shared redis.sphinx
@@ -234,6 +247,25 @@ func PricingCachePath() string { return GetOr(PricingCache, DefaultPricingCache)
 func RedisURLValue() (string, bool) {
 	u := os.Getenv(RedisURL)
 	return u, u != ""
+}
+
+// EnforceMacaroonsValue parses BIFROST_PLUGIN_ENFORCE_MACAROONS.
+// set=false when the variable is unset or empty (caller keeps the
+// config.json value). err is non-nil for any value outside the
+// recognised truthy/falsy sets — the caller decides what to do with
+// a typo; this package never guesses which way it was meant.
+func EnforceMacaroonsValue() (value bool, set bool, err error) {
+	raw := strings.TrimSpace(os.Getenv(EnforceMacaroons))
+	if raw == "" {
+		return false, false, nil
+	}
+	switch strings.ToLower(raw) {
+	case "1", "true", "yes", "on":
+		return true, true, nil
+	case "0", "false", "no", "off":
+		return false, true, nil
+	}
+	return false, true, fmt.Errorf("%s=%q: want one of 1/true/yes/on or 0/false/no/off", EnforceMacaroons, raw)
 }
 
 // IsProduction reports whether the plugin is running in a

--- a/gateway/internal/env/env_test.go
+++ b/gateway/internal/env/env_test.go
@@ -1,0 +1,42 @@
+package env
+
+import "testing"
+
+func TestEnforceMacaroonsValue(t *testing.T) {
+	cases := []struct {
+		raw       string
+		wantVal   bool
+		wantSet   bool
+		wantError bool
+	}{
+		{"", false, false, false},
+		{"   ", false, false, false},
+		{"true", true, true, false},
+		{"TRUE", true, true, false},
+		{"1", true, true, false},
+		{"yes", true, true, false},
+		{"on", true, true, false},
+		{" true ", true, true, false},
+		{"false", false, true, false},
+		{"0", false, true, false},
+		{"no", false, true, false},
+		{"OFF", false, true, false},
+		// Typos must surface as errors, never as a silent default.
+		{"ture", false, true, true},
+		{"enabled", false, true, true},
+		{"2", false, true, true},
+	}
+	for _, c := range cases {
+		t.Setenv(EnforceMacaroons, c.raw)
+		val, set, err := EnforceMacaroonsValue()
+		if (err != nil) != c.wantError {
+			t.Fatalf("%q: err=%v, wantError=%v", c.raw, err, c.wantError)
+		}
+		if set != c.wantSet {
+			t.Fatalf("%q: set=%v, want %v", c.raw, set, c.wantSet)
+		}
+		if err == nil && val != c.wantVal {
+			t.Fatalf("%q: value=%v, want %v", c.raw, val, c.wantVal)
+		}
+	}
+}

--- a/gateway/main.go
+++ b/gateway/main.go
@@ -54,8 +54,10 @@ const PluginName = "stakgraph-gateway"
 //     and falls back to observability mode. See
 //     gateway/plans/phases/phase-6-plugin-enforcement.md "Namespace".
 //  5. auth.Init + auth.SetTrustRegistry — parses the plugin's
-//     enforce_macaroons flag from the config block and wires the
-//     trust registry into the verifier. See
+//     enforce_macaroons flag from the config block (overridable via
+//     BIFROST_PLUGIN_ENFORCE_MACAROONS; an unparseable value logs an
+//     ERROR and is ignored) and wires the trust registry into the
+//     verifier. See
 //     gateway/plans/phases/phase-4-macaroon-shape.md ("Bifrost-
 //     plugin adapter").
 //  6. adminapi.Start — boots the loopback HTTP server.
@@ -87,7 +89,8 @@ func Init(config any) error {
 		return err
 	}
 	auth.SetTrustRegistry(reg)
-	pluginlog.Logf("auth: macaroon adapter wired enforce=%t", auth.GetConfig().EnforceMacaroons)
+	authCfg := auth.GetConfig()
+	pluginlog.Logf("auth: macaroon adapter wired enforce=%t source=%s", authCfg.EnforceMacaroons, authCfg.EnforceMacaroonsSource)
 
 	// Model-price catalog for the phase-6 accumulator: loads the
 	// persisted datasheet, then fetches bifrost's published sheet in

--- a/gateway/scripts/smoke-test-enforcement.sh
+++ b/gateway/scripts/smoke-test-enforcement.sh
@@ -26,10 +26,14 @@
 #     in the bifrost container logs
 #   - a logs row written with the dim-header values present
 #
+# To exercise enforce mode instead, start the gateway with
+# BIFROST_PLUGIN_ENFORCE_MACAROONS=true (env override of the config.json
+# flag; see docker-compose.yml) — a bad or missing macaroon then 401s
+# while the good-macaroon call below still 200s.
+#
 # Later iterations of this script will add:
 #   - attenuation chain (parent → child macaroons)
-#   - enforce-mode (BIFROST_PLUGIN_ENFORCE_MACAROONS=true → 401 on bad
-#     macaroon, 200 on good)
+#   - enforce-mode assertions (401 on bad macaroon, 200 on good)
 #   - per-run cost cap exceeded (Redis-side accumulator check)
 #   - kill switch (POST /_plugin/runs/:id/kill → next call 402s)
 #

--- a/gateway/scripts/smoke-test-phase-11.sh
+++ b/gateway/scripts/smoke-test-phase-11.sh
@@ -30,7 +30,8 @@
 # the local docker-compose); the log line tells us what the adapter
 # would have done in enforce mode. Promoting these checks to "block
 # the request and assert HTTP status" is a one-line flip of
-# enforce_macaroons in gateway/data/config.json.
+# enforce_macaroons in gateway/data/config.json, or start the gateway
+# with BIFROST_PLUGIN_ENFORCE_MACAROONS=true).
 #
 # Usage
 # -----


### PR DESCRIPTION
## What

`enforce_macaroons` lives in `gateway/data/config.json`, which is baked into the image and re-seeded into the data volume on every boot. Flipping a swarm from shadow to enforce mode therefore needed a new image. sphinx-swarm only passes env vars, so this adds one.

- `BIFROST_PLUGIN_ENFORCE_MACAROONS` overrides the config block when set. Truthy `1/true/yes/on`, falsy `0/false/no/off`, case-insensitive. Unset or empty keeps the config.json value.
- Boot line names the winner so it's greppable: `auth: macaroon adapter wired enforce=<bool> source=env|config|default|env-invalid`.
- Documented in `docker-compose.yml`, the auth package doc, and the two enforcement smoke scripts.

### Why a typo is not fatal

First cut failed `Init` on an unparseable value, matching the trust/redis posture. The live test showed what that actually does: bifrost-http logs `failed to load plugin` and keeps running, the wrapper waits 5s then serves `:8181` with `plugin_routes_enabled=false`, the container reports healthy, and inference flows with **no macaroon verification, no dim canonicalization, and `/_plugin/*` at 503**. That's worse than shadow mode. So a bad value now logs at ERROR, sets `source=env-invalid`, and the config.json value stands. The wrapper's fail-open posture itself is flagged as a separate follow-up.

## Verification

Unit: parser table test in `internal/env`, override tests in `internal/auth` (env over config both directions, nil config, sibling fields preserved, garbage falls back with `env-invalid`). Full suite green.

Live, rebuilt image, three boots:

| env value | boot line | no macaroon | garbage macaroon | valid macaroon |
|---|---|---|---|---|
| `true` | `enforce=true source=env` | 401 `x-macaroon header is required` | 401 malformed | 200, `mode=enforce` |
| unset | `enforce=false source=config` | 200 (shadow) | | |
| `ture` | `enforce=false source=env-invalid` + ERROR line, plugin `active`, `/_plugin/health` 200 | 200 (shadow) | | |

## Outside this repo

`sphinx-swarm/src/images/bifrost.rs` needs to pass `BIFROST_PLUGIN_ENFORCE_MACAROONS` through for per-swarm control.