### PR TITLE
gateway ui: render xAI in the canvas providers column

### DIFF
--- a/gateway/internal/adminapi/ui/src/pages/Canvas.tsx
+++ b/gateway/internal/adminapi/ui/src/pages/Canvas.tsx
@@ -17,10 +17,9 @@
 //     requestCount are summed over all that user's pairings.
 //   - Gateway: singleton. customData.totalCost = swarm-wide total
 //     (sum of every row's cost).
-//   - Providers: hardcoded 4 — anthropic / openai / openrouter /
-//     google — pulled from gateway/docker-compose.yml env. Real
-//     per-provider spend lands when the matrix endpoint grows a
-//     provider dimension.
+//   - Providers: hardcoded 5 — anthropic / openai / openrouter /
+//     gemini / xai. customData.totalCost + requestCount come from
+//     the per-row `providers[]` slice the matrix endpoint returns.
 //
 // The canvas takes over the full shell-main area; the WindowPicker
 // floats in the top-right corner as the only chrome. No numeric
@@ -57,11 +56,16 @@ const fmtInt = (v: number) =>
   new Intl.NumberFormat("en-US").format(Math.round(v));
 
 // Hardcoded provider list — these ids match Bifrost's `provider`
-// column on every log row (`gateway/data/config.json`'s `providers`
-// map), so the per-provider rollup from the matrix endpoint
-// dispatches against `customData.icon` cleanly. The order here is
-// the vertical render order in the providers column.
-const PROVIDERS = ["anthropic", "openai", "openrouter", "gemini"];
+// column on every log row, so the per-provider rollup from the
+// matrix endpoint dispatches against `customData.icon` cleanly.
+// Deliberately a superset of `gateway/data/config.json`'s current
+// `providers` map: a provider that's been dropped from (or not yet
+// added to) the seed config still gets a card showing $0, rather
+// than having its historical spend silently vanish from the column.
+// Every id here needs a PROVIDER_DISPLAY entry in canvasTheme.ts.
+// The order here is the vertical render order in the providers
+// column.
+const PROVIDERS = ["anthropic", "openai", "openrouter", "gemini", "xai"];
 
 // Column x-coordinates (canvas-space, centered around 0). Spacing
 // picked so even the widest columns (gateway 220) don't touch their


### PR DESCRIPTION
## Summary
- #1673 added the xai entry to `PROVIDER_DISPLAY` and the icon table in `canvasTheme.ts`, but `Canvas.tsx`'s hardcoded `PROVIDERS` list was never updated. That list drives both the provider cards and the gateway→provider edges, so the canvas drew no xAI card and any xai spend from the matrix endpoint was silently dropped from the column.
- Adds `xai` as the fifth provider and keeps `gemini`. The list is now deliberately a superset of `gateway/data/config.json`'s current providers map: a provider absent from the seed config still gets a $0 card rather than having its historical spend vanish.
- Refreshes the stale header comment (still said "google", and claimed per-provider spend was pending a matrix-endpoint change that already landed).

## Test plan
- [x] `npm run build` in `gateway/internal/adminapi/ui` (tsc -b + vite) passes
- [ ] Open the canvas against a gateway with grok traffic and confirm the xAI card + edge render with real spend