### PR TITLE
aieo: provider-agnostic web_fetch (HTTP shim off Anthropic) + aieo@0.1.37

### DIFF
--- a/mcp/src/aieo/package.json
+++ b/mcp/src/aieo/package.json
@@ -1,6 +1,6 @@
 {
   "name": "aieo",
-  "version": "0.1.36",
+  "version": "0.1.37",
   "main": "./dist/index.js",
   "type": "module",
   "module": "./dist/index.mjs",
@@ -12,12 +12,13 @@
   "repository": "https://github.com/stakwork/stakgraph",
   "scripts": {
     "build": "tsup",
-    "test": "tsx ./src/__tests__/search.test.ts && tsx ./src/__tests__/provider.test.ts",
+    "test": "tsx ./src/__tests__/search.test.ts && tsx ./src/__tests__/fetch.test.ts && tsx ./src/__tests__/provider.test.ts",
     "try": "ts-node ./src/test/try.ts",
     "try-anthropic": "ts-node ./src/test/try-anthropic.ts",
     "try-kimi": "ts-node ./src/test/try-kimi.ts",
     "try-grok": "tsx ./src/test/try-grok.ts",
     "try-search": "tsx ./src/test/try-search.ts",
+    "try-fetch": "tsx ./src/test/try-fetch.ts",
     "cite-rate": "tsx ./src/test/cite-rate.ts"
   },
   "keywords": [

--- a/mcp/src/aieo/src/__tests__/fetch.test.ts
+++ b/mcp/src/aieo/src/__tests__/fetch.test.ts
@@ -1,0 +1,423 @@
+import {
+  createWebFetch,
+  validateFetchUrl,
+  isPrivateAddress,
+  htmlToText,
+  resolveFetchBackend,
+  captureNativeFetchResults,
+  WEB_FETCH_TOOL_NAME,
+  type WebFetchResult,
+} from "../fetch.js";
+
+type TestCase = { label: string; run: () => Promise<void> | void };
+
+function assert(cond: unknown, msg: string): void {
+  if (!cond) throw new Error(msg);
+}
+
+async function rejects(fn: () => Promise<unknown>, pattern: RegExp, label: string): Promise<void> {
+  try {
+    await fn();
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    assert(pattern.test(msg), `${label}: rejected, but message "${msg}" !~ ${pattern}`);
+    return;
+  }
+  throw new Error(`${label}: expected a rejection`);
+}
+
+const PUBLIC = async () => ["93.184.216.34"];
+const PRIVATE = async () => ["10.0.0.5"];
+const MIXED = async () => ["93.184.216.34", "10.0.0.5"];
+
+/** Stub global fetch; returns the list of URLs it was called with. */
+function stubFetch(handler: (url: string) => Response | Promise<Response>): string[] {
+  const calls: string[] = [];
+  (globalThis as any).fetch = async (url: unknown) => {
+    calls.push(String(url));
+    return handler(String(url));
+  };
+  return calls;
+}
+
+const html = (body: string, headers: Record<string, string> = {}) =>
+  new Response(body, {
+    status: 200,
+    headers: { "content-type": "text/html; charset=utf-8", ...headers },
+  });
+
+const redirect = (to: string, status = 302) =>
+  new Response(null, { status, headers: { location: to } });
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const exec = (t: any, input: any) => t.execute(input, { toolCallId: "t", messages: [] });
+
+const PAGE = `<!doctype html>
+<html><head>
+  <title> Hello &amp; World </title>
+  <style>body { color: red }</style>
+  <script>alert("nope")</script>
+</head>
+<body>
+  <!-- a comment -->
+  <h1>Heading</h1>
+  <p>Tom &amp; Jerry &mdash; &#8220;quoted&#8221; &#x27;x&#x27;&nbsp;done</p>
+  <ul><li>one</li><li>two</li></ul>
+  <svg><text>vector junk</text></svg>
+  <p>Last<br>line</p>
+</body></html>`;
+
+const tests: TestCase[] = [
+  {
+    label: "anthropic keeps the native tool; others fall to http",
+    run() {
+      assert(resolveFetchBackend("anthropic") === "anthropic", "anthropic → anthropic");
+      for (const p of ["openai", "google", "openrouter", "xai"] as const) {
+        assert(resolveFetchBackend(p) === "http", `${p} → http`);
+      }
+    },
+  },
+  {
+    label: "anthropic path: no key → tool undefined; with key → native tool",
+    run() {
+      delete process.env.ANTHROPIC_API_KEY;
+      const none = createWebFetch({ provider: "anthropic" });
+      assert(none.tool === undefined, "tool should be undefined without a key");
+      assert(none.backend === undefined, "backend should be undefined without a key");
+      const native = createWebFetch({ provider: "anthropic", apiKey: "sk-ant-fake" });
+      assert(!!native.tool, "tool present with a key");
+      assert(native.native === true, "anthropic is native");
+      assert(native.backend === "anthropic", "backend is anthropic");
+    },
+  },
+  {
+    label: "http path needs no key",
+    run() {
+      delete process.env.ANTHROPIC_API_KEY;
+      const wf = createWebFetch({ provider: "openai" });
+      assert(!!wf.tool, "tool present");
+      assert(wf.native === false, "shim is not native");
+      assert(wf.backend === "http", "backend is http");
+      assert(WEB_FETCH_TOOL_NAME === "web_fetch", "tool name matches Anthropic's native name");
+    },
+  },
+  {
+    label: "isPrivateAddress classifies v4, v6 and mapped literals",
+    run() {
+      const blocked = [
+        "127.0.0.1", "10.1.2.3", "172.16.0.1", "172.31.255.255", "192.168.1.1",
+        "169.254.169.254", "100.64.0.1", "0.0.0.0", "255.255.255.255", "224.0.0.1",
+        "::1", "::", "fe80::1", "fc00::1", "fd12:3456::1", "ff02::1",
+        "::ffff:127.0.0.1", "::ffff:10.0.0.1", "[::1]", "64:ff9b::a00:1", "2002:a00:1::1",
+        "not-an-ip", "",
+      ];
+      for (const ip of blocked) assert(isPrivateAddress(ip) === true, `${ip} should be private`);
+      const allowed = ["8.8.8.8", "93.184.216.34", "172.32.0.1", "100.128.0.1", "2606:4700::1111", "::ffff:8.8.8.8"];
+      for (const ip of allowed) assert(isPrivateAddress(ip) === false, `${ip} should be public`);
+    },
+  },
+  {
+    label: "validateFetchUrl rejects bad schemes, credentials, local names and private literals",
+    async run() {
+      const cases: Array<[string, RegExp]> = [
+        ["file:///etc/passwd", /http\(s\)/],
+        ["ftp://example.com/x", /http\(s\)/],
+        ["javascript:alert(1)", /http\(s\)|valid absolute/],
+        ["not a url", /valid absolute/],
+        ["https://user:pw@example.com/", /credentials/],
+        ["http://localhost:3000/", /local/],
+        ["http://api.localhost/", /local/],
+        ["http://127.0.0.1/", /private or reserved/],
+        ["http://[::1]/", /private or reserved/],
+        ["http://2130706433/", /private or reserved/],
+        ["http://0x7f000001/", /private or reserved/],
+        ["http://169.254.169.254/latest/meta-data", /private or reserved/],
+        ["http://10.0.0.1:8080/", /private or reserved/],
+      ];
+      for (const [url, pattern] of cases) {
+        await rejects(() => validateFetchUrl(url, { lookup: PUBLIC }), pattern, url);
+      }
+    },
+  },
+  {
+    label: "validateFetchUrl resolves hostnames and refuses private or mixed answers",
+    async run() {
+      const ok = await validateFetchUrl("https://example.com/page", { lookup: PUBLIC });
+      assert(ok.hostname === "example.com", "public host passes");
+      await rejects(
+        () => validateFetchUrl("https://intranet.example.com/", { lookup: PRIVATE }),
+        /resolves to a private/,
+        "private resolution",
+      );
+      await rejects(
+        () => validateFetchUrl("https://mixed.example.com/", { lookup: MIXED }),
+        /resolves to a private/,
+        "mixed resolution",
+      );
+      await rejects(
+        () => validateFetchUrl("https://nope.example.com/", { lookup: async () => [] }),
+        /Could not resolve/,
+        "empty resolution",
+      );
+      await rejects(
+        () => validateFetchUrl("https://nx.example.com/", { lookup: async () => { throw new Error("ENOTFOUND"); } }),
+        /Could not resolve .*ENOTFOUND/,
+        "resolver error",
+      );
+      const literal = await validateFetchUrl("http://93.184.216.34/", {
+        lookup: async () => { throw new Error("should not resolve a literal"); },
+      });
+      assert(literal.hostname === "93.184.216.34", "public literal passes without DNS");
+    },
+  },
+  {
+    label: "allowed and blocked domains match the host and its subdomains",
+    async run() {
+      const allow = { lookup: PUBLIC, allowedDomains: ["example.com", "https://docs.other.org/"] };
+      await validateFetchUrl("https://example.com/", allow);
+      await validateFetchUrl("https://deep.docs.example.com/", allow);
+      await validateFetchUrl("https://docs.other.org/x", allow);
+      await rejects(() => validateFetchUrl("https://notexample.com/", allow), /not in the allowed/, "suffix trick");
+      await rejects(() => validateFetchUrl("https://other.org/", allow), /not in the allowed/, "parent of allowed sub");
+      const block = { lookup: PUBLIC, blockedDomains: ["evil.com"] };
+      await validateFetchUrl("https://fine.com/", block);
+      await rejects(() => validateFetchUrl("https://sub.evil.com/", block), /blocked/, "blocked subdomain");
+    },
+  },
+  {
+    label: "http path converts html to text and records the page",
+    async run() {
+      stubFetch(() => html(PAGE));
+      const wf = createWebFetch({ provider: "openai", lookup: PUBLIC });
+      const out = (await exec(wf.tool, { url: "https://example.com/page" })) as WebFetchResult;
+      assert(out.type === "web_fetch_result", `type: ${JSON.stringify(out)}`);
+      assert(out.title === "Hello & World", `title: ${out.title}`);
+      assert(out.text!.includes("Tom & Jerry — “quoted” 'x' done"), `entities: ${out.text}`);
+      assert(!out.text!.includes("alert"), "script removed");
+      assert(!out.text!.includes("color"), "style removed");
+      assert(!out.text!.includes("vector junk"), "svg removed");
+      assert(!out.text!.includes("comment"), "comment removed");
+      assert(out.text!.includes("- one\n- two"), `list items: ${out.text}`);
+      assert(out.text!.includes("Last\nline"), `br: ${out.text}`);
+      assert(out.text!.startsWith("Heading"), `leading: ${out.text!.slice(0, 20)}`);
+      assert(out.mediaType === "text/html", `mediaType: ${out.mediaType}`);
+      assert(out.truncated === false, "not truncated");
+      assert(out.url === "https://example.com/page", `url: ${out.url}`);
+      assert(!Number.isNaN(Date.parse(out.retrievedAt!)), "retrievedAt is a date");
+      assert(wf.results.length === 1 && wf.results[0] === out, "recorded in results");
+    },
+  },
+  {
+    label: "htmlToText shapes blocks, lists and breaks",
+    run() {
+      const { title, text } = htmlToText("<h1>Title</h1><p>a<br>b</p><ul><li>x</li><li>y</li></ul>");
+      assert(title === null, "no title");
+      assert(text === "Title\n\na\nb\n\n- x\n- y", `got: ${JSON.stringify(text)}`);
+      assert(htmlToText("&amp;lt; &#0; &#xZZ;").text === "&lt; &#0; &#xZZ;", "double-encoded and invalid entities survive");
+    },
+  },
+  {
+    label: "text budget truncates and flags; maxContentTokens alone derives it",
+    async run() {
+      const body = `<html><body><p>${"x".repeat(500)}</p></body></html>`;
+      stubFetch(() => html(body));
+      const chars = createWebFetch({ provider: "openai", lookup: PUBLIC, maxCharacters: 50 });
+      const a = (await exec(chars.tool, { url: "https://example.com/" })) as WebFetchResult;
+      assert(a.text!.length === 50 && a.truncated === true, `chars: len=${a.text!.length} truncated=${a.truncated}`);
+      const tokens = createWebFetch({ provider: "openai", lookup: PUBLIC, maxContentTokens: 10 });
+      const b = (await exec(tokens.tool, { url: "https://example.com/" })) as WebFetchResult;
+      assert(b.text!.length === 40 && b.truncated === true, `tokens: len=${b.text!.length}`);
+    },
+  },
+  {
+    label: "json and plain text pass through; html served as text/plain is sniffed",
+    async run() {
+      stubFetch(() => new Response('{"a":1}', { status: 200, headers: { "content-type": "application/json" } }));
+      const wf = createWebFetch({ provider: "google", lookup: PUBLIC });
+      const j = (await exec(wf.tool, { url: "https://api.example.com/x" })) as WebFetchResult;
+      assert(j.text === '{"a":1}' && j.title === null && j.mediaType === "application/json", `json: ${JSON.stringify(j)}`);
+
+      stubFetch(() => new Response("<!doctype html><html><head><title>T</title></head><body>hi</body></html>", {
+        status: 200, headers: { "content-type": "text/plain" },
+      }));
+      const s = (await exec(wf.tool, { url: "https://example.com/raw" })) as WebFetchResult;
+      assert(s.title === "T" && s.text === "hi", `sniffed: ${JSON.stringify(s)}`);
+
+      stubFetch(() => new Response(new Uint8Array([0xe9, 0x74, 0xe9]), {
+        status: 200, headers: { "content-type": "text/plain; charset=iso-8859-1" },
+      }));
+      const l = (await exec(wf.tool, { url: "https://example.com/latin" })) as WebFetchResult;
+      assert(l.text === "été", `charset honored: ${l.text}`);
+    },
+  },
+  {
+    label: "redirects are followed hop by hop and every hop is re-validated",
+    async run() {
+      const calls = stubFetch((url) =>
+        url === "https://example.com/start" ? redirect("/next")
+        : url === "https://example.com/next" ? redirect("https://final.example.org/page", 301)
+        : html("<title>Final</title>"),
+      );
+      const wf = createWebFetch({ provider: "xai", lookup: PUBLIC });
+      const out = (await exec(wf.tool, { url: "https://example.com/start" })) as WebFetchResult;
+      assert(out.url === "https://final.example.org/page", `final url: ${out.url}`);
+      assert(out.title === "Final", "landed on the final page");
+      assert(calls.length === 3, `hops: ${calls.length}`);
+
+      stubFetch(() => redirect("http://169.254.169.254/latest/meta-data"));
+      const ssrf = (await exec(wf.tool, { url: "https://example.com/open-redirect" })) as { error?: string };
+      assert(/private or reserved/.test(ssrf.error ?? ""), `redirect to metadata blocked: ${ssrf.error}`);
+
+      const resolver = async (host: string) => (host === "internal.example.com" ? ["10.0.0.9"] : ["93.184.216.34"]);
+      stubFetch(() => redirect("https://internal.example.com/"));
+      const wf2 = createWebFetch({ provider: "xai", lookup: resolver });
+      const hop = (await exec(wf2.tool, { url: "https://example.com/" })) as { error?: string };
+      assert(/resolves to a private/.test(hop.error ?? ""), `redirect to private host blocked: ${hop.error}`);
+
+      let n = 0;
+      stubFetch(() => redirect(`https://example.com/loop${n++}`));
+      const loop = (await exec(wf.tool, { url: "https://example.com/loop" })) as { error?: string };
+      assert(/Too many redirects/.test(loop.error ?? ""), `loop: ${loop.error}`);
+
+      stubFetch(() => new Response(null, { status: 302 }));
+      const bare = (await exec(wf.tool, { url: "https://example.com/bare" })) as { error?: string };
+      assert(/without a Location/.test(bare.error ?? ""), `bare redirect: ${bare.error}`);
+    },
+  },
+  {
+    label: "http errors, unsupported types and pdfs come back as errors, not throws",
+    async run() {
+      // Seven failing calls below; keep them under the budget so the last
+      // ones don't trip the maxUses guard instead of the case under test.
+      const wf = createWebFetch({ provider: "openai", lookup: PUBLIC, maxUses: 20 });
+      stubFetch(() => new Response("gone", { status: 404 }));
+      const nf = (await exec(wf.tool, { url: "https://example.com/missing" })) as { error?: string };
+      assert(/HTTP 404/.test(nf.error ?? ""), `404: ${nf.error}`);
+
+      stubFetch(() => new Response(new Uint8Array([1, 2, 3]), { status: 200, headers: { "content-type": "image/png" } }));
+      const img = (await exec(wf.tool, { url: "https://example.com/a.png" })) as { error?: string };
+      assert(/Unsupported content type: image\/png/.test(img.error ?? ""), `png: ${img.error}`);
+
+      stubFetch(() => new Response("%PDF-1.4", { status: 200, headers: { "content-type": "application/pdf" } }));
+      const pdf = (await exec(wf.tool, { url: "https://example.com/a.pdf" })) as { error?: string };
+      assert(/PDF/.test(pdf.error ?? ""), `pdf: ${pdf.error}`);
+
+      (globalThis as any).fetch = async () => {
+        throw Object.assign(new TypeError("fetch failed"), {
+          cause: Object.assign(new Error("certificate has expired"), { code: "CERT_HAS_EXPIRED" }),
+        });
+      };
+      const down = (await exec(wf.tool, { url: "https://example.com/" })) as { error?: string };
+      assert(
+        /Could not connect to example\.com: certificate has expired \(CERT_HAS_EXPIRED\)/.test(down.error ?? ""),
+        `transport cause surfaced: ${down.error}`,
+      );
+
+      (globalThis as any).fetch = async () => {
+        throw new DOMException("The operation was aborted due to timeout", "TimeoutError");
+      };
+      const slow = (await exec(wf.tool, { url: "https://example.com/" })) as { error?: string };
+      assert(/timed out/.test(slow.error ?? ""), `timeout: ${slow.error}`);
+
+      (globalThis as any).fetch = async () => { throw new TypeError("fetch failed"); };
+      const bare = (await exec(wf.tool, { url: "https://example.com/" })) as { error?: string };
+      assert(/fetch failed/.test(bare.error ?? ""), `no cause falls back to message: ${bare.error}`);
+
+      const bad = (await exec(wf.tool, { url: "file:///etc/passwd" })) as { error?: string };
+      assert(/http\(s\)/.test(bad.error ?? ""), `guard surfaces to the model: ${bad.error}`);
+      assert(wf.results.length === 0, "failures record nothing");
+    },
+  },
+  {
+    label: "maxUses is enforced in-process on the http path",
+    async run() {
+      stubFetch(() => html("<title>a</title>"));
+      const wf = createWebFetch({ provider: "openai", lookup: PUBLIC, maxUses: 1 });
+      await exec(wf.tool, { url: "https://example.com/1" });
+      const blocked = (await exec(wf.tool, { url: "https://example.com/2" })) as { error?: string };
+      assert(/budget exhausted/.test(blocked.error ?? ""), `second call refused: ${blocked.error}`);
+      assert(wf.results.length === 1, "refused call adds no results");
+    },
+  },
+  {
+    label: "capture() is a no-op on the http path (no double-count)",
+    async run() {
+      stubFetch(() => html("<title>a</title>"));
+      const wf = createWebFetch({ provider: "openai", lookup: PUBLIC });
+      await exec(wf.tool, { url: "https://example.com/" });
+      wf.capture([
+        {
+          type: "tool-result",
+          toolName: WEB_FETCH_TOOL_NAME,
+          output: { type: "web_fetch_result", url: "https://example.com/", content: { title: "a", source: { type: "text", data: "a" } } },
+        },
+      ]);
+      assert(wf.results.length === 1, `expected 1 result, got ${wf.results.length}`);
+    },
+  },
+  {
+    label: "captureNativeFetchResults walks output and result shapes, skips errors and junk",
+    run() {
+      const target: WebFetchResult[] = [];
+      captureNativeFetchResults(
+        [
+          {
+            type: "tool-result",
+            toolName: WEB_FETCH_TOOL_NAME,
+            output: {
+              type: "web_fetch_result",
+              url: "https://a.com",
+              retrievedAt: "2026-09-10T00:00:00Z",
+              content: { type: "document", title: "A", source: { type: "text", mediaType: "text/plain", data: "page text" } },
+            },
+          },
+          {
+            type: "tool-result",
+            toolName: WEB_FETCH_TOOL_NAME,
+            result: {
+              type: "web_fetch_result",
+              url: "https://b.com/doc.pdf",
+              retrieved_at: null,
+              content: { type: "document", title: null, source: { type: "base64", media_type: "application/pdf", data: "JVBERi0=" } },
+            },
+          },
+          {
+            type: "tool-result",
+            toolName: WEB_FETCH_TOOL_NAME,
+            isError: true,
+            output: { type: "web_fetch_tool_result_error", errorCode: "url_not_accessible" },
+          },
+          { type: "tool-result", toolName: "other_tool", output: { type: "web_fetch_result", url: "https://nope.com" } },
+          { type: "tool-result", toolName: WEB_FETCH_TOOL_NAME, output: "not an object" },
+          { type: "text", text: "hi" },
+        ],
+        target,
+      );
+      assert(target.length === 2, `expected 2, got ${target.length}`);
+      assert(target[0].text === "page text" && target[0].title === "A", "text source captured");
+      assert(target[0].mediaType === "text/plain" && target[0].retrievedAt === "2026-09-10T00:00:00Z", "fields mapped");
+      assert(target[1].text === undefined, "pdf base64 is not surfaced as text");
+      assert(target[1].mediaType === "application/pdf" && target[1].title === null, "snake_case shape tolerated");
+      captureNativeFetchResults("not an array", target);
+      assert(target.length === 2, "non-array content ignored");
+    },
+  },
+];
+
+let passed = 0;
+let failed = 0;
+
+for (const tc of tests) {
+  try {
+    await tc.run();
+    console.log(`✅ PASS: ${tc.label}`);
+    passed++;
+  } catch (err: any) {
+    console.error(`❌ FAIL: ${tc.label}`);
+    console.error(`   ${err.message}`);
+    failed++;
+  }
+}
+
+console.log(`\nResults: ${passed} passed, ${failed} failed`);
+if (failed > 0) process.exit(1);

--- a/mcp/src/aieo/src/fetch.ts
+++ b/mcp/src/aieo/src/fetch.ts
@@ -1,0 +1,679 @@
+import { tool } from "ai";
+import { z } from "zod";
+import { createAnthropic } from "@ai-sdk/anthropic";
+import { BlockList, isIP } from "node:net";
+import { lookup as dnsLookup } from "node:dns/promises";
+import { Provider, getGatewayBaseURL, normalizeApiKey } from "./provider.js";
+
+/**
+ * Web fetch, uniform across providers. Sibling of `./search.js`.
+ *
+ * Anthropic ships a server-executed `web_fetch` tool: given a URL, their
+ * API retrieves the page (HTML or PDF), turns it into text and hands it
+ * to the model with no round-trip through us. Same reasons that make it
+ * the best option when available: no extra hop, nothing to host,
+ * nothing to secure.
+ *
+ * Nobody else has one. So, as with search: keep Anthropic native, and
+ * give every other provider a client-executed tool of the same name and
+ * result shape, backed by a plain HTTP GET plus an HTML-to-text pass.
+ *
+ * Two things differ from search that consumers should know:
+ *
+ *   1. On the Anthropic path the model can only fetch URLs that already
+ *      appeared in the conversation — pasted by the user, or returned by
+ *      an earlier `web_search` / `web_fetch`. It refuses URLs it made
+ *      up. The HTTP path has no such memory and fetches whatever the
+ *      model asks for; what it WON'T do is reach anything private.
+ *
+ *   2. The HTTP path runs in *our* process, so the model can point it at
+ *      our network. Every URL — and every redirect hop — is checked
+ *      before connecting: http(s) only, no credentials, and the host
+ *      must resolve exclusively to public unicast addresses (loopback,
+ *      RFC 1918, link-local incl. cloud metadata, CGNAT, ULA and the
+ *      v4-in-v6 forms are all refused). There is a DNS-rebinding window
+ *      between our lookup and the socket's own; pin `allowedDomains` if
+ *      the deployment cares.
+ *
+ * Usage:
+ *
+ *   const wf = createWebFetch({ provider, apiKey });
+ *   const tools = { ...(wf.tool ? { [WEB_FETCH_TOOL_NAME]: wf.tool } : {}) };
+ *   // in onStepFinish:  wf.capture(step.content)
+ *   // afterwards:       wf.results — every page fetched, in order
+ */
+
+/** Tool name registered with the model. Matches Anthropic's native name
+ *  so consumers key UI and step-walking off one string on both paths. */
+export const WEB_FETCH_TOOL_NAME = "web_fetch";
+
+/** Which implementation backs the tool. */
+export type FetchBackend = "anthropic" | "http";
+
+/**
+ * One fetched page. Same fields on both paths; the notes say where the
+ * backends differ in what they put in them.
+ */
+export interface WebFetchResult {
+  /** Where the content came from. The final URL after redirects on the
+   *  HTTP path; the URL Anthropic reports on the native path. */
+  url: string;
+  title: string | null;
+  /**
+   * Extracted text. Absent for a PDF on the Anthropic path — their API
+   * returns it base64-encoded, which is only useful to their model.
+   */
+  text?: string;
+  /** Original `content-type` on the HTTP path; Anthropic's normalized
+   *  `text/plain` / `application/pdf` on the native path. */
+  mediaType: string | null;
+  retrievedAt: string | null;
+  /** True when the HTTP path cut the text at `maxCharacters`. */
+  truncated?: boolean;
+  type: "web_fetch_result";
+}
+
+export interface WebFetchOptions {
+  /** Max `web_fetch` calls per run. Default 5. Enforced in-process on
+   *  the HTTP path, passed as `max_uses` to Anthropic. */
+  maxUses?: number;
+  /**
+   * Text budget per page on the HTTP path, in characters. Default
+   * 40000 — about 10k tokens. When only `maxContentTokens` is given,
+   * derived from it at 4 chars/token so one option covers both paths.
+   */
+  maxCharacters?: number;
+  /**
+   * Content budget per page on the Anthropic path, in tokens (their
+   * `max_content_tokens`). Unset means Anthropic's own default. When
+   * only `maxCharacters` is given, derived from it.
+   */
+  maxContentTokens?: number;
+  /** Only fetch from these domains. Subdomains are included, so
+   *  `example.com` admits `docs.example.com`. */
+  allowedDomains?: string[];
+  blockedDomains?: string[];
+}
+
+/** Resolve a hostname to every address it answers with. */
+export type HostLookup = (hostname: string) => Promise<string[]>;
+
+export interface CreateWebFetchOptions extends WebFetchOptions {
+  /** LLM provider driving the run — decides the backend. */
+  provider: Provider;
+  /** LLM API key. Only used on the Anthropic path. Falls back to env. */
+  apiKey?: string;
+  /** Force a backend regardless of provider. `"http"` is how you A/B
+   *  the shim against Anthropic's native tool on identical prompts. */
+  backend?: FetchBackend;
+  abortSignal?: AbortSignal;
+  /**
+   * Override hostname resolution on the HTTP path. Tests inject a stub
+   * here; a deployment with its own resolver policy can too. Must return
+   * every address the host resolves to — the guard refuses a host if ANY
+   * of them is private.
+   */
+  lookup?: HostLookup;
+}
+
+export interface WebFetchHandle {
+  /** Register under {@link WEB_FETCH_TOOL_NAME}. `undefined` only when
+   *  the Anthropic path has no API key — drop the tool rather than
+   *  failing the request. The HTTP path needs no key. */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  tool: any | undefined;
+  backend: FetchBackend | undefined;
+  /** True when the fetch runs server-side (Anthropic). */
+  native: boolean;
+  /** Every page fetched during the run, in order. */
+  results: WebFetchResult[];
+  /**
+   * Feed each step's content here (AI SDK `onStepFinish`). Walks
+   * Anthropic tool-results into `results`; a no-op on the HTTP path,
+   * where `execute` already appended them. Safe to call either way.
+   */
+  capture(stepContent: unknown): void;
+}
+
+const DEFAULT_MAX_USES = 5;
+const DEFAULT_MAX_CHARACTERS = 40_000;
+const CHARS_PER_TOKEN = 4;
+const DEFAULT_TIMEOUT_MS = 20_000;
+const MAX_REDIRECTS = 5;
+/** Raw bytes read from a response before giving up on it. HTML runs
+ *  several times its text; 4 MiB covers any page whose text fits the
+ *  default budget with room to spare. */
+const MAX_BODY_BYTES = 4 * 1024 * 1024;
+const USER_AGENT = "aieo-web-fetch/1 (+https://github.com/stakwork/stakgraph)";
+const ACCEPT =
+  "text/html, application/xhtml+xml, text/plain;q=0.9, application/json;q=0.9, text/*;q=0.8, */*;q=0.5";
+
+/**
+ * Which backend a provider gets. Anthropic keeps its native tool;
+ * everything else falls to the HTTP shim.
+ */
+export function resolveFetchBackend(provider: Provider): FetchBackend {
+  return provider === "anthropic" ? "anthropic" : "http";
+}
+
+// ── Address guard ──────────────────────────────────────────────────────
+
+/**
+ * Addresses the HTTP path never connects to. Built once.
+ *
+ * `BlockList` checks an IPv4-mapped IPv6 address (`::ffff:a.b.c.d`)
+ * against the v4 rules by itself. NAT64 and 6to4 embed a v4 address in
+ * a way it doesn't unpack, so those prefixes are refused whole — neither
+ * is a plausible target for a page fetch.
+ */
+const PRIVATE_ADDRESSES = buildBlockList();
+
+function buildBlockList(): BlockList {
+  const b = new BlockList();
+  const v4: Array<[string, number]> = [
+    ["0.0.0.0", 8], // "this" network
+    ["10.0.0.0", 8], // RFC 1918
+    ["100.64.0.0", 10], // carrier-grade NAT
+    ["127.0.0.0", 8], // loopback
+    ["169.254.0.0", 16], // link-local, incl. cloud metadata at 169.254.169.254
+    ["172.16.0.0", 12], // RFC 1918
+    ["192.0.0.0", 24], // IETF protocol assignments
+    ["192.168.0.0", 16], // RFC 1918
+    ["198.18.0.0", 15], // benchmarking
+    ["224.0.0.0", 4], // multicast
+    ["240.0.0.0", 4], // reserved, incl. broadcast
+  ];
+  for (const [net, prefix] of v4) b.addSubnet(net, prefix, "ipv4");
+  b.addAddress("::", "ipv6"); // unspecified
+  b.addAddress("::1", "ipv6"); // loopback
+  const v6: Array<[string, number]> = [
+    ["64:ff9b::", 96], // NAT64
+    ["2002::", 16], // 6to4
+    ["fc00::", 7], // unique local
+    ["fe80::", 10], // link-local
+    ["fec0::", 10], // site-local (deprecated, still routed on old gear)
+    ["ff00::", 8], // multicast
+  ];
+  for (const [net, prefix] of v6) b.addSubnet(net, prefix, "ipv6");
+  return b;
+}
+
+/**
+ * True for an IP literal (v4 or v6, brackets tolerated) the HTTP path
+ * refuses to connect to. Anything that isn't an IP literal is `true`
+ * too: an address we can't classify isn't one we connect to.
+ */
+export function isPrivateAddress(ip: string): boolean {
+  const bare = ip.startsWith("[") && ip.endsWith("]") ? ip.slice(1, -1) : ip;
+  const family = isIP(bare);
+  try {
+    if (family === 4) return PRIVATE_ADDRESSES.check(bare, "ipv4");
+    if (family === 6) return PRIVATE_ADDRESSES.check(bare, "ipv6");
+  } catch {
+    // Zone ids and other oddities BlockList can't parse.
+  }
+  return true;
+}
+
+const defaultLookup: HostLookup = async (hostname) => {
+  const addresses = await dnsLookup(hostname, { all: true });
+  return addresses.map((a) => a.address);
+};
+
+function matchesDomain(host: string, domains: string[]): boolean {
+  return domains.some((d) => {
+    const dom = d
+      .trim()
+      .toLowerCase()
+      .replace(/^https?:\/\//, "")
+      .replace(/\/.*$/, "")
+      .replace(/^\*\./, "")
+      .replace(/\.$/, "");
+    return !!dom && (host === dom || host.endsWith("." + dom));
+  });
+}
+
+/**
+ * Validate a URL before the HTTP path connects to it. Throws a readable
+ * error on any rejection — the model gets the message back as the
+ * tool's `error` and can pick a different URL.
+ *
+ * A hostname is resolved and refused if ANY of its addresses is
+ * private: a host that answers with a mix is misconfigured or hostile,
+ * and we'd have no say in which address the socket picks.
+ */
+export async function validateFetchUrl(
+  raw: string,
+  opts: { allowedDomains?: string[]; blockedDomains?: string[]; lookup?: HostLookup } = {},
+): Promise<URL> {
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    throw new Error(`Not a valid absolute URL: ${raw}`);
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") {
+    throw new Error(`Only http(s) URLs can be fetched, got ${url.protocol}`);
+  }
+  if (url.username || url.password) {
+    throw new Error("URLs with embedded credentials are not fetched");
+  }
+  // WHATWG parsing already normalized the numeric IPv4 forms
+  // (`http://2130706433/`, `http://0x7f.1/`) to dotted quads.
+  const host = url.hostname.replace(/\.$/, "").toLowerCase();
+  if (!host) throw new Error("URL has no host");
+  if (host === "localhost" || host.endsWith(".localhost")) {
+    throw new Error("Refusing to fetch a local address");
+  }
+  if (opts.allowedDomains?.length && !matchesDomain(host, opts.allowedDomains)) {
+    throw new Error(`${host} is not in the allowed domains`);
+  }
+  if (opts.blockedDomains?.length && matchesDomain(host, opts.blockedDomains)) {
+    throw new Error(`${host} is a blocked domain`);
+  }
+
+  const literal = host.startsWith("[") ? host.slice(1, -1) : host;
+  if (isIP(literal)) {
+    if (isPrivateAddress(literal)) {
+      throw new Error("Refusing to fetch a private or reserved address");
+    }
+    return url;
+  }
+
+  let addresses: string[];
+  try {
+    addresses = await (opts.lookup ?? defaultLookup)(host);
+  } catch (err) {
+    throw new Error(
+      `Could not resolve ${host}: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+  if (!addresses.length) throw new Error(`Could not resolve ${host}`);
+  if (addresses.some(isPrivateAddress)) {
+    throw new Error(`Refusing to fetch ${host}: it resolves to a private or reserved address`);
+  }
+  return url;
+}
+
+// ── HTTP path ──────────────────────────────────────────────────────────
+
+export interface FetchUrlOptions {
+  maxCharacters?: number;
+  allowedDomains?: string[];
+  blockedDomains?: string[];
+  abortSignal?: AbortSignal;
+  timeoutMs?: number;
+  lookup?: HostLookup;
+}
+
+/**
+ * Raw fetch-and-extract. Exposed for callers that want a page without
+ * an LLM in the loop (a URL enrichment pass, a link preview).
+ *
+ * Throws on any rejection or failure — {@link createWebFetch} catches
+ * and hands the model a readable error instead of failing the turn.
+ */
+export async function fetchUrl(
+  rawUrl: string,
+  opts: FetchUrlOptions = {},
+): Promise<WebFetchResult> {
+  const maxCharacters = opts.maxCharacters ?? DEFAULT_MAX_CHARACTERS;
+  const signals = [AbortSignal.timeout(opts.timeoutMs ?? DEFAULT_TIMEOUT_MS)];
+  if (opts.abortSignal) signals.push(opts.abortSignal);
+  const signal = AbortSignal.any(signals);
+
+  let url = await validateFetchUrl(rawUrl, opts);
+  let res: Response;
+  for (let hop = 0; ; hop++) {
+    try {
+      res = await fetch(url, {
+        method: "GET",
+        redirect: "manual",
+        signal,
+        headers: { "user-agent": USER_AGENT, accept: ACCEPT },
+      });
+    } catch (err) {
+      throw new Error(`Could not connect to ${url.hostname}: ${describeTransportError(err)}`);
+    }
+    if (!isRedirect(res.status)) break;
+    // Every hop is re-validated: a public host that 302s to
+    // 169.254.169.254 is the classic SSRF bypass.
+    const location = res.headers.get("location");
+    await discard(res);
+    if (!location) throw new Error(`Redirect (${res.status}) without a Location header`);
+    if (hop >= MAX_REDIRECTS) throw new Error(`Too many redirects (more than ${MAX_REDIRECTS})`);
+    let next: string;
+    try {
+      next = new URL(location, url).toString();
+    } catch {
+      throw new Error(`Redirect to an invalid URL: ${location}`);
+    }
+    url = await validateFetchUrl(next, opts);
+  }
+
+  if (!res.ok) {
+    await discard(res);
+    throw new Error(`HTTP ${res.status} fetching ${url.hostname}`);
+  }
+  const contentType = res.headers.get("content-type") ?? "";
+  const mediaType = contentType.split(";")[0].trim().toLowerCase() || null;
+  if (mediaType === "application/pdf") {
+    await discard(res);
+    throw new Error(
+      "PDF documents are not supported by this fetch backend (only Anthropic's native web_fetch reads PDFs)",
+    );
+  }
+  if (!isTextual(mediaType)) {
+    await discard(res);
+    throw new Error(`Unsupported content type: ${mediaType}`);
+  }
+
+  const { bytes, capped } = await readCapped(res, MAX_BODY_BYTES);
+  const raw = decode(bytes, contentType);
+  const isHtml =
+    mediaType === "text/html" || mediaType === "application/xhtml+xml" || looksLikeHtml(raw);
+  const { title, text } = isHtml ? htmlToText(raw) : { title: null, text: raw.trim() };
+  const truncated = capped || text.length > maxCharacters;
+  return {
+    url: url.toString(),
+    title,
+    text: truncated ? text.slice(0, maxCharacters) : text,
+    mediaType,
+    retrievedAt: new Date().toISOString(),
+    truncated,
+    type: "web_fetch_result",
+  };
+}
+
+/**
+ * undici wraps every transport failure as `TypeError: fetch failed` and
+ * puts the real reason on `cause` — an expired certificate, ECONNREFUSED,
+ * a reset. Surface that: "fetch failed" tells the model (and whoever
+ * reads the logs) nothing.
+ */
+function describeTransportError(err: unknown): string {
+  const e = err as {
+    name?: string;
+    message?: string;
+    cause?: { code?: string; message?: string };
+  };
+  if (e?.name === "TimeoutError") return "timed out";
+  if (e?.name === "AbortError") return "aborted";
+  const cause = e?.cause;
+  if (cause?.message) return cause.code ? `${cause.message} (${cause.code})` : cause.message;
+  return e?.message ?? String(err);
+}
+
+function isRedirect(status: number): boolean {
+  return status === 301 || status === 302 || status === 303 || status === 307 || status === 308;
+}
+
+/** Release a response we won't read, so its connection goes back to the pool. */
+async function discard(res: Response): Promise<void> {
+  await res.body?.cancel().catch(() => {});
+}
+
+function isTextual(mediaType: string | null): boolean {
+  // No header at all: read it and sniff.
+  if (!mediaType) return true;
+  if (mediaType.startsWith("text/")) return true;
+  if (mediaType.endsWith("+json") || mediaType.endsWith("+xml")) return true;
+  return (
+    mediaType === "application/json" ||
+    mediaType === "application/xml" ||
+    mediaType === "application/xhtml+xml" ||
+    mediaType === "application/javascript"
+  );
+}
+
+async function readCapped(
+  res: Response,
+  maxBytes: number,
+): Promise<{ bytes: Uint8Array; capped: boolean }> {
+  const body = res.body;
+  if (!body) return { bytes: new Uint8Array(await res.arrayBuffer()), capped: false };
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  let capped = false;
+  for (;;) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (!value) continue;
+    if (total + value.byteLength > maxBytes) {
+      chunks.push(value.subarray(0, maxBytes - total));
+      total = maxBytes;
+      capped = true;
+      await reader.cancel().catch(() => {});
+      break;
+    }
+    chunks.push(value);
+    total += value.byteLength;
+  }
+  const out = new Uint8Array(total);
+  let offset = 0;
+  for (const c of chunks) {
+    out.set(c, offset);
+    offset += c.byteLength;
+  }
+  return { bytes: out, capped };
+}
+
+function decode(bytes: Uint8Array, contentType: string): string {
+  const charset = /charset=["']?([\w.:-]+)/i.exec(contentType)?.[1] ?? "utf-8";
+  try {
+    return new TextDecoder(charset).decode(bytes);
+  } catch {
+    return new TextDecoder("utf-8").decode(bytes);
+  }
+}
+
+function looksLikeHtml(s: string): boolean {
+  return /^\s*(?:<!doctype\s+html|<html[\s>]|<head[\s>]|<body[\s>])/i.test(s.slice(0, 1024));
+}
+
+// ── HTML → text ────────────────────────────────────────────────────────
+
+const NAMED_ENTITIES: Record<string, string> = {
+  nbsp: " ",
+  lt: "<",
+  gt: ">",
+  quot: '"',
+  apos: "'",
+  mdash: "—",
+  ndash: "–",
+  hellip: "…",
+  copy: "©",
+  reg: "®",
+  trade: "™",
+  laquo: "«",
+  raquo: "»",
+  ldquo: "“",
+  rdquo: "”",
+  lsquo: "‘",
+  rsquo: "’",
+  bull: "•",
+  middot: "·",
+  times: "×",
+  deg: "°",
+};
+
+function codePoint(cp: number, fallback: string): string {
+  if (!Number.isFinite(cp) || cp <= 0 || cp > 0x10ffff || (cp >= 0xd800 && cp <= 0xdfff)) {
+    return fallback;
+  }
+  return String.fromCodePoint(cp);
+}
+
+/** Numeric and the common named entities. `&amp;` goes last so
+ *  `&amp;lt;` decodes to the literal `&lt;` the author wrote. */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&#x([0-9a-f]{1,6});/gi, (m, hex: string) => codePoint(parseInt(hex, 16), m))
+    .replace(/&#(\d{1,7});/g, (m, dec: string) => codePoint(parseInt(dec, 10), m))
+    .replace(/&([a-z]+);/gi, (m, name: string) => NAMED_ENTITIES[name.toLowerCase()] ?? m)
+    .replace(/&amp;/g, "&");
+}
+
+const BLOCK_TAGS =
+  "p|div|section|article|header|footer|main|aside|nav|h[1-6]|ul|ol|tr|table|thead|tbody|tfoot|blockquote|pre|hr|dd|dt|dl|figure|figcaption|form|fieldset|address|details|summary";
+
+/**
+ * Dependency-free HTML to text. Good enough for a model to read a page;
+ * not a renderer. Scripts, styles and SVG go away entirely; block-level
+ * boundaries become line breaks; list items get a leading dash; the
+ * rest of the markup is dropped and entities decoded. Whitespace is
+ * collapsed except for line breaks, so `<pre>` keeps its lines but not
+ * its indentation.
+ */
+export function htmlToText(html: string): { title: string | null; text: string } {
+  const titleMatch = /<title[^>]*>([\s\S]*?)<\/title>/i.exec(html);
+  const title = titleMatch
+    ? decodeEntities(titleMatch[1]).replace(/\s+/g, " ").trim() || null
+    : null;
+
+  const stripped = html
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<(script|style|noscript|svg|template|head)\b[\s\S]*?<\/\1\s*>/gi, " ")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<li\b[^>]*>/gi, "\n- ")
+    .replace(new RegExp(`<\\/?(?:${BLOCK_TAGS})\\b[^>]*>`, "gi"), "\n")
+    .replace(/<[^>]+>/g, " ");
+
+  const text = decodeEntities(stripped)
+    .replace(/[ \t\r\f\v ]+/g, " ")
+    .replace(/ ?\n ?/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+
+  return { title, text };
+}
+
+// ── Handle ─────────────────────────────────────────────────────────────
+
+/**
+ * Build the `web_fetch` tool for a run. See the module header for the
+ * usage shape.
+ */
+export function createWebFetch(opts: CreateWebFetchOptions): WebFetchHandle {
+  const results: WebFetchResult[] = [];
+  const backend = opts.backend ?? resolveFetchBackend(opts.provider);
+  const maxUses = opts.maxUses ?? DEFAULT_MAX_USES;
+  const maxCharacters =
+    opts.maxCharacters ??
+    (opts.maxContentTokens ? opts.maxContentTokens * CHARS_PER_TOKEN : DEFAULT_MAX_CHARACTERS);
+  const maxContentTokens =
+    opts.maxContentTokens ??
+    (opts.maxCharacters ? Math.ceil(opts.maxCharacters / CHARS_PER_TOKEN) : undefined);
+
+  if (backend === "anthropic") {
+    const apiKey =
+      normalizeApiKey(opts.apiKey) || normalizeApiKey(process.env.ANTHROPIC_API_KEY);
+    if (!apiKey) {
+      return emptyFetchHandle(results);
+    }
+    const baseURL = getGatewayBaseURL("anthropic");
+    const anthropic = createAnthropic({ apiKey, ...(baseURL && { baseURL }) });
+    return {
+      tool: anthropic.tools.webFetch_20250910({
+        maxUses,
+        ...(maxContentTokens ? { maxContentTokens } : {}),
+        ...(opts.allowedDomains?.length ? { allowedDomains: opts.allowedDomains } : {}),
+        ...(opts.blockedDomains?.length ? { blockedDomains: opts.blockedDomains } : {}),
+      }),
+      backend,
+      native: true,
+      results,
+      capture: (stepContent) => captureNativeFetchResults(stepContent, results),
+    };
+  }
+
+  let uses = 0;
+  return {
+    tool: tool({
+      description:
+        "Fetch a specific web page by URL and return its text. HTML is converted to plain text; " +
+        "JSON and plain text come back as-is. Use this to read a page whose address you already " +
+        "have — one the user gave you, or one returned by web_search. It is not a search engine: " +
+        "it needs a full http(s) URL. PDFs and other binary content are not supported.",
+      inputSchema: z.object({
+        url: z.string().describe("The absolute http(s) URL to fetch."),
+      }),
+      execute: async ({ url }: { url: string }, ctx?: { abortSignal?: AbortSignal }) => {
+        if (uses >= maxUses) {
+          return {
+            error: `web_fetch budget exhausted (${maxUses} calls). Work with what you have.`,
+          };
+        }
+        uses++;
+        try {
+          const page = await fetchUrl(url, {
+            maxCharacters,
+            allowedDomains: opts.allowedDomains,
+            blockedDomains: opts.blockedDomains,
+            abortSignal: ctx?.abortSignal ?? opts.abortSignal,
+            lookup: opts.lookup,
+          });
+          results.push(page);
+          return page;
+        } catch (err) {
+          return {
+            error: `Fetch failed: ${err instanceof Error ? err.message : String(err)}`,
+          };
+        }
+      },
+    }),
+    backend,
+    native: false,
+    results,
+    // HTTP results are appended by `execute` above; walking the step
+    // would double-count them.
+    capture: () => {},
+  };
+}
+
+function emptyFetchHandle(results: WebFetchResult[]): WebFetchHandle {
+  return {
+    tool: undefined,
+    backend: undefined,
+    native: false,
+    results,
+    capture: () => {},
+  };
+}
+
+/**
+ * Walk one AI SDK step's content for `web_fetch` tool-results and
+ * append each page to `target`, in order.
+ *
+ * Tolerates both result shapes (`output` and `result`) and both key
+ * casings for the nested fields — adapters vary across AI SDK versions,
+ * and a shape we don't recognize should cost us a bookkeeping entry,
+ * not the run. Anthropic's error results (`web_fetch_tool_result_error`)
+ * are skipped: there's no page to record.
+ */
+export function captureNativeFetchResults(
+  stepContent: unknown,
+  target: WebFetchResult[],
+): void {
+  if (!Array.isArray(stepContent)) return;
+  for (const content of stepContent) {
+    if (content?.type !== "tool-result") continue;
+    if (content?.toolName !== WEB_FETCH_TOOL_NAME) continue;
+    const body = content.output ?? content.result ?? null;
+    if (!body || typeof body !== "object") continue;
+    if (body.type !== "web_fetch_result" || typeof body.url !== "string") continue;
+    const doc = body.content ?? {};
+    const source = doc.source ?? {};
+    target.push({
+      url: body.url,
+      title: doc.title ?? null,
+      ...(source.type === "text" && typeof source.data === "string"
+        ? { text: source.data }
+        : {}),
+      mediaType: source.mediaType ?? source.media_type ?? null,
+      retrievedAt: body.retrievedAt ?? body.retrieved_at ?? null,
+      type: "web_fetch_result",
+    });
+  }
+}

--- a/mcp/src/aieo/src/index.ts
+++ b/mcp/src/aieo/src/index.ts
@@ -5,6 +5,7 @@ export * from "./usage.js";
 export * from "./prompt.js";
 export * from "./tools.js";
 export * from "./search.js";
+export * from "./fetch.js";
 
 export type { ModelMessage } from "ai";
 export type { Tool, ToolSet } from "ai";

--- a/mcp/src/aieo/src/test/try-fetch.ts
+++ b/mcp/src/aieo/src/test/try-fetch.ts
@@ -1,0 +1,68 @@
+import { generateText, stepCountIs } from "ai";
+import * as dotenv from "dotenv";
+import { getModelDetails, getProviderOptions } from "../provider.js";
+import { createWebFetch, WEB_FETCH_TOOL_NAME } from "../fetch.js";
+
+dotenv.config({ path: "../../.env" });
+
+// `npm run try-fetch -- https://some.url` to point both backends at a page.
+const URL_TO_FETCH = process.argv.find((a) => /^https?:\/\//.test(a)) ?? "https://sphinx.chat";
+
+// The URL is in the prompt on purpose: Anthropic's native tool only
+// fetches URLs that already appeared in the conversation.
+const PROMPT =
+  `Fetch ${URL_TO_FETCH} and write exactly 3 short bullet points about what the page says. ` +
+  "Quote the page title in the first bullet.";
+
+async function run(label: string, modelName: string) {
+  console.log(`\n${"=".repeat(70)}\n${label}\n${"=".repeat(70)}`);
+  const { model, provider, apiKey, modelId } = getModelDetails(modelName);
+  const wf = createWebFetch({ provider, apiKey, maxCharacters: 12_000 });
+  console.log(`backend=${wf.backend} native=${wf.native} hasTool=${!!wf.tool}`);
+  if (!wf.tool) {
+    console.error("no tool — missing key for this backend");
+    return;
+  }
+
+  const started = Date.now();
+  const res = await generateText({
+    model,
+    tools: { [WEB_FETCH_TOOL_NAME]: wf.tool },
+    system: "You are a concise research assistant.",
+    prompt: PROMPT,
+    stopWhen: stepCountIs(4),
+    providerOptions: getProviderOptions(provider, "fast", modelId) as any,
+    onStepFinish: (step) => {
+      const calls = step.content
+        .filter((c: any) => c.type === "tool-call")
+        .map((c: any) => `${c.toolName}(${JSON.stringify(c.input)?.slice(0, 80)})`);
+      if (calls.length) console.log(`  step: ${calls.join(", ")}`);
+      const errors = step.content
+        .filter((c: any) => c.type === "tool-result" && (c.isError || c.output?.error))
+        .map((c: any) => JSON.stringify(c.output ?? c.result)?.slice(0, 200));
+      if (errors.length) console.log(`  tool errors: ${errors.join(" | ")}`);
+      wf.capture(step.content);
+    },
+  });
+  const elapsed = ((Date.now() - started) / 1000).toFixed(1);
+
+  console.log(`\nsteps=${res.steps.length} elapsed=${elapsed}s captured=${wf.results.length}`);
+  for (const r of wf.results) {
+    console.log(
+      `  ${r.url}  title=${JSON.stringify(r.title)} type=${r.mediaType} ` +
+        `${r.text ? `(${r.text.length}b text${r.truncated ? ", truncated" : ""})` : "(no text)"}`,
+    );
+  }
+  console.log(`\n--- model text ---\n${res.text}`);
+}
+
+async function main() {
+  await run("ANTHROPIC (native web_fetch)", "sonnet").catch((e) =>
+    console.error("anthropic failed:", e?.message || e),
+  );
+  await run("XAI / GROK (http shim)", "grok").catch((e) =>
+    console.error("grok failed:", e?.message || e),
+  );
+}
+
+main();

--- a/mcp/src/aieo/src/tools.ts
+++ b/mcp/src/aieo/src/tools.ts
@@ -1,22 +1,24 @@
 import { createAnthropic } from "@ai-sdk/anthropic";
 import { Provider, getGatewayBaseURL } from "./provider.js";
 import { createWebSearch } from "./search.js";
+import { createWebFetch } from "./fetch.js";
 
-export type ProviderTool = "webSearch" | "bash";
+export type ProviderTool = "webSearch" | "webFetch" | "bash";
 
 /**
  * Provider-native tool by name.
  *
- * `webSearch` is special: only Anthropic has a native one, so every
- * other provider gets the Exa-backed shim from `./search.js` instead of
- * an exception. That keeps the tool available (and named `web_search`)
- * on any model. This entry point returns the bare tool — for citation
- * indices and the matching prompt snippet, call `createWebSearch`
- * directly.
+ * `webSearch` and `webFetch` are special: only Anthropic has native
+ * ones, so every other provider gets a shim of the same name and result
+ * shape instead of an exception — Exa-backed search from `./search.js`,
+ * a guarded HTTP GET from `./fetch.js`. That keeps both tools available
+ * (as `web_search` / `web_fetch`) on any model. This entry point returns
+ * the bare tool — for the result bookkeeping, citation indices and
+ * prompt snippet, call `createWebSearch` / `createWebFetch` directly.
  *
- * Returns `undefined` for `webSearch` when the chosen backend has no key
+ * Returns `undefined` for those two when the chosen backend has no key
  * configured; callers should drop the tool rather than fail the request.
- * Non-`webSearch` tools still throw for unsupported providers.
+ * Other tools still throw for unsupported providers.
  */
 export function getProviderTool(
   provider: Provider,
@@ -25,6 +27,9 @@ export function getProviderTool(
 ): any {
   if (toolName === "webSearch") {
     return createWebSearch({ provider, apiKey }).tool;
+  }
+  if (toolName === "webFetch") {
+    return createWebFetch({ provider, apiKey }).tool;
   }
   switch (provider) {
     case "anthropic":


### PR DESCRIPTION
## What

Sibling of the `web_search` shim (#1637). Anthropic keeps its native, server-executed `web_fetch`; every other provider gets a client-executed tool of the same name and result shape, backed by a guarded HTTP GET plus a dependency-free HTML-to-text pass.

- `createWebFetch({ provider, apiKey, ... })` returns the same handle shape as `createWebSearch` (`tool` / `backend` / `native` / `results` / `capture`). `getProviderTool` gains `"webFetch"`.
- Options: `maxUses` (in-process on the shim, `max_uses` to Anthropic), `maxCharacters` / `maxContentTokens` (each derived from the other so one option covers both paths), `allowedDomains` / `blockedDomains`.
- `fetchUrl()` and `htmlToText()` are exported for callers that want a page without an LLM in the loop.

### SSRF guard on the HTTP path

The shim runs in our process, so the model can point it at our network. Every URL and every redirect hop is validated before connecting: http(s) only, no embedded credentials, `localhost` refused, and the host must resolve exclusively to public unicast addresses. Loopback, RFC 1918, link-local including cloud metadata, CGNAT, ULA, NAT64/6to4 and v4-mapped v6 are all refused; a host that answers with a mix is refused. Bodies cap at 4 MiB, redirects at 5. Failures return to the model as a readable tool error with undici's transport cause surfaced (`certificate has expired (CERT_HAS_EXPIRED)` rather than `fetch failed`).

Known gap, documented in the module: there is a DNS-rebinding window between our lookup and the socket's own. Pin `allowedDomains` if a deployment cares.

## Verification

- `npm test`: 16 new fetch tests (backend selection, address classification, URL guard, domain lists, extraction, budgets, charset, redirect re-validation incl. an open redirect to `169.254.169.254`, error surfacing, native-result capture) plus the existing search and provider suites, all green.
- `npm run build` (tsup, incl. DTS) succeeds. `tsc --noEmit` reports errors only inside `@openrouter/ai-sdk-provider`'s own `.d.ts` in the parent `node_modules`, which is pre-existing and unrelated.
- `npm run try-fetch` live against both backends:

| URL | Anthropic native | HTTP shim (Grok) |
|---|---|---|
| `docs.getbifrost.ai/migration-guides/v2.0.0` | captured, 12016 chars | captured, title extracted, 12000 chars (truncated at the script's budget) |
| `sphinx.chat` | captured | tool error `certificate has expired (CERT_HAS_EXPIRED)` surfaced to the model |

That second row is a real finding, not a bug here: sphinx.chat's certificate expired on 2026-06-10 (`curl` and `openssl s_client` agree). Anthropic's fetcher evidently doesn't enforce expiry.

## Not in this PR

`mcp/package-lock.json` still pins `aieo@0.1.29` from npm; publishing 0.1.37 and bumping the consumer is the same separate step as for 0.1.36.