### PR TITLE
gateway: account usage for Responses-shaped results (Anthropic-native /v1/messages)

### DIFF
--- a/gateway/internal/hooks/llm_posthook.go
+++ b/gateway/internal/hooks/llm_posthook.go
@@ -35,16 +35,14 @@ func LLMPost(
 		hadErr  = bifrostErr != nil
 	)
 
-	// Try to pull usage/cost if the provider populated it (Chat responses).
-	var usage *schemas.BifrostLLMUsage
-	if hadResp && resp.ChatResponse != nil {
-		usage = resp.ChatResponse.Usage
-	}
+	// Pull usage/cost from whichever response shape the provider
+	// populated (Chat or Responses — see callUsageOf).
+	call := callUsageOf(resp)
 	var promptTokens, completionTokens, totalTokens int
-	if usage != nil {
-		promptTokens = usage.PromptTokens
-		completionTokens = usage.CompletionTokens
-		totalTokens = usage.TotalTokens
+	if call.usage != nil {
+		promptTokens = call.usage.PromptTokens
+		completionTokens = call.usage.CompletionTokens
+		totalTokens = call.usage.TotalTokens
 	}
 
 	// Phase-6 accumulator writes. Streaming requests are accounted
@@ -60,8 +58,8 @@ func LLMPost(
 			}
 		case hadResp && !isStreamRequest(resp):
 			if pluginctx.MarkAccounted(ctx) {
-				costUSD = resolveCost(resp.ChatResponse, usage, dims)
-				auth.ApplyToLLMPost(claims, costUSD, toolCallNames(resp.ChatResponse))
+				costUSD = resolveCost(call, dims)
+				auth.ApplyToLLMPost(claims, costUSD, call.tools)
 			}
 		}
 	}
@@ -92,8 +90,89 @@ func isStreamRequest(resp *schemas.BifrostResponse) bool {
 	return strings.HasSuffix(string(ef.RequestType), "_stream")
 }
 
-// resolveCost turns a chat response's usage into dollars. Precedence
-// per the phase-6 accumulator design:
+// callUsage is the accounting view of one completed call, normalized
+// across the Bifrost response shapes that can carry billable usage:
+//
+//   - Chat (RequestType "chat_completion[_stream]"): the OpenAI
+//     /chat/completions shape, usage as BifrostLLMUsage.
+//   - Responses (RequestType "responses[_stream]"): the OpenAI
+//     /responses shape, usage as ResponsesResponseUsage. Bifrost core
+//     v1.6 routes the Anthropic-native /anthropic/v1/messages
+//     integration through this type, so every Claude call made with
+//     the Anthropic SDK lands here — with ChatResponse nil.
+//
+// Everything downstream (resolveCost, the accumulator, the log line)
+// reads this struct and never touches the raw shapes again.
+type callUsage struct {
+	usage    *schemas.BifrostLLMUsage
+	model    string // resolved model, falling back to the wire model
+	provider string // Bifrost provider id that served the call
+	tools    []string
+}
+
+// callUsageOf picks whichever shape a non-streaming BifrostResponse
+// carries. Zero value (nil usage) for nil, for a shape without
+// usage, or for the streaming set-up firing.
+func callUsageOf(resp *schemas.BifrostResponse) callUsage {
+	switch {
+	case resp == nil:
+		return callUsage{}
+	case resp.ChatResponse != nil:
+		return chatCallUsage(resp.ChatResponse)
+	case resp.ResponsesResponse != nil:
+		return responsesCallUsage(resp.ResponsesResponse, &resp.ResponsesResponse.ExtraFields)
+	}
+	return callUsage{}
+}
+
+func chatCallUsage(chat *schemas.BifrostChatResponse) callUsage {
+	return callUsage{
+		usage:    chat.Usage,
+		model:    resolvedModel(chat.Model, &chat.ExtraFields),
+		provider: extraFieldsProvider(&chat.ExtraFields),
+		tools:    toolCallNames(chat),
+	}
+}
+
+// responsesCallUsage builds the view of a Responses-shaped result. ef
+// is the extra-fields block that carries routing for this call: the
+// response's own for a non-streaming result, the chunk's for a
+// stream terminal event (core stamps routing on the chunk, and the
+// nested Response.ExtraFields is typically blank there).
+func responsesCallUsage(r *schemas.BifrostResponsesResponse, ef *schemas.BifrostResponseExtraFields) callUsage {
+	return callUsage{
+		usage:    responsesUsage(r.Usage),
+		model:    resolvedModel(r.Model, ef),
+		provider: extraFieldsProvider(ef),
+		tools:    responsesToolCallNames(r.Output),
+	}
+}
+
+// responsesUsage maps ResponsesResponseUsage onto the chat-shaped
+// BifrostLLMUsage the pricing path consumes: input→prompt,
+// output→completion, total→total, provider-computed Cost verbatim.
+// Bifrost already folds cached tokens into InputTokens (same
+// convention as PromptTokens on the chat shape), so there is no
+// cache arithmetic to do here. TotalTokens is recomputed only when
+// the provider left it zero.
+func responsesUsage(u *schemas.ResponsesResponseUsage) *schemas.BifrostLLMUsage {
+	if u == nil {
+		return nil
+	}
+	total := u.TotalTokens
+	if total == 0 {
+		total = u.InputTokens + u.OutputTokens
+	}
+	return &schemas.BifrostLLMUsage{
+		PromptTokens:     u.InputTokens,
+		CompletionTokens: u.OutputTokens,
+		TotalTokens:      total,
+		Cost:             u.Cost,
+	}
+}
+
+// resolveCost turns a call's usage into dollars. Precedence per the
+// phase-6 accumulator design:
 //
 //  1. Provider-computed Usage.Cost.TotalCost (only some providers).
 //  2. auth.PriceCall on the (provider, resolved model) pair —
@@ -104,42 +183,49 @@ func isStreamRequest(resp *schemas.BifrostResponse) bool {
 //     wire model bare ("grok-4").
 //  3. $0, with a loud log — an unpriced model must be visible in
 //     `docker logs`, not silently guessed at.
-func resolveCost(chat *schemas.BifrostChatResponse, usage *schemas.BifrostLLMUsage, dims map[string]string) float64 {
+func resolveCost(call callUsage, dims map[string]string) float64 {
+	usage := call.usage
 	if usage == nil {
 		return 0
 	}
 	if usage.Cost != nil && usage.Cost.TotalCost > 0 {
 		return usage.Cost.TotalCost
 	}
-	model, provider := "", ""
-	if chat != nil {
-		if model = chat.ExtraFields.ResolvedModelUsed; model == "" {
-			model = chat.Model
-		}
-		provider = responseProvider(chat)
-	}
-	if cost, ok := auth.PriceCall(provider, model, usage.PromptTokens, usage.CompletionTokens); ok {
+	if cost, ok := auth.PriceCall(call.provider, call.model, usage.PromptTokens, usage.CompletionTokens); ok {
 		return cost
 	}
 	if usage.TotalTokens > 0 {
 		pluginlog.Warnf(
 			"accounting: no price for provider=%q model=%q (run_id=%s) — %d tokens accumulated as $0; add a model_pricing entry",
-			provider, model, dims[pluginctx.DimRunID], usage.TotalTokens,
+			call.provider, call.model, dims[pluginctx.DimRunID], usage.TotalTokens,
 		)
 	}
 	return 0
 }
 
-// responseProvider returns the Bifrost provider id that actually
-// served a chat response. RoutingInfo.Provider is the current field;
+// resolvedModel prefers the model Bifrost actually resolved the
+// request to over the wire model the response echoes, so aliases
+// price against the real row.
+func resolvedModel(wire string, ef *schemas.BifrostResponseExtraFields) string {
+	if ef != nil && ef.ResolvedModelUsed != "" {
+		return ef.ResolvedModelUsed
+	}
+	return wire
+}
+
+// extraFieldsProvider returns the Bifrost provider id that actually
+// served a response. RoutingInfo.Provider is the current field;
 // ExtraFields.Provider is its deprecated twin, still populated by
 // core v1.6 and kept as the fallback for chunks that only carry the
 // old shape.
-func responseProvider(chat *schemas.BifrostChatResponse) string {
-	if p := chat.ExtraFields.RoutingInfo.Provider; p != "" {
+func extraFieldsProvider(ef *schemas.BifrostResponseExtraFields) string {
+	if ef == nil {
+		return ""
+	}
+	if p := ef.RoutingInfo.Provider; p != "" {
 		return string(p)
 	}
-	return string(chat.ExtraFields.Provider)
+	return string(ef.Provider)
 }
 
 // toolCallNames collects the tool names invoked in a non-streaming
@@ -162,6 +248,26 @@ func toolCallNames(chat *schemas.BifrostChatResponse) []string {
 				names = append(names, *tc.Function.Name)
 			}
 		}
+	}
+	return names
+}
+
+// responsesToolCallNames is toolCallNames for the Responses shape,
+// where a tool call is an output item of type "function_call" whose
+// name rides on the embedded ResponsesToolMessage. Other item kinds
+// (message, reasoning, server-side tool calls like web_search_call)
+// are not client tool invocations and are skipped. Nil when the
+// response called no tools.
+func responsesToolCallNames(output []schemas.ResponsesMessage) []string {
+	var names []string
+	for _, item := range output {
+		if item.Type == nil || *item.Type != schemas.ResponsesMessageTypeFunctionCall {
+			continue
+		}
+		if item.ResponsesToolMessage == nil || item.Name == nil || *item.Name == "" {
+			continue
+		}
+		names = append(names, *item.Name)
 	}
 	return names
 }

--- a/gateway/internal/hooks/llm_posthook_test.go
+++ b/gateway/internal/hooks/llm_posthook_test.go
@@ -60,24 +60,24 @@ func TestResolveCost_Precedence(t *testing.T) {
 		TotalTokens:      2000,
 		Cost:             &schemas.BifrostCost{TotalCost: 0.5},
 	}
-	if got := resolveCost(chat, usage, dims); got != 0.5 {
+	if got := chatCost(chat, usage, dims); got != 0.5 {
 		t.Fatalf("provider cost should win, got %v", got)
 	}
 
 	// 2. Falls back to the pricing table: 1000*1/1e6 + 1000*10/1e6 = 0.011.
 	usage.Cost = nil
-	if got := resolveCost(chat, usage, dims); got != 0.011 {
+	if got := chatCost(chat, usage, dims); got != 0.011 {
 		t.Fatalf("table cost = %v, want 0.011", got)
 	}
 
 	// 3. Unpriced model → 0.
 	chat.Model = "mystery-model"
-	if got := resolveCost(chat, usage, dims); got != 0 {
+	if got := chatCost(chat, usage, dims); got != 0 {
 		t.Fatalf("unpriced model cost = %v, want 0", got)
 	}
 
 	// Nil usage → 0.
-	if got := resolveCost(chat, nil, dims); got != 0 {
+	if got := chatCost(chat, nil, dims); got != 0 {
 		t.Fatalf("nil usage cost = %v, want 0", got)
 	}
 }
@@ -95,7 +95,7 @@ func TestResolveCost_PrefersResolvedModel(t *testing.T) {
 		},
 	}
 	usage := &schemas.BifrostLLMUsage{PromptTokens: 500, CompletionTokens: 500, TotalTokens: 1000}
-	if got := resolveCost(chat, usage, map[string]string{}); got != 0.001 {
+	if got := chatCost(chat, usage, map[string]string{}); got != 0.001 {
 		t.Fatalf("resolved-model cost = %v, want 0.001", got)
 	}
 }
@@ -123,20 +123,28 @@ func TestResolveCost_ProviderNamespacedCatalog(t *testing.T) {
 			RoutingInfo:       schemas.RoutingInfo{Provider: schemas.XAI, Model: "grok-4"},
 		},
 	}
-	if got := resolveCost(chat, usage, map[string]string{}); got != 0.001 {
+	if got := chatCost(chat, usage, map[string]string{}); got != 0.001 {
 		t.Fatalf("RoutingInfo provider cost = %v, want 0.001", got)
 	}
 
 	// Older chunks only carry the deprecated ExtraFields.Provider.
 	chat.ExtraFields.RoutingInfo = schemas.RoutingInfo{}
 	chat.ExtraFields.Provider = schemas.XAI
-	if got := resolveCost(chat, usage, map[string]string{}); got != 0.001 {
+	if got := chatCost(chat, usage, map[string]string{}); got != 0.001 {
 		t.Fatalf("deprecated provider field cost = %v, want 0.001", got)
 	}
 
 	// No provider anywhere → the namespaced row is unreachable → $0.
 	chat.ExtraFields.Provider = ""
-	if got := resolveCost(chat, usage, map[string]string{}); got != 0 {
+	if got := chatCost(chat, usage, map[string]string{}); got != 0 {
 		t.Fatalf("provider-less cost = %v, want 0", got)
 	}
+}
+
+// chatCost prices a chat-shaped response the way LLMPost does, with
+// the usage supplied separately so the precedence cases can vary it.
+func chatCost(chat *schemas.BifrostChatResponse, usage *schemas.BifrostLLMUsage, dims map[string]string) float64 {
+	call := chatCallUsage(chat)
+	call.usage = usage
+	return resolveCost(call, dims)
 }

--- a/gateway/internal/hooks/responses_usage_test.go
+++ b/gateway/internal/hooks/responses_usage_test.go
@@ -1,0 +1,372 @@
+package hooks
+
+import (
+	"context"
+	"math"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/maximhq/bifrost/core/schemas"
+	"github.com/redis/go-redis/v9"
+
+	macaroon "github.com/stakwork/stakgraph/gateway/auth/go"
+	"github.com/stakwork/stakgraph/gateway/internal/auth"
+	"github.com/stakwork/stakgraph/gateway/internal/pluginctx"
+	"github.com/stakwork/stakgraph/gateway/internal/redisclient"
+)
+
+// Bifrost core v1.6 routes the Anthropic-native /anthropic/v1/messages
+// integration as RequestType "responses", so every Claude call made
+// with the Anthropic SDK arrives here with ChatResponse nil and usage
+// on ResponsesResponse. Before this coverage the hooks read only the
+// chat shape and accounted such calls at prompt=0 completion=0
+// cost=$0 (observed on swarm38, 2026-09-10).
+
+func msgType(t schemas.ResponsesMessageType) *schemas.ResponsesMessageType { return &t }
+
+func functionCallItem(name string) schemas.ResponsesMessage {
+	return schemas.ResponsesMessage{
+		Type: msgType(schemas.ResponsesMessageTypeFunctionCall),
+		ResponsesToolMessage: &schemas.ResponsesToolMessage{
+			Name:   strPtr(name),
+			CallID: strPtr("call_" + name),
+		},
+	}
+}
+
+func TestResponsesUsage_MapsOntoChatShape(t *testing.T) {
+	if responsesUsage(nil) != nil {
+		t.Fatal("nil usage must stay nil")
+	}
+	cost := &schemas.BifrostCost{TotalCost: 0.25}
+	got := responsesUsage(&schemas.ResponsesResponseUsage{
+		InputTokens: 120, OutputTokens: 30, TotalTokens: 150, Cost: cost,
+	})
+	if got.PromptTokens != 120 || got.CompletionTokens != 30 || got.TotalTokens != 150 {
+		t.Fatalf("token mapping = %+v, want prompt=120 completion=30 total=150", *got)
+	}
+	if got.Cost != cost {
+		t.Fatal("provider-computed cost must carry over verbatim")
+	}
+	// A provider that leaves total_tokens unset still bills the sum.
+	got = responsesUsage(&schemas.ResponsesResponseUsage{InputTokens: 7, OutputTokens: 3})
+	if got.TotalTokens != 10 {
+		t.Fatalf("total fallback = %d, want 10", got.TotalTokens)
+	}
+}
+
+func TestResponsesToolCallNames(t *testing.T) {
+	output := []schemas.ResponsesMessage{
+		{Type: msgType(schemas.ResponsesMessageTypeReasoning)},
+		functionCallItem("grep"),
+		{Type: msgType(schemas.ResponsesMessageTypeMessage)},
+		// Server-side tool: not a client tool invocation.
+		{
+			Type:                 msgType(schemas.ResponsesMessageTypeWebSearchCall),
+			ResponsesToolMessage: &schemas.ResponsesToolMessage{Name: strPtr("web_search")},
+		},
+		functionCallItem("read"),
+		// function_call without the tool embed / without a name:
+		// skipped, never a nil deref.
+		{Type: msgType(schemas.ResponsesMessageTypeFunctionCall)},
+		{Type: msgType(schemas.ResponsesMessageTypeFunctionCall), ResponsesToolMessage: &schemas.ResponsesToolMessage{}},
+		{},
+	}
+	got := responsesToolCallNames(output)
+	if len(got) != 2 || got[0] != "grep" || got[1] != "read" {
+		t.Fatalf("responsesToolCallNames = %v, want [grep read]", got)
+	}
+	if responsesToolCallNames(nil) != nil {
+		t.Fatal("no output must yield nil names")
+	}
+}
+
+func TestCallUsageOf_ResponsesShape(t *testing.T) {
+	resp := &schemas.BifrostResponse{ResponsesResponse: &schemas.BifrostResponsesResponse{
+		Model:  "some-alias",
+		Usage:  &schemas.ResponsesResponseUsage{InputTokens: 1000, OutputTokens: 1000, TotalTokens: 2000},
+		Output: []schemas.ResponsesMessage{functionCallItem("grep")},
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType:       schemas.ResponsesRequest,
+			ResolvedModelUsed: "claude-sonnet-5",
+			RoutingInfo:       schemas.RoutingInfo{Provider: schemas.Anthropic, Model: "claude-sonnet-5"},
+		},
+	}}
+	call := callUsageOf(resp)
+	if call.usage == nil || call.usage.PromptTokens != 1000 || call.usage.CompletionTokens != 1000 || call.usage.TotalTokens != 2000 {
+		t.Fatalf("usage = %+v, want 1000/1000/2000", call.usage)
+	}
+	if call.model != "claude-sonnet-5" || call.provider != "anthropic" {
+		t.Fatalf("model/provider = %q/%q, want claude-sonnet-5/anthropic", call.model, call.provider)
+	}
+	if len(call.tools) != 1 || call.tools[0] != "grep" {
+		t.Fatalf("tools = %v, want [grep]", call.tools)
+	}
+	if isStreamRequest(resp) {
+		t.Fatal(`"responses" is not a stream request type`)
+	}
+
+	if callUsageOf(nil).usage != nil || callUsageOf(&schemas.BifrostResponse{}).usage != nil {
+		t.Fatal("nil / empty response must yield nil usage")
+	}
+}
+
+func TestResolveCost_ResponsesShape(t *testing.T) {
+	auth.SetConfigForTest(auth.Config{ModelPricing: map[string]auth.ModelPrice{
+		"claude-sonnet-5": {InputPerMTok: 1.0, OutputPerMTok: 10.0},
+	}})
+	t.Cleanup(func() { auth.SetConfigForTest(auth.Config{}) })
+
+	r := &schemas.BifrostResponsesResponse{
+		Model: "claude-sonnet-5",
+		Usage: &schemas.ResponsesResponseUsage{
+			InputTokens: 1000, OutputTokens: 1000, TotalTokens: 2000,
+			Cost: &schemas.BifrostCost{TotalCost: 0.5},
+		},
+	}
+	// Provider-computed cost wins, exactly as on the chat path.
+	if got := resolveCost(responsesCallUsage(r, &r.ExtraFields), nil); got != 0.5 {
+		t.Fatalf("provider cost should win, got %v", got)
+	}
+	// Then the pricing table: 1000*1/1e6 + 1000*10/1e6 = 0.011.
+	r.Usage.Cost = nil
+	if got := resolveCost(responsesCallUsage(r, &r.ExtraFields), nil); got != 0.011 {
+		t.Fatalf("table cost = %v, want 0.011", got)
+	}
+}
+
+func TestStreamCallUsage_OnlyTerminalResponsesEvents(t *testing.T) {
+	usage := &schemas.ResponsesResponseUsage{InputTokens: 100, OutputTokens: 1, TotalTokens: 101}
+	chunk := func(typ schemas.ResponsesStreamResponseType, r *schemas.BifrostResponsesResponse) *schemas.BifrostStreamChunk {
+		return &schemas.BifrostStreamChunk{BifrostResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Type: typ, Response: r,
+		}}
+	}
+	// Non-terminal events carry usage too (Anthropic forwards
+	// message_start's on response.created) and must be ignored.
+	for _, typ := range []schemas.ResponsesStreamResponseType{
+		schemas.ResponsesStreamResponseTypeCreated,
+		schemas.ResponsesStreamResponseTypeInProgress,
+		schemas.ResponsesStreamResponseTypeOutputTextDelta,
+	} {
+		if got := streamCallUsage(chunk(typ, &schemas.BifrostResponsesResponse{Usage: usage})); got.usage != nil {
+			t.Fatalf("%s must not be accountable, got %+v", typ, got.usage)
+		}
+	}
+	for _, typ := range []schemas.ResponsesStreamResponseType{
+		schemas.ResponsesStreamResponseTypeCompleted,
+		schemas.ResponsesStreamResponseTypeIncomplete,
+		schemas.ResponsesStreamResponseTypeFailed,
+	} {
+		if got := streamCallUsage(chunk(typ, &schemas.BifrostResponsesResponse{Usage: usage})); got.usage == nil || got.usage.TotalTokens != 101 {
+			t.Fatalf("%s must be accountable, got %+v", typ, got.usage)
+		}
+	}
+	// Terminal event with no nested response / no usage: nothing to bill.
+	if got := streamCallUsage(chunk(schemas.ResponsesStreamResponseTypeCompleted, nil)); got.usage != nil {
+		t.Fatal("completed without a response must not be accountable")
+	}
+	if got := streamCallUsage(chunk(schemas.ResponsesStreamResponseTypeCompleted, &schemas.BifrostResponsesResponse{})); got.usage != nil {
+		t.Fatal("completed without usage must not be accountable")
+	}
+	if got := streamCallUsage(&schemas.BifrostStreamChunk{}); got.usage != nil {
+		t.Fatal("empty chunk must not be accountable")
+	}
+}
+
+// --- end-to-end through the hook bodies, against miniredis ---------
+
+// newMiniRedis mirrors the auth package's helper: points redisclient
+// at an in-process miniredis so ApplyToLLMPost has somewhere to write.
+func newMiniRedis(t *testing.T) *miniredis.Miniredis {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	c := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	redisclient.SetClientForTest(c)
+	t.Cleanup(func() {
+		redisclient.SetClientForTest(nil)
+		_ = c.Close()
+	})
+	return mr
+}
+
+// newClaimsContext returns a request context carrying a single-layer
+// verified chain for run r_resp / agent chat-agent.
+func newClaimsContext() *schemas.BifrostContext {
+	exp := time.Now().Add(time.Hour).UTC().Format(time.RFC3339)
+	ctx := schemas.NewBifrostContext(context.Background(), time.Time{})
+	pluginctx.SetVerifiedClaims(ctx, &macaroon.Claims{
+		OrgID:     "org_test",
+		UserID:    "u_test",
+		AgentName: "chat-agent",
+		RunID:     "r_resp",
+		EffectiveCaveats: macaroon.EffectiveCaveats{
+			Agents: []string{"chat-agent"},
+			Exp:    exp,
+		},
+		Chain: []macaroon.ChainLayer{{RunID: "r_resp", Exp: exp}},
+	})
+	return ctx
+}
+
+// waitFor polls until cond holds: ApplyToLLMPost writes on a
+// goroutine, so the accumulators land shortly after the hook returns.
+func waitFor(t *testing.T, what string, cond func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(3 * time.Second)
+	for !cond() {
+		if time.Now().After(deadline) {
+			t.Fatalf("timed out waiting for %s", what)
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+}
+
+func hashFloat(mr *miniredis.Miniredis, key string) float64 {
+	f, err := strconv.ParseFloat(mr.HGet(key, "total"), 64)
+	if err != nil {
+		return math.NaN()
+	}
+	return f
+}
+
+func waitForAccounting(t *testing.T, mr *miniredis.Miniredis, wantCost float64, wantTools []string) {
+	t.Helper()
+	waitFor(t, "cost:run", func() bool {
+		return math.Abs(hashFloat(mr, "bifrost:cost:run:r_resp")-wantCost) < 1e-9
+	})
+	waitFor(t, "tools:run", func() bool {
+		got, _ := mr.List("bifrost:tools:run:r_resp")
+		return len(got) == len(wantTools)
+	})
+	if got := mr.HGet("bifrost:steps:run:r_resp", "total"); got != "1" {
+		t.Fatalf("steps:run = %q, want 1", got)
+	}
+	// LPUSH order: most recent tool first.
+	got, _ := mr.List("bifrost:tools:run:r_resp")
+	for i, want := range wantTools {
+		if got[i] != want {
+			t.Fatalf("tools:run = %v, want %v", got, wantTools)
+		}
+	}
+}
+
+func TestLLMPost_ResponsesShape_Accounts(t *testing.T) {
+	mr := newMiniRedis(t)
+	auth.SetConfigForTest(auth.Config{ModelPricing: map[string]auth.ModelPrice{
+		"claude-sonnet-5": {InputPerMTok: 1000, OutputPerMTok: 10000},
+	}})
+	t.Cleanup(func() { auth.SetConfigForTest(auth.Config{}) })
+	ctx := newClaimsContext()
+
+	resp := &schemas.BifrostResponse{ResponsesResponse: &schemas.BifrostResponsesResponse{
+		Model:  "claude-sonnet-5",
+		Usage:  &schemas.ResponsesResponseUsage{InputTokens: 1000, OutputTokens: 1000, TotalTokens: 2000},
+		Output: []schemas.ResponsesMessage{functionCallItem("grep"), functionCallItem("read")},
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType: schemas.ResponsesRequest,
+			RoutingInfo: schemas.RoutingInfo{Provider: schemas.Anthropic, Model: "claude-sonnet-5"},
+		},
+	}}
+	if _, _, err := LLMPost(ctx, resp, nil); err != nil {
+		t.Fatal(err)
+	}
+
+	// 1000*1000/1e6 + 1000*10000/1e6 = 1 + 10.
+	waitForAccounting(t, mr, 11, []string{"read", "grep"})
+	if pluginctx.MarkAccounted(ctx) {
+		t.Fatal("LLMPost must have consumed the request's accounting slot")
+	}
+}
+
+// The set-up firing for a Responses stream carries no usage; it must
+// leave the accounting slot for the terminal chunk.
+func TestLLMPost_ResponsesStreamSetup_DefersToChunks(t *testing.T) {
+	ctx := newClaimsContext()
+	resp := &schemas.BifrostResponse{ResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+		Type:        schemas.ResponsesStreamResponseTypeCreated,
+		ExtraFields: schemas.BifrostResponseExtraFields{RequestType: schemas.ResponsesStreamRequest},
+	}}
+	if _, _, err := LLMPost(ctx, resp, nil); err != nil {
+		t.Fatal(err)
+	}
+	if !pluginctx.MarkAccounted(ctx) {
+		t.Fatal("stream set-up firing must not consume the accounting slot")
+	}
+}
+
+func TestStreamChunk_ResponsesTerminalEvent_Accounts(t *testing.T) {
+	mr := newMiniRedis(t)
+	auth.SetConfigForTest(auth.Config{ModelPricing: map[string]auth.ModelPrice{
+		"claude-sonnet-5": {InputPerMTok: 1000, OutputPerMTok: 1000},
+	}})
+	t.Cleanup(func() { auth.SetConfigForTest(auth.Config{}) })
+	ctx := newClaimsContext()
+	req := &schemas.HTTPRequest{Path: "/anthropic/v1/messages"}
+
+	// Core stamps routing on every chunk's own ExtraFields; the
+	// nested Response's block stays blank.
+	ef := schemas.BifrostResponseExtraFields{
+		RequestType:       schemas.ResponsesStreamRequest,
+		ResolvedModelUsed: "claude-sonnet-5",
+		RoutingInfo:       schemas.RoutingInfo{Provider: schemas.Anthropic, Model: "claude-sonnet-5"},
+	}
+	event := func(typ schemas.ResponsesStreamResponseType, r *schemas.BifrostResponsesResponse) *schemas.BifrostStreamChunk {
+		return &schemas.BifrostStreamChunk{BifrostResponsesStreamResponse: &schemas.BifrostResponsesStreamResponse{
+			Type: typ, Response: r, ExtraFields: ef,
+		}}
+	}
+	// response.created forwards message_start's input-only usage
+	// (100 in / 1 out → would price at 0.101). It must not be billed.
+	created := event(schemas.ResponsesStreamResponseTypeCreated, &schemas.BifrostResponsesResponse{
+		Model: "claude-sonnet-5",
+		Usage: &schemas.ResponsesResponseUsage{InputTokens: 100, OutputTokens: 1, TotalTokens: 101},
+	})
+	inProgress := event(schemas.ResponsesStreamResponseTypeInProgress, &schemas.BifrostResponsesResponse{})
+	delta := event(schemas.ResponsesStreamResponseTypeOutputTextDelta, nil)
+	completed := event(schemas.ResponsesStreamResponseTypeCompleted, &schemas.BifrostResponsesResponse{
+		Model:  "claude-sonnet-5",
+		Usage:  &schemas.ResponsesResponseUsage{InputTokens: 100, OutputTokens: 400, TotalTokens: 500},
+		Output: []schemas.ResponsesMessage{functionCallItem("grep")},
+	})
+	// A duplicate terminal event must not double-count.
+	for _, c := range []*schemas.BifrostStreamChunk{created, inProgress, delta, completed, completed} {
+		if _, err := StreamChunk(ctx, req, c); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// 100*1000/1e6 + 400*1000/1e6 = 0.1 + 0.4 — the completed
+	// event's usage, once.
+	waitForAccounting(t, mr, 0.5, []string{"grep"})
+	if pluginctx.MarkAccounted(ctx) {
+		t.Fatal("StreamChunk must have consumed the request's accounting slot")
+	}
+}
+
+// Regression guard for the chat stream shape the refactor shares
+// code with: the usage-bearing final chunk still accounts.
+func TestStreamChunk_ChatFinalChunk_StillAccounts(t *testing.T) {
+	mr := newMiniRedis(t)
+	auth.SetConfigForTest(auth.Config{ModelPricing: map[string]auth.ModelPrice{
+		"gpt-x": {InputPerMTok: 1000, OutputPerMTok: 1000},
+	}})
+	t.Cleanup(func() { auth.SetConfigForTest(auth.Config{}) })
+	ctx := newClaimsContext()
+	req := &schemas.HTTPRequest{Path: "/v1/chat/completions"}
+
+	chunk := &schemas.BifrostStreamChunk{BifrostChatResponse: &schemas.BifrostChatResponse{
+		Model: "gpt-x",
+		Usage: &schemas.BifrostLLMUsage{PromptTokens: 100, CompletionTokens: 400, TotalTokens: 500},
+		ExtraFields: schemas.BifrostResponseExtraFields{
+			RequestType: schemas.ChatCompletionStreamRequest,
+			RoutingInfo: schemas.RoutingInfo{Provider: schemas.OpenAI, Model: "gpt-x"},
+		},
+	}}
+	if _, err := StreamChunk(ctx, req, chunk); err != nil {
+		t.Fatal(err)
+	}
+	waitForAccounting(t, mr, 0.5, nil)
+}

--- a/gateway/internal/hooks/stream_chunk.go
+++ b/gateway/internal/hooks/stream_chunk.go
@@ -11,16 +11,15 @@ import (
 // StreamChunk is the body of HTTPTransportStreamChunkHook. It fires
 // once per streamed chunk. PostLLMHook does NOT carry usage for
 // streaming responses, so phase-6 cost accounting for streams lives
-// here: Bifrost normalizes providers to the OpenAI stream shape,
-// where usage arrives once on the final chunk (include_usage is on
-// by default). MarkAccounted guards the "provider emits usage on
-// more than one chunk" case — first usage-bearing chunk wins, and a
-// second one is ignored rather than double-counted.
+// here. Which chunk carries the usage depends on the request type —
+// see streamCallUsage. MarkAccounted guards the "provider emits
+// usage on more than one chunk" case — first accountable chunk
+// wins, and a second one is ignored rather than double-counted.
 //
-// Stream tool-call names arrive as per-chunk deltas that would need
-// cross-chunk assembly to reconstruct; the tools:run history
-// currently comes from non-streaming responses only. Revisit when
-// the phase-6 PreLLMHook tool-loop check lands.
+// Chat-stream tool-call names arrive as per-chunk deltas that would
+// need cross-chunk assembly to reconstruct, so chat streams feed no
+// tools:run history. Responses streams do: the terminal event
+// carries the fully assembled output items, function_call included.
 //
 // Logging policy: one log line per chunk would flood output, so we
 // only emit on error chunks and on the accounting chunk.
@@ -52,8 +51,8 @@ func StreamChunk(
 		return chunk, nil
 	}
 
-	chat := chunk.BifrostChatResponse
-	if claims == nil || chat == nil || chat.Usage == nil || chat.Usage.TotalTokens == 0 {
+	call := streamCallUsage(chunk)
+	if claims == nil || call.usage == nil || call.usage.TotalTokens == 0 {
 		return chunk, nil
 	}
 	if !pluginctx.MarkAccounted(ctx) {
@@ -61,16 +60,67 @@ func StreamChunk(
 	}
 
 	dims := pluginctx.Dims(ctx)
-	costUSD := resolveCost(chat, chat.Usage, dims)
-	auth.ApplyToLLMPost(claims, costUSD, nil)
+	costUSD := resolveCost(call, dims)
+	auth.ApplyToLLMPost(claims, costUSD, call.tools)
 	pluginlog.Logf(
 		"StreamChunk accounted run_id=%s agent=%s prompt_tokens=%d completion_tokens=%d total_tokens=%d cost_usd=%.6f",
 		dims[pluginctx.DimRunID],
 		dims[pluginctx.DimAgentName],
-		chat.Usage.PromptTokens,
-		chat.Usage.CompletionTokens,
-		chat.Usage.TotalTokens,
+		call.usage.PromptTokens,
+		call.usage.CompletionTokens,
+		call.usage.TotalTokens,
 		costUSD,
 	)
 	return chunk, nil
+}
+
+// streamCallUsage returns the accountable usage a chunk carries, or
+// the zero value (nil usage) for every chunk that must not be
+// billed. The rule differs per stream shape:
+//
+//   - chat_completion_stream: Bifrost normalizes providers to the
+//     OpenAI stream shape, where usage arrives once on the final
+//     chunk (include_usage is on by default). Any usage-bearing
+//     chunk is therefore the final one.
+//   - responses_stream: usage rides on the nested Response object of
+//     the terminal event (response.completed / .incomplete /
+//     .failed). It is NOT safe to take the first usage-bearing
+//     event: the Anthropic provider forwards message_start's
+//     input-only usage on response.created, so a first-wins rule
+//     would bill the prompt and drop the completion tokens.
+func streamCallUsage(chunk *schemas.BifrostStreamChunk) callUsage {
+	switch {
+	case chunk.BifrostChatResponse != nil:
+		chat := chunk.BifrostChatResponse
+		return callUsage{
+			usage:    chat.Usage,
+			model:    resolvedModel(chat.Model, &chat.ExtraFields),
+			provider: extraFieldsProvider(&chat.ExtraFields),
+		}
+	case chunk.BifrostResponsesStreamResponse != nil:
+		sr := chunk.BifrostResponsesStreamResponse
+		if sr.Response == nil || !isTerminalResponsesEvent(sr.Type) {
+			return callUsage{}
+		}
+		// Routing lives on the chunk; fall back to the nested
+		// response's block only when the chunk carries none.
+		ef := &sr.ExtraFields
+		if extraFieldsProvider(ef) == "" && ef.ResolvedModelUsed == "" {
+			ef = &sr.Response.ExtraFields
+		}
+		return responsesCallUsage(sr.Response, ef)
+	}
+	return callUsage{}
+}
+
+// isTerminalResponsesEvent reports whether a Responses stream event
+// closes the response and so carries its final usage.
+func isTerminalResponsesEvent(t schemas.ResponsesStreamResponseType) bool {
+	switch t {
+	case schemas.ResponsesStreamResponseTypeCompleted,
+		schemas.ResponsesStreamResponseTypeIncomplete,
+		schemas.ResponsesStreamResponseTypeFailed:
+		return true
+	}
+	return false
 }

--- a/gateway/plans/phases/phase-6-plugin-enforcement.md
+++ b/gateway/plans/phases/phase-6-plugin-enforcement.md
@@ -5,10 +5,17 @@
 > writes `cost:run` / `steps:run` per chain layer (each with its own
 > layer-exp TTL), `cost:ua` when the UA carries a budget,
 > `cost:agent:<name>:<bucket>` for configured agents, and
-> `tools:run` history (non-streaming responses only for now).
-> Streaming requests account on the final usage-bearing chunk in
-> `hooks/stream_chunk.go`; `pluginctx.MarkAccounted` guards
-> double-counting. Bucket keys come from `gateway/internal/duration`
+> `tools:run` history (non-streaming responses, plus Responses-API
+> streams, whose terminal event carries the assembled output).
+> Usage is read from whichever shape core populated — Chat, or
+> Responses (the Anthropic-native `/anthropic/v1/messages`
+> integration routes as `RequestType = "responses"` in core v1.6, so
+> Claude calls made with the Anthropic SDK arrive with `ChatResponse`
+> nil). Streaming requests account on the final usage-bearing chunk
+> in `hooks/stream_chunk.go` — for Responses streams that is the
+> terminal `response.completed` event, never `response.created`,
+> which only carries `message_start`'s input usage;
+> `pluginctx.MarkAccounted` guards double-counting. Bucket keys come from `gateway/internal/duration`
 > (shared with the adminapi budget endpoint, so reader and writer
 > can't drift). Cost source: provider-computed `Usage.Cost` when
 > present, else the `model_pricing` config table (operator


### PR DESCRIPTION
## Problem

Bifrost core v1.6.2 routes the Anthropic-native `/anthropic/v1/messages` integration as `RequestType = "responses"`. Those calls reach `PostLLMHook` with `resp.ChatResponse == nil` and usage on `resp.ResponsesResponse.Usage` (`*schemas.ResponsesResponseUsage`). The hook only read the chat shape, so every Claude call made with the Anthropic SDK was accounted at `cost=0` and fed nothing into the phase-6 accumulators. Prod evidence from swarm38, 2026-09-10:

```
PreLLMHook provider=anthropic model=claude-sonnet-5 request_type=responses ...
PostLLMHook run_id=26e1b2b3-... agent=chat-agent had_resp=true had_err=false prompt_tokens=0 completion_tokens=0 total_tokens=0 cost_usd=0.000000 elapsed_ms=2581
HTTPTransportPostHook path=/anthropic/v1/messages status=200 body_bytes=506
```

## Changes

**`internal/hooks/llm_posthook.go`**
- New `callUsage` struct: the shape-agnostic view (usage, resolved model, provider, tool names) that `resolveCost`, the accumulator, and the log line consume. `callUsageOf(resp)` picks Chat or Responses.
- Responses mapping: `InputTokens→prompt`, `OutputTokens→completion`, `TotalTokens→total` (recomputed from the sum only if the provider left it zero), `Usage.Cost` carried verbatim so provider-computed `TotalCost` wins exactly like the chat path.
- Tool names from `function_call` output items (`ResponsesToolMessage.Name`); server-side tool items and nameless items are skipped.
- `resolveCost` now takes the view. The provider-aware `auth.PriceCall(provider, model, …)` lookup, the xAI/OpenRouter note, and the `PostLLMHook …` log format are unchanged, so `docker logs` greps still work.

**`internal/hooks/stream_chunk.go`**
- `responses_stream` chunks are `chunk.BifrostResponsesStreamResponse`. There is no usage field on the stream event itself in v1.6.2; usage rides on the nested `Response.Usage` of the terminal event (`response.completed` / `.incomplete` / `.failed`).
- Gating is on the terminal event type, not "first usage-bearing chunk": the Anthropic provider forwards `message_start`'s input-only usage on `response.created`, so a first-wins rule would bill the prompt and drop the completion tokens.
- Routing (provider / resolved model) is read from the chunk's own `ExtraFields`, falling back to the nested response's block.
- Responses streams now also feed `tools:run`, since the terminal event carries the assembled output items. Chat streams still don't (per-chunk deltas).

**Tests** (`internal/hooks/responses_usage_test.go`, plus a `chatCost` helper so the existing `resolveCost` tests keep their shape)
- Unit: usage mapping + cost passthrough, tool-name extraction, `callUsageOf` model/provider resolution, cost precedence on the Responses shape, terminal-vs-non-terminal stream gating.
- End-to-end against miniredis: `LLMPost` with a Responses non-stream result writes `cost:run` / `steps:run` / `tools:run`; the streaming set-up firing leaves the accounting slot alone; `StreamChunk` over `created → in_progress → delta → completed → completed` bills the completed event's usage exactly once; chat final-chunk regression guard.

**Docs**: phase-6 status note updated to describe both shapes and the terminal-event rule.

## Verification

```
cd gateway && go vet ./... && go test ./...
go test -race -count=5 ./internal/hooks/
```

All green. (`go build ./...` on the root package fails with "function main is undeclared" — pre-existing, it's a `-buildmode=plugin` package; `./internal/...` builds.)
