### PR TITLE
gateway: restore gemini as the fifth provider alongside xai

### DIFF
--- a/gateway/data/config.json
+++ b/gateway/data/config.json
@@ -42,6 +42,16 @@
         }
       ]
     },
+    "gemini": {
+      "keys": [
+        {
+          "name": "gemini-key-1",
+          "value": "env.GOOGLE_API_KEY",
+          "models": ["*"],
+          "weight": 1.0
+        }
+      ]
+    },
     "xai": {
       "keys": [
         {

--- a/gateway/docker-compose.yml
+++ b/gateway/docker-compose.yml
@@ -90,6 +90,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}
     depends_on:
       redis:

--- a/gateway/plans/llm-governance-v2.md
+++ b/gateway/plans/llm-governance-v2.md
@@ -135,7 +135,7 @@ Bifrost natively enforces:
 | Daily $ budget     | Customer (per user) | $1000/day                                              |
 | Rate limit RPM     | Customer (per user) | 1000 RPM                                               |
 | Rate limit TPM     | Customer (per user) | 5M TPM                                                 |
-| Provider allowlist | VK                  | `[anthropic, openai, openrouter, xai]`, all `["*"]` |
+| Provider allowlist | VK                  | `[anthropic, openai, openrouter, gemini, xai]`, all `["*"]` |
 | Model allowlist    | VK                  | `["*"]` initially                                      |
 | `is_active`        | Customer (per user) | `true` by default; `false` disables account org-wide   |
 
@@ -173,6 +173,7 @@ POST /api/governance/virtual-keys
       { provider: "anthropic", allowed_models: ["*"] },
       { provider: "openai",    allowed_models: ["*"] },
       { provider: "openrouter",allowed_models: ["*"] },
+      { provider: "gemini",    allowed_models: ["*"] },
       { provider: "xai",       allowed_models: ["*"] },
     ]
   }

--- a/gateway/plans/phases/phase-1-reconciler.md
+++ b/gateway/plans/phases/phase-1-reconciler.md
@@ -255,7 +255,7 @@ Filters available on this endpoint (lines 369-380 of governance.go):
           "budgets": [],
           "rate_limit": null
         }
-        // … openai, openrouter, xai
+        // … openai, openrouter, gemini, xai
       ],
       "mcp_configs": [],
       "budgets": [],
@@ -306,6 +306,7 @@ Content-Type: application/json
     { "provider": "anthropic",  "allowed_models": ["*"], "key_ids": ["*"] },
     { "provider": "openai",     "allowed_models": ["*"], "key_ids": ["*"] },
     { "provider": "openrouter", "allowed_models": ["*"], "key_ids": ["*"] },
+    { "provider": "gemini",     "allowed_models": ["*"], "key_ids": ["*"] },
     { "provider": "xai",        "allowed_models": ["*"], "key_ids": ["*"] }
   ]
 }

--- a/mcp/docs/gateway/README.md
+++ b/mcp/docs/gateway/README.md
@@ -7,10 +7,12 @@ Runs Bifrost locally on `http://localhost:8181` so MCP can be tested with
 ## Layout
 
 - `docker-compose.yml` — Bifrost service, host port `8181 -> container 8080`.
-- `data/config.json` — seed config: Anthropic + OpenAI + OpenRouter + xAI
-  providers, API keys read from `env.*`, `config_store` enabled (SQLite) so the
-  Web UI works. (xAI has no dedicated Bifrost route; the MCP client sends Grok
-  through `/openai/v1` with an `xai/`-prefixed model id.)
+- `data/config.json` — seed config: Anthropic + OpenAI + OpenRouter + Gemini
+  + xAI providers, API keys read from `env.*`, `config_store` enabled (SQLite)
+  so the Web UI works. (Bifrost calls Google's public Gemini API `gemini`; the
+  MCP client side calls the same thing `google`. xAI has no dedicated Bifrost
+  route; the MCP client sends Grok through `/openai/v1` with an `xai/`-prefixed
+  model id.)
 - `data/config.db`, `data/logs.db` — created on first boot; gitignored.
 - `.env` — symlinked to `../../.env` (the MCP `.env`) so docker-compose picks up
   `ANTHROPIC_API_KEY` etc. without copy-paste.

--- a/mcp/docs/gateway/data/config.json
+++ b/mcp/docs/gateway/data/config.json
@@ -35,6 +35,16 @@
         }
       ]
     },
+    "gemini": {
+      "keys": [
+        {
+          "name": "gemini-key-1",
+          "value": "env.GOOGLE_API_KEY",
+          "models": ["*"],
+          "weight": 1.0
+        }
+      ]
+    },
     "xai": {
       "keys": [
         {

--- a/mcp/docs/gateway/docker-compose.yml
+++ b/mcp/docs/gateway/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       ANTHROPIC_API_KEY: ${ANTHROPIC_API_KEY:-}
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY:-}
+      GOOGLE_API_KEY: ${GOOGLE_API_KEY:-}
       XAI_API_KEY: ${XAI_API_KEY:-}
     ports:
       # Host 8181 -> container 8080. MCP server uses LLM_GATEWAY_URL=http://localhost:8181.


### PR DESCRIPTION
## Summary
- #1673 swapped `gemini` for `xai` in the seed config, compose env, plan docs, and the `mcp/docs/gateway` seed copy. The intent was to add xAI, not drop Gemini. This puts the `gemini` provider back in every one of those spots, reading `env.GOOGLE_API_KEY` as before, so the gateway targets **anthropic / openai / openrouter / gemini / xai**.
- Provider order in both `config.json` files matches the admin UI's canvas column (#1676), which already renders all five.
- No Go changes: nothing server-side hardcodes the provider list, and the `x-goog-api-key` transport tests never stopped covering Gemini.

## Test plan
- [x] Both `config.json` files parse; `providers` keys are `anthropic, openai, openrouter, gemini, xai`
- [x] `docker compose config -q` passes for `gateway/` and `mcp/docs/gateway/`
- [ ] Boot the image with `GOOGLE_API_KEY` set and confirm a `gemini/...` call routes and prices